### PR TITLE
refactor(loomark): decompose update_model into concern sub-dispatchers

### DIFF
--- a/apps/loomark/internal/rabbita/application.mbt
+++ b/apps/loomark/internal/rabbita/application.mbt
@@ -359,7 +359,7 @@ fn preview_view(
     selected=raw_selected,
     attrs=@html.Attrs::build()
       .aria_label("Raw Markdown")
-      .on_click(_ => emit(SelectRaw)),
+      .on_click(_ => emit(Navigation(SelectRaw))),
     style=["min-height:2.75rem;flex:0 0 3.25rem;padding:0"],
     mode_icon("m8 9-3 3 3 3m8-6 3 3-3 3m-2-8-4 16"),
   )
@@ -369,7 +369,7 @@ fn preview_view(
     selected=preview_selected,
     attrs=@html.Attrs::build()
       .aria_label("Preview")
-      .on_click(_ => emit(SelectPreview)),
+      .on_click(_ => emit(Navigation(SelectPreview))),
     style=["min-height:2.75rem;flex:0 0 3.25rem;padding:0"],
     mode_icon(
       "M2 12s3.5-6 10-6 10 6 10 6-3.5 6-10 6S2 12 2 12Zm10 3a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z",
@@ -381,7 +381,7 @@ fn preview_view(
     selected=block_selected,
     attrs=@html.Attrs::build()
       .aria_label("Block view")
-      .on_click(_ => emit(SelectBlock)),
+      .on_click(_ => emit(Navigation(SelectBlock))),
     style=["min-height:2.75rem;flex:0 0 3.25rem;padding:0"],
     mode_icon("M4 4h6v6H4V4Zm10 0h6v6h-6V4ZM4 14h6v6H4v-6Zm10 0h6v6h-6v-6Z"),
   )
@@ -408,7 +408,7 @@ fn preview_view(
         },
       )
       .aria_pressed(model.split_preview_open.to_string()),
-    on_click=emit(ToggleSplitPreview),
+    on_click=emit(Navigation(ToggleSplitPreview)),
     mode_icon("M4 4h6v16H4V4Zm10 0h6v16h-6V4Z"),
   )
   let examples = @html.div(
@@ -423,35 +423,35 @@ fn preview_view(
         attrs=@html.Attrs::build().aria_label(
           "Apply Markdown feature tour example",
         ),
-        on_click=emit(ReplaceSource(MARKDOWN_DEMO_SOURCE)),
+        on_click=emit(Editing(ReplaceSource(MARKDOWN_DEMO_SOURCE))),
         "Demo",
       ),
       @rui.button(
         variant=@rui.Ghost,
         size=@rui.Xs,
         attrs=@html.Attrs::build().aria_label("Apply Hello example"),
-        on_click=emit(ReplaceSource(HELLO_EXAMPLE_SOURCE)),
+        on_click=emit(Editing(ReplaceSource(HELLO_EXAMPLE_SOURCE))),
         "Hello",
       ),
       @rui.button(
         variant=@rui.Ghost,
         size=@rui.Xs,
         attrs=@html.Attrs::build().aria_label("Guide: Apply Blog example"),
-        on_click=emit(ReplaceSource(BLOG_EXAMPLE_SOURCE)),
+        on_click=emit(Editing(ReplaceSource(BLOG_EXAMPLE_SOURCE))),
         "Guide",
       ),
       @rui.button(
         variant=@rui.Ghost,
         size=@rui.Xs,
         attrs=@html.Attrs::build().aria_label("Apply List example"),
-        on_click=emit(ReplaceSource(LIST_EXAMPLE_SOURCE)),
+        on_click=emit(Editing(ReplaceSource(LIST_EXAMPLE_SOURCE))),
         "List",
       ),
       @rui.button(
         variant=@rui.Ghost,
         size=@rui.Xs,
         attrs=@html.Attrs::build().aria_label("Apply Code example"),
-        on_click=emit(ReplaceSource(CODE_EXAMPLE_SOURCE)),
+        on_click=emit(Editing(ReplaceSource(CODE_EXAMPLE_SOURCE))),
         "Code",
       ),
     ],
