### PR TITLE
perf(loomark): coalesce Raw input transactions

### DIFF
--- a/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
+++ b/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
@@ -1754,6 +1754,30 @@ test("external source replacement supersedes pending Raw input", async ({ browse
   }
 })
 
+test("failed external source replacement preserves pending Raw input", async ({ browser }) => {
+  const host = await mountHost(browser, "start")
+  try {
+    await forceEditorFailure(host.page)
+    await expect.poll(async () => (await snapshot(host.page)).editor_failure_armed).toBe(true)
+    await host.page.locator("#loomark-input").evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.value += "X"
+      textarea.dispatchEvent(new Event("input", { bubbles: true }))
+    })
+    await requestSource(host.page, "external")
+    await expect.poll(async () => (await snapshot(host.page)).error_code)
+      .toBe("editor-commit-failed")
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("startX")
+    await expect(host.page.locator("#loomark-input")).toHaveValue("startX")
+    expect(await snapshot(host.page)).toMatchObject({
+      source: "startX",
+      committed_change_count: 1,
+    })
+  } finally {
+    await host.context.close()
+  }
+})
+
 test("snapshot restore supersedes pending Raw input", async ({ browser }) => {
   const host = await mountHost(browser, "start")
   try {

--- a/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
+++ b/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
@@ -1610,6 +1610,184 @@ test("Raw textarea input uses the atomic editor transaction and mode toolbar", a
   }
 })
 
+test("Raw input coalesces a same-task burst into one commit", async ({ browser }) => {
+  const host = await mountHost(browser, "start")
+  try {
+    const input = host.page.locator("#loomark-input")
+    await input.focus()
+    await input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.setSelectionRange(textarea.value.length, textarea.value.length)
+      for (const character of "abcdefghij") {
+        textarea.value += character
+        textarea.setSelectionRange(textarea.value.length, textarea.value.length)
+        textarea.dispatchEvent(new Event("input", { bubbles: true }))
+      }
+    })
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("startabcdefghij")
+    expect(await snapshot(host.page)).toMatchObject({
+      source: "startabcdefghij",
+      committed_change_count: 1,
+    })
+    await expect(input).toHaveValue("startabcdefghij")
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("pending Raw input survives leaving the Raw view", async ({ browser }) => {
+  const host = await mountHost(browser, "start")
+  try {
+    const input = host.page.locator("#loomark-input")
+    await input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.focus()
+      textarea.value += "X"
+      textarea.setSelectionRange(textarea.value.length, textarea.value.length)
+      textarea.dispatchEvent(new Event("input", { bubbles: true }))
+    })
+    await selectBlock(host.page)
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("startX")
+    expect(await snapshot(host.page)).toMatchObject({ mode: "block", source: "startX" })
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("a newer Block edit supersedes pending Raw input", async ({ browser }) => {
+  const host = await mountHost(browser, "start")
+  try {
+    await host.page.evaluate(async moduleUrl => {
+      const rawInput = document.getElementById("loomark-input") as HTMLTextAreaElement
+      rawInput.value += "X"
+      rawInput.setSelectionRange(rawInput.value.length, rawInput.value.length)
+      rawInput.dispatchEvent(new Event("input", { bubbles: true }))
+      const module = await import(moduleUrl)
+      module.dev_host_select_block()
+      await new Promise<void>(resolve => requestAnimationFrame(() => resolve()))
+      const blockInput = document.getElementById("loomark-block-input") as HTMLTextAreaElement
+      blockInput.value = "block"
+      blockInput.setSelectionRange(blockInput.value.length, blockInput.value.length)
+      blockInput.dispatchEvent(new Event("input", { bubbles: true }))
+    }, moduleUrl)
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("block")
+    expect(await snapshot(host.page)).toMatchObject({
+      source: "block",
+      committed_change_count: 1,
+    })
+    await host.page.waitForTimeout(100)
+    expect(await snapshot(host.page)).toMatchObject({
+      source: "block",
+      committed_change_count: 1,
+    })
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("rejected pending Raw input does not repair a removed Raw control", async ({ browser }) => {
+  const host = await mountHost(browser, "start")
+  try {
+    await forceEditorFailure(host.page)
+    await expect.poll(async () => (await snapshot(host.page)).editor_failure_armed).toBe(true)
+    const input = host.page.locator("#loomark-input")
+    await input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.value += "X"
+      textarea.setSelectionRange(textarea.value.length, textarea.value.length)
+      textarea.dispatchEvent(new Event("input", { bubbles: true }))
+    })
+    await selectBlock(host.page)
+    await expect.poll(async () => (await snapshot(host.page)).error_code).toBe("editor-commit-failed")
+    expect(await snapshot(host.page)).toMatchObject({
+      source: "start",
+      mode: "block",
+      error_operation: "editor-dispatch",
+    })
+    await host.page.waitForTimeout(100)
+    expect(await snapshot(host.page)).not.toMatchObject({ error_code: "browser-effect-failed" })
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("rejected pending Raw input does not repair a closed Raw surface in Preview", async ({ browser }) => {
+  const host = await mountHost(browser, "start")
+  try {
+    await forceEditorFailure(host.page)
+    await expect.poll(async () => (await snapshot(host.page)).editor_failure_armed).toBe(true)
+    const input = host.page.locator("#loomark-input")
+    await input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.value += "X"
+      textarea.setSelectionRange(textarea.value.length, textarea.value.length)
+      textarea.dispatchEvent(new Event("input", { bubbles: true }))
+    })
+    await selectPreview(host.page)
+    await expect.poll(async () => (await snapshot(host.page)).error_code).toBe("editor-commit-failed")
+    expect(await snapshot(host.page)).toMatchObject({
+      source: "start",
+      mode: "preview",
+      error_operation: "editor-dispatch",
+    })
+    await host.page.waitForTimeout(100)
+    expect(await snapshot(host.page)).not.toMatchObject({ error_code: "browser-effect-failed" })
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("external source replacement supersedes pending Raw input", async ({ browser }) => {
+  const host = await mountHost(browser, "start")
+  try {
+    await host.page.locator("#loomark-input").evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.value += "X"
+      textarea.dispatchEvent(new Event("input", { bubbles: true }))
+    })
+    await requestSource(host.page, "external")
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("external")
+    await host.page.waitForTimeout(100)
+    expect(await snapshot(host.page)).toMatchObject({ source: "external" })
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("snapshot restore supersedes pending Raw input", async ({ browser }) => {
+  const host = await mountHost(browser, "start")
+  try {
+    await host.page.locator("#loomark-input").evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.value += "X"
+      textarea.dispatchEvent(new Event("input", { bubbles: true }))
+    })
+    await restoreSnapshot(host.page, 1, "restored", "raw")
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("restored")
+    await host.page.waitForTimeout(100)
+    expect(await snapshot(host.page)).toMatchObject({ source: "restored", mode: "raw" })
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("rejected snapshot preserves pending Raw input", async ({ browser }) => {
+  const host = await mountHost(browser, "start")
+  try {
+    await host.page.locator("#loomark-input").evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.value += "X"
+      textarea.dispatchEvent(new Event("input", { bubbles: true }))
+    })
+    await restoreSnapshot(host.page, 999, "ignored", "raw")
+    await expect.poll(async () => (await snapshot(host.page)).error_code)
+      .toBe("unsupported-snapshot-version")
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("startX")
+  } finally {
+    await host.context.close()
+  }
+})
+
 test("Raw textarea editor failure preserves committed state and consumes the arm", async ({ browser }) => {
   const host = await mountHost(browser, "before\n")
   try {
@@ -1737,7 +1915,7 @@ test("rejected Raw repair yields to a newer same-frame input", async ({ browser 
   }
 })
 
-test("Raw typed input preserves LF, CRLF, CR, EOF, and empty EOF sources", async ({ browser }) => {
+test("Raw source transport preserves LF, CRLF, CR, EOF, and empty EOF sources", async ({ browser }) => {
   const host = await mountHost(browser, "seed\n")
   try {
     await selectRaw(host.page)

--- a/apps/loomark/internal/rabbita/application.mbt
+++ b/apps/loomark/internal/rabbita/application.mbt
@@ -317,8 +317,9 @@ fn preview_document_view(model : DriverModel) -> @rabbita_runtime.Html {
 fn raw_editor_view(
   model : DriverModel,
   emit : @cmd.Emit[DriverEvent],
+  raw_input_coordinator : RawInputCoordinator,
 ) -> @rabbita_runtime.Html {
-  let source = model.document.source()
+  let source = raw_input_coordinator.display_source(model.document.source())
   @rui.textarea(
     id="loomark-input",
     value=source,
@@ -327,7 +328,9 @@ fn raw_editor_view(
     style=[
       "min-height:clamp(24rem,70vh,36rem);width:min(calc(100% - 4rem),46rem);margin-inline:auto;field-sizing:fixed;resize:none;--rui-control-base-border:transparent;--rui-control-base-shadow:none;border-left:1px solid var(--rui-border);border-right:1px solid var(--rui-border);border-top:0;border-bottom:0;border-radius:0;background:transparent;padding:1rem;font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,\"Liberation Mono\",\"Courier New\",monospace;font-size:0.875rem;line-height:1.65",
     ],
-    on_input=@cmd.Emit(source => raw_input_command(source, emit)),
+    on_input=@cmd.Emit(source => {
+      raw_input_command(source, raw_input_coordinator, emit)
+    }),
   )
 }
 
@@ -335,9 +338,10 @@ fn raw_editor_view(
 fn editor_view(
   model : DriverModel,
   emit : @cmd.Emit[DriverEvent],
+  raw_input_coordinator : RawInputCoordinator,
 ) -> @rabbita_runtime.Html {
   match model.state.mode() {
-    @core.Raw => raw_editor_view(model, emit)
+    @core.Raw => raw_editor_view(model, emit, raw_input_coordinator)
     @core.Preview => preview_document_view(model)
     @core.Block => block_editor_view(model, emit)
   }
@@ -579,7 +583,7 @@ fn driver_event_name(event : DriverEvent) -> String {
     Editing(edit_event) =>
       match edit_event {
         ReplaceSource(_) => "source"
-        RawInput(_, _) => "raw-input"
+        RawInput(_, _, _) => "raw-input"
         BlockFocused(_) => "block-focused"
         BlockHeading(_, _) => "block-heading"
         BlockToggleList(_) => "block-toggle-list"
@@ -663,7 +667,7 @@ fn parse_driver_event(detail : String) -> DriverEvent {
   } else if detail.has_prefix("source|") {
     Editing(ReplaceSource(detail["source|".length():].to_owned()))
   } else if detail.has_prefix("raw-input|") {
-    Editing(RawInput(detail["raw-input|".length():].to_owned(), None))
+    Editing(RawInput(detail["raw-input|".length():].to_owned(), None, None))
   } else if detail == "editor-failure" {
     Lifecycle(EditorFailure)
   } else if detail.has_prefix("restore-focus|") {
@@ -763,7 +767,8 @@ fn editing_mode_applicable(
 ) -> String? {
   match event {
     ReplaceSource(_) | ProbeBlockSelection(_) => None
-    RawInput(_, _) =>
+    RawInput(_, _, Some(_)) => None
+    RawInput(_, _, None) =>
       if mode == @core.Raw || (mode == @core.Preview && split_preview_open) {
         None
       } else {
@@ -791,11 +796,19 @@ fn editing_mode_applicable(
 fn update_editing(
   editor : @markdown.MarkdownEditor,
   attachment : @md_markdown.MarkdownSemanticAttachment,
+  raw_input_coordinator : RawInputCoordinator,
   model : DriverModel,
   latest_model : @ref.Ref[DriverModel?],
   event : EditingEvent,
   emit : @cmd.Emit[DriverEvent],
 ) -> (DriverModel, @cmd.Cmd) {
+  let raw_token_active = match event {
+    RawInput(_, _, Some(token)) => raw_input_coordinator.is_active(token)
+    _ => true
+  }
+  if event is RawInput(_, _, Some(_)) && !raw_token_active {
+    return (model, @rabbita_runtime.none)
+  }
   match
     editing_mode_applicable(event, model.state.mode(), model.split_preview_open) {
     Some(message) => {
@@ -806,12 +819,22 @@ fn update_editing(
     }
     None =>
       match event {
-        ReplaceSource(source) | RawInput(source, _) => {
+        ReplaceSource(source) | RawInput(source, _, _) => {
+          if event is ReplaceSource(_) {
+            raw_input_coordinator.cancel_pending()
+          }
           let raw_selection = match event {
-            RawInput(_, selection) => selection
+            RawInput(_, selection, _) => selection
             _ => None
           }
-          let raw_event = event is RawInput(_, _)
+          let raw_event = event is RawInput(_, _, _)
+          let raw_token = match event {
+            RawInput(_, _, token) => token
+            _ => None
+          }
+          let raw_input_epoch = raw_input_coordinator.epoch()
+          let mut raw_completion_seen = false
+          let mut raw_completion_command = @rabbita_runtime.none
           let transition = @core.reduce(
             model.state,
             @core.ApplicationEvent::RequestCanonicalSource(source~),
@@ -845,6 +868,28 @@ fn update_editing(
                 persistence_command = @cmd.batch([
                   persistence_command, commit_command,
                 ])
+                match (raw_token, raw_completion_seen) {
+                  (Some(token), false) => {
+                    raw_completion_seen = true
+                    let repair_generation = next.text_input_generation
+                    let repair_revision = next.source_revision
+                    raw_completion_command = raw_input_coordinator.complete(
+                      token,
+                      source,
+                      raw_selection,
+                      accepted,
+                      () => {
+                        raw_input_repair_eligible(
+                          latest_model.val,
+                          repair_generation,
+                          repair_revision,
+                        )
+                      },
+                      emit,
+                    )
+                  }
+                  _ => ()
+                }
                 restore_raw_value = restore_raw_value ||
                   (raw_event && !accepted)
               }
@@ -854,6 +899,15 @@ fn update_editing(
                 )
             }
           }
+          if !raw_completion_seen {
+            match raw_token {
+              Some(token) => raw_input_coordinator.cancel(token)
+              None => ()
+            }
+          }
+          persistence_command = @cmd.batch([
+            persistence_command, raw_completion_command,
+          ])
           let command = if restore_raw_value {
             let repair_generation = next.text_input_generation
             let repair_source_revision = next.source_revision
@@ -861,9 +915,9 @@ fn update_editing(
               scheduler => {
                 ignore(scheduler)
                 let accepted_source = next.document.source()
-                if repair_eligible(
+                if raw_input_coordinator.epoch() == raw_input_epoch &&
+                  raw_input_repair_eligible(
                     latest_model.val,
-                    @core.Raw,
                     repair_generation,
                     repair_source_revision,
                   ) {
@@ -968,7 +1022,7 @@ fn update_editing(
                 @markdown.Heading(level~) if level == requested_level => 0
                 _ => requested_level
               }
-              commit_block_toolbar_request(
+              let (next, applied, command) = commit_block_toolbar_request(
                 editor,
                 attachment,
                 model,
@@ -981,6 +1035,10 @@ fn update_editing(
                 "loomark-heading-" + requested_level.to_string(),
                 emit,
               )
+              if applied {
+                raw_input_coordinator.cancel_pending()
+              }
+              (next, command)
             }
           }
         BlockToggleList(originating_selection) =>
@@ -1006,7 +1064,7 @@ fn update_editing(
                   .unwrap_or(@rabbita_runtime.none)
                 return (model, command)
               }
-              commit_block_toolbar_request(
+              let (next, applied, command) = commit_block_toolbar_request(
                 editor,
                 attachment,
                 model,
@@ -1018,6 +1076,10 @@ fn update_editing(
                 "loomark-toggle-list",
                 emit,
               )
+              if applied {
+                raw_input_coordinator.cancel_pending()
+              }
+              (next, command)
             }
           }
         BlockDelete =>
@@ -1028,8 +1090,8 @@ fn update_editing(
               )
               (next, @rabbita_runtime.none)
             }
-            Some(block) =>
-              commit_block_toolbar_request(
+            Some(block) => {
+              let (next, applied, command) = commit_block_toolbar_request(
                 editor,
                 attachment,
                 model,
@@ -1039,6 +1101,11 @@ fn update_editing(
                 "loomark-delete-block",
                 emit,
               )
+              if applied {
+                raw_input_coordinator.cancel_pending()
+              }
+              (next, command)
+            }
           }
         BlockInput(node_id~, input_id~, text=proposed_text, selection_offset~) => {
           let (next, committed_selection, accepted, persistence_command) = commit_block_request(
@@ -1052,6 +1119,9 @@ fn update_editing(
             "editor-dispatch",
             emit,
           )
+          if accepted && next.source_revision != model.source_revision {
+            raw_input_coordinator.cancel_pending()
+          }
           let selection = match committed_selection {
             Some(selection) =>
               block_selection_from_commit(
@@ -1148,7 +1218,7 @@ fn update_editing(
           }
         }
         BlockSplit(node_id~, offset~) => {
-          let (next, committed_selection, _, persistence_command) = commit_block_request(
+          let (next, committed_selection, accepted, persistence_command) = commit_block_request(
             editor,
             attachment,
             model,
@@ -1156,6 +1226,9 @@ fn update_editing(
             "editor-dispatch",
             emit,
           )
+          if accepted && next.source_revision != model.source_revision {
+            raw_input_coordinator.cancel_pending()
+          }
           let selection = match committed_selection {
             Some(selection) =>
               block_selection_from_commit(next.document, selection)
@@ -1191,7 +1264,7 @@ fn update_editing(
           }
         }
         BlockMerge(node_id~, selection=originating_selection) => {
-          let (next, committed_selection, _, persistence_command) = commit_block_request(
+          let (next, committed_selection, accepted, persistence_command) = commit_block_request(
             editor,
             attachment,
             model,
@@ -1199,6 +1272,9 @@ fn update_editing(
             "editor-dispatch",
             emit,
           )
+          if accepted && next.source_revision != model.source_revision {
+            raw_input_coordinator.cancel_pending()
+          }
           let resolved_selection = match committed_selection {
             Some(selection) =>
               block_selection_from_commit(next.document, selection)
@@ -1299,6 +1375,9 @@ fn update_editing(
               accepted~,
               changed~,
             )
+            if accepted && changed {
+              raw_input_coordinator.cancel_pending()
+            }
             let expected_revision = if kind == "stale" {
               previous_revision
             } else {
@@ -1564,6 +1643,7 @@ fn update_probe(
 fn update_lifecycle(
   editor : @markdown.MarkdownEditor,
   attachment : @md_markdown.MarkdownSemanticAttachment,
+  raw_input_coordinator : RawInputCoordinator,
   model : DriverModel,
   event : LifecycleEvent,
   emit : @cmd.Emit[DriverEvent],
@@ -1621,6 +1701,7 @@ fn update_lifecycle(
         }
       }
       if accepted {
+        raw_input_coordinator.cancel_pending()
         next = { ..next, state: transition.state() }
       }
       next = update_preview_document(
@@ -1692,6 +1773,7 @@ fn update_lifecycle(
 fn update_model(
   editor : @markdown.MarkdownEditor,
   attachment : @md_markdown.MarkdownSemanticAttachment,
+  raw_input_coordinator : RawInputCoordinator,
   model : DriverModel,
   latest_model : @ref.Ref[DriverModel?],
   event : DriverEvent,
@@ -1700,6 +1782,11 @@ fn update_model(
   let (next, command) = match event {
     Archive(completion) => update_archive_tracker(model, completion)
     _ if model.fatal => {
+      match event {
+        Editing(RawInput(_, _, Some(token))) =>
+          raw_input_coordinator.cancel(token)
+        _ => ()
+      }
       let next = {
         ..model,
         rejection: Some(
@@ -1709,12 +1796,17 @@ fn update_model(
       (next, @rabbita_runtime.none)
     }
     Editing(edit_event) =>
-      update_editing(editor, attachment, model, latest_model, edit_event, emit)
+      update_editing(
+        editor, attachment, raw_input_coordinator, model, latest_model, edit_event,
+        emit,
+      )
     Navigation(nav_event) =>
       update_navigation(attachment, model, latest_model, nav_event, emit)
     Probe(probe_event) => update_probe(model, probe_event, emit)
     Lifecycle(life_event) =>
-      update_lifecycle(editor, attachment, model, life_event, emit)
+      update_lifecycle(
+        editor, attachment, raw_input_coordinator, model, life_event, emit,
+      )
   }
   publish(next)
   (next, command)
@@ -1904,8 +1996,11 @@ fn build_application(
   view : (DriverModel, @cmd.Emit[DriverEvent], @rabbita_runtime.Html) -> @rabbita_runtime.Html,
 ) -> @rabbita_runtime.App {
   let latest_model : @ref.Ref[DriverModel?] = { val: None }
+  let raw_input_coordinator = RawInputCoordinator::RawInputCoordinator()
   let update = (model, event, emit) => {
-    update_model(editor, attachment, model, latest_model, event, emit)
+    update_model(
+      editor, attachment, raw_input_coordinator, model, latest_model, event, emit,
+    )
   }
   @rabbita_runtime.new(() => {
     let (model, emit) = @rabbita_runtime.create_state_with_init(
@@ -1922,7 +2017,7 @@ fn build_application(
       update~,
       subscriptions~,
     )
-    let active_view = application_view(model, emit)
+    let active_view = application_view(model, emit, raw_input_coordinator)
     model.view2(active_view, (model, active_view) => {
       latest_model.val = Some(model)
       view(model, emit, active_view)

--- a/apps/loomark/internal/rabbita/application.mbt
+++ b/apps/loomark/internal/rabbita/application.mbt
@@ -820,9 +820,6 @@ fn update_editing(
     None =>
       match event {
         ReplaceSource(source) | RawInput(source, _, _) => {
-          if event is ReplaceSource(_) {
-            raw_input_coordinator.cancel_pending()
-          }
           let raw_selection = match event {
             RawInput(_, selection, _) => selection
             _ => None
@@ -865,6 +862,9 @@ fn update_editing(
                   accepted~,
                   changed~,
                 )
+                if event is ReplaceSource(_) && accepted {
+                  raw_input_coordinator.cancel_pending()
+                }
                 persistence_command = @cmd.batch([
                   persistence_command, commit_command,
                 ])

--- a/apps/loomark/internal/rabbita/document_transaction.mbt
+++ b/apps/loomark/internal/rabbita/document_transaction.mbt
@@ -186,7 +186,7 @@ fn commit_block_toolbar_request(
   originating_selection : BlockSelection?,
   control_id : String,
   emit : @cmd.Emit[DriverEvent],
-) -> (DriverModel, @cmd.Cmd) {
+) -> (DriverModel, Bool, @cmd.Cmd) {
   let (committed, committed_selection, _, persistence_command) = commit_block_request(
     editor, attachment, model, request, "editor-dispatch", emit,
   )
@@ -209,6 +209,7 @@ fn commit_block_toolbar_request(
     Some(selection) =>
       (
         next,
+        applied,
         @cmd.batch([
           persistence_command,
           block_selection_after_render(
@@ -222,12 +223,13 @@ fn commit_block_toolbar_request(
       )
     None =>
       if applied {
-        (next, persistence_command)
+        (next, applied, persistence_command)
       } else {
         match originating_selection {
           Some(selection) =>
             (
               next,
+              applied,
               @cmd.batch([
                 persistence_command,
                 block_selection_after_render(
@@ -242,6 +244,7 @@ fn commit_block_toolbar_request(
           None =>
             (
               next,
+              applied,
               @cmd.batch([
                 persistence_command,
                 after_render(

--- a/apps/loomark/internal/rabbita/driver_types.mbt
+++ b/apps/loomark/internal/rabbita/driver_types.mbt
@@ -4,7 +4,7 @@
 /// from the mode gate (driver source replacement works in any mode).
 priv enum EditingEvent {
   ReplaceSource(String)
-  RawInput(String, @dom_boundary.TextSelection?)
+  RawInput(String, @dom_boundary.TextSelection?, Int?)
   BlockFocused(String)
   BlockHeading(Int, BlockSelection?)
   BlockToggleList(BlockSelection?)

--- a/apps/loomark/internal/rabbita/editing_mode_wbtest.mbt
+++ b/apps/loomark/internal/rabbita/editing_mode_wbtest.mbt
@@ -45,7 +45,7 @@ test "source replacement and the block selection probe are exempt from the mode 
 
 ///|
 test "raw input requires Raw mode or a split-open Preview" {
-  let raw = RawInput("source", None)
+  let raw = RawInput("source", None, None)
   assert_eq(editing_mode_applicable(raw, raw_mode(), false), None)
   assert_eq(editing_mode_applicable(raw, preview_mode(), true), None)
   assert_eq(

--- a/apps/loomark/internal/rabbita/effect_decision.mbt
+++ b/apps/loomark/internal/rabbita/effect_decision.mbt
@@ -5,7 +5,8 @@
 ///
 /// `repair_eligible` guards the raw/block input repair: a repair scheduled
 /// for a specific mode, input generation, and source revision only writes
-/// when the rendered model still matches all three. A missing model (no
+/// when the rendered model still matches all three. Preview repairs also
+/// require the split Raw surface to remain rendered. A missing model (no
 /// render yet) is never eligible.
 fn repair_eligible(
   current : DriverModel?,
@@ -14,10 +15,38 @@ fn repair_eligible(
   expected_revision : Int,
 ) -> Bool {
   match current {
-    Some(current) =>
+    Some(current) => {
+      let control_rendered = match expected_mode {
+        @core.Raw => true
+        @core.Preview => current.split_preview_open
+        @core.Block => true
+      }
       current.state.mode() == expected_mode &&
       current.text_input_generation == expected_generation &&
-      current.source_revision == expected_revision
+      current.source_revision == expected_revision &&
+      control_rendered
+    }
+    None => false
+  }
+}
+
+///|
+/// A Raw repair is valid while the Raw control is still rendered. In split
+/// Preview the application mode is Preview, but the Raw textarea remains in
+/// the DOM; Block mode never provides a valid Raw repair target.
+fn raw_input_repair_eligible(
+  current : DriverModel?,
+  expected_generation : Int,
+  expected_revision : Int,
+) -> Bool {
+  match current {
+    Some(current) =>
+      current.text_input_generation == expected_generation &&
+      current.source_revision == expected_revision &&
+      (
+        current.state.mode() == @core.Raw ||
+        (current.state.mode() == @core.Preview && current.split_preview_open)
+      )
     None => false
   }
 }

--- a/apps/loomark/internal/rabbita/effect_decision_wbtest.mbt
+++ b/apps/loomark/internal/rabbita/effect_decision_wbtest.mbt
@@ -39,6 +39,66 @@ test "repair_eligible requires mode, generation, and revision to match" {
   assert_false(repair_eligible(Some(model), @core.Raw, 4, 7))
   assert_false(repair_eligible(Some(model), @core.Raw, 3, 8))
   assert_true(repair_eligible(Some(model), @core.Raw, 3, 7))
+  let preview = {
+    ..model,
+    state: @core.ApplicationState::ApplicationState(@core.Preview),
+    split_preview_open: true,
+  }
+  assert_true(repair_eligible(Some(preview), @core.Preview, 3, 7))
+  assert_false(
+    repair_eligible(
+      Some({ ..preview, split_preview_open: false }),
+      @core.Preview,
+      3,
+      7,
+    ),
+  )
+}
+
+///|
+test "raw repair requires a rendered Raw control" {
+  let editor = try! @markdown.MarkdownEditor(
+    agent_id="agent-a",
+    source="# Title",
+  )
+  let model = {
+    ..test_model(editor.snapshot()),
+    text_input_generation: 3,
+    source_revision: 7,
+  }
+  assert_true(raw_input_repair_eligible(Some(model), 3, 7))
+  assert_true(
+    raw_input_repair_eligible(
+      Some({
+        ..model,
+        state: @core.ApplicationState::ApplicationState(@core.Preview),
+        split_preview_open: true,
+      }),
+      3,
+      7,
+    ),
+  )
+  assert_false(
+    raw_input_repair_eligible(
+      Some({
+        ..model,
+        state: @core.ApplicationState::ApplicationState(@core.Preview),
+        split_preview_open: false,
+      }),
+      3,
+      7,
+    ),
+  )
+  assert_false(
+    raw_input_repair_eligible(
+      Some({
+        ..model,
+        state: @core.ApplicationState::ApplicationState(@core.Block),
+      }),
+      3,
+      7,
+    ),
+  )
 }
 
 ///|

--- a/apps/loomark/internal/rabbita/split_view.mbt
+++ b/apps/loomark/internal/rabbita/split_view.mbt
@@ -43,6 +43,7 @@ fn split_presentation(model : DriverModel) -> SplitPresentation {
 fn mode_view(
   model : DriverModel,
   emit : @cmd.Emit[DriverEvent],
+  raw_input_coordinator : RawInputCoordinator,
 ) -> @rabbita_runtime.Html {
   if model.state.mode() == @core.Block {
     @html.div(
@@ -56,7 +57,7 @@ fn mode_view(
           style=[
             "width:100%;min-width:0;flex:1;min-height:0;display:flex;overflow-y:auto",
           ],
-          editor_view(model, emit),
+          editor_view(model, emit, raw_input_coordinator),
         ),
       ],
     )
@@ -64,7 +65,7 @@ fn mode_view(
     @html.div(
       id="loomark-active-view",
       style=["width:100%;min-width:0;display:flex"],
-      editor_view(model, emit),
+      editor_view(model, emit, raw_input_coordinator),
     )
   }
 }
@@ -73,14 +74,16 @@ fn mode_view(
 fn single_view(
   model : @rabbita_runtime.Val[DriverModel],
   emit : @cmd.Emit[DriverEvent],
+  raw_input_coordinator : RawInputCoordinator,
 ) -> @rabbita_runtime.Val[@rabbita_runtime.Html] {
-  model.view(model => mode_view(model, emit))
+  model.view(model => mode_view(model, emit, raw_input_coordinator))
 }
 
 ///|
 fn resizable_split_view(
   model : @rabbita_runtime.Val[DriverModel],
   emit : @cmd.Emit[DriverEvent],
+  raw_input_coordinator : RawInputCoordinator,
   orientation : @rui.SeparatorOrientation,
 ) -> @rabbita_runtime.Val[@rabbita_runtime.Html] {
   @rui.resizable_panel_group_with_input(
@@ -97,10 +100,10 @@ fn resizable_split_view(
         @html.div(
           id="loomark-active-view",
           style=["width:100%;min-width:0;display:flex"],
-          raw_editor_view(model, emit),
+          raw_editor_view(model, emit, raw_input_coordinator),
         )
       } else {
-        mode_view(model, emit)
+        mode_view(model, emit, raw_input_coordinator)
       }
       @html.fragment([
         @rui.resizable_panel(
@@ -131,16 +134,18 @@ fn resizable_split_view(
 fn side_by_side_view(
   model : @rabbita_runtime.Val[DriverModel],
   emit : @cmd.Emit[DriverEvent],
+  raw_input_coordinator : RawInputCoordinator,
 ) -> @rabbita_runtime.Val[@rabbita_runtime.Html] {
-  resizable_split_view(model, emit, @rui.Horizontal)
+  resizable_split_view(model, emit, raw_input_coordinator, @rui.Horizontal)
 }
 
 ///|
 fn stacked_view(
   model : @rabbita_runtime.Val[DriverModel],
   emit : @cmd.Emit[DriverEvent],
+  raw_input_coordinator : RawInputCoordinator,
 ) -> @rabbita_runtime.Val[@rabbita_runtime.Html] {
-  resizable_split_view(model, emit, @rui.Vertical)
+  resizable_split_view(model, emit, raw_input_coordinator, @rui.Vertical)
 }
 
 ///|
@@ -149,13 +154,14 @@ fn stacked_view(
 fn application_view(
   model : @rabbita_runtime.Val[DriverModel],
   emit : @cmd.Emit[DriverEvent],
+  raw_input_coordinator : RawInputCoordinator,
 ) -> @rabbita_runtime.Val[@rabbita_runtime.Html] {
   let presentation = model.map(split_presentation)
   presentation.switch(presentation => {
     match presentation {
-      SingleSurface => single_view(model, emit)
-      SideBySide => side_by_side_view(model, emit)
-      Stacked => stacked_view(model, emit)
+      SingleSurface => single_view(model, emit, raw_input_coordinator)
+      SideBySide => side_by_side_view(model, emit, raw_input_coordinator)
+      Stacked => stacked_view(model, emit, raw_input_coordinator)
     }
   })
 }

--- a/apps/loomark/internal/rabbita/text_control_repair.mbt
+++ b/apps/loomark/internal/rabbita/text_control_repair.mbt
@@ -43,21 +43,266 @@ fn rejected_text_selection(
 }
 
 ///|
-/// Capture the live Raw selection before the accepted model may need to repair
-/// a rejected controlled value on the same textarea node.
-fn raw_input_command(
+/// The delay groups rapid native input events into one editor transaction.
+const RAW_INPUT_DEBOUNCE_MS : Int = 50
+
+///|
+/// Keep the latest native Raw value while one deferred commit is in flight.
+/// The browser can continue updating the textarea without queuing stale
+/// canonical-source commits behind an expensive editor transaction.
+///
+/// The token and one-shot retry preserve the existing rejected-edit behavior:
+/// if the transaction fails, the latest native value gets one more chance
+/// instead of being lost by coalescing.
+priv struct RawInputCoordinator {
+  pending_source : @ref.Ref[String?]
+  pending_count : @ref.Ref[Int]
+  scheduled : @ref.Ref[Bool]
+  schedule_generation : @ref.Ref[Int]
+  retry_budget : @ref.Ref[Int]
+  repair_pending : @ref.Ref[Bool]
+  retry_selection : @ref.Ref[@dom_boundary.TextSelection?]
+  input_epoch : @ref.Ref[Int]
+  next_token : @ref.Ref[Int]
+  in_flight_token : @ref.Ref[Int?]
+  in_flight_count : @ref.Ref[Int?]
+}
+
+///|
+fn RawInputCoordinator::RawInputCoordinator() -> RawInputCoordinator {
+  {
+    pending_source: @ref.Ref(None),
+    pending_count: @ref.Ref(0),
+    scheduled: @ref.Ref(false),
+    schedule_generation: @ref.Ref(0),
+    retry_budget: @ref.Ref(0),
+    repair_pending: @ref.Ref(false),
+    retry_selection: @ref.Ref(None),
+    input_epoch: @ref.Ref(0),
+    next_token: @ref.Ref(0),
+    in_flight_token: @ref.Ref(None),
+    in_flight_count: @ref.Ref(None),
+  }
+}
+
+///|
+fn RawInputCoordinator::epoch(self : RawInputCoordinator) -> Int {
+  self.input_epoch.val
+}
+
+///|
+fn RawInputCoordinator::display_source(
+  self : RawInputCoordinator,
+  committed_source : String,
+) -> String {
+  match self.pending_source.val {
+    Some(source) => source
+    None => committed_source
+  }
+}
+
+///|
+fn RawInputCoordinator::schedule(
+  self : RawInputCoordinator,
+  emit : @cmd.Emit[DriverEvent],
+) -> @cmd.Cmd {
+  guard !self.scheduled.val else { return @rabbita_runtime.none }
+  self.schedule_generation.val += 1
+  let generation = self.schedule_generation.val
+  self.scheduled.val = true
+  @cmd.delay(
+    @cmd.custom_cmd(scheduler => {
+      if self.schedule_generation.val == generation {
+        self.flush(scheduler, emit)
+      }
+    }),
+    RAW_INPUT_DEBOUNCE_MS,
+  )
+}
+
+///|
+/// Move the trailing edge when a newer native value arrives.
+fn RawInputCoordinator::reschedule(
+  self : RawInputCoordinator,
+  emit : @cmd.Emit[DriverEvent],
+) -> @cmd.Cmd {
+  self.schedule_generation.val += 1
+  self.scheduled.val = false
+  self.schedule(emit)
+}
+
+///|
+fn read_raw_selection() -> @dom_boundary.TextSelection? {
+  try @dom_boundary.read_text_selection_id("loomark-input") catch {
+    _ => None
+  } noraise {
+    selection => Some(selection)
+  }
+}
+
+///|
+fn RawInputCoordinator::flush(
+  self : RawInputCoordinator,
+  scheduler : &@cmd.Scheduler,
+  emit : @cmd.Emit[DriverEvent],
+) -> Unit {
+  self.scheduled.val = false
+  match self.pending_source.val {
+    None => ()
+    Some(source) => {
+      self.pending_source.val = None
+      let input_count = self.pending_count.val
+      self.pending_count.val = 0
+      let token = self.next_token.val
+      self.next_token.val = token + 1
+      self.in_flight_token.val = Some(token)
+      self.in_flight_count.val = Some(input_count)
+      let selection = match self.retry_selection.val {
+        Some(selection) => {
+          self.retry_selection.val = None
+          Some(selection)
+        }
+        None => read_raw_selection()
+      }
+      scheduler.add(emit(Editing(RawInput(source, selection, Some(token)))))
+    }
+  }
+}
+
+///|
+fn RawInputCoordinator::enqueue(
+  self : RawInputCoordinator,
   source : String,
   emit : @cmd.Emit[DriverEvent],
 ) -> @cmd.Cmd {
-  @cmd.custom_cmd(scheduler => {
-    let selection = @dom_boundary.read_text_selection_id("loomark-input") catch {
-      error => {
-        scheduler.add(emit(Navigation(EffectFailed(error.message()))))
-        return
-      }
+  self.input_epoch.val += 1
+  match self.pending_source.val {
+    None => self.pending_count.val = 1
+    Some(_) => self.pending_count.val += 1
+  }
+  self.pending_source.val = Some(source)
+  self.retry_selection.val = None
+  self.retry_budget.val = 1
+  self.reschedule(emit)
+}
+
+///|
+/// Complete a deferred transaction and retry one rejected native value.
+fn RawInputCoordinator::complete(
+  self : RawInputCoordinator,
+  token : Int,
+  source : String,
+  selection : @dom_boundary.TextSelection?,
+  accepted : Bool,
+  repair_check : () -> Bool,
+  emit : @cmd.Emit[DriverEvent],
+) -> @cmd.Cmd {
+  guard self.in_flight_token.val == Some(token) else {
+    return @rabbita_runtime.none
+  }
+  self.in_flight_token.val = None
+  let input_count = self.in_flight_count.val
+  self.in_flight_count.val = None
+  let can_retry = match input_count {
+    Some(count) => count > 1
+    None => false
+  }
+  if accepted {
+    let needs_repair = self.repair_pending.val &&
+      self.pending_source.val is None
+    self.retry_budget.val = 0
+    self.repair_pending.val = false
+    let repair_epoch = self.input_epoch.val
+    let command = match self.pending_source.val {
+      Some(_) => self.schedule(emit)
+      None => @rabbita_runtime.none
     }
-    scheduler.add(emit(Editing(RawInput(source, Some(selection)))))
-  })
+    if needs_repair {
+      @cmd.batch([
+        command,
+        after_render(
+          scheduler => {
+            ignore(scheduler)
+            if self.input_epoch.val != repair_epoch || !repair_check() {
+              return
+            }
+            @dom_boundary.write_text_value_id("loomark-input", source)
+            match selection {
+              Some(selection) =>
+                @dom_boundary.write_text_selection_id(
+                  "loomark-input", selection,
+                )
+              None => ()
+            }
+          },
+          emit,
+        ),
+      ])
+    } else {
+      command
+    }
+  } else if self.retry_budget.val > 0 && can_retry {
+    self.input_epoch.val += 1
+    self.retry_budget.val -= 1
+    self.repair_pending.val = true
+    self.retry_selection.val = selection
+    if self.pending_source.val is None {
+      self.pending_count.val = 1
+      self.pending_source.val = Some(source)
+    }
+    self.schedule(emit)
+  } else {
+    self.pending_source.val = None
+    self.repair_pending.val = false
+    self.retry_selection.val = None
+    @rabbita_runtime.none
+  }
+}
+
+///|
+/// Drop native input that is superseded by an external canonical-source
+/// operation. The generation invalidates the already-created timer without
+/// requiring timer cancellation support from the command layer.
+fn RawInputCoordinator::cancel_pending(self : RawInputCoordinator) -> Unit {
+  self.input_epoch.val += 1
+  self.schedule_generation.val += 1
+  self.scheduled.val = false
+  self.pending_source.val = None
+  self.pending_count.val = 0
+  self.retry_budget.val = 0
+  self.repair_pending.val = false
+  self.retry_selection.val = None
+  self.in_flight_token.val = None
+  self.in_flight_count.val = None
+}
+
+///|
+fn RawInputCoordinator::is_active(
+  self : RawInputCoordinator,
+  token : Int,
+) -> Bool {
+  self.in_flight_token.val == Some(token)
+}
+
+///|
+fn RawInputCoordinator::cancel(self : RawInputCoordinator, token : Int) -> Unit {
+  if self.in_flight_token.val == Some(token) {
+    self.input_epoch.val += 1
+    self.in_flight_token.val = None
+    self.in_flight_count.val = None
+    self.repair_pending.val = false
+    self.retry_selection.val = None
+  }
+}
+
+///|
+/// Defer Raw input handling and retain only the latest native value.
+fn raw_input_command(
+  source : String,
+  coordinator : RawInputCoordinator,
+  emit : @cmd.Emit[DriverEvent],
+) -> @cmd.Cmd {
+  coordinator.enqueue(source, emit)
 }
 
 ///|

--- a/docs/research/2026-08-07-rabbita-cancelable-keyed-command-spec.md
+++ b/docs/research/2026-08-07-rabbita-cancelable-keyed-command-spec.md
@@ -1,0 +1,386 @@
+# Rabbita Cancelable and Keyed Delayed Commands
+
+**Date:** 2026-08-07
+**Status:** Draft specification included in a Canopy pull request
+**Publication:** No upstream Rabbita issue or comment was created.
+**Owner boundary:** Rabbita scheduler/runtime, with Loomark as the motivating consumer.
+
+## Problem Statement
+
+Loomark's Raw Markdown textarea becomes slow when the document is large. A
+browser probe over a roughly 20,000-character document found one native input
+event per keystroke and one textarea listener, but each event synchronously
+entered the editor transaction path. That path performs canonical-source
+commit, parser/projection refresh, snapshot construction, receipt/history
+work, and rendering on the browser's main thread.
+
+The clean baseline took approximately 1,343 ms for ten characters, with
+individual input work commonly around 100–150 ms. The current Loomark
+workaround keeps the textarea responsive by retaining the latest native value
+and using a 50 ms trailing debounce. It reduced the same typing probe to about
+77 ms of input-loop time and about 240 ms until the canonical model settled,
+with one commit instead of ten.
+
+The workaround also had to implement application-owned state for:
+
+- replacing an outstanding delayed input with a newer one;
+- invalidating stale timers and queued messages;
+- cancelling pending work when an external source or accepted snapshot wins;
+- retaining selection information across a rejected edit and retry;
+- preventing DOM repair after the Raw surface has disappeared; and
+- preventing callbacks from surviving application lifecycle changes.
+
+Rabbita already provides one-shot commands, delayed commands, scheduler
+message delivery, and post-render effects. Its long-lived subscriptions have
+an explicit unload lifecycle. Its delayed command primitive does not currently
+provide an equivalent cancellation or cleanup contract.
+
+Upstream Rabbita issue #139, “Cmd effects have no cancellation or cleanup
+lifecycle,” describes the same framework gap: an asynchronous or callback-based
+effect may continue after its owner is detached and may enqueue a stale
+message. That issue is directly relevant to lifecycle cleanup, but it does not
+by itself define keyed replacement or trailing-edge debounce semantics.
+
+## Solution
+
+Add an opt-in, lifecycle-aware scheduling primitive to Rabbita while keeping
+message coalescing an explicit application policy.
+
+From an application author's perspective:
+
+- a one-shot delayed command continues to be available;
+- a keyed debounce can replace an earlier pending command for the same purpose;
+- a keyed command can be cancelled before it starts;
+- pending commands are cleaned up when their owning application scope is
+  disposed; and
+- stale callbacks cannot deliver messages after cancellation or disposal.
+
+Loomark should continue to own the meaning of Raw input. Rabbita should only
+own the generic scheduling, replacement, cancellation, and lifecycle mechanics.
+
+The highest test seam is the Rabbita scheduler/runtime. Loomark integration is
+a secondary confirmation seam used after the generic primitive is proven.
+
+## User Stories
+
+1. As a Loomark user, I want the Raw textarea to accept keystrokes immediately,
+   so that editor computation does not block native text entry.
+2. As a Loomark user, I want rapid Raw edits to settle to the latest source,
+   so that Preview and the canonical document do not process ten redundant
+   full-source replacements.
+3. As a Loomark user, I want the latest source to appear in the controlled
+   textarea while a commit is pending, so that a rerender does not overwrite my
+   native input.
+4. As a Loomark user, I want a single isolated input to retain its current
+   behavior, so that debouncing does not require a burst of events to work.
+5. As a Loomark user, I want my caret and selection preserved when an edit is
+   rejected, so that deferred processing does not move the cursor unexpectedly.
+6. As a Loomark user, I want a newer edit to supersede an older repair, so that
+   an earlier callback cannot erase text I entered afterward.
+7. As a Loomark user, I want an edit that is pending while I leave Raw mode to
+   follow a defined policy, so that switching views cannot silently lose text.
+8. As a Loomark user, I want an explicit source replacement to supersede
+   pending native input, so that loading a preset or external source does not
+   get overwritten by an old timer.
+9. As a Loomark user, I want a valid snapshot restore to supersede pending Raw
+   input, so that an explicit restore remains authoritative.
+10. As a Loomark user, I want a rejected snapshot request to leave pending Raw
+    input intact, so that an invalid request does not discard valid user work.
+11. As a Loomark user, I want closing a split Preview or unmounting the editor
+    to stop obsolete DOM effects, so that missing controls do not produce
+    spurious errors.
+12. As a collaborator, I want the application to choose explicitly whether
+    input may be coalesced, so that CRDT operations and presence updates are
+    not silently dropped by a generic UI framework.
+13. As an application author, I want to schedule a delayed command under a
+    stable key, so that I can replace work for one purpose without affecting
+    unrelated delayed work.
+14. As an application author, I want different schedule keys to operate
+    independently, so that a search debounce cannot cancel a persistence
+    retry.
+15. As an application author, I want to cancel a pending command declaratively
+    from the update result, so that I do not have to retain an imperative timer
+    handle in model state.
+16. As an application author, I want cancellation to be scoped to one mounted
+    application, so that two mounted applications cannot cancel each other's
+    work by reusing a label.
+17. As an application author, I want cancellation to be safe when a callback is
+    already racing with the scheduler, so that a stale message cannot appear
+    merely because a timer callback reached the queue boundary.
+18. As an application author, I want existing fire-and-forget commands to keep
+    working without cleanup boilerplate, so that the new lifecycle contract is
+    backwards-compatible.
+19. As an application author, I want a cleanup callback to run at most once,
+    so that aborting a request, closing a scope, and completing a request do
+    not release the same resource twice.
+20. As an application author, I want cleanup to run when the owning component
+    or application is disposed, so that timers, listeners, and callback-based
+    effects do not outlive their owner.
+21. As a Rabbita maintainer, I want the scheduler to manage timer lifetime,
+    so that applications do not need generation counters solely because the
+    framework cannot cancel a timer.
+22. As a Rabbita maintainer, I want keyed replacement to be opt-in, so that
+    the framework never assumes that two messages with the same type are
+    semantically interchangeable.
+23. As a Rabbita maintainer, I want the API to work with the existing Command
+    and Scheduler model, so that applications do not need a second effect
+    system.
+24. As a Rabbita maintainer, I want runtime tests to use deterministic timer
+    control, so that cancellation and race behavior can be verified without
+    wall-clock sleeps.
+25. As a Rabbita maintainer, I want disposal behavior to work across supported
+    JavaScript and browser runtimes, so that lifecycle guarantees do not depend
+    on one test harness.
+26. As a Canopy maintainer, I want editor-specific selection repair to remain
+    outside Rabbita, so that the UI framework does not acquire Markdown or
+    UTF-16 domain semantics.
+27. As a Canopy maintainer, I want the editor's text-diff optimization to
+    remain in the editor façade, so that scheduler changes do not become a
+    prerequisite for core editing correctness.
+28. As a performance investigator, I want to distinguish input-loop latency
+    from canonical-settle latency, so that a debounce does not appear to be a
+    false zero-cost optimization.
+29. As a reviewer, I want tests to assert external behavior rather than
+    internal generation counters, so that the implementation can change while
+    lifecycle and ordering guarantees remain protected.
+30. As a library consumer, I want the existing non-keyed delay behavior to
+    remain available, so that adopting keyed scheduling is incremental rather
+    than a forced migration.
+
+## Implementation Decisions
+
+### Ownership boundary
+
+Rabbita owns generic effect scheduling:
+
+- delayed execution;
+- keyed replacement;
+- cancellation before execution;
+- cleanup registration;
+- scheduler/application disposal; and
+- stale callback suppression at the scheduler boundary.
+
+The application owns domain semantics:
+
+- whether a message can be coalesced;
+- which value is the latest authoritative value;
+- whether a failed message should be retried;
+- how selection, focus, persistence, collaboration, and canonical source are
+  reconciled; and
+- whether an external operation supersedes pending user input.
+
+The framework must not inspect message variants or automatically merge all
+input events.
+
+### Public naming
+
+Use an opaque `ScheduleKey` for the identity of scheduled work. The key is
+scoped to the owning Scheduler/application and must not be globally shared
+state.
+
+Use `debounce` for an opt-in trailing-edge replacement operation. The name
+communicates that a newer command for the same key resets the wait and replaces
+the older pending command.
+
+Use `cancel` for the declarative cancellation operation. Keep the existing
+`delay` primitive for independent one-shot work whose prior instances must not
+be replaced.
+
+Use `delay_ms` as the public duration label. It is clearer at call sites than a
+bare integer and preserves the fact that the duration is wall-clock scheduling,
+not a frame count.
+
+### Command contract
+
+A debounced command has these semantics:
+
+- scheduling a key replaces the not-yet-started command currently registered
+  for that key;
+- the replacement waits for the complete delay after the latest schedule;
+- when the command starts, the key is no longer pending;
+- cancelling a key prevents its pending command from starting;
+- cancellation is best-effort once execution has already begun;
+- a callback that races with cancellation must check its active generation
+  before enqueuing a message; and
+- a disposed owner prevents both new effect delivery and stale message
+  delivery.
+
+The command remains declarative. Applications request scheduling or
+cancellation by returning Commands; they do not store mutable timer handles in
+their domain model.
+
+### Cleanup contract
+
+Extend the effect lifecycle without breaking existing fire-and-forget effects.
+An effect may optionally provide an idempotent cleanup operation. The runtime
+invokes cleanup when the owning scope is disposed or when a keyed pending effect
+is replaced/cancelled, according to the effect's ownership contract.
+
+Cleanup must not be assumed to interrupt arbitrary synchronous work already in
+progress. It must prevent future callbacks and future message delivery where
+the runtime controls the boundary.
+
+The runtime must define whether cleanup is associated with the whole mounted
+application, a component/state-machine scope, or both. The scope must be
+stable and explicit; a command returned from one mounted application must not
+be cancelled by a second application that happens to use the same key label.
+
+### Keyed scheduling scope
+
+Keys are scheduler-local. A human-readable namespace may be used to construct
+or debug a key, but identity must not depend on a process-global mutable map.
+This keeps multiple tabs, tests, and independent mounts isolated.
+
+The initial feature should support one keyed trailing-edge policy. A general
+`throttle`, `sample`, or multi-message buffer should not be added until a
+separate use case establishes its semantics.
+
+### Framework and application interaction
+
+The generic primitive accepts a complete Command. It does not need to know the
+payload type or how the command was produced. Loomark can therefore continue
+to read the Raw selection at command execution time and attach its own
+application-level validation and repair checks.
+
+The framework's cancellation contract is a prerequisite for simplifying
+Loomark's timer and stale-callback bookkeeping, but it does not replace
+Loomark's input epoch, source conflict policy, or selection repair.
+
+### Rendering and post-render effects
+
+The existing post-render phase remains an explicit DOM effect phase. A generic
+keyed delayed command must not automatically decide whether a post-render write
+is still valid against the current model. The application continues to provide
+model revision, mode, surface availability, and input-epoch checks for DOM
+repair.
+
+A future keyed post-render effect may reuse the same lifecycle machinery, but it
+is not required for the first implementation unless the runtime can specify
+clear ordering and disposal guarantees.
+
+### Compatibility and migration
+
+Existing delayed commands remain valid and retain their current independent
+one-shot behavior. The new keyed API is additive.
+
+Loomark can migrate its timer replacement and disposal mechanism first, then
+retain its domain-specific coordinator for pending source, selection, retry,
+and canonical-source conflict decisions.
+
+The text-diff reuse change in the Canopy editor façade is independent of this
+Rabbita specification and must not be folded into the framework API.
+
+## Testing Decisions
+
+### Test seam
+
+Use the highest existing seam: the Rabbita scheduler/runtime harness. The
+runtime already has lifecycle-oriented subscription tests with controllable
+browser callbacks and explicit unload assertions. Extend that style with a
+controllable timer backend or timer harness rather than using real 50 ms sleeps.
+
+A small integration seam in Loomark should remain as a regression guard, but it
+should not be the primary proof of generic scheduler behavior.
+
+### External behavior over implementation details
+
+Tests should observe:
+
+- which Commands run;
+- which messages reach the update loop;
+- whether cleanup ran and ran only once;
+- whether replacement leaves only the latest command;
+- whether cancellation suppresses future delivery; and
+- whether disposal suppresses future delivery.
+
+Tests should not assert a particular generation counter, map layout, timer ID,
+or internal Ref arrangement.
+
+### Required scheduler/runtime cases
+
+1. A non-keyed delayed command still runs once.
+2. Two different keys both run independently.
+3. Scheduling the same key twice runs only the latest command.
+4. Repeated same-key scheduling waits from the latest call, proving trailing
+   debounce rather than fixed-window coalescing.
+5. Cancelling a pending key prevents its command and message.
+6. Cancelling an unknown or already-fired key is harmless.
+7. Replacing a key invokes cleanup for the superseded pending effect exactly
+   once when cleanup is registered.
+8. Application disposal invokes cleanup for every pending keyed effect.
+9. Disposal is idempotent.
+10. A callback that reaches the timer boundary after cancellation cannot enqueue
+    a stale message.
+11. A callback that has already started follows the documented best-effort
+    cancellation contract.
+12. Key reuse after a command fires creates a fresh schedule.
+13. Keys from separate scheduler/application instances do not interfere.
+14. Existing fire-and-forget effects require no cleanup callback.
+15. Supported JavaScript/browser targets compile and execute the same lifecycle
+    contract.
+
+### Loomark integration cases
+
+After the generic runtime tests pass, retain or add external-behavior tests for:
+
+- rapid Raw typing settling to the latest source;
+- one commit for a same-task input burst;
+- pending Raw input surviving a mode change;
+- external source replacement superseding pending Raw input;
+- valid snapshot restore superseding pending Raw input;
+- rejected snapshot restore preserving pending Raw input;
+- rejected Raw input preserving selection and avoiding stale repair; and
+- split Preview closing before repair without a missing-DOM error.
+
+The existing browser benchmark should report both input-loop latency and
+canonical-settle latency, plus commit count. The performance target is not zero
+settle latency; it is prompt native input with bounded and observable deferred
+settling.
+
+### Prior art
+
+The scheduler lifecycle tests should follow Rabbita's existing subscription
+cleanup and retained-subscription/tagger-refresh tests. Loomark integration
+should follow its existing fresh-context browser tests and snapshot-based
+external behavior assertions. Canopy's prior browser performance notes already
+separate input handling, model refresh, rendering, and paint timing; the new
+benchmark should preserve that phase distinction.
+
+## Out of Scope
+
+- Automatically debouncing every DOM input event.
+- Automatically dropping or merging arbitrary Rabbita Messages.
+- Choosing whether CRDT operations, undo entries, presence updates, or
+  persistence writes may be coalesced.
+- Markdown parsing, projection, snapshot, or history optimization.
+- UTF-16 selection mapping, focus restoration, or controlled-input repair.
+- Worker offload or background parsing.
+- A general stream-processing, throttle, sample, or buffer API.
+- Replacing the existing `Sub` lifecycle model; subscriptions remain the owner
+  of long-lived external signals.
+- Changing the public behavior of existing non-keyed delayed Commands.
+- Editing or publishing the upstream Rabbita GitHub issue from this repository.
+- Updating Canopy's vendored Rabbita submodule as part of this local
+  specification.
+
+## Further Notes
+
+This specification is local-only by request. Upstream issue #139 is a reference
+for the lifecycle gap, not a publication target for this document.
+
+The most important distinction is between **cancellation** and **coalescing**:
+
+- cancellation is a framework resource/lifecycle guarantee;
+- coalescing is an application semantic decision;
+- debounce is a reusable opt-in scheduling policy built on cancellation; and
+- domain repair remains an application responsibility.
+
+The current Loomark workaround demonstrates that this split is practical. A
+Rabbita lifecycle-aware keyed scheduler would remove timer and stale-callback
+plumbing, but it would not remove the need for a Loomark-level policy object
+that understands canonical source, selection, editor rejection, and external
+source authority.
+
+No upstream Rabbita issue or comment was created while writing this
+specification. The document is included in a Canopy pull request as a local
+analysis/specification; it does not propose publishing to the Rabbita tracker.

--- a/modules/canopy/editor/markdown/editor.mbt
+++ b/modules/canopy/editor/markdown/editor.mbt
@@ -753,14 +753,22 @@ fn MarkdownEditor::commit_recording_transforms(
       } else {
         // The synchronization edit returns the same splice used internally,
         // so the receipt does not compute the text diff a second time.
-        let change = self.editor.set_text_with_change(source)
-        self.editor.refresh()
-        Ok(
-          (
-            MarkdownCommitResult::Applied(self.snapshot(), None),
-            @vector.Vector::singleton(MarkdownTextTransform::{ change, }),
-          ),
-        )
+        let (change, accepted) = self.editor.set_text_with_change(source)
+        if accepted {
+          self.editor.refresh()
+          Ok(
+            (
+              MarkdownCommitResult::Applied(self.snapshot(), None),
+              @vector.Vector::singleton(MarkdownTextTransform::{ change, }),
+            ),
+          )
+        } else {
+          Err(
+            MarkdownEditorError::EditFailed(
+              detail="source replacement rejected",
+            ),
+          )
+        }
       }
     }
     ReplaceText(start~, delete_len~, inserted~) => {

--- a/modules/canopy/editor/markdown/editor.mbt
+++ b/modules/canopy/editor/markdown/editor.mbt
@@ -751,10 +751,9 @@ fn MarkdownEditor::commit_recording_transforms(
       if before == source {
         Ok((MarkdownCommitResult::Unchanged(self.snapshot()), @vector.new()))
       } else {
-        // set_text uses this same shared splice contract. Computing it here is
-        // the only path without caller- or lowering-supplied edit information.
-        let change = @text_change.compute_text_change(before, source)
-        self.editor.set_text(source)
+        // The synchronization edit returns the same splice used internally,
+        // so the receipt does not compute the text diff a second time.
+        let change = self.editor.set_text_with_change(source)
         self.editor.refresh()
         Ok(
           (

--- a/modules/canopy/editor/pkg.generated.mbti
+++ b/modules/canopy/editor/pkg.generated.mbti
@@ -206,7 +206,7 @@ pub fn[T] SyncEditor::set_local_presence(Self[T], String, String, selection? : (
 pub fn[T] SyncEditor::set_on_status_change(Self[T], ((@sync_session.SyncStatus) -> Unit)?) -> Unit
 pub fn[T : Eq] SyncEditor::set_text(Self[T], String) -> Unit
 pub fn[T : Eq] SyncEditor::set_text_and_record(Self[T], String, Int) -> Unit
-pub fn[T : Eq] SyncEditor::set_text_with_change(Self[T], String) -> @text_change.TextChange
+pub fn[T : Eq] SyncEditor::set_text_with_change(Self[T], String) -> (@text_change.TextChange, Bool)
 pub fn[T] SyncEditor::set_tracking(Self[T], Bool) -> Unit
 pub fn[T] SyncEditor::set_watchdog_scheduler(Self[T], ((Int, Int) -> Unit)?) -> Unit
 pub fn[T] SyncEditor::set_watchdog_timeout(Self[T], Int) -> Unit

--- a/modules/canopy/editor/pkg.generated.mbti
+++ b/modules/canopy/editor/pkg.generated.mbti
@@ -16,6 +16,7 @@ import {
   "dowdiness/loom/pipeline",
   "dowdiness/pretty",
   "dowdiness/seam",
+  "dowdiness/text_change",
   "moonbitlang/core/debug",
 }
 
@@ -205,6 +206,7 @@ pub fn[T] SyncEditor::set_local_presence(Self[T], String, String, selection? : (
 pub fn[T] SyncEditor::set_on_status_change(Self[T], ((@sync_session.SyncStatus) -> Unit)?) -> Unit
 pub fn[T : Eq] SyncEditor::set_text(Self[T], String) -> Unit
 pub fn[T : Eq] SyncEditor::set_text_and_record(Self[T], String, Int) -> Unit
+pub fn[T : Eq] SyncEditor::set_text_with_change(Self[T], String) -> @text_change.TextChange
 pub fn[T] SyncEditor::set_tracking(Self[T], Bool) -> Unit
 pub fn[T] SyncEditor::set_watchdog_scheduler(Self[T], ((Int, Int) -> Unit)?) -> Unit
 pub fn[T] SyncEditor::set_watchdog_timeout(Self[T], Int) -> Unit

--- a/modules/canopy/editor/sync_editor.mbt
+++ b/modules/canopy/editor/sync_editor.mbt
@@ -469,13 +469,15 @@ pub fn[T : Eq] SyncEditor::apply_span_edits(
   let sorted = edits.copy()
   sorted.sort_by(fn(a, b) { b.start.compare(a.start) })
   for edit in sorted {
-    self.apply_text_edit_internal(
-      edit.start,
-      edit.delete_len,
-      edit.inserted,
-      timestamp_ms,
-      true, // record_undo — grouped by capture timeout
-      false, // move_cursor_to_edit_end
+    ignore(
+      self.apply_text_edit_internal(
+        edit.start,
+        edit.delete_len,
+        edit.inserted,
+        timestamp_ms,
+        true, // record_undo — grouped by capture timeout
+        false, // move_cursor_to_edit_end
+      ),
     )
   }
   // Drop a pre-pushed hint when the batch produced no text change (T4).

--- a/modules/canopy/editor/sync_editor_text.mbt
+++ b/modules/canopy/editor/sync_editor_text.mbt
@@ -384,6 +384,34 @@ pub fn[T : Eq] SyncEditor::apply_text_edit_exact(
 }
 
 ///|
+/// Replace the document text with `new_text` and return the exact splice used.
+///
+/// Like `set_text`, this is a bulk synchronization operation: it does not
+/// record undo history and moves the cursor to the end of the replacement.
+/// Returning the splice lets façade callers reuse the text-diff result when
+/// they need to publish a transform alongside the edit.
+pub fn[T : Eq] SyncEditor::set_text_with_change(
+  self : SyncEditor[T],
+  new_text : String,
+) -> @text_change.TextChange {
+  let old_text = self.doc.text()
+  let splice = @text_change.compute_text_change(old_text, new_text)
+  if splice.is_noop() {
+    return splice
+  }
+  self.taint_pending_transforms()
+  self.apply_text_edit_internal(
+    splice.start,
+    splice.delete_len,
+    splice.inserted,
+    0,
+    false,
+    true,
+  )
+  splice
+}
+
+///|
 /// Replace the document text with `new_text` via a single range edit.
 ///
 /// **CRDT position caveat:** `replace_range` inserts all characters as a
@@ -400,20 +428,7 @@ pub fn[T : Eq] SyncEditor::set_text(
   self : SyncEditor[T],
   new_text : String,
 ) -> Unit {
-  let old_text = self.doc.text()
-  if old_text == new_text {
-    return
-  }
-  self.taint_pending_transforms()
-  let splice = @text_change.compute_text_change(old_text, new_text)
-  self.apply_text_edit_internal(
-    splice.start,
-    splice.delete_len,
-    splice.inserted,
-    0,
-    false,
-    true,
-  )
+  ignore(self.set_text_with_change(new_text))
 }
 
 ///|

--- a/modules/canopy/editor/sync_editor_text.mbt
+++ b/modules/canopy/editor/sync_editor_text.mbt
@@ -335,17 +335,15 @@ fn[T : Eq] SyncEditor::apply_text_edit_internal(
   timestamp_ms : Int,
   record_undo : Bool,
   move_cursor_to_edit_end : Bool,
-) -> Unit {
-  ignore(
-    self.apply_text_edit_with_policy(
-      start,
-      deleted_len,
-      inserted,
-      timestamp_ms,
-      record_undo,
-      move_cursor_to_edit_end,
-      SnapToGrapheme,
-    ),
+) -> Bool {
+  self.apply_text_edit_with_policy(
+    start,
+    deleted_len,
+    inserted,
+    timestamp_ms,
+    record_undo,
+    move_cursor_to_edit_end,
+    SnapToGrapheme,
   )
 }
 
@@ -358,8 +356,10 @@ pub fn[T : Eq] SyncEditor::apply_text_edit(
   timestamp_ms : Int,
 ) -> Unit {
   self.taint_pending_transforms()
-  self.apply_text_edit_internal(
-    start, deleted_len, inserted, timestamp_ms, true, true,
+  ignore(
+    self.apply_text_edit_internal(
+      start, deleted_len, inserted, timestamp_ms, true, true,
+    ),
   )
 }
 
@@ -384,7 +384,8 @@ pub fn[T : Eq] SyncEditor::apply_text_edit_exact(
 }
 
 ///|
-/// Replace the document text with `new_text` and return the exact splice used.
+/// Replace the document text with `new_text` and return the exact splice used
+/// together with whether the edit was accepted.
 ///
 /// Like `set_text`, this is a bulk synchronization operation: it does not
 /// record undo history and moves the cursor to the end of the replacement.
@@ -393,14 +394,14 @@ pub fn[T : Eq] SyncEditor::apply_text_edit_exact(
 pub fn[T : Eq] SyncEditor::set_text_with_change(
   self : SyncEditor[T],
   new_text : String,
-) -> @text_change.TextChange {
+) -> (@text_change.TextChange, Bool) {
   let old_text = self.doc.text()
   let splice = @text_change.compute_text_change(old_text, new_text)
   if splice.is_noop() {
-    return splice
+    return (splice, true)
   }
   self.taint_pending_transforms()
-  self.apply_text_edit_internal(
+  let accepted = self.apply_text_edit_internal(
     splice.start,
     splice.delete_len,
     splice.inserted,
@@ -408,7 +409,7 @@ pub fn[T : Eq] SyncEditor::set_text_with_change(
     false,
     true,
   )
-  splice
+  (splice, accepted)
 }
 
 ///|
@@ -445,7 +446,9 @@ pub fn[T : Eq] SyncEditor::insert_at(
     return
   }
   self.taint_pending_transforms()
-  self.apply_text_edit_internal(position, 0, text, timestamp_ms, true, false)
+  ignore(
+    self.apply_text_edit_internal(position, 0, text, timestamp_ms, true, false),
+  )
 }
 
 ///|
@@ -462,7 +465,9 @@ pub fn[T : Eq] SyncEditor::delete_at(
     return false
   }
   self.taint_pending_transforms()
-  self.apply_text_edit_internal(position, 1, "", timestamp_ms, true, false)
+  ignore(
+    self.apply_text_edit_internal(position, 1, "", timestamp_ms, true, false),
+  )
   true
 }
 
@@ -478,12 +483,14 @@ pub fn[T : Eq] SyncEditor::set_text_and_record(
   }
   self.taint_pending_transforms()
   let splice = @text_change.compute_text_change(old_text, new_text)
-  self.apply_text_edit_internal(
-    splice.start,
-    splice.delete_len,
-    splice.inserted,
-    timestamp_ms,
-    true,
-    false,
+  ignore(
+    self.apply_text_edit_internal(
+      splice.start,
+      splice.delete_len,
+      splice.inserted,
+      timestamp_ms,
+      true,
+      false,
+    ),
   )
 }

--- a/modules/canopy/editor/sync_editor_text_wbtest.mbt
+++ b/modules/canopy/editor/sync_editor_text_wbtest.mbt
@@ -1,6 +1,17 @@
 // Whitebox tests for position-based edit API (insert_at / delete_at).
 
 ///|
+test "set_text_with_change returns the applied splice" {
+  let editor = try! @probe.new_test_editor("test-agent")
+  editor.set_text("hello")
+  let change = editor.set_text_with_change("hello!")
+  inspect(change.start, content="5")
+  inspect(change.delete_len, content="0")
+  inspect(change.inserted, content="!")
+  inspect(editor.get_text(), content="hello!")
+}
+
+///|
 test "insert_at inserts at specified position without moving cursor" {
   let editor = try! @probe.new_test_editor("test-agent")
   editor.set_text("hello")

--- a/modules/canopy/editor/sync_editor_text_wbtest.mbt
+++ b/modules/canopy/editor/sync_editor_text_wbtest.mbt
@@ -4,11 +4,24 @@
 test "set_text_with_change returns the applied splice" {
   let editor = try! @probe.new_test_editor("test-agent")
   editor.set_text("hello")
-  let change = editor.set_text_with_change("hello!")
+  let (change, accepted) = editor.set_text_with_change("hello!")
+  assert_true(accepted)
   inspect(change.start, content="5")
   inspect(change.delete_len, content="0")
   inspect(change.inserted, content="!")
   inspect(editor.get_text(), content="hello!")
+}
+
+///|
+test "set_text_with_change returns a replacement splice" {
+  let editor = try! @probe.new_test_editor("replacement-agent")
+  editor.set_text("hello")
+  let (change, accepted) = editor.set_text_with_change("jello")
+  assert_true(accepted)
+  inspect(change.start, content="0")
+  inspect(change.delete_len, content="1")
+  inspect(change.inserted, content="j")
+  inspect(editor.get_text(), content="jello")
 }
 
 ///|

--- a/modules/canopy/editor/sync_editor_tree_edit.mbt
+++ b/modules/canopy/editor/sync_editor_tree_edit.mbt
@@ -47,13 +47,15 @@ pub fn[T : Eq + @loom_core.Renderable] SyncEditor::delete_node(
   }
   let placeholder = @loom_core.Renderable::placeholder(node.kind)
   let delete_len = range.end - range.start
-  self.apply_text_edit_internal(
-    range.start,
-    delete_len,
-    placeholder,
-    timestamp_ms,
-    true,
-    false,
+  ignore(
+    self.apply_text_edit_internal(
+      range.start,
+      delete_len,
+      placeholder,
+      timestamp_ms,
+      true,
+      false,
+    ),
   )
   Ok(())
 }
@@ -78,13 +80,15 @@ pub fn[T : Eq] SyncEditor::commit_edit(
     Some(r) => r
   }
   let delete_len = range.end - range.start
-  self.apply_text_edit_internal(
-    range.start,
-    delete_len,
-    new_text,
-    timestamp_ms,
-    true,
-    true,
+  ignore(
+    self.apply_text_edit_internal(
+      range.start,
+      delete_len,
+      new_text,
+      timestamp_ms,
+      true,
+      true,
+    ),
   )
   Ok(())
 }
@@ -120,13 +124,15 @@ pub fn[T : Eq] SyncEditor::apply_text_transform(
     Ok(r) => r
   }
   let delete_len = range.end - range.start
-  self.apply_text_edit_internal(
-    range.start,
-    delete_len,
-    replacement,
-    timestamp_ms,
-    true,
-    false,
+  ignore(
+    self.apply_text_edit_internal(
+      range.start,
+      delete_len,
+      replacement,
+      timestamp_ms,
+      true,
+      false,
+    ),
   )
   Ok(())
 }


### PR DESCRIPTION
## Summary

- Coalesce only Raw Markdown native input with a 50 ms trailing boundary, retaining the latest displayed value while the canonical editor transaction is pending.
- Guard delayed input, retry, external replacement, snapshot restore, mode changes, and DOM repair with generations, input epochs, and in-flight tokens.
- Reuse the exact `TextChange` splice from `SyncEditor::set_text_with_change` when publishing Markdown commit transforms.
- Include the local Rabbita `ScheduleKey` / `debounce` / `cancel` analysis and specification.

## Why

Large Raw documents previously performed an expensive synchronous editor commit for every native input event. The isolated browser probe measured roughly 1,343 ms for ten characters in a 250-block document. The optimized probe reached approximately 77 ms of typing-loop time, approximately 240 ms until settling, and one canonical commit.

This PR keeps Markdown-specific source authority, UTF-16 selection repair, retry, and Preview semantics in Loomark. The accompanying Rabbita document records the reusable framework boundary: scheduling and lifecycle primitives belong in Rabbita; coalescing policy and domain repair belong in the application.

Rabbita PR #125 (VDOM diff optimization) is related only as a separate rendering optimization candidate; it is not changed or vendored by this PR.

## UI and review evidence

- Visible labels and accessible names: N/A; no labels were removed.
- Interactive bounds, pointer feedback, and viewport reflow: existing UI behavior was covered by the browser suite; no visual layout change was introduced.
- Review findings: the stale Raw-versus-Block ordering race and invalid Raw repair after leaving Raw were fixed with regression coverage.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `@cmd.delay`, `@cmd.custom_cmd`, `@cmd.batch`, `@cmd.Emit` | Rabbita command API | Yes | Existing declarative command and timer seams are retained; the application adds generation guards because keyed cancellation is not yet available. |
| `@dom_boundary.read_text_selection_id` / `write_text_selection_id` | DOM boundary adapter | Yes | Existing UTF-16 selection boundary is reused; Loomark remains responsible for repair eligibility. |
| `@text_change.compute_text_change` | `dowdiness/text_change` | Yes | The existing pure contiguous-diff implementation supplies the splice. |
| `SyncEditor::set_text` | Canopy editor | Extended | The existing bulk replacement behavior is preserved; `set_text_with_change` exposes the already-applied splice so the Markdown façade does not compute it twice. |
| MoonBit `Ref`, `Option` (`T?`), `String`, and `Result` | MoonBit core / project APIs | Yes | `Ref` holds shell-local coordinator state; optional tokens/selections and commit results preserve existing error/absence contracts. |

New helpers added:

- `RawInputCoordinator`: application-shell state for latest Raw source, trailing scheduling, retry, epochs, and in-flight token validation. It is Loomark-specific and intentionally private because Rabbita does not yet provide keyed cancellation.
- `raw_input_repair_eligible`: pure decision boundary for whether the Raw control is still rendered, including split Preview.
- `commit_block_toolbar_request` now returns whether a source change was applied so a newer structural edit can supersede pending Raw input without cancelling on a no-op.
- `SyncEditor::set_text_with_change`: exposes the splice produced by the editor's own replacement operation; this avoids duplicate diff computation at the Markdown receipt boundary.

## Validation scope

Boundary matrix / first failing regression:

- Same-task Raw burst coalesces to one commit.
- Pending Raw input survives a mode change when no newer canonical edit occurs.
- A newer Block edit, external source replacement, or accepted snapshot restore supersedes pending Raw input.
- Rejected snapshot restore preserves pending Raw input.
- Rejected Raw input preserves selection when Raw remains rendered.
- Rejected pending Raw input does not write to a removed Raw control in Block mode or closed Preview mode.
- LF, CRLF, CR, EOF, and empty-EOF source transport remain unchanged.

Target packages:

- `apps/loomark/internal/rabbita`
- `modules/canopy/editor`

Additional conditional gates:

- JavaScript dev-host artifact build.
- Dev-host TypeScript typecheck.
- Playwright dev-host E2E: 79 passed.
- Standalone production E2E was not run because the Warren binary is unavailable in this environment.

## PR-ready evidence

Validated HEAD: `b53ce6313cdcc160bed430884c1b4e38fa8e11e0`

Validated base: `origin/main@25d793b4aed3a7c6f9a7c908f649310b822c394c`

```bash
./scripts/validate-pr-ready.sh \
  --target apps/loomark/internal/rabbita \
  --target modules/canopy/editor
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for the exact HEAD and base above.
- [x] `--verify-evidence` passed immediately before opening this PR.
- [x] The committed `.mbti` diff was reviewed; it contains only the intended `SyncEditor::set_text_with_change` export/import.
- [x] No submodule pointer was changed.
- [x] Independent read-only review was run after the final fixes; no high-confidence blockers remain.

Full workspace validation also passed: `moon test` reported 4,474 passed tests before the final browser-only coverage additions; targeted final validation passed the affected package suites (26 Rabbita tests and 233 editor tests).

## Documentation

The local specification is included at:

`docs/research/2026-08-07-rabbita-cancelable-keyed-command-spec.md`

It documents the problem, extensive user stories, ownership boundary, proposed `ScheduleKey` / `debounce` / `cancel` contract, issue #139 relationship, testing seam, and out-of-scope decisions. No issue or comment was created in the Rabbita repository.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Raw editor input handling so rapid typing is consolidated reliably.
  - Preserved pending edits and text selection when switching modes or restoring snapshots.
  - Prevented stale or rejected updates from overwriting newer content.
  - Improved recovery after external edits, blocked operations, and editor lifecycle changes.
  - Prevented unwanted repairs when Raw or Preview controls are closed.
- **Improvements**
  - Source replacements now apply precise text changes while avoiding unnecessary updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->