### PR TITLE
test(loomark): wait for Block DOM convergence

### DIFF
--- a/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
+++ b/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
@@ -954,8 +954,16 @@ test("Block mode edits ordered/unordered lists and fenced code in one mixed docu
     await expect.poll(async () => (await snapshot(host.page)).source).toBe(
       "- ONE\r\n\r\n7) two\r\n~~~moonbit\r\nold\r\n~~~\r\n",
     )
+    await expect(host.page.locator("#loomark-block")).toHaveAttribute(
+      "data-loomark-source",
+      "- ONE\r\n\r\n7) two\r\n~~~moonbit\r\nold\r\n~~~\r\n",
+    )
     await host.page.locator('[data-loomark-block-kind="ordered-list-item"]').fill("TWO")
     await expect.poll(async () => (await snapshot(host.page)).source).toBe(
+      "- ONE\r\n\r\n7) TWO\r\n~~~moonbit\r\nold\r\n~~~\r\n",
+    )
+    await expect(host.page.locator("#loomark-block")).toHaveAttribute(
+      "data-loomark-source",
       "- ONE\r\n\r\n7) TWO\r\n~~~moonbit\r\nold\r\n~~~\r\n",
     )
     await host.page.locator('[data-loomark-block-kind="code"]').fill("new")


### PR DESCRIPTION
## Summary

- wait for the controlled Block DOM to render each accepted canonical source before sending the next mixed-document edit
- keep model publication and DOM convergence as separate assertions, matching Rabbita's next-frame render contract
- leave stale Block-event rejection to #1163 rather than testing it accidentally through a timing-dependent content-edit case

## UI and review evidence

N/A — test-only synchronization change; no UI or visual behavior changed.

- [x] Any claimed Canopy rule cites its repository source; external guidance, recommendations, and preferences are labeled as such

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| Playwright `expect(...).toHaveAttribute` | `@playwright/test` | Yes | Auto-retries until Rabbita has patched the controlled Block DOM |
| Existing `data-loomark-source` render marker | `apps/loomark/internal/rabbita/block_view.mbt` | Yes | Directly observes the render boundary owned by this test |

New helpers added: none.

## Validation scope

Boundary matrix / first failing regression:

| Model source | Block DOM source | Next edit |
|---|---|---|
| updated | stale | wait |
| updated | matching | continue |

Before this change, the focused test reproduced the CI symptom 4 times in 50 sequential runs. After the change, it passed 100/100 sequential runs.

Target packages:

- `--no-target "Test-only Playwright DOM-render synchronization; no MoonBit package changed"`

Additional conditional gates:

- focused mixed-document Playwright test, `--workers=1 --repeat-each=100`: 100 passed
- full Loomark Dev Host E2E suite: 80 passed
- dev-host TypeScript typecheck: passed through `scripts/test-loomark-dev-host-e2e.sh`
- independent review: PASS, no findings

## PR-ready evidence

Validated HEAD: `b7827c4c20cdd3ab1d7fa650de0e3c8c21c188e4`

Validated base: `origin/main@ce8f7ad9d69ac8e8e60c807de0532452da3a5770`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh \
  --no-target "Test-only Playwright DOM-render synchronization; no MoonBit package changed"
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for the exact HEAD and base above.
- [x] The base was fetched again and `--verify-evidence` passed immediately before this PR was opened.
- [x] The committed `.mbti` diff against the validated base was reviewed; there is no `.mbti` diff.
- [x] No submodule pointer changed.
- [x] Validation was rerun after the commit.
- [x] Independent review findings were resolved before the final validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced Block mode coverage for mixed documents containing unordered and ordered lists.
  * Added verification that the editor’s source metadata remains canonical after list-item edits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->