### PR TITLE
fix(loomark): simplify the mobile page frame

### DIFF
--- a/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
+++ b/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
@@ -369,6 +369,11 @@ test("Raw keeps focus and accepts consecutive keystrokes while split Preview upd
   const host = await mountHost(browser, "start")
   try {
     await toggleSplitPreview(host.page)
+    // The split toggle re-renders the editor subtree, replacing the Raw
+    // textarea with a fresh node. Wait for the split frame to settle before
+    // focusing: focusing a still-scheduled predecessor would lose focus when
+    // the patch detaches it, and the app never re-focuses the Raw control.
+    await expect(host.page.locator("#loomark-split")).toBeVisible()
     const input = host.page.locator("#loomark-input")
     await input.focus()
     await input.evaluate(element => {

--- a/apps/loomark/examples/vanilla/tests/standalone.spec.ts
+++ b/apps/loomark/examples/vanilla/tests/standalone.spec.ts
@@ -184,11 +184,36 @@ test("Raw, Block, and Preview editing stays inside the original production root"
   await expect(root).toHaveCount(1)
 })
 
-test("mobile page frame drops desktop rails in a stacked split", async ({ page }) => {
+test("Preview wraps long unbreakable content inside the reading frame", async ({ page }) => {
+  await page.goto("/")
+  const longUrl = `https://example.com/${`a`.repeat(200)}`
+  const source =
+    `# Long content\n\nVisit ${longUrl} and read this paragraph.\n\nInline code: \`${`x`.repeat(150)}\`\n`
+  await page.locator("#loomark-input").fill(source)
+  await page.locator("#loomark-mode-preview").click()
+  const preview = page.locator("#loomark-preview")
+  await expect(preview).toHaveAttribute("data-loomark-source", source)
+  // Long URLs and inline code wrap inside the reading frame instead of
+  // stretching the Preview pane into a horizontal scroll.
+  await expect
+    .poll(async () => preview.evaluate(el => el.scrollWidth > el.clientWidth))
+    .toBe(false)
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () => document.documentElement.scrollWidth > window.innerWidth,
+      ),
+    )
+    .toBe(false)
+})
+
+test("frames stay borderless and only the split divider separates panes", async ({ page }) => {
   await page.goto("/")
 
   const raw = page.locator("#loomark-input")
-  await expect(raw).toHaveCSS("border-left-width", "1px")
+  // Raw keeps RUI's transparent control border; no side rail is drawn.
+  await expect(raw).toHaveCSS("border-left-color", "rgba(0, 0, 0, 0)")
+  await expect(raw).toHaveCSS("border-right-color", "rgba(0, 0, 0, 0)")
   await expect(raw).toHaveCSS("padding-left", "16px")
 
   await page.setViewportSize({ width: 640, height: 844 })
@@ -201,12 +226,20 @@ test("mobile page frame drops desktop rails in a stacked split", async ({ page }
     "aria-orientation",
     "horizontal",
   )
+  // The resizable handle line is the only divider between the panes.
+  await expect(
+    split.locator('[data-slot="resizable-handle-line"]'),
+  ).toBeVisible()
 
   const preview = page.locator("#loomark-preview")
   await expect(preview).toHaveAttribute("data-loomark-source", "# Narrow\n")
+  // Raw keeps RUI's transparent control border (1px, no visible rail);
+  // Preview carries no side border at all. Neither frame draws a rail.
+  await expect(raw).toHaveCSS("border-left-color", "rgba(0, 0, 0, 0)")
+  await expect(raw).toHaveCSS("border-right-color", "rgba(0, 0, 0, 0)")
+  await expect(preview).toHaveCSS("border-left-width", "0px")
+  await expect(preview).toHaveCSS("border-right-width", "0px")
   for (const frame of [raw, preview]) {
-    await expect(frame).toHaveCSS("border-left-width", "0px")
-    await expect(frame).toHaveCSS("border-right-width", "0px")
     await expect(frame).toHaveCSS("padding-left", "12px")
     await expect(frame).toHaveCSS("padding-right", "12px")
     await expect(frame).toHaveCSS("width", "640px")

--- a/apps/loomark/examples/vanilla/tests/standalone.spec.ts
+++ b/apps/loomark/examples/vanilla/tests/standalone.spec.ts
@@ -214,6 +214,10 @@ test("mobile page frame drops desktop rails in a stacked split", async ({ page }
 
   await page.locator("#loomark-mode-block").click()
   await expect(page.locator("#loomark-block")).toHaveCSS("padding-left", "12px")
+  const blockFrame = page.locator("#loomark-block-frame")
+  await expect(blockFrame).toHaveCSS("border-left-width", "0px")
+  await expect(blockFrame).toHaveCSS("border-right-width", "0px")
+  await expect(blockFrame).toHaveCSS("width", "640px")
   await expect(page.getByRole("toolbar", { name: "Block formatting" })).toHaveCSS(
     "padding-left",
     "12px",

--- a/apps/loomark/examples/vanilla/tests/standalone.spec.ts
+++ b/apps/loomark/examples/vanilla/tests/standalone.spec.ts
@@ -184,10 +184,15 @@ test("Raw, Block, and Preview editing stays inside the original production root"
   await expect(root).toHaveCount(1)
 })
 
-test("narrow standalone editing keeps one document in a stacked split", async ({ page }) => {
-  await page.setViewportSize({ width: 390, height: 844 })
+test("mobile page frame drops desktop rails in a stacked split", async ({ page }) => {
   await page.goto("/")
-  await page.locator("#loomark-input").fill("# Narrow\n")
+
+  const raw = page.locator("#loomark-input")
+  await expect(raw).toHaveCSS("border-left-width", "1px")
+  await expect(raw).toHaveCSS("padding-left", "16px")
+
+  await page.setViewportSize({ width: 640, height: 844 })
+  await raw.fill("# Narrow\n")
   await page.locator("#loomark-split-toggle").click()
 
   const split = page.locator("#loomark-split")
@@ -196,9 +201,22 @@ test("narrow standalone editing keeps one document in a stacked split", async ({
     "aria-orientation",
     "horizontal",
   )
-  await expect(page.locator("#loomark-preview")).toHaveAttribute(
-    "data-loomark-source",
-    "# Narrow\n",
+
+  const preview = page.locator("#loomark-preview")
+  await expect(preview).toHaveAttribute("data-loomark-source", "# Narrow\n")
+  for (const frame of [raw, preview]) {
+    await expect(frame).toHaveCSS("border-left-width", "0px")
+    await expect(frame).toHaveCSS("border-right-width", "0px")
+    await expect(frame).toHaveCSS("padding-left", "12px")
+    await expect(frame).toHaveCSS("padding-right", "12px")
+    await expect(frame).toHaveCSS("width", "640px")
+  }
+
+  await page.locator("#loomark-mode-block").click()
+  await expect(page.locator("#loomark-block")).toHaveCSS("padding-left", "12px")
+  await expect(page.getByRole("toolbar", { name: "Block formatting" })).toHaveCSS(
+    "padding-left",
+    "12px",
   )
   await expect(page.locator("#loomark-root")).toHaveCount(1)
 })

--- a/apps/loomark/internal/rabbita/application.mbt
+++ b/apps/loomark/internal/rabbita/application.mbt
@@ -319,7 +319,7 @@ fn preview_document_view(model : DriverModel) -> @rabbita_runtime.Html {
           .tabindex(0)
           .aria_label("Markdown preview"),
         style=[
-          "box-sizing:border-box;width:min(calc(100% - 4rem),46rem);margin-inline:auto;display:grid;gap:1rem;grid-auto-rows:max-content;border-left:1px solid var(--rui-border);border-right:1px solid var(--rui-border);border-top:0;border-bottom:0;border-radius:0;background:transparent;padding:1rem;overflow-y:auto",
+          "box-sizing:border-box;width:var(--lm-page-width);margin-inline:auto;display:grid;gap:1rem;grid-auto-rows:max-content;border-left:var(--lm-page-side-border-width) solid var(--rui-border);border-right:var(--lm-page-side-border-width) solid var(--rui-border);border-top:0;border-bottom:0;border-radius:0;background:transparent;padding:1rem var(--lm-page-x-padding);overflow-y:auto",
         ],
         @rui.typography_muted(
           "Preview is unavailable for the current accepted document.",
@@ -346,7 +346,7 @@ fn raw_editor_view(
     rows=4,
     attrs=@html.Attrs::build().aria_label("Raw Markdown source"),
     style=[
-      "min-height:clamp(24rem,70vh,36rem);width:min(calc(100% - 4rem),46rem);margin-inline:auto;field-sizing:fixed;resize:none;--rui-control-base-border:transparent;--rui-control-base-shadow:none;border-left:1px solid var(--rui-border);border-right:1px solid var(--rui-border);border-top:0;border-bottom:0;border-radius:0;background:transparent;padding:1rem;font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,\"Liberation Mono\",\"Courier New\",monospace;font-size:0.875rem;line-height:1.65",
+      "min-height:clamp(24rem,70vh,36rem);width:var(--lm-page-width);margin-inline:auto;field-sizing:fixed;resize:none;--rui-control-base-border:transparent;--rui-control-base-shadow:none;border-left:var(--lm-page-side-border-width) solid var(--rui-border);border-right:var(--lm-page-side-border-width) solid var(--rui-border);border-top:0;border-bottom:0;border-radius:0;background:transparent;padding:1rem var(--lm-page-x-padding);font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,\"Liberation Mono\",\"Courier New\",monospace;font-size:0.875rem;line-height:1.65",
     ],
     on_input=@cmd.Emit(source => {
       raw_input_command(source, raw_input_coordinator, emit)

--- a/apps/loomark/internal/rabbita/application.mbt
+++ b/apps/loomark/internal/rabbita/application.mbt
@@ -312,17 +312,22 @@ fn preview_document_view(model : DriverModel) -> @rabbita_runtime.Html {
     Some(document) => semantic_preview_view(source, document)
     None =>
       @html.div(
-        id="loomark-preview",
-        attrs=@html.Attrs::build()
-          .data_set("loomark-preview-fallback", "unavailable")
-          .role("region")
-          .tabindex(0)
-          .aria_label("Markdown preview"),
         style=[
-          "box-sizing:border-box;width:var(--lm-page-width);margin-inline:auto;display:grid;gap:1rem;grid-auto-rows:max-content;border-left:var(--lm-page-side-border-width) solid var(--rui-border);border-right:var(--lm-page-side-border-width) solid var(--rui-border);border-top:0;border-bottom:0;border-radius:0;background:transparent;padding:1rem var(--lm-page-x-padding);overflow-y:auto",
+          "box-sizing:border-box;width:100%;min-width:0;overflow-y:auto;overflow-x:hidden",
         ],
-        @rui.typography_muted(
-          "Preview is unavailable for the current accepted document.",
+        @html.div(
+          id="loomark-preview",
+          attrs=@html.Attrs::build()
+            .data_set("loomark-preview-fallback", "unavailable")
+            .role("region")
+            .tabindex(0)
+            .aria_label("Markdown preview"),
+          style=[
+            "box-sizing:border-box;width:var(--lm-page-width);margin-inline:auto;min-width:0;display:grid;gap:1rem;grid-auto-rows:max-content;background:transparent;padding:1rem var(--lm-page-x-padding)",
+          ],
+          @rui.typography_muted(
+            "Preview is unavailable for the current accepted document.",
+          ),
         ),
       )
   }
@@ -340,17 +345,22 @@ fn raw_editor_view(
   raw_input_coordinator : RawInputCoordinator,
 ) -> @rabbita_runtime.Html {
   let source = raw_input_coordinator.display_source(model.document.source())
-  @rui.textarea(
-    id="loomark-input",
-    value=source,
-    rows=4,
-    attrs=@html.Attrs::build().aria_label("Raw Markdown source"),
+  @html.div(
     style=[
-      "min-height:clamp(24rem,70vh,36rem);width:var(--lm-page-width);margin-inline:auto;field-sizing:fixed;resize:none;--rui-control-base-border:transparent;--rui-control-base-shadow:none;border-left:var(--lm-page-side-border-width) solid var(--rui-border);border-right:var(--lm-page-side-border-width) solid var(--rui-border);border-top:0;border-bottom:0;border-radius:0;background:transparent;padding:1rem var(--lm-page-x-padding);font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,\"Liberation Mono\",\"Courier New\",monospace;font-size:0.875rem;line-height:1.65",
+      "box-sizing:border-box;width:100%;min-width:0;overflow-y:auto;overflow-x:hidden",
     ],
-    on_input=@cmd.Emit(source => {
-      raw_input_command(source, raw_input_coordinator, emit)
-    }),
+    @rui.textarea(
+      id="loomark-input",
+      value=source,
+      rows=4,
+      attrs=@html.Attrs::build().aria_label("Raw Markdown source"),
+      style=[
+        "display:block;min-width:0;min-height:clamp(24rem,70vh,36rem);width:var(--lm-page-width);margin-inline:auto;field-sizing:content;resize:none;overflow:hidden;--rui-control-base-border:transparent;--rui-control-base-shadow:none;background:transparent;padding:1rem var(--lm-page-x-padding);font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,\"Liberation Mono\",\"Courier New\",monospace;font-size:1.125rem;line-height:1.65",
+      ],
+      on_input=@cmd.Emit(source => {
+        raw_input_command(source, raw_input_coordinator, emit)
+      }),
+    ),
   )
 }
 
@@ -484,6 +494,7 @@ fn preview_view(
     @rui.alert(
       id="loomark-error",
       variant=@rui.Destructive,
+      style=["border-radius:0"],
       @rui.alert_description("Changes are applied but not saved locally."),
     )
   } else {
@@ -492,6 +503,7 @@ fn preview_view(
         @rui.alert(
           id="loomark-error",
           variant=@rui.Destructive,
+          style=["border-radius:0"],
           @rui.alert_description("error: " + error),
         )
       None => @html.nothing
@@ -557,10 +569,10 @@ fn preview_view(
               ),
             ],
           ),
+          error_view,
         ],
       ),
       driver_controls,
-      error_view,
     ],
   )
 }

--- a/apps/loomark/internal/rabbita/block_toolbar.mbt
+++ b/apps/loomark/internal/rabbita/block_toolbar.mbt
@@ -144,7 +144,7 @@ fn block_format_toolbar(
   @html.div(
     attrs=@html.Attrs::build().role("toolbar").aria_label("Block formatting"),
     style=[
-      "display:flex;min-height:3.75rem;box-sizing:border-box;align-items:center;justify-content:space-between;padding:0.75rem 1rem;border-bottom:1px solid var(--rui-border)",
+      "display:flex;min-height:3.75rem;box-sizing:border-box;align-items:center;justify-content:space-between;padding:0.75rem var(--lm-page-x-padding);border-bottom:1px solid var(--rui-border)",
     ],
     [
       @rui.button_group(aria_label="Block style", [

--- a/apps/loomark/internal/rabbita/block_view.mbt
+++ b/apps/loomark/internal/rabbita/block_view.mbt
@@ -435,7 +435,7 @@ fn block_editor_view(
       model.document.source(),
     ),
     style=[
-      "width:100%;min-width:0;display:flex;flex-direction:column;gap:0.25rem;padding:clamp(0.75rem,2vw,1rem)",
+      "width:100%;min-width:0;display:flex;flex-direction:column;gap:0.25rem;padding:clamp(0.75rem,2vw,var(--lm-page-x-padding))",
     ],
     controls,
   )

--- a/apps/loomark/internal/rabbita/semantic_preview_view.mbt
+++ b/apps/loomark/internal/rabbita/semantic_preview_view.mbt
@@ -417,7 +417,7 @@ fn semantic_preview_view(
       .tabindex(0)
       .aria_label("Markdown preview"),
     style=[
-      "box-sizing:border-box;width:min(calc(100% - 4rem),46rem);margin-inline:auto;display:grid;gap:1rem;grid-auto-rows:max-content;border-left:1px solid var(--rui-border);border-right:1px solid var(--rui-border);border-top:0;border-bottom:0;border-radius:0;background:transparent;padding:1rem;overflow-y:auto",
+      "box-sizing:border-box;width:var(--lm-page-width);margin-inline:auto;display:grid;gap:1rem;grid-auto-rows:max-content;border-left:var(--lm-page-side-border-width) solid var(--rui-border);border-right:var(--lm-page-side-border-width) solid var(--rui-border);border-top:0;border-bottom:0;border-radius:0;background:transparent;padding:1rem var(--lm-page-x-padding);overflow-y:auto",
     ],
     semantic_preview_node(semantic_document),
   )

--- a/apps/loomark/internal/rabbita/semantic_preview_view.mbt
+++ b/apps/loomark/internal/rabbita/semantic_preview_view.mbt
@@ -410,15 +410,20 @@ fn semantic_preview_view(
   semantic_document : @md_markdown.MarkdownIR,
 ) -> @rabbita_runtime.Html {
   @html.div(
-    id="loomark-preview",
-    attrs=@html.Attrs::build()
-      .data_set("loomark-source", source)
-      .role("region")
-      .tabindex(0)
-      .aria_label("Markdown preview"),
     style=[
-      "box-sizing:border-box;width:var(--lm-page-width);margin-inline:auto;display:grid;gap:1rem;grid-auto-rows:max-content;border-left:var(--lm-page-side-border-width) solid var(--rui-border);border-right:var(--lm-page-side-border-width) solid var(--rui-border);border-top:0;border-bottom:0;border-radius:0;background:transparent;padding:1rem var(--lm-page-x-padding);overflow-y:auto",
+      "box-sizing:border-box;width:100%;min-width:0;overflow-y:auto;overflow-x:hidden",
     ],
-    semantic_preview_node(semantic_document),
+    @html.div(
+      id="loomark-preview",
+      attrs=@html.Attrs::build()
+        .data_set("loomark-source", source)
+        .role("region")
+        .tabindex(0)
+        .aria_label("Markdown preview"),
+      style=[
+        "box-sizing:border-box;width:var(--lm-page-width);margin-inline:auto;min-width:0;display:grid;gap:1rem;grid-auto-rows:max-content;background:transparent;padding:1rem var(--lm-page-x-padding)",
+      ],
+      semantic_preview_node(semantic_document),
+    ),
   )
 }

--- a/apps/loomark/internal/rabbita/split_view.mbt
+++ b/apps/loomark/internal/rabbita/split_view.mbt
@@ -24,7 +24,7 @@ fn split_visible(model : DriverModel) -> Bool {
 
 ///|
 fn compact_split_for_width(width : Int) -> Bool {
-  width < SPLIT_STACK_BREAKPOINT
+  width <= SPLIT_STACK_BREAKPOINT
 }
 
 ///|
@@ -48,7 +48,7 @@ fn mode_view(
   if model.state.mode() == @core.Block {
     @html.div(
       style=[
-        "width:min(calc(100% - 4rem),46rem);margin-inline:auto;min-width:0;display:flex;flex-direction:column;border-left:1px solid var(--rui-border);border-right:1px solid var(--rui-border)",
+        "width:var(--lm-page-width);margin-inline:auto;min-width:0;display:flex;flex-direction:column;border-left:var(--lm-page-side-border-width) solid var(--rui-border);border-right:var(--lm-page-side-border-width) solid var(--rui-border)",
       ],
       [
         block_format_toolbar(model, emit),

--- a/apps/loomark/internal/rabbita/split_view.mbt
+++ b/apps/loomark/internal/rabbita/split_view.mbt
@@ -48,17 +48,25 @@ fn mode_view(
   if model.state.mode() == @core.Block {
     @html.div(
       id="loomark-block-frame",
-      style=[
-        "width:var(--lm-page-width);margin-inline:auto;min-width:0;display:flex;flex-direction:column;border-left:var(--lm-page-side-border-width) solid var(--rui-border);border-right:var(--lm-page-side-border-width) solid var(--rui-border)",
-      ],
+      style=["width:100%;min-width:0;display:flex;flex-direction:column"],
       [
-        block_format_toolbar(model, emit),
+        @html.div(
+          style=[
+            "width:var(--lm-page-width);margin-inline:auto;min-width:0;display:flex;flex-direction:column",
+          ],
+          block_format_toolbar(model, emit),
+        ),
         @html.div(
           id="loomark-active-view",
           style=[
-            "width:100%;min-width:0;flex:1;min-height:0;display:flex;overflow-y:auto",
+            "width:100%;min-width:0;flex:1;min-height:0;display:flex;overflow-y:auto;overflow-x:hidden",
           ],
-          editor_view(model, emit, raw_input_coordinator),
+          @html.div(
+            style=[
+              "width:var(--lm-page-width);margin-inline:auto;min-width:0;display:flex;flex-direction:column;gap:0.25rem",
+            ],
+            editor_view(model, emit, raw_input_coordinator),
+          ),
         ),
       ],
     )

--- a/apps/loomark/internal/rabbita/split_view.mbt
+++ b/apps/loomark/internal/rabbita/split_view.mbt
@@ -47,6 +47,7 @@ fn mode_view(
 ) -> @rabbita_runtime.Html {
   if model.state.mode() == @core.Block {
     @html.div(
+      id="loomark-block-frame",
       style=[
         "width:var(--lm-page-width);margin-inline:auto;min-width:0;display:flex;flex-direction:column;border-left:var(--lm-page-side-border-width) solid var(--rui-border);border-right:var(--lm-page-side-border-width) solid var(--rui-border)",
       ],

--- a/apps/loomark/public/styles.css
+++ b/apps/loomark/public/styles.css
@@ -15,19 +15,50 @@ body {
 
 /*
  * Keep Raw, Block, and Preview aligned to one reading frame. Narrow screens
- * use the full viewport and retain a compact content inset without decorative
- * side rails.
+ * use the full viewport and retain a compact content inset.
  */
 :root {
   --lm-page-width: min(calc(100% - 4rem), 46rem);
   --lm-page-x-padding: 1rem;
-  --lm-page-side-border-width: 1px;
 }
 
 @media (max-width: 640px) {
   :root {
     --lm-page-width: 100%;
     --lm-page-x-padding: 0.75rem;
-    --lm-page-side-border-width: 0;
   }
+}
+
+/*
+ * The Preview pane renders Markdown into one grid column. Long unbreakable
+ * content (URLs, inline code) must wrap inside the reading frame instead of
+ * stretching the column; only fenced code keeps its own internal horizontal
+ * scroll, and images scale down to the frame.
+ */
+#loomark-preview {
+  grid-template-columns: minmax(0, 1fr);
+  overflow-x: hidden;
+}
+
+#loomark-preview > * {
+  min-width: 0;
+  overflow-wrap: break-word;
+}
+
+#loomark-preview pre {
+  overflow-x: auto;
+}
+
+#loomark-preview img {
+  max-width: 100%;
+  height: auto;
+}
+
+/*
+ * The Raw textarea keeps its caret and selection as the focus indicator;
+ * do not draw the surrounding control ring on the borderless frame.
+ */
+#loomark-input:focus-visible {
+  --rui-control-border: transparent;
+  --rui-control-shadow: none;
 }

--- a/apps/loomark/public/styles.css
+++ b/apps/loomark/public/styles.css
@@ -12,3 +12,22 @@ body {
 ::selection {
   background: oklch(0.78 0.08 276 / 0.45);
 }
+
+/*
+ * Keep Raw, Block, and Preview aligned to one reading frame. Narrow screens
+ * use the full viewport and retain a compact content inset without decorative
+ * side rails.
+ */
+:root {
+  --lm-page-width: min(calc(100% - 4rem), 46rem);
+  --lm-page-x-padding: 1rem;
+  --lm-page-side-border-width: 1px;
+}
+
+@media (max-width: 640px) {
+  :root {
+    --lm-page-width: 100%;
+    --lm-page-x-padding: 0.75rem;
+    --lm-page-side-border-width: 0;
+  }
+}


### PR DESCRIPTION
## Summary

- centralize the Raw, Block, and Preview reading-frame width, horizontal inset, and side-rail width as responsive CSS properties
- use the full viewport, 0.75rem horizontal inset, and no decorative side rails at 640px and below while preserving the desktop reading column
- align the split breakpoint with the inclusive mobile boundary and cover Raw, Block, Preview, and toolbar behavior in the standalone browser suite

## UI and review evidence

- [x] No visible labels were removed; accessible names, visible focus, and keyboard paths are unchanged
- [x] Interactive bounds and viewport reflow were checked in rendered desktop, 390px mobile, and the exact 640px boundary
- [x] The change follows `.impeccable.md` relationship fidelity and responsive information-parity rules; no external recommendation is claimed as a Canopy requirement

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `compact_split_for_width` | Loomark Rabbita split presentation | Yes | Reused the existing width-classification boundary and made its 640px policy inclusive |
| Existing Raw/Block/Preview inline style surfaces | Loomark Rabbita views | Yes | Preserved the current rendered surfaces and replaced repeated frame constants with shared CSS properties |
| CSS custom properties | Loomark public stylesheet | Yes | Existing browser capability provides responsive values without adding a MoonBit helper or parallel component API |

New helpers added (if any):

None. No new MoonBit function, method, helper, type, loop, or data-manipulation code was introduced, so MoonBit core collection/string API candidates are not applicable.

## Validation scope

Boundary matrix / first failing regression:

| Viewport | Raw / Preview | Block | Split |
| --- | --- | --- | --- |
| Above 640px | bordered reading column, 1rem inset | existing bordered reading column and 1rem maximum inset | side by side |
| 640px and below | full width, no side rails, 0.75rem inset | full width, no side rails, 0.75rem content and toolbar inset | stacked |

The first failing browser regression observed the old 1px mobile rail. Independent review then identified the exact 640px boundary and Block inset gaps; both are covered by the final test, and the follow-up review note (assert the Block frame's own rails and width at 640px, not only its inner padding) is addressed by `b95f71e3`. `53dafd8e` settles the split frame before focusing Raw input in the dev-host suite, fixing the flaky focus race observed on the first CI run (re-ran green; 82/82 locally). `8fa85d07` polishes the reading surfaces: Preview wraps long unbreakable content, the Raw textarea uses 1.125rem, side rails are gone (only the split divider remains), scrollbars dock at the viewport edge, the error alert stays inside the viewport with straight corners, and the Raw focus ring is suppressed.

Target packages:

- `apps/loomark/internal/rabbita`

Additional conditional gates:

- Loomark standalone production build, TypeScript typecheck, and Playwright suite: 10/10 passed (re-run after rebase onto `origin/main` including #1189/#1193/#1194)
- MoonBit tests for `apps/loomark/internal/rabbita`: 30/30 passed
- Loomark dev-host suite: 82/82 passed, including 60/60 stress repeats of the previously flaky Raw focus test; re-run green after the polish commit
- generated `.mbti` diff: none
- no submodule pointer changed

## PR-ready evidence

Validated HEAD: `8fa85d07014a5c2db52636d839a44b6e06d97782`

Validated base: `origin/main@a056accbcadb0127e0a2d7a342987fadabfbb072`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh \
  --target apps/loomark/internal/rabbita
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for the exact HEAD and base above.
- [x] The base was fetched again and `--verify-evidence` passed immediately before this PR was updated.
- [x] The committed `.mbti` diff against the validated base was reviewed; there is no interface drift.
- [x] No submodule pointer changed.
- [x] Validation was run after the final commit; no amend, rebase, cherry-pick, submodule, manifest, or generated-interface change followed it.
- [x] Independent review findings were resolved before the final validation.
