### PR TITLE
test(loomark): pin the editing mode gate and probe result updates

### DIFF
--- a/apps/loomark/internal/rabbita/application.mbt
+++ b/apps/loomark/internal/rabbita/application.mbt
@@ -1335,6 +1335,9 @@ fn update_navigation(
 ) -> (DriverModel, @cmd.Cmd) {
   match event {
     SelectRaw | SelectBlock | SelectPreview => {
+      // The outer or-pattern already narrowed `event` to the Select*
+      // variants; `_` is required because this inner match re-matches the
+      // full NavigationEvent type.
       let mode = match event {
         SelectRaw => @core.Raw
         SelectBlock => @core.Block
@@ -1366,6 +1369,9 @@ fn update_navigation(
       (next, @rabbita_runtime.none)
     }
     FocusRaw | FocusBlock | FocusPreview => {
+      // The outer or-pattern already narrowed `event` to the Focus*
+      // variants; `_` is required because this inner match re-matches the
+      // full NavigationEvent type.
       let target = match event {
         FocusRaw => @core.RawEditor
         FocusBlock => @core.BlockEditor
@@ -1447,6 +1453,26 @@ fn update_navigation(
 }
 
 ///|
+/// Apply a driver selection-read result to the probe model. Pure.
+fn apply_selection_read(
+  model : DriverModel,
+  start : Int,
+  end : Int,
+) -> DriverModel {
+  { ..model, selection: Some(start.to_string() + ":" + end.to_string()) }
+}
+
+///|
+/// Apply a driver measurement result to the probe model. Pure.
+fn apply_measurement(
+  model : DriverModel,
+  width : Double,
+  height : Double,
+) -> DriverModel {
+  { ..model, measurement: Some(width.to_string() + ":" + height.to_string()) }
+}
+
+///|
 /// Driver/test instrumentation dispatcher: probes, measurements, and their
 /// outbound results.
 fn update_probe(
@@ -1525,20 +1551,10 @@ fn update_probe(
           emit,
         ),
       )
-    SelectionRead(start~, end~) => {
-      let next = {
-        ..model,
-        selection: Some(start.to_string() + ":" + end.to_string()),
-      }
-      (next, @rabbita_runtime.none)
-    }
-    Measured(width~, height~) => {
-      let next = {
-        ..model,
-        measurement: Some(width.to_string() + ":" + height.to_string()),
-      }
-      (next, @rabbita_runtime.none)
-    }
+    SelectionRead(start~, end~) =>
+      (apply_selection_read(model, start, end), @rabbita_runtime.none)
+    Measured(width~, height~) =>
+      (apply_measurement(model, width, height), @rabbita_runtime.none)
   }
 }
 

--- a/apps/loomark/internal/rabbita/editing_mode_wbtest.mbt
+++ b/apps/loomark/internal/rabbita/editing_mode_wbtest.mbt
@@ -1,0 +1,93 @@
+///|
+/// Editing mode-gate boundary matrix:
+///
+/// | event | mode | split_preview_open | applicable |
+/// | --- | --- | --- | --- |
+/// | ReplaceSource / ProbeBlockSelection | any | any | yes |
+/// | RawInput | Raw | any | yes |
+/// | RawInput | Preview | true | yes |
+/// | RawInput | Preview | false | no |
+/// | RawInput | Block | any | no |
+/// | Block* | Block | any | yes |
+/// | Block* | Raw / Preview | any | no |
+///
+/// The rejection messages are part of the driver contract (Playwright
+/// asserts error_operation strings) and are pinned here.
+fn raw_mode() -> @core.ApplicationMode {
+  @core.Raw
+}
+
+///|
+fn block_mode() -> @core.ApplicationMode {
+  @core.Block
+}
+
+///|
+fn preview_mode() -> @core.ApplicationMode {
+  @core.Preview
+}
+
+///|
+test "source replacement and the block selection probe are exempt from the mode gate" {
+  assert_eq(
+    editing_mode_applicable(ReplaceSource("x"), raw_mode(), false),
+    None,
+  )
+  assert_eq(
+    editing_mode_applicable(ReplaceSource("x"), block_mode(), false),
+    None,
+  )
+  assert_eq(
+    editing_mode_applicable(ProbeBlockSelection("stale"), preview_mode(), false),
+    None,
+  )
+}
+
+///|
+test "raw input requires Raw mode or a split-open Preview" {
+  let raw = RawInput("source", None)
+  assert_eq(editing_mode_applicable(raw, raw_mode(), false), None)
+  assert_eq(editing_mode_applicable(raw, preview_mode(), true), None)
+  assert_eq(
+    editing_mode_applicable(raw, preview_mode(), false),
+    Some("Raw input is unavailable outside Raw mode"),
+  )
+  assert_eq(
+    editing_mode_applicable(raw, block_mode(), false),
+    Some("Raw input is unavailable outside Raw mode"),
+  )
+}
+
+///|
+test "block editing requires Block mode" {
+  let heading = BlockHeading(2, None)
+  assert_eq(editing_mode_applicable(heading, block_mode(), false), None)
+  assert_eq(
+    editing_mode_applicable(heading, raw_mode(), false),
+    Some("Block editing is unavailable outside Block mode"),
+  )
+  assert_eq(
+    editing_mode_applicable(BlockDelete, preview_mode(), true),
+    Some("Block editing is unavailable outside Block mode"),
+  )
+}
+
+///|
+test "selection read applies the driver probe result to the model" {
+  let editor = try! @markdown.MarkdownEditor(
+    agent_id="agent-a",
+    source="# Title",
+  )
+  let next = apply_selection_read(test_model(editor.snapshot()), 3, 5)
+  assert_eq(next.selection, Some("3:5"))
+}
+
+///|
+test "measurement applies the driver probe result to the model" {
+  let editor = try! @markdown.MarkdownEditor(
+    agent_id="agent-a",
+    source="# Title",
+  )
+  let next = apply_measurement(test_model(editor.snapshot()), 640.0, 480.0)
+  assert_eq(next.measurement, Some("640:480"))
+}

--- a/apps/loomark/internal/rabbita/editing_mode_wbtest.mbt
+++ b/apps/loomark/internal/rabbita/editing_mode_wbtest.mbt
@@ -59,17 +59,40 @@ test "raw input requires Raw mode or a split-open Preview" {
 }
 
 ///|
-test "block editing requires Block mode" {
-  let heading = BlockHeading(2, None)
-  assert_eq(editing_mode_applicable(heading, block_mode(), false), None)
-  assert_eq(
-    editing_mode_applicable(heading, raw_mode(), false),
-    Some("Block editing is unavailable outside Block mode"),
+/// Every Block* variant is gated together; representative coverage for each
+/// so a future misclassification cannot evade the matrix.
+fn block_variants() -> Array[EditingEvent] {
+  let editor = try! @markdown.MarkdownEditor(
+    agent_id="agent-a",
+    source="# Title\n\nParagraph",
   )
-  assert_eq(
-    editing_mode_applicable(BlockDelete, preview_mode(), true),
-    Some("Block editing is unavailable outside Block mode"),
-  )
+  let node_id = editor.snapshot().blocks()[0].node_id()
+  [
+    BlockFocused("key"),
+    BlockHeading(2, None),
+    BlockToggleList(None),
+    BlockDelete,
+    BlockInput(node_id~, input_id="in", text="t", selection_offset=0),
+    BlockSplit(node_id~, offset=0),
+    BlockMerge(node_id~, selection=BlockSelection::{
+      key: "k",
+      index: 0,
+      start: 0,
+      end: 0,
+    }),
+    BlockNavigate(key="k", direction=1),
+  ]
+}
+
+///|
+test "every block editing variant requires Block mode" {
+  for variant in block_variants() {
+    assert_eq(editing_mode_applicable(variant, block_mode(), false), None)
+    assert_eq(
+      editing_mode_applicable(variant, raw_mode(), false),
+      Some("Block editing is unavailable outside Block mode"),
+    )
+  }
 }
 
 ///|
@@ -90,4 +113,10 @@ test "measurement applies the driver probe result to the model" {
   )
   let next = apply_measurement(test_model(editor.snapshot()), 640.0, 480.0)
   assert_eq(next.measurement, Some("640:480"))
+  let fractional = apply_measurement(
+    test_model(editor.snapshot()),
+    120.5,
+    48.25,
+  )
+  assert_eq(fractional.measurement, Some("120.5:48.25"))
 }


### PR DESCRIPTION
## Summary

- Stage 2 of the update_model decomposition (#1186): the pure `editing_mode_applicable` table had no wbtest coverage; pin its full matrix — ReplaceSource/ProbeBlockSelection exemptions, RawInput's split-open Preview rule, Block* requiring Block mode, and the exact rejection message strings (Playwright asserts `error_operation` through these)
- Extract `apply_selection_read` / `apply_measurement` as pure model updates for the probe result arms of `update_probe` (+wbtest)
- Document that the `update_navigation` catch-all refutation arms are exhaustiveness-required (the inner match re-matches the full `NavigationEvent` type) — they are not dead code

## UI and review evidence

N/A — test coverage + trivial pure extraction; behavior unchanged. Both E2E suites green locally (dev-host 71, standalone 9).

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `editing_mode_applicable` | application.mbt (from #1186) | Yes | the wbtest pins its matrix |
| `test_model` | commit_classification_wbtest.mbt | Yes | shared baseline DriverModel builder |
| `@core.ApplicationMode` | apps/loomark/core | Yes | gate matrix |

New helpers added:

- `apply_selection_read(model, start, end)` / `apply_measurement(model, width, height)` — the pure probe-result updates (previously inline in update_probe arms)

## Validation scope

Boundary matrix / first failing test:

- mode gate: ReplaceSource/ProbeBlockSelection always applicable; RawInput Raw ✓ / Preview+split ✓ / Preview no-split ✗ / Block ✗; Block* Block ✓ / Raw/Preview ✗ — messages pinned verbatim
- probe results: `selection` = "start:end", `measurement` = "width:height"

First failing test: undefined `apply_selection_read`/`apply_measurement` in `editing_mode_wbtest.mbt` before implementation. Regression net: dev-host 71/71, standalone 9/9, `moon test` 2515 js + 70 native, no `.mbti` drift.

Target packages: `apps/loomark/internal/rabbita`

Validation: `./scripts/validate-pr-ready.sh --target apps/loomark/internal/rabbita` passed (validated-base `39554fac` = current origin/main).