@@ -576,45 +576,57 @@ fn private_dev_host_preview_view(
 ///|
 fn driver_event_name(event : DriverEvent) -> String {
   match event {
-    ReplaceSource(_) => "source"
-    SelectRaw => "select-raw"
-    SelectBlock => "select-block"
-    SelectPreview => "select-preview"
-    ToggleSplitPreview => "toggle-split"
-    BlockFocused(_) => "block-focused"
-    BlockHeading(_, _) => "block-heading"
-    BlockToggleList(_) => "block-toggle-list"
-    BlockDelete => "block-delete"
-    RawInput(_, _) => "raw-input"
-    BlockInput(..) => "block-input"
-    BlockSplit(..) => "block-split"
-    BlockMerge(..) => "block-merge"
-    BlockNavigate(..) => "block-navigate"
-    BlockSelectionRejected(_, _) => "block-selection-rejected"
-    ProbeBlockSelection(_) => "probe-block-selection"
-    EditorFailure => "editor-failure"
-    RestoreSnapshot(..) => "restore-snapshot"
-    FocusPreview => "focus-preview"
-    FocusBlock => "focus-block"
-    FocusRaw => "focus-raw"
-    RestoreFocus(_) => "restore-focus"
-    FocusRejected(_) => "focus-rejected"
-    WriteSelection(..) => "write-selection"
-    WriteSelectionFailure => "write-selection-failure"
-    MeasurePreview => "measure-preview"
-    MeasureFailure => "measure-failure"
-    SelectionRead(..) => "selection-read"
-    Measured(..) => "measured"
-    EffectFailed(_) => "effect-failed"
-    CustomEvent(_) => "custom-event"
-    ControlInstalled => "control-installed"
-    SubscriptionInstalled => "subscription-installed"
-    SubscriptionUnloaded => "subscription-unloaded"
-    InvalidRequest(_) => "invalid-request"
-    StopListening => "stop-listening"
-    Fatal(_) => "fatal"
-    Resize(_) => "resize"
-    ArchiveWriteCompleted(_) => "archive-write-completed"
+    Editing(edit_event) =>
+      match edit_event {
+        ReplaceSource(_) => "source"
+        RawInput(_, _) => "raw-input"
+        BlockFocused(_) => "block-focused"
+        BlockHeading(_, _) => "block-heading"
+        BlockToggleList(_) => "block-toggle-list"
+        BlockDelete => "block-delete"
+        BlockInput(..) => "block-input"
+        BlockSplit(..) => "block-split"
+        BlockMerge(..) => "block-merge"
+        BlockNavigate(..) => "block-navigate"
+        ProbeBlockSelection(_) => "probe-block-selection"
+      }
+    Navigation(nav_event) =>
+      match nav_event {
+        SelectRaw => "select-raw"
+        SelectBlock => "select-block"
+        SelectPreview => "select-preview"
+        ToggleSplitPreview => "toggle-split"
+        FocusPreview => "focus-preview"
+        FocusBlock => "focus-block"
+        FocusRaw => "focus-raw"
+        RestoreFocus(_) => "restore-focus"
+        FocusRejected(_) => "focus-rejected"
+        EffectFailed(_) => "effect-failed"
+        BlockSelectionRejected(_, _) => "block-selection-rejected"
+      }
+    Probe(probe_event) =>
+      match probe_event {
+        WriteSelection(..) => "write-selection"
+        WriteSelectionFailure => "write-selection-failure"
+        MeasurePreview => "measure-preview"
+        MeasureFailure => "measure-failure"
+        SelectionRead(..) => "selection-read"
+        Measured(..) => "measured"
+      }
+    Lifecycle(life_event) =>
+      match life_event {
+        EditorFailure => "editor-failure"
+        RestoreSnapshot(..) => "restore-snapshot"
+        CustomEvent(_) => "custom-event"
+        ControlInstalled => "control-installed"
+        SubscriptionInstalled => "subscription-installed"
+        SubscriptionUnloaded => "subscription-unloaded"
+        InvalidRequest(_) => "invalid-request"
+        StopListening => "stop-listening"
+        Fatal(_) => "fatal"
+        Resize(_) => "resize"
+      }
+    Archive(_) => "archive-write-completed"
   }
 }
 
@@ -623,53 +635,53 @@ fn driver_event_name(event : DriverEvent) -> String {
 /// handle to the generated JavaScript boundary.
 fn parse_driver_event(detail : String) -> DriverEvent {
   if detail == "select-raw" {
-    SelectRaw
+    Navigation(SelectRaw)
   } else if detail == "select-block" {
-    SelectBlock
+    Navigation(SelectBlock)
   } else if detail == "select-preview" {
-    SelectPreview
+    Navigation(SelectPreview)
   } else if detail == "toggle-split" {
-    ToggleSplitPreview
+    Navigation(ToggleSplitPreview)
   } else if detail == "focus-preview" {
-    FocusPreview
+    Navigation(FocusPreview)
   } else if detail == "focus-block" {
-    FocusBlock
+    Navigation(FocusBlock)
   } else if detail == "focus-raw" {
-    FocusRaw
+    Navigation(FocusRaw)
   } else if detail == "probe-stale-block-selection" {
-    ProbeBlockSelection("stale")
+    Editing(ProbeBlockSelection("stale"))
   } else if detail == "probe-deleted-block-selection" {
-    ProbeBlockSelection("deleted")
+    Editing(ProbeBlockSelection("deleted"))
   } else if detail == "write-selection-failure" {
-    WriteSelectionFailure
+    Probe(WriteSelectionFailure)
   } else if detail == "measure-preview" {
-    MeasurePreview
+    Probe(MeasurePreview)
   } else if detail == "measure-failure" {
-    MeasureFailure
+    Probe(MeasureFailure)
   } else if detail == "stop-listening" {
-    StopListening
+    Lifecycle(StopListening)
   } else if detail.has_prefix("source|") {
-    ReplaceSource(detail["source|".length():].to_owned())
+    Editing(ReplaceSource(detail["source|".length():].to_owned()))
   } else if detail.has_prefix("raw-input|") {
-    RawInput(detail["raw-input|".length():].to_owned(), None)
+    Editing(RawInput(detail["raw-input|".length():].to_owned(), None))
   } else if detail == "editor-failure" {
-    EditorFailure
+    Lifecycle(EditorFailure)
   } else if detail.has_prefix("restore-focus|") {
-    RestoreFocus(detail["restore-focus|".length():].to_owned())
+    Navigation(RestoreFocus(detail["restore-focus|".length():].to_owned()))
   } else if detail.has_prefix("restore-snapshot|") {
     let payload = detail["restore-snapshot|".length():].to_owned()
     let parsed = @json.parse(payload) catch {
-      _ => return InvalidRequest("restore-snapshot")
+      _ => return Lifecycle(InvalidRequest("restore-snapshot"))
     }
     match parsed {
       Json::Object(fields) => {
         let version = match fields.get("version") {
           Some(Json::Number(value, ..)) => value.to_int()
-          _ => return InvalidRequest("restore-snapshot")
+          _ => return Lifecycle(InvalidRequest("restore-snapshot"))
         }
         let source = match fields.get("source") {
           Some(Json::String(value)) => value
-          _ => return InvalidRequest("restore-snapshot")
+          _ => return Lifecycle(InvalidRequest("restore-snapshot"))
         }
         let mode = match fields.get("mode") {
           Some(Json::String(value)) =>
@@ -677,28 +689,30 @@ fn parse_driver_event(detail : String) -> DriverEvent {
               "raw" => @core.Raw
               "block" => @core.Block
               "preview" => @core.Preview
-              _ => return InvalidRequest("restore-snapshot")
+              _ => return Lifecycle(InvalidRequest("restore-snapshot"))
             }
-          _ => return InvalidRequest("restore-snapshot")
+          _ => return Lifecycle(InvalidRequest("restore-snapshot"))
         }
-        RestoreSnapshot(version~, source~, mode~)
+        Lifecycle(RestoreSnapshot(version~, source~, mode~))
       }
-      _ => InvalidRequest("restore-snapshot")
+      _ => Lifecycle(InvalidRequest("restore-snapshot"))
     }
   } else if detail.has_prefix("write-selection|") {
     let parts = detail["write-selection|".length():].split("|").to_array()
-    guard parts.length() == 2 else { return InvalidRequest("write-selection") }
+    guard parts.length() == 2 else {
+      return Lifecycle(InvalidRequest("write-selection"))
+    }
     let start = @string.parse_int(parts[0], base=10) catch {
-      _ => return InvalidRequest("write-selection")
+      _ => return Lifecycle(InvalidRequest("write-selection"))
     }
     let end = @string.parse_int(parts[1], base=10) catch {
-      _ => return InvalidRequest("write-selection")
+      _ => return Lifecycle(InvalidRequest("write-selection"))
     }
-    WriteSelection(start~, end~)
+    Probe(WriteSelection(start~, end~))
   } else if detail.has_prefix("fatal|") {
-    Fatal(detail["fatal|".length():].to_owned())
+    Lifecycle(Fatal(detail["fatal|".length():].to_owned()))
   } else {
-    InvalidRequest("unknown")
+    Lifecycle(InvalidRequest("unknown"))
   }
 }
 
@@ -715,599 +729,832 @@ fn dispatch_driver(detail : String) -> Unit {
 }
 
 ///|
-fn update_model(
+
+///|
+/// Archive completion channel: tracker acknowledgment always lands, even in
+/// fatal state, so an older acknowledgment cannot clear a newer warning.
+fn update_archive_tracker(
+  model : DriverModel,
+  completion : @archive_storage.LocalArchiveWriteCompletion,
+) -> (DriverModel, @cmd.Cmd) {
+  let tracker = match completion.result() {
+    @archive_storage.LocalArchiveStorageWrite::Stored =>
+      model.archive_tracker.complete_success(completion.request_id())
+    @archive_storage.LocalArchiveStorageWrite::Failed(_) =>
+      model.archive_tracker.complete_failure(completion.request_id())
+  }
+  let next = {
+    ..model,
+    archive_tracker: tracker,
+    local_storage_warning: tracker.has_warning(),
+  }
+  (next, @rabbita_runtime.none)
+}
+
+///|
+/// Mode gate for editing-surface events. ReplaceSource is deliberately
+/// exempt: driver source replacement works in any mode. The split Preview
+/// pairs the Raw textarea with the rendered Preview even while the Preview
+/// tab is selected, so Raw input stays live there.
+fn editing_mode_applicable(
+  event : EditingEvent,
+  mode : @core.ApplicationMode,
+  split_preview_open : Bool,
+) -> String? {
+  match event {
+    ReplaceSource(_) | ProbeBlockSelection(_) => None
+    RawInput(_, _) =>
+      if mode == @core.Raw || (mode == @core.Preview && split_preview_open) {
+        None
+      } else {
+        Some("Raw input is unavailable outside Raw mode")
+      }
+    BlockFocused(_)
+    | BlockHeading(_, _)
+    | BlockToggleList(_)
+    | BlockDelete
+    | BlockInput(..)
+    | BlockSplit(..)
+    | BlockMerge(..)
+    | BlockNavigate(..) =>
+      if mode == @core.Block {
+        None
+      } else {
+        Some("Block editing is unavailable outside Block mode")
+      }
+  }
+}
+
+///|
+/// Editing-surface dispatcher: mode-gated input and structural requests
+/// through the atomic editor façade.
+fn update_editing(
   editor : @markdown.MarkdownEditor,
   attachment : @md_markdown.MarkdownSemanticAttachment,
   model : DriverModel,
   latest_model : @ref.Ref[DriverModel?],
-  event : DriverEvent,
+  event : EditingEvent,
   emit : @cmd.Emit[DriverEvent],
 ) -> (DriverModel, @cmd.Cmd) {
-  if event is ArchiveWriteCompleted(completion) {
-    let tracker = match completion.result() {
-      @archive_storage.LocalArchiveStorageWrite::Stored =>
-        model.archive_tracker.complete_success(completion.request_id())
-      @archive_storage.LocalArchiveStorageWrite::Failed(_) =>
-        model.archive_tracker.complete_failure(completion.request_id())
-    }
-    let next = {
-      ..model,
-      archive_tracker: tracker,
-      local_storage_warning: tracker.has_warning(),
-    }
-    publish(next)
-    return (next, @rabbita_runtime.none)
-  }
-  if model.fatal {
-    let next = {
-      ..model,
-      rejection: Some(
-        "operation=" + driver_event_name(event) + ";reason=fatal-state",
-      ),
-    }
-    publish(next)
-    return (next, @rabbita_runtime.none)
-  }
-  // The split Preview pairs the Raw textarea with the rendered Preview even
-  // while the Preview tab is selected, so Raw input stays live there.
-  let raw_editable = model.state.mode() == @core.Raw ||
-    (model.state.mode() == @core.Preview && model.split_preview_open)
-  if !raw_editable && event is RawInput(_, _) {
-    let next = record_error(
-      model, "mode-inapplicable", "editor-dispatch", "Raw input is unavailable outside Raw mode",
-    )
-    publish(next)
-    return (next, @rabbita_runtime.none)
-  }
-  if model.state.mode() != @core.Block &&
-    (
-      event is BlockInput(..) ||
-      event is BlockSplit(..) ||
-      event is BlockMerge(..) ||
-      event is BlockNavigate(..) ||
-      event is BlockFocused(_) ||
-      event is BlockHeading(_, _) ||
-      event is BlockToggleList(_) ||
-      event is BlockDelete
-    ) {
-    let next = record_error(
-      model, "mode-inapplicable", "editor-dispatch", "Block editing is unavailable outside Block mode",
-    )
-    publish(next)
-    return (next, @rabbita_runtime.none)
-  }
-  match event {
-    ArchiveWriteCompleted(_) => (model, @rabbita_runtime.none)
-    ReplaceSource(source) | RawInput(source, _) => {
-      let raw_selection = match event {
-        RawInput(_, selection) => selection
-        _ => None
-      }
-      let raw_event = event is RawInput(_, _)
-      let transition = @core.reduce(
-        model.state,
-        @core.ApplicationEvent::RequestCanonicalSource(source~),
+  match
+    editing_mode_applicable(event, model.state.mode(), model.split_preview_open) {
+    Some(message) => {
+      let next = record_error(
+        model, "mode-inapplicable", "editor-dispatch", message,
       )
-      let mut next = if raw_event {
-        { ..model, text_input_generation: model.text_input_generation + 1 }
-      } else {
-        model
-      }
-      let mut restore_raw_value = false
-      let mut persistence_command = @rabbita_runtime.none
-      for decision in transition.decisions() {
-        match decision {
-          @core.ReplaceCanonicalSource(source) => {
-            let old_requested = preview_requested(next)
-            let (committed, accepted, changed, commit_command) = commit_source(
+      (next, @rabbita_runtime.none)
+    }
+    None =>
+      match event {
+        ReplaceSource(source) | RawInput(source, _) => {
+          let raw_selection = match event {
+            RawInput(_, selection) => selection
+            _ => None
+          }
+          let raw_event = event is RawInput(_, _)
+          let transition = @core.reduce(
+            model.state,
+            @core.ApplicationEvent::RequestCanonicalSource(source~),
+          )
+          let mut next = if raw_event {
+            { ..model, text_input_generation: model.text_input_generation + 1 }
+          } else {
+            model
+          }
+          let mut restore_raw_value = false
+          let mut persistence_command = @rabbita_runtime.none
+          for decision in transition.decisions() {
+            match decision {
+              @core.ReplaceCanonicalSource(source) => {
+                let old_requested = preview_requested(next)
+                let (committed, accepted, changed, commit_command) = commit_source(
+                  editor,
+                  next,
+                  transition.state(),
+                  source,
+                  "editor-dispatch",
+                  emit,
+                )
+                next = update_preview_document(
+                  attachment,
+                  committed,
+                  old_requested,
+                  accepted~,
+                  changed~,
+                )
+                persistence_command = @cmd.batch([
+                  persistence_command, commit_command,
+                ])
+                restore_raw_value = restore_raw_value ||
+                  (raw_event && !accepted)
+              }
+              @core.SnapshotRejected(_) =>
+                next = record_error(
+                  next, "invalid-snapshot", "editor-dispatch", "snapshot rejected",
+                )
+            }
+          }
+          let command = if restore_raw_value {
+            let repair_generation = next.text_input_generation
+            let repair_source_revision = next.source_revision
+            after_render(
+              scheduler => {
+                ignore(scheduler)
+                let accepted_source = next.document.source()
+                if repair_eligible(
+                    latest_model.val,
+                    @core.Raw,
+                    repair_generation,
+                    repair_source_revision,
+                  ) {
+                  @dom_boundary.write_text_value_id(
+                    "loomark-input", accepted_source,
+                  )
+                  match raw_selection {
+                    Some(selection) =>
+                      @dom_boundary.write_text_selection_id(
+                        "loomark-input",
+                        rejected_text_selection(
+                          accepted_source, source, selection,
+                        ),
+                      )
+                    None => ()
+                  }
+                }
+              },
+              emit,
+            )
+          } else {
+            @rabbita_runtime.none
+          }
+          (next, @cmd.batch([persistence_command, command]))
+        }
+        BlockFocused(key) =>
+          if model.active_block_key == Some(key) {
+            (model, @rabbita_runtime.none)
+          } else {
+            let (_, selected_index) = model.document
+              .blocks()
+              .fold(init=(0, None), (state, block) => {
+                let (index, found) = state
+                (
+                  index + 1,
+                  match found {
+                    Some(_) => found
+                    None => if block.key() == key { Some(index) } else { None }
+                  },
+                )
+              })
+            match selected_index {
+              None => {
+                let next = record_error(
+                  model, "block-selection-rejected", "editor-dispatch", "focused block is unavailable",
+                )
+                (next, @rabbita_runtime.none)
+              }
+              Some(index) => {
+                let next = { ..model, active_block_key: Some(key) }
+                (
+                  next,
+                  after_render(
+                    scheduler => {
+                      ignore(scheduler)
+                      @dom_boundary.focus_id(block_input_id(index))
+                    },
+                    emit,
+                  ),
+                )
+              }
+            }
+          }
+        BlockHeading(requested_level, originating_selection) =>
+          match block_format_target(model, originating_selection) {
+            None => {
+              let next = record_error(
+                model, "block-selection-rejected", "editor-dispatch", "formatting requires an active block",
+              )
+              (next, @rabbita_runtime.none)
+            }
+            Some(block) => {
+              guard block_allows_heading(block.kind()) else {
+                let command = originating_selection
+                  .map(selection => {
+                    block_selection_after_render(
+                      latest_model,
+                      selection,
+                      model.source_revision,
+                      report_superseded=true,
+                      emit,
+                    )
+                  })
+                  .unwrap_or(@rabbita_runtime.none)
+                return (model, command)
+              }
+              if requested_level == 0 && block.kind() is @markdown.Paragraph {
+                let command = originating_selection
+                  .map(selection => {
+                    block_selection_after_render(
+                      latest_model,
+                      selection,
+                      model.source_revision,
+                      report_superseded=true,
+                      emit,
+                    )
+                  })
+                  .unwrap_or(@rabbita_runtime.none)
+                return (model, command)
+              }
+              let target_level = match block.kind() {
+                @markdown.Heading(level~) if level == requested_level => 0
+                _ => requested_level
+              }
+              commit_block_toolbar_request(
+                editor,
+                attachment,
+                model,
+                latest_model,
+                @markdown.MarkdownEditRequest::ChangeHeadingLevel(
+                  node_id=block.node_id(),
+                  level=target_level,
+                ),
+                originating_selection,
+                "loomark-heading-" + requested_level.to_string(),
+                emit,
+              )
+            }
+          }
+        BlockToggleList(originating_selection) =>
+          match block_format_target(model, originating_selection) {
+            None => {
+              let next = record_error(
+                model, "block-selection-rejected", "editor-dispatch", "formatting requires an active block",
+              )
+              (next, @rabbita_runtime.none)
+            }
+            Some(block) => {
+              guard block_allows_list(block.kind()) else {
+                let command = originating_selection
+                  .map(selection => {
+                    block_selection_after_render(
+                      latest_model,
+                      selection,
+                      model.source_revision,
+                      report_superseded=true,
+                      emit,
+                    )
+                  })
+                  .unwrap_or(@rabbita_runtime.none)
+                return (model, command)
+              }
+              commit_block_toolbar_request(
+                editor,
+                attachment,
+                model,
+                latest_model,
+                @markdown.MarkdownEditRequest::ToggleListItem(
+                  node_id=block.node_id(),
+                ),
+                originating_selection,
+                "loomark-toggle-list",
+                emit,
+              )
+            }
+          }
+        BlockDelete =>
+          match active_block(model) {
+            None => {
+              let next = record_error(
+                model, "block-selection-rejected", "editor-dispatch", "deletion requires an active block",
+              )
+              (next, @rabbita_runtime.none)
+            }
+            Some(block) =>
+              commit_block_toolbar_request(
+                editor,
+                attachment,
+                model,
+                latest_model,
+                @markdown.MarkdownEditRequest::Delete(node_id=block.node_id()),
+                None,
+                "loomark-delete-block",
+                emit,
+              )
+          }
+        BlockInput(node_id~, input_id~, text=proposed_text, selection_offset~) => {
+          let (next, committed_selection, accepted, persistence_command) = commit_block_request(
+            editor,
+            attachment,
+            model,
+            @markdown.MarkdownEditRequest::CommitTextControlEdit(
+              node_id~,
+              new_text=proposed_text,
+            ),
+            "editor-dispatch",
+            emit,
+          )
+          let selection = match committed_selection {
+            Some(selection) =>
+              block_selection_from_commit(
+                next.document,
+                selection,
+                offset=selection_offset,
+              )
+            None => None
+          }
+          let next = {
+            ..next,
+            text_input_generation: model.text_input_generation + 1,
+            active_block_key: match selection {
+              Some(selection) => Some(selection.key)
+              None => model.active_block_key
+            },
+            selection: match selection {
+              Some(selection) => Some(block_selection_label(selection))
+              None => None
+            },
+          }
+          match selection {
+            Some(selection) =>
+              (
+                next,
+                @cmd.batch([
+                  persistence_command,
+                  block_selection_after_render(
+                    latest_model,
+                    selection,
+                    next.source_revision,
+                    report_superseded=false,
+                    emit,
+                  ),
+                ]),
+              )
+            None =>
+              if accepted {
+                (next, persistence_command)
+              } else {
+                let accepted_text = next.document
+                  .blocks()
+                  .fold(init=None, (found, block) => {
+                    match found {
+                      Some(_) => found
+                      None =>
+                        if block.node_id() == node_id {
+                          Some(block.text())
+                        } else {
+                          None
+                        }
+                    }
+                  })
+                match accepted_text {
+                  Some(text) => {
+                    let offset = rejected_text_offset(
+                      text, proposed_text, selection_offset,
+                    )
+                    let repair_generation = next.text_input_generation
+                    let repair_source_revision = next.source_revision
+                    (
+                      next,
+                      @cmd.batch([
+                        persistence_command,
+                        after_render(
+                          scheduler => {
+                            ignore(scheduler)
+                            if repair_eligible(
+                                latest_model.val,
+                                @core.Block,
+                                repair_generation,
+                                repair_source_revision,
+                              ) {
+                              @dom_boundary.write_text_value_id(input_id, text)
+                              @dom_boundary.focus_id(input_id)
+                              @dom_boundary.write_text_selection_id(
+                                input_id,
+                                @dom_boundary.TextSelection(
+                                  offset,
+                                  offset,
+                                  @dom_boundary.NoDirection,
+                                ),
+                              )
+                            }
+                          },
+                          emit,
+                        ),
+                      ]),
+                    )
+                  }
+                  None => (next, persistence_command)
+                }
+              }
+          }
+        }
+        BlockSplit(node_id~, offset~) => {
+          let (next, committed_selection, _, persistence_command) = commit_block_request(
+            editor,
+            attachment,
+            model,
+            @markdown.MarkdownEditRequest::SplitBlock(node_id~, offset~),
+            "editor-dispatch",
+            emit,
+          )
+          let selection = match committed_selection {
+            Some(selection) =>
+              block_selection_from_commit(next.document, selection)
+            None => None
+          }
+          let next = {
+            ..next,
+            active_block_key: match selection {
+              Some(selection) => Some(selection.key)
+              None => model.active_block_key
+            },
+            selection: match selection {
+              Some(selection) => Some(block_selection_label(selection))
+              None => None
+            },
+          }
+          match selection {
+            Some(selection) =>
+              (
+                next,
+                @cmd.batch([
+                  persistence_command,
+                  block_selection_after_render(
+                    latest_model,
+                    selection,
+                    next.source_revision,
+                    report_superseded=false,
+                    emit,
+                  ),
+                ]),
+              )
+            None => (next, persistence_command)
+          }
+        }
+        BlockMerge(node_id~, selection=originating_selection) => {
+          let (next, committed_selection, _, persistence_command) = commit_block_request(
+            editor,
+            attachment,
+            model,
+            @markdown.MarkdownEditRequest::MergeWithPrevious(node_id~),
+            "editor-dispatch",
+            emit,
+          )
+          let resolved_selection = match committed_selection {
+            Some(selection) =>
+              block_selection_from_commit(next.document, selection)
+            None => None
+          }
+          let next = {
+            ..next,
+            active_block_key: match resolved_selection {
+              Some(selection) => Some(selection.key)
+              None => model.active_block_key
+            },
+            selection: match resolved_selection {
+              Some(selection) => Some(block_selection_label(selection))
+              None => None
+            },
+          }
+          match resolved_selection {
+            Some(selection) =>
+              (
+                next,
+                @cmd.batch([
+                  persistence_command,
+                  block_selection_after_render(
+                    latest_model,
+                    selection,
+                    next.source_revision,
+                    report_superseded=false,
+                    emit,
+                  ),
+                ]),
+              )
+            None =>
+              (
+                next,
+                @cmd.batch([
+                  persistence_command,
+                  block_selection_after_render(
+                    latest_model,
+                    originating_selection,
+                    next.source_revision,
+                    report_superseded=true,
+                    emit,
+                  ),
+                ]),
+              )
+          }
+        }
+        BlockNavigate(key~, direction~) =>
+          match block_navigation_selection(model.document, key, direction) {
+            None => (model, @rabbita_runtime.none)
+            Some(selection) => {
+              let next = {
+                ..model,
+                active_block_key: Some(selection.key),
+                selection: Some(block_selection_label(selection)),
+              }
+              (
+                next,
+                block_selection_after_render(
+                  latest_model,
+                  selection,
+                  next.source_revision,
+                  report_superseded=true,
+                  emit,
+                ),
+              )
+            }
+          }
+        ProbeBlockSelection(kind) => {
+          let blocks = model.document.blocks().to_array()
+          if blocks.is_empty() {
+            let next = record_error(
+              model, "block-selection-rejected", "browser-effect", "block selection probe has no target",
+            )
+            (next, @rabbita_runtime.none)
+          } else {
+            let block = blocks[0]
+            let selection = BlockSelection::{
+              key: block.key(),
+              index: 0,
+              start: 0,
+              end: 0,
+            }
+            let previous_revision = model.source_revision
+            let source = if kind == "deleted" { "" } else { "replacement\n" }
+            let (committed, accepted, changed, persistence_command) = commit_source(
               editor,
-              next,
-              transition.state(),
+              model,
+              model.state,
               source,
               "editor-dispatch",
               emit,
             )
-            next = update_preview_document(
+            let next = update_preview_document(
               attachment,
               committed,
-              old_requested,
+              preview_requested(model),
               accepted~,
               changed~,
             )
-            persistence_command = @cmd.batch([
-              persistence_command, commit_command,
-            ])
-            restore_raw_value = restore_raw_value || (raw_event && !accepted)
-          }
-          @core.SnapshotRejected(_) =>
-            next = record_error(
-              next, "invalid-snapshot", "editor-dispatch", "snapshot rejected",
+            let expected_revision = if kind == "stale" {
+              previous_revision
+            } else {
+              next.source_revision
+            }
+            (
+              next,
+              @cmd.batch([
+                persistence_command,
+                block_selection_after_render(
+                  latest_model,
+                  selection,
+                  expected_revision,
+                  report_superseded=true,
+                  emit,
+                ),
+              ]),
             )
+          }
         }
       }
-      publish(next)
-      let command = if restore_raw_value {
-        let repair_generation = next.text_input_generation
-        let repair_source_revision = next.source_revision
+  }
+}
+
+///|
+/// View-surface dispatcher: mode selection, split, focus commands, and the
+/// effect reports that accompany them. Not mode-gated.
+fn update_navigation(
+  attachment : @md_markdown.MarkdownSemanticAttachment,
+  model : DriverModel,
+  latest_model : @ref.Ref[DriverModel?],
+  event : NavigationEvent,
+  emit : @cmd.Emit[DriverEvent],
+) -> (DriverModel, @cmd.Cmd) {
+  match event {
+    SelectRaw | SelectBlock | SelectPreview => {
+      let mode = match event {
+        SelectRaw => @core.Raw
+        SelectBlock => @core.Block
+        SelectPreview => @core.Preview
+        _ => @core.Raw
+      }
+      let transition = @core.reduce(
+        model.state,
+        @core.ApplicationEvent::SelectMode(mode~),
+      )
+      let next = update_preview_document(
+        attachment,
+        { ..model, state: transition.state() },
+        preview_requested(model),
+        accepted=true,
+        changed=false,
+      )
+      (next, @rabbita_runtime.none)
+    }
+    ToggleSplitPreview => {
+      let old_requested = preview_requested(model)
+      let next = update_preview_document(
+        attachment,
+        { ..model, split_preview_open: !model.split_preview_open },
+        old_requested,
+        accepted=true,
+        changed=false,
+      )
+      (next, @rabbita_runtime.none)
+    }
+    FocusRaw | FocusBlock | FocusPreview => {
+      let target = match event {
+        FocusRaw => @core.RawEditor
+        FocusBlock => @core.BlockEditor
+        FocusPreview => @core.PreviewControl
+        _ => @core.PreviewControl
+      }
+      let locator = @core.FocusLocator(
+        target~,
+        source_revision=model.source_revision,
+      )
+      let token = encode_focus_token(target, model.source_revision)
+      match @core.decide_focus(model.state, model.source_revision, locator) {
+        @core.Compatible(_) => {
+          let next = match target {
+            @core.BlockEditor => {
+              let active_block_key = model.document
+                .blocks()
+                .get(0)
+                .map(block => block.key())
+              { ..model, active_block_key, }
+            }
+            _ => model
+          }
+          (next, focus_latest_after_render(latest_model, locator, token, emit))
+        }
+        @core.Rejected(error) => reject_focus(model, error)
+      }
+    }
+    FocusRejected(error) => reject_focus(model, error)
+    RestoreFocus(token) =>
+      match decode_focus_token(token) {
+        Ok(locator) =>
+          match
+            @core.decide_focus(model.state, model.source_revision, locator) {
+            @core.Compatible(target) => {
+              let next = match target {
+                @core.BlockEditor => {
+                  let active_block_key = model.document
+                    .blocks()
+                    .get(0)
+                    .map(block => block.key())
+                  { ..model, active_block_key, }
+                }
+                _ => model
+              }
+              (
+                next,
+                focus_latest_after_render(latest_model, locator, token, emit),
+              )
+            }
+            @core.Rejected(error) => reject_focus(model, error)
+          }
+        Err(error) => reject_focus_token(model, error)
+      }
+    EffectFailed(message) => {
+      let next = record_error(
+        model, "browser-effect-failed", "browser-effect", message,
+      )
+      (next, @rabbita_runtime.none)
+    }
+    BlockSelectionRejected(message, selection) => {
+      let next = record_error(
+        model, "block-selection-rejected", "browser-effect", message,
+      )
+      let command = match selection {
+        Some(selection) =>
+          block_selection_after_render(
+            latest_model,
+            selection,
+            next.source_revision,
+            report_superseded=true,
+            emit,
+          )
+        None => @rabbita_runtime.none
+      }
+      (next, command)
+    }
+  }
+}
+
+///|
+/// Driver/test instrumentation dispatcher: probes, measurements, and their
+/// outbound results.
+fn update_probe(
+  model : DriverModel,
+  event : ProbeEvent,
+  emit : @cmd.Emit[DriverEvent],
+) -> (DriverModel, @cmd.Cmd) {
+  match event {
+    WriteSelection(start~, end~) =>
+      (
+        model,
+        after_render(
+          scheduler => {
+            let selection = @dom_boundary.TextSelection(
+              start,
+              end,
+              @dom_boundary.NoDirection,
+            )
+            @dom_boundary.write_text_selection_id("loomark-input", selection)
+            let read = @dom_boundary.read_text_selection_id("loomark-input")
+            scheduler.add(
+              emit(Probe(SelectionRead(start=read.start(), end=read.end()))),
+            )
+          },
+          emit,
+        ),
+      )
+    WriteSelectionFailure =>
+      (
+        model,
         after_render(
           scheduler => {
             ignore(scheduler)
-            let accepted_source = next.document.source()
-            if repair_eligible(
-                latest_model.val,
-                @core.Raw,
-                repair_generation,
-                repair_source_revision,
-              ) {
-              @dom_boundary.write_text_value_id(
-                "loomark-input", accepted_source,
-              )
-              match raw_selection {
-                Some(selection) =>
-                  @dom_boundary.write_text_selection_id(
-                    "loomark-input",
-                    rejected_text_selection(accepted_source, source, selection),
-                  )
-                None => ()
-              }
-            }
+            let selection = @dom_boundary.TextSelection(
+              0,
+              1,
+              @dom_boundary.NoDirection,
+            )
+            @dom_boundary.write_text_selection_id(
+              "loomark-missing-input", selection,
+            )
           },
           emit,
-        )
-      } else {
-        @rabbita_runtime.none
-      }
-      (next, @cmd.batch([persistence_command, command]))
-    }
-    BlockFocused(key) =>
-      if model.active_block_key == Some(key) {
-        publish(model)
-        (model, @rabbita_runtime.none)
-      } else {
-        let (_, selected_index) = model.document
-          .blocks()
-          .fold(init=(0, None), (state, block) => {
-            let (index, found) = state
-            (
-              index + 1,
-              match found {
-                Some(_) => found
-                None => if block.key() == key { Some(index) } else { None }
-              },
-            )
-          })
-        match selected_index {
-          None => {
-            let next = record_error(
-              model, "block-selection-rejected", "editor-dispatch", "focused block is unavailable",
-            )
-            publish(next)
-            (next, @rabbita_runtime.none)
-          }
-          Some(index) => {
-            let next = { ..model, active_block_key: Some(key) }
-            publish(next)
-            (
-              next,
-              after_render(
-                scheduler => {
-                  ignore(scheduler)
-                  @dom_boundary.focus_id(block_input_id(index))
-                },
-                emit,
-              ),
-            )
-          }
-        }
-      }
-    BlockHeading(requested_level, originating_selection) =>
-      match block_format_target(model, originating_selection) {
-        None => {
-          let next = record_error(
-            model, "block-selection-rejected", "editor-dispatch", "formatting requires an active block",
-          )
-          publish(next)
-          (next, @rabbita_runtime.none)
-        }
-        Some(block) => {
-          guard block_allows_heading(block.kind()) else {
-            publish(model)
-            let command = originating_selection
-              .map(selection => {
-                block_selection_after_render(
-                  latest_model,
-                  selection,
-                  model.source_revision,
-                  report_superseded=true,
-                  emit,
-                )
-              })
-              .unwrap_or(@rabbita_runtime.none)
-            return (model, command)
-          }
-          if requested_level == 0 && block.kind() is @markdown.Paragraph {
-            publish(model)
-            let command = originating_selection
-              .map(selection => {
-                block_selection_after_render(
-                  latest_model,
-                  selection,
-                  model.source_revision,
-                  report_superseded=true,
-                  emit,
-                )
-              })
-              .unwrap_or(@rabbita_runtime.none)
-            return (model, command)
-          }
-          let target_level = match block.kind() {
-            @markdown.Heading(level~) if level == requested_level => 0
-            _ => requested_level
-          }
-          commit_block_toolbar_request(
-            editor,
-            attachment,
-            model,
-            latest_model,
-            @markdown.MarkdownEditRequest::ChangeHeadingLevel(
-              node_id=block.node_id(),
-              level=target_level,
-            ),
-            originating_selection,
-            "loomark-heading-" + requested_level.to_string(),
-            emit,
-          )
-        }
-      }
-    BlockToggleList(originating_selection) =>
-      match block_format_target(model, originating_selection) {
-        None => {
-          let next = record_error(
-            model, "block-selection-rejected", "editor-dispatch", "formatting requires an active block",
-          )
-          publish(next)
-          (next, @rabbita_runtime.none)
-        }
-        Some(block) => {
-          guard block_allows_list(block.kind()) else {
-            publish(model)
-            let command = originating_selection
-              .map(selection => {
-                block_selection_after_render(
-                  latest_model,
-                  selection,
-                  model.source_revision,
-                  report_superseded=true,
-                  emit,
-                )
-              })
-              .unwrap_or(@rabbita_runtime.none)
-            return (model, command)
-          }
-          commit_block_toolbar_request(
-            editor,
-            attachment,
-            model,
-            latest_model,
-            @markdown.MarkdownEditRequest::ToggleListItem(
-              node_id=block.node_id(),
-            ),
-            originating_selection,
-            "loomark-toggle-list",
-            emit,
-          )
-        }
-      }
-    BlockDelete =>
-      match active_block(model) {
-        None => {
-          let next = record_error(
-            model, "block-selection-rejected", "editor-dispatch", "deletion requires an active block",
-          )
-          publish(next)
-          (next, @rabbita_runtime.none)
-        }
-        Some(block) =>
-          commit_block_toolbar_request(
-            editor,
-            attachment,
-            model,
-            latest_model,
-            @markdown.MarkdownEditRequest::Delete(node_id=block.node_id()),
-            None,
-            "loomark-delete-block",
-            emit,
-          )
-      }
-    BlockInput(node_id~, input_id~, text=proposed_text, selection_offset~) => {
-      let (next, committed_selection, accepted, persistence_command) = commit_block_request(
-        editor,
-        attachment,
-        model,
-        @markdown.MarkdownEditRequest::CommitTextControlEdit(
-          node_id~,
-          new_text=proposed_text,
         ),
-        "editor-dispatch",
-        emit,
       )
-      let selection = match committed_selection {
-        Some(selection) =>
-          block_selection_from_commit(
-            next.document,
-            selection,
-            offset=selection_offset,
-          )
-        None => None
-      }
-      let next = {
-        ..next,
-        text_input_generation: model.text_input_generation + 1,
-        active_block_key: match selection {
-          Some(selection) => Some(selection.key)
-          None => model.active_block_key
-        },
-        selection: match selection {
-          Some(selection) => Some(block_selection_label(selection))
-          None => None
-        },
-      }
-      publish(next)
-      match selection {
-        Some(selection) =>
-          (
-            next,
-            @cmd.batch([
-              persistence_command,
-              block_selection_after_render(
-                latest_model,
-                selection,
-                next.source_revision,
-                report_superseded=false,
-                emit,
-              ),
-            ]),
-          )
-        None =>
-          if accepted {
-            (next, persistence_command)
-          } else {
-            let accepted_text = next.document
-              .blocks()
-              .fold(init=None, (found, block) => {
-                match found {
-                  Some(_) => found
-                  None =>
-                    if block.node_id() == node_id {
-                      Some(block.text())
-                    } else {
-                      None
-                    }
-                }
-              })
-            match accepted_text {
-              Some(text) => {
-                let offset = rejected_text_offset(
-                  text, proposed_text, selection_offset,
-                )
-                let repair_generation = next.text_input_generation
-                let repair_source_revision = next.source_revision
-                (
-                  next,
-                  @cmd.batch([
-                    persistence_command,
-                    after_render(
-                      scheduler => {
-                        ignore(scheduler)
-                        if repair_eligible(
-                            latest_model.val,
-                            @core.Block,
-                            repair_generation,
-                            repair_source_revision,
-                          ) {
-                          @dom_boundary.write_text_value_id(input_id, text)
-                          @dom_boundary.focus_id(input_id)
-                          @dom_boundary.write_text_selection_id(
-                            input_id,
-                            @dom_boundary.TextSelection(
-                              offset,
-                              offset,
-                              @dom_boundary.NoDirection,
-                            ),
-                          )
-                        }
-                      },
-                      emit,
-                    ),
-                  ]),
-                )
-              }
-              None => (next, persistence_command)
-            }
-          }
-      }
-    }
-    BlockSplit(node_id~, offset~) => {
-      let (next, committed_selection, _, persistence_command) = commit_block_request(
-        editor,
-        attachment,
+    MeasurePreview =>
+      (
         model,
-        @markdown.MarkdownEditRequest::SplitBlock(node_id~, offset~),
-        "editor-dispatch",
-        emit,
-      )
-      let selection = match committed_selection {
-        Some(selection) => block_selection_from_commit(next.document, selection)
-        None => None
-      }
-      let next = {
-        ..next,
-        active_block_key: match selection {
-          Some(selection) => Some(selection.key)
-          None => model.active_block_key
-        },
-        selection: match selection {
-          Some(selection) => Some(block_selection_label(selection))
-          None => None
-        },
-      }
-      publish(next)
-      match selection {
-        Some(selection) =>
-          (
-            next,
-            @cmd.batch([
-              persistence_command,
-              block_selection_after_render(
-                latest_model,
-                selection,
-                next.source_revision,
-                report_superseded=false,
-                emit,
+        after_render(
+          scheduler => {
+            let measurement = @dom_boundary.measure_element_id(
+              "loomark-preview",
+            )
+            scheduler.add(
+              emit(
+                Probe(
+                  Measured(
+                    width=measurement.offset_width(),
+                    height=measurement.offset_height(),
+                  ),
+                ),
               ),
-            ]),
-          )
-        None => (next, persistence_command)
-      }
-    }
-    BlockMerge(node_id~, selection=originating_selection) => {
-      let (next, committed_selection, _, persistence_command) = commit_block_request(
-        editor,
-        attachment,
-        model,
-        @markdown.MarkdownEditRequest::MergeWithPrevious(node_id~),
-        "editor-dispatch",
-        emit,
-      )
-      let resolved_selection = match committed_selection {
-        Some(selection) => block_selection_from_commit(next.document, selection)
-        None => None
-      }
-      let next = {
-        ..next,
-        active_block_key: match resolved_selection {
-          Some(selection) => Some(selection.key)
-          None => model.active_block_key
-        },
-        selection: match resolved_selection {
-          Some(selection) => Some(block_selection_label(selection))
-          None => None
-        },
-      }
-      publish(next)
-      match resolved_selection {
-        Some(selection) =>
-          (
-            next,
-            @cmd.batch([
-              persistence_command,
-              block_selection_after_render(
-                latest_model,
-                selection,
-                next.source_revision,
-                report_superseded=false,
-                emit,
-              ),
-            ]),
-          )
-        None =>
-          (
-            next,
-            @cmd.batch([
-              persistence_command,
-              block_selection_after_render(
-                latest_model,
-                originating_selection,
-                next.source_revision,
-                report_superseded=true,
-                emit,
-              ),
-            ]),
-          )
-      }
-    }
-    BlockNavigate(key~, direction~) =>
-      match block_navigation_selection(model.document, key, direction) {
-        None => {
-          publish(model)
-          (model, @rabbita_runtime.none)
-        }
-        Some(selection) => {
-          let next = {
-            ..model,
-            active_block_key: Some(selection.key),
-            selection: Some(block_selection_label(selection)),
-          }
-          publish(next)
-          (
-            next,
-            block_selection_after_render(
-              latest_model,
-              selection,
-              next.source_revision,
-              report_superseded=true,
-              emit,
-            ),
-          )
-        }
-      }
-    ProbeBlockSelection(kind) => {
-      let blocks = model.document.blocks().to_array()
-      if blocks.is_empty() {
-        let next = record_error(
-          model, "block-selection-rejected", "browser-effect", "block selection probe has no target",
-        )
-        publish(next)
-        (next, @rabbita_runtime.none)
-      } else {
-        let block = blocks[0]
-        let selection = BlockSelection::{
-          key: block.key(),
-          index: 0,
-          start: 0,
-          end: 0,
-        }
-        let previous_revision = model.source_revision
-        let source = if kind == "deleted" { "" } else { "replacement\n" }
-        let (committed, accepted, changed, persistence_command) = commit_source(
-          editor,
-          model,
-          model.state,
-          source,
-          "editor-dispatch",
+            )
+          },
           emit,
-        )
-        let next = update_preview_document(
-          attachment,
-          committed,
-          preview_requested(model),
-          accepted~,
-          changed~,
-        )
-        publish(next)
-        let expected_revision = if kind == "stale" {
-          previous_revision
-        } else {
-          next.source_revision
-        }
-        (
-          next,
-          @cmd.batch([
-            persistence_command,
-            block_selection_after_render(
-              latest_model,
-              selection,
-              expected_revision,
-              report_superseded=true,
-              emit,
-            ),
-          ]),
-        )
+        ),
+      )
+    MeasureFailure =>
+      (
+        model,
+        after_render(
+          scheduler => {
+            ignore(scheduler)
+            ignore(@dom_boundary.measure_element_id("loomark-missing-preview"))
+          },
+          emit,
+        ),
+      )
+    SelectionRead(start~, end~) => {
+      let next = {
+        ..model,
+        selection: Some(start.to_string() + ":" + end.to_string()),
       }
+      (next, @rabbita_runtime.none)
     }
+    Measured(width~, height~) => {
+      let next = {
+        ..model,
+        measurement: Some(width.to_string() + ":" + height.to_string()),
+      }
+      (next, @rabbita_runtime.none)
+    }
+  }
+}
+
+///|
+/// Application-control dispatcher: failures, restore, subscriptions, fatal,
+/// resize, and driver protocol errors.
+fn update_lifecycle(
+  editor : @markdown.MarkdownEditor,
+  attachment : @md_markdown.MarkdownSemanticAttachment,
+  model : DriverModel,
+  event : LifecycleEvent,
+  emit : @cmd.Emit[DriverEvent],
+) -> (DriverModel, @cmd.Cmd) {
+  match event {
     EditorFailure => {
       let next = { ..model, fail_next_editor_commit: true }
-      publish(next)
       (next, @rabbita_runtime.none)
     }
     RestoreSnapshot(version~, source~, mode~) => {
@@ -1367,215 +1614,7 @@ fn update_model(
         accepted~,
         changed=source_changed,
       )
-      publish(next)
       (next, persistence_command)
-    }
-    SelectRaw | SelectBlock | SelectPreview => {
-      let mode = match event {
-        SelectRaw => @core.Raw
-        SelectBlock => @core.Block
-        SelectPreview => @core.Preview
-        _ => @core.Raw
-      }
-      let transition = @core.reduce(
-        model.state,
-        @core.ApplicationEvent::SelectMode(mode~),
-      )
-      let next = update_preview_document(
-        attachment,
-        { ..model, state: transition.state() },
-        preview_requested(model),
-        accepted=true,
-        changed=false,
-      )
-      publish(next)
-      (next, @rabbita_runtime.none)
-    }
-    ToggleSplitPreview => {
-      let old_requested = preview_requested(model)
-      let next = update_preview_document(
-        attachment,
-        { ..model, split_preview_open: !model.split_preview_open },
-        old_requested,
-        accepted=true,
-        changed=false,
-      )
-      publish(next)
-      (next, @rabbita_runtime.none)
-    }
-    FocusRaw | FocusBlock | FocusPreview => {
-      let target = match event {
-        FocusRaw => @core.RawEditor
-        FocusBlock => @core.BlockEditor
-        FocusPreview => @core.PreviewControl
-        _ => @core.PreviewControl
-      }
-      let locator = @core.FocusLocator(
-        target~,
-        source_revision=model.source_revision,
-      )
-      let token = encode_focus_token(target, model.source_revision)
-      match @core.decide_focus(model.state, model.source_revision, locator) {
-        @core.Compatible(_) => {
-          let next = match target {
-            @core.BlockEditor => {
-              let active_block_key = model.document
-                .blocks()
-                .get(0)
-                .map(block => block.key())
-              { ..model, active_block_key, }
-            }
-            _ => model
-          }
-          publish(next)
-          (next, focus_latest_after_render(latest_model, locator, token, emit))
-        }
-        @core.Rejected(error) => reject_focus(model, error)
-      }
-    }
-    FocusRejected(error) => reject_focus(model, error)
-    RestoreFocus(token) =>
-      match decode_focus_token(token) {
-        Ok(locator) =>
-          match
-            @core.decide_focus(model.state, model.source_revision, locator) {
-            @core.Compatible(target) => {
-              let next = match target {
-                @core.BlockEditor => {
-                  let active_block_key = model.document
-                    .blocks()
-                    .get(0)
-                    .map(block => block.key())
-                  { ..model, active_block_key, }
-                }
-                _ => model
-              }
-              publish(next)
-              (
-                next,
-                focus_latest_after_render(latest_model, locator, token, emit),
-              )
-            }
-            @core.Rejected(error) => reject_focus(model, error)
-          }
-        Err(error) => reject_focus_token(model, error)
-      }
-    WriteSelection(start~, end~) => {
-      publish(model)
-      (
-        model,
-        after_render(
-          scheduler => {
-            let selection = @dom_boundary.TextSelection(
-              start,
-              end,
-              @dom_boundary.NoDirection,
-            )
-            @dom_boundary.write_text_selection_id("loomark-input", selection)
-            let read = @dom_boundary.read_text_selection_id("loomark-input")
-            scheduler.add(
-              emit(SelectionRead(start=read.start(), end=read.end())),
-            )
-          },
-          emit,
-        ),
-      )
-    }
-    WriteSelectionFailure => {
-      publish(model)
-      (
-        model,
-        after_render(
-          scheduler => {
-            ignore(scheduler)
-            let selection = @dom_boundary.TextSelection(
-              0,
-              1,
-              @dom_boundary.NoDirection,
-            )
-            @dom_boundary.write_text_selection_id(
-              "loomark-missing-input", selection,
-            )
-          },
-          emit,
-        ),
-      )
-    }
-    MeasurePreview => {
-      publish(model)
-      (
-        model,
-        after_render(
-          scheduler => {
-            let measurement = @dom_boundary.measure_element_id(
-              "loomark-preview",
-            )
-            scheduler.add(
-              emit(
-                Measured(
-                  width=measurement.offset_width(),
-                  height=measurement.offset_height(),
-                ),
-              ),
-            )
-          },
-          emit,
-        ),
-      )
-    }
-    MeasureFailure => {
-      publish(model)
-      (
-        model,
-        after_render(
-          scheduler => {
-            ignore(scheduler)
-            ignore(@dom_boundary.measure_element_id("loomark-missing-preview"))
-          },
-          emit,
-        ),
-      )
-    }
-    SelectionRead(start~, end~) => {
-      let next = {
-        ..model,
-        selection: Some(start.to_string() + ":" + end.to_string()),
-      }
-      publish(next)
-      (next, @rabbita_runtime.none)
-    }
-    Measured(width~, height~) => {
-      let next = {
-        ..model,
-        measurement: Some(width.to_string() + ":" + height.to_string()),
-      }
-      publish(next)
-      (next, @rabbita_runtime.none)
-    }
-    EffectFailed(message) => {
-      let next = record_error(
-        model, "browser-effect-failed", "browser-effect", message,
-      )
-      publish(next)
-      (next, @rabbita_runtime.none)
-    }
-    BlockSelectionRejected(message, selection) => {
-      let next = record_error(
-        model, "block-selection-rejected", "browser-effect", message,
-      )
-      publish(next)
-      let command = match selection {
-        Some(selection) =>
-          block_selection_after_render(
-            latest_model,
-            selection,
-            next.source_revision,
-            report_superseded=true,
-            emit,
-          )
-        None => @rabbita_runtime.none
-      }
-      (next, command)
     }
     CustomEvent(detail) => {
       let next = {
@@ -1583,22 +1622,18 @@ fn update_model(
         event_detail: Some(detail),
         event_count: model.event_count + 1,
       }
-      publish(next)
       (next, @rabbita_runtime.none)
     }
     ControlInstalled => {
       let next = { ..model, control_ready: true }
-      publish(next)
       (next, @rabbita_runtime.none)
     }
     SubscriptionInstalled => {
       let next = { ..model, event_install_count: model.event_install_count + 1 }
-      publish(next)
       (next, @rabbita_runtime.none)
     }
     SubscriptionUnloaded => {
       let next = { ..model, event_unload_count: model.event_unload_count + 1 }
-      publish(next)
       (next, @rabbita_runtime.none)
     }
     InvalidRequest(message) => {
@@ -1613,17 +1648,14 @@ fn update_model(
         "editor-dispatch",
         "invalid driver request: " + message,
       )
-      publish(next)
       (next, @rabbita_runtime.none)
     }
     StopListening => {
       let next = { ..model, listening: false }
-      publish(next)
       (next, @rabbita_runtime.none)
     }
     Fatal(message) => {
       let next = { ..model, fatal: true, error: Some(message), rejection: None }
-      publish(next)
       (next, @rabbita_runtime.none)
     }
     Resize(viewport) => {
@@ -1632,10 +1664,44 @@ fn update_model(
         compact_split: compact_split_for_width(viewport.width),
         resize_count: model.resize_count + 1,
       }
-      publish(next)
       (next, @rabbita_runtime.none)
     }
   }
+}
+
+///|
+/// Total dispatch: the envelope constructor encodes the concern, so routing
+/// cannot misclassify. Archive completions land even in fatal state; the
+/// fatal rejection guard covers every other event.
+fn update_model(
+  editor : @markdown.MarkdownEditor,
+  attachment : @md_markdown.MarkdownSemanticAttachment,
+  model : DriverModel,
+  latest_model : @ref.Ref[DriverModel?],
+  event : DriverEvent,
+  emit : @cmd.Emit[DriverEvent],
+) -> (DriverModel, @cmd.Cmd) {
+  let (next, command) = match event {
+    Archive(completion) => update_archive_tracker(model, completion)
+    _ if model.fatal => {
+      let next = {
+        ..model,
+        rejection: Some(
+          "operation=" + driver_event_name(event) + ";reason=fatal-state",
+        ),
+      }
+      (next, @rabbita_runtime.none)
+    }
+    Editing(edit_event) =>
+      update_editing(editor, attachment, model, latest_model, edit_event, emit)
+    Navigation(nav_event) =>
+      update_navigation(attachment, model, latest_model, nav_event, emit)
+    Probe(probe_event) => update_probe(model, probe_event, emit)
+    Lifecycle(life_event) =>
+      update_lifecycle(editor, attachment, model, life_event, emit)
+  }
+  publish(next)
+  (next, command)
 }
 
 ///|
@@ -1663,7 +1729,7 @@ fn driver_control_subscription_loader(
           _ => None
         }
         match subscription {
-          Some(_) => scheduler.add(tagger(ControlInstalled))
+          Some(_) => scheduler.add(tagger(Lifecycle(ControlInstalled)))
           None => ()
         }
       }
@@ -1718,7 +1784,7 @@ fn driver_test_subscription_loader(
         match subscription {
           Some(_) => {
             installed = true
-            scheduler.add(lifecycle_tagger(SubscriptionInstalled))
+            scheduler.add(lifecycle_tagger(Lifecycle(SubscriptionInstalled)))
           }
           None => ()
         }
@@ -1739,7 +1805,7 @@ fn driver_test_subscription_loader(
             }
             if installed {
               installed = false
-              scheduler.add(lifecycle_tagger(SubscriptionUnloaded))
+              scheduler.add(lifecycle_tagger(Lifecycle(SubscriptionUnloaded)))
             }
           }
         },
@@ -1776,7 +1842,7 @@ fn driver_test_subscription(
     "loomark.driver-event",
     @sub.Local,
     DriverSubscription::Test(
-      emit.map(detail => CustomEvent(detail + "|" + source)),
+      emit.map(detail => Lifecycle(CustomEvent(detail + "|" + source))),
       emit,
     ),
     driver_test_subscription_loader,
@@ -1791,7 +1857,7 @@ fn standalone_subscriptions(
   if model.fatal {
     @sub.none
   } else {
-    @sub.on_resize(emit.map(viewport => Resize(viewport)))
+    @sub.on_resize(emit.map(viewport => Lifecycle(Resize(viewport))))
   }
 }
 
@@ -1805,7 +1871,7 @@ fn private_dev_host_subscriptions(
     control
   } else {
     @sub.batch([
-      @sub.on_resize(emit.map(viewport => Resize(viewport))),
+      @sub.on_resize(emit.map(viewport => Lifecycle(Resize(viewport)))),
       driver_test_subscription(emit, model.document.source()),
       control,
     ])
@@ -1831,7 +1897,7 @@ fn build_application(
         let command = match baseline {
           Some((request_id, encoded)) =>
             @archive_storage.replace(request_id, encoded, completed=completion => {
-              emit(ArchiveWriteCompleted(completion))
+              emit(Archive(completion))
             })
           None => @rabbita_runtime.none
         }

--- a/apps/loomark/internal/rabbita/block_toolbar.mbt
+++ b/apps/loomark/internal/rabbita/block_toolbar.mbt
@@ -70,7 +70,7 @@ fn heading_toolbar_button(
       .aria_label(label)
       .aria_keyshortcuts(shortcut)
       .aria_pressed((selected_level == Some(level)).to_string()),
-    on_click=emit(BlockHeading(level, None)),
+    on_click=emit(Editing(BlockHeading(level, None))),
     visible_label,
   )
 }
@@ -92,7 +92,7 @@ fn list_toolbar_button(
       .aria_label(label)
       .aria_keyshortcuts("Control+Shift+L")
       .aria_pressed(selected.to_string()),
-    on_click=emit(BlockToggleList(None)),
+    on_click=emit(Editing(BlockToggleList(None))),
     mode_icon("M6 6h11M6 10h11M6 14h11M3 6h.01M3 10h.01M3 14h.01"),
   )
 }
@@ -109,7 +109,7 @@ fn delete_toolbar_button(
     disabled~,
     title="Delete block",
     attrs=@html.Attrs::build().aria_label("Delete selected block"),
-    on_click=emit(BlockDelete),
+    on_click=emit(Editing(BlockDelete)),
     mode_icon("M4 6h12M8 3h4l1 3H7l1-3M6 6l.7 11h6.6L14 6M8.5 9v5M11.5 9v5"),
   )
 }

--- a/apps/loomark/internal/rabbita/block_view.mbt
+++ b/apps/loomark/internal/rabbita/block_view.mbt
@@ -64,30 +64,34 @@ fn block_structural_key_event(
   if key == "Enter" {
     if block_allows_heading(kind) {
       if selection.start() == selection.end() {
-        return Some(BlockSplit(node_id~, offset=selection.start()))
+        return Some(Editing(BlockSplit(node_id~, offset=selection.start())))
       }
       return Some(
-        BlockSelectionRejected(
-          "block split requires a collapsed selection",
-          Some({
-            key: block_key,
-            index: block_index,
-            start: selection.start(),
-            end: selection.end(),
-          }),
+        Navigation(
+          BlockSelectionRejected(
+            "block split requires a collapsed selection",
+            Some({
+              key: block_key,
+              index: block_index,
+              start: selection.start(),
+              end: selection.end(),
+            }),
+          ),
         ),
       )
     }
     if block_allows_list(kind) {
       return Some(
-        BlockSelectionRejected(
-          "list structural editing is unavailable",
-          Some({
-            key: block_key,
-            index: block_index,
-            start: selection.start(),
-            end: selection.end(),
-          }),
+        Navigation(
+          BlockSelectionRejected(
+            "list structural editing is unavailable",
+            Some({
+              key: block_key,
+              index: block_index,
+              start: selection.start(),
+              end: selection.end(),
+            }),
+          ),
         ),
       )
     }
@@ -99,19 +103,21 @@ fn block_structural_key_event(
       text_length == 0 &&
       selection.start() == 0 =>
       Some(
-        BlockMerge(node_id~, selection={
-          key: block_key,
-          index: block_index,
-          start: selection.start(),
-          end: selection.end(),
-        }),
+        Editing(
+          BlockMerge(node_id~, selection={
+            key: block_key,
+            index: block_index,
+            start: selection.start(),
+            end: selection.end(),
+          }),
+        ),
       )
     "Backspace" if has_previous && selection.start() == 0 =>
-      Some(BlockNavigate(key=block_key, direction=-1))
+      Some(Editing(BlockNavigate(key=block_key, direction=-1)))
     "ArrowLeft" | "ArrowUp" if has_previous && selection.start() == 0 =>
-      Some(BlockNavigate(key=block_key, direction=-1))
+      Some(Editing(BlockNavigate(key=block_key, direction=-1)))
     "ArrowRight" | "ArrowDown" if has_next && selection.start() == text_length =>
-      Some(BlockNavigate(key=block_key, direction=1))
+      Some(Editing(BlockNavigate(key=block_key, direction=1)))
     _ => None
   }
 }
@@ -139,7 +145,7 @@ fn block_shortcut_event(
   meta : Bool,
   composing : Bool,
   repeated : Bool,
-) -> DriverEvent? {
+) -> EditingEvent? {
   guard ctrl && !alt && !meta && !composing && !repeated else { return None }
   if shift {
     if key == "l" || key == "L" {
@@ -335,7 +341,7 @@ fn block_input(
       match shortcut {
         Some(shortcut) => {
           let selection = @dom_boundary.read_text_selection_id(input_id) catch {
-            error => return emit(EffectFailed(error.message()))
+            error => return emit(Navigation(EffectFailed(error.message())))
           }
           let selection = Some({
             key: block.key(),
@@ -349,11 +355,11 @@ fn block_input(
             shortcut => shortcut
           }
           event.prevent_default()
-          emit(shortcut)
+          emit(Editing(shortcut))
         }
         None if block_key_uses_selection(event.key()) => {
           let selection = @dom_boundary.read_text_selection_id(input_id) catch {
-            error => return emit(EffectFailed(error.message()))
+            error => return emit(Navigation(EffectFailed(error.message())))
           }
           match
             block_structural_key_event(
@@ -386,7 +392,7 @@ fn block_input(
   let attrs = if active {
     attrs
   } else {
-    attrs.on_focus(_ => emit(BlockFocused(block.key())))
+    attrs.on_focus(_ => emit(Editing(BlockFocused(block.key()))))
   }
   let input = @rui.textarea(
     id=input_id,

--- a/apps/loomark/internal/rabbita/document_transaction.mbt
+++ b/apps/loomark/internal/rabbita/document_transaction.mbt
@@ -38,7 +38,7 @@ fn archive_replacement(
   }
   let (archive_tracker, request_id) = model.archive_tracker.request()
   let command = @archive_storage.replace(request_id, prepared.encoded(), completed=completion => {
-    emit(ArchiveWriteCompleted(completion))
+    emit(Archive(completion))
   })
   ({ ..model, archive_tracker, }, command)
 }

--- a/apps/loomark/internal/rabbita/document_transaction.mbt
+++ b/apps/loomark/internal/rabbita/document_transaction.mbt
@@ -205,7 +205,6 @@ fn commit_block_toolbar_request(
       None => if applied { None } else { committed.selection }
     },
   }
-  publish(next)
   match selection {
     Some(selection) =>
       (

--- a/apps/loomark/internal/rabbita/driver_types.mbt
+++ b/apps/loomark/internal/rabbita/driver_types.mbt
@@ -1,16 +1,14 @@
 ///|
-/// Private pre-`MountedApp` application and test-driver seam.
-priv enum DriverEvent {
+/// Editing-surface events: mode-gated input and structural requests that
+/// cross the atomic editor façade. ReplaceSource is deliberately exempt
+/// from the mode gate (driver source replacement works in any mode).
+priv enum EditingEvent {
   ReplaceSource(String)
-  SelectRaw
-  SelectBlock
-  SelectPreview
-  ToggleSplitPreview
+  RawInput(String, @dom_boundary.TextSelection?)
   BlockFocused(String)
   BlockHeading(Int, BlockSelection?)
   BlockToggleList(BlockSelection?)
   BlockDelete
-  RawInput(String, @dom_boundary.TextSelection?)
   BlockInput(
     node_id~ : @markdown.MarkdownNodeId,
     input_id~ : String,
@@ -20,26 +18,48 @@ priv enum DriverEvent {
   BlockSplit(node_id~ : @markdown.MarkdownNodeId, offset~ : Int)
   BlockMerge(node_id~ : @markdown.MarkdownNodeId, selection~ : BlockSelection)
   BlockNavigate(key~ : String, direction~ : Int)
-  BlockSelectionRejected(String, BlockSelection?)
   ProbeBlockSelection(String)
-  EditorFailure
-  RestoreSnapshot(
-    version~ : Int,
-    source~ : String,
-    mode~ : @core.ApplicationMode
-  )
+}
+
+///|
+/// View-surface events: mode selection, split, focus commands, and the
+/// effect reports that accompany them. Not mode-gated.
+priv enum NavigationEvent {
+  SelectRaw
+  SelectBlock
+  SelectPreview
+  ToggleSplitPreview
   FocusPreview
   FocusBlock
   FocusRaw
   RestoreFocus(String)
   FocusRejected(@core.FocusDecisionError)
+  EffectFailed(String)
+  BlockSelectionRejected(String, BlockSelection?)
+}
+
+///|
+/// Driver/test instrumentation events: probes, measurements, and their
+/// outbound results.
+priv enum ProbeEvent {
   WriteSelection(start~ : Int, end~ : Int)
   WriteSelectionFailure
   MeasurePreview
   MeasureFailure
   SelectionRead(start~ : Int, end~ : Int)
   Measured(width~ : Double, height~ : Double)
-  EffectFailed(String)
+}
+
+///|
+/// Application-control events: failures, restore, subscriptions, fatal,
+/// resize, and driver protocol errors.
+priv enum LifecycleEvent {
+  EditorFailure
+  RestoreSnapshot(
+    version~ : Int,
+    source~ : String,
+    mode~ : @core.ApplicationMode
+  )
   CustomEvent(String)
   ControlInstalled
   SubscriptionInstalled
@@ -48,7 +68,18 @@ priv enum DriverEvent {
   StopListening
   Fatal(String)
   Resize(@common.Viewport)
-  ArchiveWriteCompleted(@archive_storage.LocalArchiveWriteCompletion)
+}
+
+///|
+/// Dispatch envelope: the concern of an event is encoded by the
+/// constructor, so update_model's routing is total and misrouting is
+/// unrepresentable. Archive completions are processed even in fatal state.
+priv enum DriverEvent {
+  Editing(EditingEvent)
+  Navigation(NavigationEvent)
+  Probe(ProbeEvent)
+  Lifecycle(LifecycleEvent)
+  Archive(@archive_storage.LocalArchiveWriteCompletion)
 }
 
 ///|

--- a/apps/loomark/internal/rabbita/focus_runtime.mbt
+++ b/apps/loomark/internal/rabbita/focus_runtime.mbt
@@ -106,7 +106,6 @@ fn reject_focus(
 ) -> (DriverModel, @cmd.Cmd) {
   let (code, message) = focus_rejection(error)
   let next = record_error(model, code, "browser-effect", message)
-  publish(next)
   (next, @rabbita_runtime.none)
 }
 
@@ -117,7 +116,6 @@ fn reject_focus_token(
 ) -> (DriverModel, @cmd.Cmd) {
   let (code, message) = focus_token_error(error)
   let next = record_error(model, code, "browser-effect", message)
-  publish(next)
   (next, @rabbita_runtime.none)
 }
 

--- a/apps/loomark/internal/rabbita/focus_runtime.mbt
+++ b/apps/loomark/internal/rabbita/focus_runtime.mbt
@@ -129,7 +129,8 @@ fn after_render(
   @cmd.custom_cmd(
     scheduler => {
       action(scheduler) catch {
-        error => scheduler.add(failed(EffectFailed(error.message())))
+        error =>
+          scheduler.add(failed(Navigation(EffectFailed(error.message()))))
       }
     },
     kind=@cmd.AfterRender,
@@ -175,26 +176,41 @@ fn block_selection_after_render(
         BlockSelectionDecision::Superseded =>
           if report_superseded {
             scheduler.add(
-              emit(BlockSelectionRejected("block selection is stale", None)),
+              emit(
+                Navigation(
+                  BlockSelectionRejected("block selection is stale", None),
+                ),
+              ),
             )
           }
         BlockSelectionDecision::ModeStale =>
           scheduler.add(
-            emit(BlockSelectionRejected("block selection mode is stale", None)),
+            emit(
+              Navigation(
+                BlockSelectionRejected("block selection mode is stale", None),
+              ),
+            ),
           )
         BlockSelectionDecision::TargetUnavailable =>
           scheduler.add(
             emit(
-              BlockSelectionRejected(
-                "block selection target is unavailable",
-                None,
+              Navigation(
+                BlockSelectionRejected(
+                  "block selection target is unavailable",
+                  None,
+                ),
               ),
             ),
           )
         BlockSelectionDecision::ModelUnavailable =>
           scheduler.add(
             emit(
-              BlockSelectionRejected("block selection model unavailable", None),
+              Navigation(
+                BlockSelectionRejected(
+                  "block selection model unavailable",
+                  None,
+                ),
+              ),
             ),
           )
       }
@@ -224,13 +240,17 @@ fn focus_latest_after_render(
               @dom_boundary.focus_id(focus_target_id(target)) catch {
                 error => {
                   detached_focus_token.val = previous_token
-                  scheduler.add(emit(EffectFailed(error.message())))
+                  scheduler.add(emit(Navigation(EffectFailed(error.message()))))
                 }
               }
             }
-            @core.Rejected(error) => scheduler.add(emit(FocusRejected(error)))
+            @core.Rejected(error) =>
+              scheduler.add(emit(Navigation(FocusRejected(error))))
           }
-        None => scheduler.add(emit(EffectFailed("focus model unavailable")))
+        None =>
+          scheduler.add(
+            emit(Navigation(EffectFailed("focus model unavailable"))),
+          )
       }
     },
     emit,

--- a/apps/loomark/internal/rabbita/text_control_repair.mbt
+++ b/apps/loomark/internal/rabbita/text_control_repair.mbt
@@ -52,11 +52,11 @@ fn raw_input_command(
   @cmd.custom_cmd(scheduler => {
     let selection = @dom_boundary.read_text_selection_id("loomark-input") catch {
       error => {
-        scheduler.add(emit(EffectFailed(error.message())))
+        scheduler.add(emit(Navigation(EffectFailed(error.message()))))
         return
       }
     }
-    scheduler.add(emit(RawInput(source, Some(selection))))
+    scheduler.add(emit(Editing(RawInput(source, Some(selection)))))
   })
 }
 
@@ -71,17 +71,19 @@ fn block_input_command(
   @cmd.custom_cmd(scheduler => {
     let selection = @dom_boundary.read_text_selection_id(input_id) catch {
       error => {
-        scheduler.add(emit(EffectFailed(error.message())))
+        scheduler.add(emit(Navigation(EffectFailed(error.message()))))
         return
       }
     }
     scheduler.add(
       emit(
-        BlockInput(
-          node_id=block.node_id(),
-          input_id~,
-          text~,
-          selection_offset=selection.end(),
+        Editing(
+          BlockInput(
+            node_id=block.node_id(),
+            input_id~,
+            text~,
+            selection_offset=selection.end(),
+          ),
         ),
       ),
     )


### PR DESCRIPTION
## Summary

- `update_model` was a 924-line monolith handling 35 event variants across five interleaved concerns (mode guards, editing commits, DOM repair, persistence, test instrumentation)
- Split `DriverEvent` into an envelope over four sub-enums — `EditingEvent`, `NavigationEvent`, `ProbeEvent`, `LifecycleEvent` — plus an `Archive` channel. The concern of an event is now encoded by its constructor: `update_model` is a 30-line **total** dispatch table and misrouting is unrepresentable at compile time (parse-don't-validate)
- Sub-dispatchers: `update_editing` (534, mode-gated via the pure `editing_mode_applicable` table), `update_navigation` (119), `update_probe` (92), `update_lifecycle` (123), `update_archive_tracker` (17)
- `publish()` collapsed from 43 call sites to one at the dispatcher end (snapshot reflects the final returned model — observationally identical)
- Archive completions land even in fatal state (prior ordering preserved)

## UI and review evidence

N/A — behavior-preserving refactor. Both E2E suites run green locally (dev-host 71, standalone 9) plus the full `moon test` workspace (2510 js + 70 native). `driver_event_name` strings unchanged (Playwright reads `event_detail` via this codec).

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `commit_source` / `commit_block_request` / `commit_block_toolbar_request` | document_transaction.mbt | Yes | editing sub-dispatcher calls the shared shell |
| `block_selection_after_render` / `focus_latest_after_render` | focus_runtime.mbt | Yes | navigation/probe dispatch to the effect commands |
| `record_error` / `reject_focus` | application/focus_runtime | Yes | shared error handling |

New helpers added:

- `EditingEvent` / `NavigationEvent` / `ProbeEvent` / `LifecycleEvent` sub-enums + `DriverEvent` envelope — the type-level routing
- `editing_mode_applicable(event, mode, split_preview_open) -> String?` — the pure mode-gate table (ReplaceSource and ProbeBlockSelection exempt, matching prior behavior; message strings unchanged)
- `update_archive_tracker` — archive completion channel

## Validation scope

Boundary matrix / first failing test:

- Routing: every DriverEvent construction site classifies into exactly one sub-enum; the dispatcher match is exhaustive (compile-enforced)
- Mode gate: RawInput requires Raw or Preview+split; Block* require Block; ReplaceSource/ProbeBlockSelection always applicable (unchanged strings)
- Ordering: Archive processed before the fatal guard; fatal rejects everything else (unchanged)
- publish: 43 branch-local calls → 1 dispatcher-end call; snapshot content identical (Playwright suite green)

First failing check: `moon check` errors on every unwrapped construction site after the enum split (compile-driven migration). Regression net: dev-host 71/71, standalone 9/9, `moon test` 2510 js + 70 native, `moon fmt && moon info` no `.mbti` drift (all new items package-private).

Target packages: `apps/loomark/internal/rabbita`

Validation: `./scripts/validate-pr-ready.sh --target apps/loomark/internal/rabbita` passed (validated-base `67b59668` = current origin/main).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of editing, navigation, lifecycle, archive, and diagnostic events.
  * Added structured validation for document snapshots and selections.
  * Added a feature-tour example in Markdown.

* **Bug Fixes**
  * Improved error handling for browser effects, focus changes, selection reads, and rendering.
  * Archive completion continues processing even when the application enters a fatal state.
  * Editing actions now respect the active editing mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->