### PR TITLE
fix(editor): preserve Markdown across parser failure

### DIFF
--- a/adapters/editor/README.md
+++ b/adapters/editor/README.md
@@ -76,6 +76,13 @@ Anything imported from `@canopy/loom`, `@canopy/lang`, or `@canopy/eg-walker` in
 | `HTMLAdapter`                     | unstable   | DOM-only adapter, primarily for tests and previews.|
 | `MarkdownPreview`                 | unstable   | Helper view for markdown rendering.                |
 | `BlockInput`                      | internal   | Used by Canopy demos; not for external consumption.|
+| `adaptMoonBitModule`              | unstable   | Host quarantine for generated MoonBit `Result` exports. |
+
+`adaptMoonBitModule` belongs at the module-load boundary, never inside editor
+business logic. It unwraps generated `Result` values, redacts failure payloads,
+best-effort destroys a failed handle, and rejects later calls through that
+adapted module. Raw generated modules retain their typed MoonBit result shape;
+application code receives direct values or a structured `CanopyHostError`.
 
 External consumers should program against `stable` exports. `unstable` exports may break in minor versions until they graduate.
 

--- a/adapters/editor/index.ts
+++ b/adapters/editor/index.ts
@@ -16,3 +16,13 @@ export { CM6Adapter } from './cm6-adapter';
 export { PMAdapter, pmAdapterSchema } from './pm-adapter';
 export { MarkdownPreview } from './markdown-preview';
 export { BlockInput } from './block-input';
+export {
+  adaptMoonBitModule,
+  CanopyHostError,
+} from './moonbit-result';
+export type {
+  AdaptedMoonBitModule,
+  CanopyHostErrorCode,
+  MoonBitModuleAdapterOptions,
+  MoonBitResult,
+} from './moonbit-result';

--- a/adapters/editor/moonbit-result.ts
+++ b/adapters/editor/moonbit-result.ts
@@ -1,0 +1,195 @@
+/** The structural JavaScript representation emitted for MoonBit Result. */
+export type MoonBitResult<T, E> =
+  | { readonly $tag: 1; readonly _0: T }
+  | { readonly $tag: 0; readonly _0: E };
+
+export type CanopyHostErrorCode =
+  | 'ParserFailure'
+  | 'DisposedHandle'
+  | 'HostOperationFailure';
+
+export class CanopyHostError extends Error {
+  readonly code: CanopyHostErrorCode;
+  readonly operation: string;
+  readonly handleInvalidated: boolean;
+
+  constructor(
+    code: CanopyHostErrorCode,
+    operation: string,
+    handleInvalidated: boolean,
+  ) {
+    super('Canopy host operation failed');
+    this.name = 'CanopyHostError';
+    this.code = code;
+    this.operation = operation;
+    this.handleInvalidated = handleInvalidated;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+type AnyFunction = (...args: any[]) => any;
+type FunctionKey<T> = {
+  [K in keyof T]-?: T[K] extends AnyFunction ? K : never;
+}[keyof T] & string;
+type ResultValue<T> = T extends { readonly $tag: 1; readonly _0: infer Value }
+  ? Value
+  : T extends { readonly $tag: 0; readonly _0: any }
+    ? never
+    : T;
+type AdaptedFunction<T> = T extends (...args: infer Args) => infer Return
+  ? (...args: Args) => ResultValue<Return>
+  : T;
+
+/**
+ * The host-facing shape of a generated module after structural Result exports
+ * have been unwrapped. Raw generated modules remain free to expose Result.
+ */
+export type AdaptedMoonBitModule<T extends object> = {
+  [K in keyof T]: AdaptedFunction<T[K]>;
+};
+
+export interface MoonBitModuleAdapterOptions<
+  T extends object,
+  CreateKeys extends readonly FunctionKey<T>[] = readonly FunctionKey<T>[],
+  DestroyKeys extends readonly FunctionKey<T>[] = readonly FunctionKey<T>[],
+  TryDestroyKeys extends readonly FunctionKey<T>[] = readonly FunctionKey<T>[],
+> {
+  readonly createFunctions?: CreateKeys;
+  readonly destroyFunctions?: DestroyKeys;
+  readonly tryDestroyFunctions?: TryDestroyKeys;
+  readonly initialHandles?: readonly number[];
+}
+
+function isMoonBitResult(value: unknown): value is MoonBitResult<unknown, unknown> {
+  if (typeof value !== 'object' || value === null) return false;
+  const candidate = value as { $tag?: unknown; _0?: unknown };
+  return (
+    (candidate.$tag === 0 || candidate.$tag === 1) &&
+    Object.prototype.hasOwnProperty.call(candidate, '_0')
+  );
+}
+
+type ClassifiedResult =
+  | { readonly kind: 'value'; readonly value: unknown }
+  | { readonly kind: 'failure' };
+
+function ifMoonBitResultValue(value: unknown): ClassifiedResult {
+  if (!isMoonBitResult(value)) return { kind: 'value', value };
+  if (value.$tag === 1) return { kind: 'value', value: value._0 };
+  return { kind: 'failure' };
+}
+
+/**
+ * Wrap one generated MoonBit module at its imperative host boundary.
+ *
+ * Result classification and unwrapping are pure. The shell owns only the
+ * invalid-handle Set and best-effort destruction after a terminal Err.
+ */
+export function adaptMoonBitModule<
+  T extends object,
+  const CreateKeys extends readonly FunctionKey<T>[],
+  const DestroyKeys extends readonly FunctionKey<T>[],
+  const TryDestroyKeys extends readonly FunctionKey<T>[],
+>(
+  raw: T,
+  options: MoonBitModuleAdapterOptions<
+    T,
+    CreateKeys,
+    DestroyKeys,
+    TryDestroyKeys
+  > = {},
+): AdaptedMoonBitModule<T> {
+  const createNames = new Set<string>(options.createFunctions ?? []);
+  const destroyNames = new Set<string>(options.destroyFunctions ?? []);
+  const tryDestroyNames = new Set<string>(options.tryDestroyFunctions ?? []);
+  const ownedHandles = new Set<number>(options.initialHandles ?? []);
+  const invalidatedHandles = new Set<number>();
+  const pendingCleanupHandles = new Set<number>();
+  const adapted: Record<string, unknown> = Object.assign(
+    Object.create(null) as Record<string, unknown>,
+    raw,
+  );
+
+  const destroyHandle = (handle: number, forceInvalidation: boolean): boolean => {
+    if (!ownedHandles.has(handle)) return true;
+    if (
+      invalidatedHandles.has(handle) &&
+      !pendingCleanupHandles.has(handle)
+    ) return true;
+    let destroyed = false;
+    const cleanupNames = tryDestroyNames.size > 0 ? tryDestroyNames : destroyNames;
+    for (const name of cleanupNames) {
+      const destroy = raw[name as keyof T];
+      if (typeof destroy !== 'function') continue;
+      try {
+        // Current FFI destructors return false when coordinator dependencies
+        // refuse teardown. Legacy destructors return Unit, which counts as
+        // successful best-effort cleanup.
+        destroyed = destroy.call(raw, handle) !== false;
+      } catch {
+        destroyed = false;
+      }
+      break;
+    }
+    if (destroyed) {
+      ownedHandles.delete(handle);
+      pendingCleanupHandles.delete(handle);
+      invalidatedHandles.add(handle);
+    } else if (forceInvalidation) {
+      // The JS handle is terminal immediately, but coordinator teardown may be
+      // refused while dependents remain. Keep ownership so a later explicit
+      // destroy can retry cleanup without permitting any other operation.
+      invalidatedHandles.add(handle);
+      pendingCleanupHandles.add(handle);
+    }
+    return destroyed;
+  };
+
+  for (const [name, member] of Object.entries(raw)) {
+    if (typeof member !== 'function') continue;
+    adapted[name] = (...args: unknown[]) => {
+      const handle = args[0];
+      const hasNumericHandle = typeof handle === 'number';
+      const isOwnedHandle = hasNumericHandle && ownedHandles.has(handle);
+      if (
+        hasNumericHandle &&
+        invalidatedHandles.has(handle) &&
+        !destroyNames.has(name) &&
+        !tryDestroyNames.has(name)
+      ) {
+        throw new CanopyHostError('DisposedHandle', name, true);
+      }
+      if (
+        (destroyNames.has(name) || tryDestroyNames.has(name)) &&
+        hasNumericHandle
+      ) {
+        return destroyHandle(handle, false);
+      }
+
+      let result: unknown;
+      try {
+        result = member.apply(raw, args);
+      } catch {
+        if (isOwnedHandle) destroyHandle(handle, true);
+        throw new CanopyHostError(
+          'HostOperationFailure',
+          name,
+          isOwnedHandle,
+        );
+      }
+      const value = ifMoonBitResultValue(result);
+      if (value.kind === 'failure') {
+        if (isOwnedHandle) destroyHandle(handle, true);
+        throw new CanopyHostError('ParserFailure', name, isOwnedHandle);
+      }
+      if (createNames.has(name) && typeof value.value === 'number') {
+        invalidatedHandles.delete(value.value);
+        pendingCleanupHandles.delete(value.value);
+        ownedHandles.add(value.value);
+      }
+      return value.value;
+    };
+  }
+
+  return adapted as AdaptedMoonBitModule<T>;
+}

--- a/adapters/editor/package.json
+++ b/adapters/editor/package.json
@@ -6,6 +6,7 @@
     "typecheck:cm6": "tsc -p tsconfig.cm6-test.json --noEmit",
     "build:test:cm6": "vite build --config vite.config.cm6-test.ts",
     "dev:test:cm6": "vite --config vite.config.cm6-test.ts",
+    "test:unit": "node --test test/moonbit-result.test.ts",
     "test:e2e:cm6": "playwright test --config test/playwright.config.ts"
   },
   "description": "UI adapters bridging Canopy's ViewPatch protocol to DOM/CodeMirror/ProseMirror renderers.",
@@ -44,6 +45,7 @@
     "./markdown-preview": "./markdown-preview.ts",
     "./block-input": "./block-input.ts",
     "./block-input.css": "./block-input.css",
+    "./moonbit-result": "./moonbit-result.ts",
     "./package.json": "./package.json"
   },
   "peerDependencies": {

--- a/adapters/editor/test/cm6-diagnostics.ts
+++ b/adapters/editor/test/cm6-diagnostics.ts
@@ -1,8 +1,15 @@
 import { EditorState } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
-import * as crdt from "../../../_build/js/release/build/dowdiness/canopy/ffi/lambda/lambda.js";
+import * as crdtRaw from "../../../_build/js/release/build/dowdiness/canopy/ffi/lambda/lambda.js";
+import { adaptMoonBitModule } from "../moonbit-result";
 import { CM6Adapter } from "../cm6-adapter";
 import type { UserIntent, ViewPatch } from "../types";
+
+const crdt = adaptMoonBitModule(crdtRaw, {
+  createFunctions: ["create_editor"],
+  destroyFunctions: ["destroy_editor"],
+  tryDestroyFunctions: ["try_destroy_editor"],
+});
 
 async function main(): Promise<void> {
   const parent = document.querySelector<HTMLElement>("#editor");

--- a/adapters/editor/test/moonbit-result.test.ts
+++ b/adapters/editor/test/moonbit-result.test.ts
@@ -1,0 +1,297 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  adaptMoonBitModule,
+  CanopyHostError,
+  type MoonBitResult,
+} from '../moonbit-result.ts';
+
+type RawModule = {
+  create: (name: string) => MoonBitResult<number, { secret: string }>;
+  read: (handle: number) => MoonBitResult<string, { secret: string }>;
+  destroy: (handle: number) => boolean | undefined;
+};
+
+const ok = <T>(value: T): MoonBitResult<T, never> => ({ $tag: 1, _0: value });
+const err = (secret: string): MoonBitResult<never, { secret: string }> => ({
+  $tag: 0,
+  _0: { secret },
+});
+
+function expectHostError(
+  action: () => unknown,
+  expected: Pick<CanopyHostError, 'code' | 'operation' | 'handleInvalidated'>,
+): CanopyHostError {
+  let thrown: unknown;
+  try {
+    action();
+  } catch (error) {
+    thrown = error;
+  }
+  assert.ok(thrown instanceof CanopyHostError);
+  assert.deepEqual(
+    {
+      code: thrown.code,
+      operation: thrown.operation,
+      handleInvalidated: thrown.handleInvalidated,
+    },
+    expected,
+  );
+  return thrown;
+}
+
+test('unwraps Ok values without changing the app-facing return shape', () => {
+  const raw: RawModule = {
+    create: () => ok(41),
+    read: () => ok('text'),
+    destroy: () => undefined,
+  };
+  const module = adaptMoonBitModule(raw, {
+    createFunctions: ['create'],
+    destroyFunctions: ['destroy'],
+  });
+
+  assert.equal(module.create('editor'), 41);
+  assert.equal(module.read(41), 'text');
+});
+
+test('throws a stable redacted error for Err values', () => {
+  const raw: RawModule = {
+    create: () => err('private parser details'),
+    read: () => ok('unused'),
+    destroy: () => undefined,
+  };
+  const module = adaptMoonBitModule(raw, {
+    createFunctions: ['create'],
+    destroyFunctions: ['destroy'],
+  });
+
+  const error = expectHostError(
+    () => module.create('editor'),
+    {
+      code: 'ParserFailure',
+      operation: 'create',
+      handleInvalidated: false,
+    },
+  );
+  assert.equal(error.name, 'CanopyHostError');
+  assert.equal(error.message, 'Canopy host operation failed');
+  assert.doesNotMatch(String(error), /_0|private parser details/);
+  assert.doesNotMatch(JSON.stringify(error), /private parser details/);
+});
+
+test('destroys and invalidates a handle when an operation returns Err', () => {
+  const destroyed: number[] = [];
+  const raw: RawModule = {
+    create: () => ok(7),
+    read: () => err('terminal failure'),
+    destroy: handle => {
+      destroyed.push(handle);
+      return undefined;
+    },
+  };
+  const module = adaptMoonBitModule(raw, {
+    createFunctions: ['create'],
+    destroyFunctions: ['destroy'],
+  });
+  const handle = module.create('editor');
+
+  expectHostError(
+    () => module.read(handle),
+    {
+      code: 'ParserFailure',
+      operation: 'read',
+      handleInvalidated: true,
+    },
+  );
+  assert.deepEqual(destroyed, [handle]);
+});
+
+test('explicit destroy is idempotent and invalidates the handle', () => {
+  const destroyed: number[] = [];
+  const raw: RawModule = {
+    create: () => ok(7),
+    read: () => ok('text'),
+    destroy: handle => {
+      destroyed.push(handle);
+      return undefined;
+    },
+  };
+  const module = adaptMoonBitModule(raw, {
+    createFunctions: ['create'],
+    destroyFunctions: ['destroy'],
+  });
+  const handle = module.create('editor');
+
+  module.destroy(handle);
+  module.destroy(handle);
+
+  assert.deepEqual(destroyed, [handle]);
+  expectHostError(
+    () => module.read(handle),
+    {
+      code: 'DisposedHandle',
+      operation: 'read',
+      handleInvalidated: true,
+    },
+  );
+});
+
+test('keeps an owned handle usable when confirmed destroy is refused', () => {
+  let legacyDestroyCalls = 0;
+  let confirmedDestroyCalls = 0;
+  const raw = {
+    create: (_name: string) => ok(7),
+    read: (_handle: number) => ok('text'),
+    destroy: (_handle: number) => {
+      legacyDestroyCalls += 1;
+    },
+    tryDestroy: (_handle: number) => {
+      confirmedDestroyCalls += 1;
+      return false;
+    },
+  };
+  const module = adaptMoonBitModule(raw, {
+    createFunctions: ['create'],
+    destroyFunctions: ['destroy'],
+    tryDestroyFunctions: ['tryDestroy'],
+  });
+  const handle = module.create('editor');
+
+  assert.equal(module.destroy(handle), false);
+  assert.equal(module.read(handle), 'text');
+  assert.equal(legacyDestroyCalls, 0);
+  assert.equal(confirmedDestroyCalls, 1);
+});
+
+test('invalidates a handle created before the adapter was installed', () => {
+  const destroyed: number[] = [];
+  const raw: RawModule = {
+    create: () => ok(7),
+    read: () => err('terminal failure'),
+    destroy: handle => {
+      destroyed.push(handle);
+      return undefined;
+    },
+  };
+  const module = adaptMoonBitModule(raw, {
+    createFunctions: ['create'],
+    destroyFunctions: ['destroy'],
+    initialHandles: [0],
+  });
+
+  expectHostError(
+    () => module.read(0),
+    {
+      code: 'ParserFailure',
+      operation: 'read',
+      handleInvalidated: true,
+    },
+  );
+  assert.deepEqual(destroyed, [0]);
+});
+
+test('retries refused cleanup without reopening a terminal handle', () => {
+  let cleanupAttempts = 0;
+  const raw = {
+    create: (_name: string) => ok(7),
+    read: (_handle: number) => err('terminal failure'),
+    destroy: (_handle: number) => undefined,
+    tryDestroy: (_handle: number) => {
+      cleanupAttempts += 1;
+      return cleanupAttempts > 1;
+    },
+  };
+  const module = adaptMoonBitModule(raw, {
+    createFunctions: ['create'],
+    destroyFunctions: ['destroy'],
+    tryDestroyFunctions: ['tryDestroy'],
+  });
+  const handle = module.create('editor');
+
+  assert.throws(() => module.read(handle), CanopyHostError);
+  expectHostError(
+    () => module.read(handle),
+    {
+      code: 'DisposedHandle',
+      operation: 'read',
+      handleInvalidated: true,
+    },
+  );
+  assert.equal(module.destroy(handle), true);
+  assert.equal(cleanupAttempts, 2);
+});
+
+test('rejects repeated operations without re-entering a failed module', () => {
+  let reads = 0;
+  const raw: RawModule = {
+    create: () => ok(7),
+    read: () => {
+      reads += 1;
+      return err('terminal failure');
+    },
+    destroy: () => undefined,
+  };
+  const module = adaptMoonBitModule(raw, {
+    createFunctions: ['create'],
+    destroyFunctions: ['destroy'],
+  });
+  const handle = module.create('editor');
+
+  assert.throws(() => module.read(handle), CanopyHostError);
+  expectHostError(
+    () => module.read(handle),
+    {
+      code: 'DisposedHandle',
+      operation: 'read',
+      handleInvalidated: true,
+    },
+  );
+  assert.equal(reads, 1);
+});
+
+test('does not destroy an unowned numeric argument', () => {
+  const destroyed: number[] = [];
+  const raw: RawModule = {
+    create: () => ok(7),
+    read: () => err('unknown handle'),
+    destroy: handle => {
+      destroyed.push(handle);
+      return undefined;
+    },
+  };
+  const module = adaptMoonBitModule(raw, {
+    createFunctions: ['create'],
+    destroyFunctions: ['destroy'],
+  });
+
+  expectHostError(
+    () => module.read(99),
+    {
+      code: 'ParserFailure',
+      operation: 'read',
+      handleInvalidated: false,
+    },
+  );
+  module.destroy(99);
+  assert.deepEqual(destroyed, []);
+});
+
+test('create failure does not destroy a nonexistent handle', () => {
+  const destroyed: number[] = [];
+  const raw: RawModule = {
+    create: () => err('secret create failure'),
+    read: () => ok('unused'),
+    destroy: handle => {
+      destroyed.push(handle);
+      return undefined;
+    },
+  };
+  const module = adaptMoonBitModule(raw, {
+    createFunctions: ['create'],
+    destroyFunctions: ['destroy'],
+  });
+
+  assert.throws(() => module.create('editor'), CanopyHostError);
+  assert.deepEqual(destroyed, []);
+});

--- a/adapters/editor/tsconfig.cm6-test.json
+++ b/adapters/editor/tsconfig.cm6-test.json
@@ -3,6 +3,7 @@
     "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
     "strict": true,
     "skipLibCheck": true,
     "noEmit": true,

--- a/apps/canvas/main/graph_dsl_adapter.mbt
+++ b/apps/canvas/main/graph_dsl_adapter.mbt
@@ -17,6 +17,7 @@ struct SourceNodePosition {
 ///|
 struct SourceBackedGraph {
   attachment : @graph_dsl.GraphAttachment
+  mut parser_failure : Failure?
   mut source : String
   mut viewport : Viewport
   mut interaction : InteractionState
@@ -34,9 +35,10 @@ fn source_graph_source_id(handle : Int) -> @core.SourceId {
 fn SourceBackedGraph::SourceBackedGraph(
   source_id : @core.SourceId,
   source : String,
-) -> SourceBackedGraph {
+) -> SourceBackedGraph raise Failure {
   {
     attachment: @graph_dsl.GraphAttachment::GraphAttachment(source_id, source),
+    parser_failure: None,
     source,
     viewport: default_source_graph_viewport(),
     interaction: @graph_model.empty_interaction(),
@@ -49,6 +51,25 @@ fn SourceBackedGraph::SourceBackedGraph(
 ///|
 fn SourceBackedGraph::dispose(self : SourceBackedGraph) -> Unit {
   self.attachment.dispose()
+}
+
+///|
+/// Enforce terminal parser health at the adapter boundary and preserve the
+/// original Loom Failure for every later attachment mutation.
+fn SourceBackedGraph::apply_attachment_mutation(
+  self : SourceBackedGraph,
+  mutation : () -> Unit raise Failure,
+) -> Unit raise Failure {
+  match self.parser_failure {
+    Some(failure) => raise failure
+    None => ()
+  }
+  mutation() catch {
+    Failure::Failure(_) as failure => {
+      self.parser_failure = Some(failure)
+      raise failure
+    }
+  }
 }
 
 ///|
@@ -504,29 +525,38 @@ fn lower_source_operation(
 fn SourceBackedGraph::apply_source_edit(
   self : SourceBackedGraph,
   edit : SourceOperationEdit,
-) -> Result[@graph_dsl.GraphDoc, String] {
+) -> Result[@graph_dsl.GraphDoc, String] raise Failure {
   let old_source = self.source
   let new_source = match edit {
-    ExactLoweredEdit(edit) => {
-      let new_source = edit.new_source()
+    ExactLoweredEdit(edit) => edit.new_source()
+    WholeSourceReplacement(new_source) => new_source
+  }
+  // Source is canonical even if parser publication fails after acceptance.
+  self.source = new_source
+  match edit {
+    ExactLoweredEdit(edit) =>
       match edit.incremental_edit() {
         Some(incremental_edit) =>
-          self.attachment.apply_edit(incremental_edit, new_source)
-        None => self.attachment.set_source(new_source)
+          self.apply_attachment_mutation(() => {
+            self.attachment.apply_edit(incremental_edit, new_source)
+          })
+        None =>
+          self.apply_attachment_mutation(() => {
+            self.attachment.set_source(new_source)
+          })
       }
-      new_source
-    }
-    WholeSourceReplacement(new_source) => {
-      self.attachment.set_source(new_source)
-      new_source
-    }
+    WholeSourceReplacement(_) =>
+      self.apply_attachment_mutation(() => {
+        self.attachment.set_source(new_source)
+      })
   }
-  self.source = new_source
   match self.attachment.current_result() {
     Ok(doc) => Ok(doc)
     Err(message) => {
       self.source = old_source
-      self.attachment.set_source(old_source)
+      self.apply_attachment_mutation(() => {
+        self.attachment.set_source(old_source)
+      })
       Err(message)
     }
   }
@@ -554,20 +584,26 @@ fn SourceBackedGraph::apply_codemirror_changes(
   self : SourceBackedGraph,
   changes : Array[@codemirror.ChangeDelta],
   expected_doc : String,
-) -> SourceGraphOperationResultJson {
-  for edit, new_source in Iter2(changes_to_edits(self.source, changes).iter()) {
-    self.attachment.apply_edit(edit, new_source)
-    self.source = new_source
+) -> SourceGraphOperationResultJson raise Failure {
+  let edits = changes_to_edits(self.source, changes)
+  let mut attachment_source = self.source
+  // The editor is canonical. Save its authoritative text before a fallible
+  // parser publication so a terminal Failure cannot leave stale/partial text.
+  self.source = expected_doc
+  for edit, new_source in Iter2(edits.iter()) {
+    self.apply_attachment_mutation(() => {
+      self.attachment.apply_edit(edit, new_source)
+    })
+    attachment_source = new_source
   }
   // Stale-editor guard: the deltas are expressed against the editor's
   // pre-transaction buffer. If the incremental result does not equal the
-  // editor's authoritative post-transaction text, `self.source` had diverged
-  // from the editor (an out-of-band TS-side graph mutation moved the source out
-  // from under a stale editor). Reparse the editor's text so the keystroke wins
-  // over the racing mutation, rather than splicing onto a mismatched base.
-  if self.source != expected_doc {
-    self.attachment.set_source(expected_doc)
-    self.source = expected_doc
+  // editor's authoritative post-transaction text, the adapter had diverged
+  // from the editor. Reparse the editor's text so the keystroke wins.
+  if attachment_source != expected_doc {
+    self.apply_attachment_mutation(() => {
+      self.attachment.set_source(expected_doc)
+    })
   }
   match source_graph_current_doc(self) {
     Ok(doc) => {
@@ -589,7 +625,7 @@ fn apply_source_graph_codemirror_changes(
   handle : Int,
   changes : Array[@codemirror.ChangeDelta],
   expected_doc : String,
-) -> SourceGraphOperationResultJson {
+) -> SourceGraphOperationResultJson raise Failure {
   match source_graph_by_handle(handle) {
     Some(graph) => graph.apply_codemirror_changes(changes, expected_doc)
     None =>
@@ -888,7 +924,7 @@ fn source_graph_insert_unique_result(
   handle : Int,
   binding_base : String,
   constructor_name : String,
-) -> SourceGraphOperationResultJson {
+) -> SourceGraphOperationResultJson raise Failure {
   let graph = match source_graph_by_handle(handle) {
     Some(graph) => graph
     None =>
@@ -935,7 +971,7 @@ fn source_graph_insert_unique_result(
 ///|
 fn source_graph_connect_sample_result(
   handle : Int,
-) -> SourceGraphOperationResultJson {
+) -> SourceGraphOperationResultJson raise Failure {
   let graph = match source_graph_by_handle(handle) {
     Some(graph) => graph
     None =>
@@ -996,7 +1032,7 @@ pub fn source_graph_insert_unique(
   handle : Int,
   binding_base : String,
   constructor_name : String,
-) -> String {
+) -> String raise Failure {
   source_graph_insert_unique_result(handle, binding_base, constructor_name)
   .to_json()
   .stringify()
@@ -1008,7 +1044,7 @@ pub fn sample_graph_dsl_source() -> String {
 }
 
 ///|
-pub fn create_source_graph(source : String) -> Int {
+pub fn create_source_graph(source : String) -> Int raise Failure {
   let handle = _source_registry.length()
   let source_id = source_graph_source_id(handle)
   _source_registry.push(Some(SourceBackedGraph(source_id, source)))
@@ -1054,7 +1090,7 @@ fn source_graph_subscribe(
 fn set_source_graph_source_checked(
   handle : Int,
   source : String,
-) -> SourceGraphOperationResultJson {
+) -> SourceGraphOperationResultJson raise Failure {
   let graph = match source_graph_by_handle(handle) {
     Some(graph) => graph
     None =>
@@ -1067,7 +1103,7 @@ fn set_source_graph_source_checked(
       )
   }
   graph.source = source
-  graph.attachment.set_source(source)
+  graph.apply_attachment_mutation(() => graph.attachment.set_source(source))
   match source_graph_current_doc(graph) {
     Ok(doc) => {
       // Reset/init path: tokens survive content-preserving edits but a reorder
@@ -1081,12 +1117,18 @@ fn set_source_graph_source_checked(
 }
 
 ///|
-pub fn set_source_graph_source(handle : Int, source : String) -> Unit {
+pub fn set_source_graph_source(
+  handle : Int,
+  source : String,
+) -> Unit raise Failure {
   ignore(set_source_graph_source_checked(handle, source))
 }
 
 ///|
-pub fn set_source_graph_source_result(handle : Int, source : String) -> String {
+pub fn set_source_graph_source_result(
+  handle : Int,
+  source : String,
+) -> String raise Failure {
   set_source_graph_source_checked(handle, source).to_json().stringify()
 }
 
@@ -1215,7 +1257,7 @@ pub fn get_source_graph_action_log(handle : Int) -> String {
 pub fn apply_source_graph_operation(
   handle : Int,
   operation_json : String,
-) -> String {
+) -> String raise Failure {
   let graph = match source_graph_by_handle(handle) {
     Some(graph) => graph
     None =>

--- a/apps/canvas/main/graph_dsl_adapter.mbt
+++ b/apps/canvas/main/graph_dsl_adapter.mbt
@@ -1052,14 +1052,18 @@ pub fn create_source_graph(source : String) -> Int raise Failure {
 }
 
 ///|
-pub fn destroy_source_graph(handle : Int) -> Unit {
+pub fn try_destroy_source_graph(handle : Int) -> Bool {
   match source_graph_by_handle(handle) {
     Some(graph) => graph.dispose()
-    None => ()
+    None => return true
   }
-  if handle >= 0 && handle < _source_registry.length() {
-    _source_registry[handle] = None
-  }
+  _source_registry[handle] = None
+  true
+}
+
+///|
+pub fn destroy_source_graph(handle : Int) -> Unit {
+  ignore(try_destroy_source_graph(handle))
 }
 
 ///|

--- a/apps/canvas/main/moon.pkg
+++ b/apps/canvas/main/moon.pkg
@@ -46,6 +46,7 @@ options(
         "get_action_log",
         "create_source_graph",
         "destroy_source_graph",
+        "try_destroy_source_graph",
         "get_source_graph_source",
         "set_source_graph_source",
         "set_source_graph_source_result",

--- a/apps/canvas/main/pkg.generated.mbti
+++ b/apps/canvas/main/pkg.generated.mbti
@@ -65,6 +65,8 @@ pub fn source_graph_pointer_up(Int, String, String, Bool) -> Unit
 
 pub fn source_graph_zoom(Int, Double, Double, Double) -> Unit
 
+pub fn try_destroy_source_graph(Int) -> Bool
+
 pub fn zoom(Int, Double, Double, Double) -> Unit
 
 // Errors

--- a/apps/canvas/main/pkg.generated.mbti
+++ b/apps/canvas/main/pkg.generated.mbti
@@ -9,11 +9,11 @@ import {
 // Values
 pub fn add_node(Int, String, Double, Double) -> Unit
 
-pub fn apply_source_graph_operation(Int, String) -> String
+pub fn apply_source_graph_operation(Int, String) -> String raise Failure
 
 pub fn create_canvas() -> Int
 
-pub fn create_source_graph(String) -> Int
+pub fn create_source_graph(String) -> Int raise Failure
 
 pub fn delete_nodes(Int, String) -> Unit
 
@@ -51,11 +51,11 @@ pub fn pointer_up(Int, String, String, Bool) -> Unit
 
 pub fn sample_graph_dsl_source() -> String
 
-pub fn set_source_graph_source(Int, String) -> Unit
+pub fn set_source_graph_source(Int, String) -> Unit raise Failure
 
-pub fn set_source_graph_source_result(Int, String) -> String
+pub fn set_source_graph_source_result(Int, String) -> String raise Failure
 
-pub fn source_graph_insert_unique(Int, String, String) -> String
+pub fn source_graph_insert_unique(Int, String, String) -> String raise Failure
 
 pub fn source_graph_pointer_down(Int, String, Double, Double) -> Unit
 

--- a/apps/canvas/main/source_demo.mbt
+++ b/apps/canvas/main/source_demo.mbt
@@ -50,6 +50,7 @@ struct SourceDemoModel {
   // `dirty` is purely a status/validity signal; it also gates `SyncFromGraph`
   // as a guard against pushing an out-of-band source over invalid typing.
   dirty : Bool
+  parser_failed : Bool
   mounted : Bool
   status : String
   status_tone : @status.Tone
@@ -182,11 +183,11 @@ fn source_demo_result_step(
 }
 
 ///|
-fn source_demo_update(
+fn source_demo_update_healthy(
   _emit : Emit[SourceDemoMsg],
   msg : SourceDemoMsg,
   model : SourceDemoModel,
-) -> (Cmd, SourceDemoModel) {
+) -> (Cmd, SourceDemoModel) raise Failure {
   match msg {
     EditorSynced(source) => (@rabbita.none, { ..model, editor: source })
     SourceChanged(changes) => {
@@ -296,6 +297,36 @@ fn source_demo_update(
         {
           ..model,
           status: "CodeMirror failed to mount: " + message,
+          status_tone: @status.Error,
+        },
+      )
+  }
+}
+
+///|
+/// Keep a Loom parser Failure distinct from graph syntax rejection. The source
+/// text remains editable and synchronized in the model, but every operation
+/// touching the terminal attachment is stopped.
+fn source_demo_update(
+  emit : Emit[SourceDemoMsg],
+  msg : SourceDemoMsg,
+  model : SourceDemoModel,
+) -> (Cmd, SourceDemoModel) {
+  if model.parser_failed {
+    return match msg {
+      EditorSynced(source) => (@rabbita.none, { ..model, editor: source })
+      _ => (@rabbita.none, model)
+    }
+  }
+  source_demo_update_healthy(emit, msg, model) catch {
+    Failure::Failure(_) =>
+      (
+        @rabbita.none,
+        {
+          ..model,
+          dirty: true,
+          parser_failed: true,
+          status: "The graph parser stopped. Source text remains available; reload to recover.",
           status_tone: @status.Error,
         },
       )
@@ -472,6 +503,7 @@ pub fn mount_source_demo(
     handle,
     editor: get_source_graph_source(handle),
     dirty: false,
+    parser_failed: false,
     mounted: false,
     status: "Source mode active: operations lower into graph-dsl text.",
     status_tone: @status.Info,

--- a/apps/canvas/web/package-lock.json
+++ b/apps/canvas/web/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "canopy-canvas",
       "dependencies": {
+        "@canopy/editor-adapter": "file:../../../adapters/editor",
         "@codemirror/commands": "^6.5.0",
         "@codemirror/state": "^6.4.0",
         "@codemirror/view": "^6.26.0"
@@ -15,6 +16,73 @@
         "typescript": "^5.4.0",
         "vite": "^5.4.0"
       }
+    },
+    "../../../adapters/editor": {
+      "name": "@canopy/editor-adapter",
+      "version": "0.1.0-alpha.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@codemirror/lint": "^6.9.7",
+        "@codemirror/state": "^6.5.0",
+        "@codemirror/view": "^6.35.0",
+        "@playwright/test": "1.61.1",
+        "@types/node": "^24.13.3",
+        "typescript": "^6.0.3",
+        "vite": "^6.0.0",
+        "vitest": "^4.1.10"
+      },
+      "peerDependencies": {
+        "@codemirror/commands": "^6.10.0",
+        "@codemirror/language": "^6.10.0",
+        "@codemirror/lint": "^6.9.7",
+        "@codemirror/state": "^6.5.0",
+        "@codemirror/view": "^6.35.0",
+        "prosemirror-commands": "^1.6.0",
+        "prosemirror-keymap": "^1.2.0",
+        "prosemirror-model": "^1.24.0",
+        "prosemirror-state": "^1.4.0",
+        "prosemirror-transform": "^1.10.0",
+        "prosemirror-view": "^1.37.0"
+      },
+      "peerDependenciesMeta": {
+        "@codemirror/commands": {
+          "optional": true
+        },
+        "@codemirror/language": {
+          "optional": true
+        },
+        "@codemirror/lint": {
+          "optional": true
+        },
+        "@codemirror/state": {
+          "optional": true
+        },
+        "@codemirror/view": {
+          "optional": true
+        },
+        "prosemirror-commands": {
+          "optional": true
+        },
+        "prosemirror-keymap": {
+          "optional": true
+        },
+        "prosemirror-model": {
+          "optional": true
+        },
+        "prosemirror-state": {
+          "optional": true
+        },
+        "prosemirror-transform": {
+          "optional": true
+        },
+        "prosemirror-view": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@canopy/editor-adapter": {
+      "resolved": "../../../adapters/editor",
+      "link": true
     },
     "node_modules/@codemirror/commands": {
       "version": "6.10.3",

--- a/apps/canvas/web/package.json
+++ b/apps/canvas/web/package.json
@@ -12,6 +12,7 @@
     "prebuild:moonbit": "cd .. && moon build --target js --release"
   },
   "dependencies": {
+    "@canopy/editor-adapter": "file:../../../adapters/editor",
     "@codemirror/commands": "^6.5.0",
     "@codemirror/state": "^6.4.0",
     "@codemirror/view": "^6.26.0"

--- a/apps/canvas/web/src/main.ts
+++ b/apps/canvas/web/src/main.ts
@@ -1,3 +1,4 @@
+import { adaptMoonBitModule } from '@canopy/editor-adapter/moonbit-result';
 import * as cmCommands from '@codemirror/commands';
 import * as cmState from '@codemirror/state';
 import * as cmView from '@codemirror/view';
@@ -1040,7 +1041,12 @@ const canopyGlobal = globalThis as typeof globalThis & {
 
 async function init(): Promise<void> {
   canopyGlobal.__canopy_codemirror = { ...cmState, ...cmView, ...cmCommands };
-  const mod = await import('@moonbit/canopy-canvas') as CanvasModule;
+  const raw = await import('@moonbit/canopy-canvas');
+  const mod: CanvasModule = adaptMoonBitModule(raw, {
+    createFunctions: ['create_source_graph'],
+    destroyFunctions: ['destroy_source_graph'],
+    tryDestroyFunctions: ['try_destroy_source_graph'],
+  });
   const sourceDemoModule = requireSourceDemoModule(mod);
   const sourceMode = sourceDemoRequested();
   adapter = sourceMode

--- a/apps/ideal/export-manifest.json
+++ b/apps/ideal/export-manifest.json
@@ -14,6 +14,7 @@
   "ffi_exports": [
     "create_editor",
     "destroy_editor",
+    "try_destroy_editor",
     "get_text",
     "set_text",
     "register_file_host",
@@ -83,6 +84,8 @@
   ],
   "app_reexports": [
     "create_editor_with_undo",
+    "destroy_editor",
+    "try_destroy_editor",
     "get_text",
     "set_text",
     "set_text_and_record",

--- a/apps/ideal/main/action_overlay_exec.mbt
+++ b/apps/ideal/main/action_overlay_exec.mbt
@@ -7,7 +7,7 @@ fn execute_action(
   action : @lambda_edits.Action,
   choice : String,
   name : String,
-) -> (Cmd, Model) {
+) -> (Cmd, Model) raise {
   match @lambda_edits.build_tree_edit_op(action.id, context, choice, name) {
     Ok(Some(op)) =>
       match commit_tree_edit(model, op) {

--- a/apps/ideal/main/action_overlay_state.mbt
+++ b/apps/ideal/main/action_overlay_state.mbt
@@ -3,7 +3,7 @@ fn open_action_overlay_from_event(
   _parent_emit : @rabbita.Emit[Msg],
   model : Model,
   node_id_str : String,
-) -> (Cmd, Model) {
+) -> (Cmd, Model) raise {
   open_action_overlay(model, node_id_str)
 }
 
@@ -70,7 +70,7 @@ fn open_action_overlay(
   model : Model,
   node_id_str : String,
   rect_json? : String = js_get_selected_node_rect(),
-) -> (Cmd, Model) {
+) -> (Cmd, Model) raise {
   if node_id_str == "" {
     return (none, model)
   }

--- a/apps/ideal/main/action_overlay_update.mbt
+++ b/apps/ideal/main/action_overlay_update.mbt
@@ -83,7 +83,7 @@ fn handle_overlay_output(
   model : Model,
   token : Int,
   output : OverlayOutput,
-) -> (Cmd, Model) {
+) -> (Cmd, Model) raise {
   guard model.overlay.active_for_token(token) is Some((context, _, _)) else {
     return (none, model)
   }

--- a/apps/ideal/main/commands.mbt
+++ b/apps/ideal/main/commands.mbt
@@ -45,20 +45,20 @@ fn sync_after_external_crdt_change(model : Model) -> Cmd {
 }
 
 ///|
-fn apply_text_edit(model : Model, text : String) -> (String, Model) {
+fn apply_text_edit(model : Model, text : String) -> (String, Model) raise {
   model.editor.set_text_and_record(text, js_now_ms())
   let changed = refresh({ ..model, next_timestamp: model.next_timestamp + 1 })
   (changed.editor.get_text(), changed)
 }
 
 ///|
-fn load_text(model : Model, text : String) -> (Cmd, Model) {
+fn load_text(model : Model, text : String) -> (Cmd, Model) raise {
   let (actual_text, changed) = apply_text_edit(model, text)
   (sync_after_local_model_change(changed, actual_text), changed)
 }
 
 ///|
-fn select_text_node_cmd(model : Model, node_id : String) -> Cmd {
+fn select_text_node_cmd(model : Model, node_id : String) -> Cmd raise {
   match parse_node_id(node_id) {
     None => none
     Some(nid) =>
@@ -80,7 +80,7 @@ fn select_text_node_cmd(model : Model, node_id : String) -> Cmd {
 }
 
 ///|
-fn select_editor_node_cmd(model : Model, node_id : String) -> Cmd {
+fn select_editor_node_cmd(model : Model, node_id : String) -> Cmd raise {
   let focus_outline = @rabbita.effect(fn() { js_focus_tree_rows() })
   if model.mode == Text {
     @rabbita.batch([select_text_node_cmd(model, node_id), focus_outline])
@@ -97,7 +97,7 @@ fn select_editor_node_cmd(model : Model, node_id : String) -> Cmd {
 /// @scope.build_scope_map that extracts projection data from SyncEditor.
 fn build_scope_map_from_editor(
   editor : @editor.SyncEditor[@ast.Term],
-) -> Map[@canopy_core.NodeId, @scope.ScopeAnnotation] {
+) -> Map[@canopy_core.NodeId, @scope.ScopeAnnotation] raise {
   match editor.get_proj_node() {
     Some(proj_root) =>
       @scope.build_scope_map(
@@ -110,7 +110,7 @@ fn build_scope_map_from_editor(
 }
 
 ///|
-fn refresh(model : Model) -> Model {
+fn refresh(model : Model) -> Model raise {
   js_perf_begin("refreshTotal")
   js_perf_begin("getProjNode")
   let proj_node = model.editor.get_proj_node()
@@ -190,7 +190,7 @@ fn can_hydrate_tree_node(model : Model, node_id : @canopy_core.NodeId) -> Bool {
 fn commit_tree_edit(
   model : Model,
   tree_op : @lambda_edits.TreeEditOp,
-) -> Result[(Cmd, Model), @canopy_core.EditError] {
+) -> Result[(Cmd, Model), @canopy_core.EditError] raise {
   match
     @lambda.apply_lambda_tree_edit(
       model.editor,

--- a/apps/ideal/main/crdt_reexport.mbt
+++ b/apps/ideal/main/crdt_reexport.mbt
@@ -4,7 +4,10 @@
 /// to load the separate @moonbit/canopy module (saves 7.6MB).
 
 ///|
-pub fn create_editor_with_undo(agent_id : String, timeout_ms : Int) -> Int {
+pub fn create_editor_with_undo(
+  agent_id : String,
+  timeout_ms : Int,
+) -> Int raise {
   @ffi.create_editor_with_undo(agent_id, timeout_ms)
 }
 
@@ -14,7 +17,7 @@ pub fn get_text(handle : Int) -> String {
 }
 
 ///|
-pub fn set_text(handle : Int, text : String) -> Unit {
+pub fn set_text(handle : Int, text : String) -> Unit raise {
   @ffi.set_text(handle, text)
 }
 
@@ -23,7 +26,7 @@ pub fn set_text_and_record(
   handle : Int,
   text : String,
   timestamp_ms : Int,
-) -> Unit {
+) -> Unit raise {
   @ffi.set_text_and_record(handle, text, timestamp_ms)
 }
 
@@ -38,7 +41,7 @@ pub fn get_source_map_json(handle : Int) -> String {
 }
 
 ///|
-pub fn get_errors_json(handle : Int) -> String {
+pub fn get_errors_json(handle : Int) -> String raise Failure {
   @ffi.get_errors_json(handle)
 }
 
@@ -48,12 +51,12 @@ pub fn get_version_json(handle : Int) -> String {
 }
 
 ///|
-pub fn insert_at(handle : Int, pos : Int, ch : String, ts : Int) -> Unit {
+pub fn insert_at(handle : Int, pos : Int, ch : String, ts : Int) -> Unit raise {
   @ffi.insert_at(handle, pos, ch, ts)
 }
 
 ///|
-pub fn delete_at(handle : Int, pos : Int, ts : Int) -> Bool {
+pub fn delete_at(handle : Int, pos : Int, ts : Int) -> Bool raise {
   @ffi.delete_at(handle, pos, ts)
 }
 
@@ -73,17 +76,21 @@ pub fn apply_sync_json(handle : Int, sync_json : String) -> String {
 }
 
 ///|
-pub fn apply_tree_edit_json(handle : Int, op_json : String, ts : Int) -> String {
+pub fn apply_tree_edit_json(
+  handle : Int,
+  op_json : String,
+  ts : Int,
+) -> String raise {
   @ffi.apply_tree_edit_json(handle, op_json, ts)
 }
 
 ///|
-pub fn undo_manager_undo(handle : Int) -> Bool {
+pub fn undo_manager_undo(handle : Int) -> Bool raise Failure {
   @ffi.undo_manager_undo(handle)
 }
 
 ///|
-pub fn undo_manager_redo(handle : Int) -> Bool {
+pub fn undo_manager_redo(handle : Int) -> Bool raise Failure {
   @ffi.undo_manager_redo(handle)
 }
 
@@ -158,7 +165,7 @@ pub fn handle_text_intent(
   deleted_len : Int,
   insert : String,
   timestamp_ms : Int,
-) -> Unit {
+) -> Unit raise {
   @ffi.handle_text_intent(handle, from, deleted_len, insert, timestamp_ms)
 }
 
@@ -174,7 +181,7 @@ pub fn handle_text_intent_checked(
   deleted_len : Int,
   insert : String,
   timestamp_ms : Int,
-) -> Bool {
+) -> Bool raise {
   @ffi.handle_text_intent_checked(
     handle, from, deleted_len, insert, timestamp_ms,
   )
@@ -182,13 +189,13 @@ pub fn handle_text_intent_checked(
 
 ///|
 /// Undo on the MoonBit editor directly and return whether it succeeded.
-pub fn handle_undo(handle : Int) -> Bool {
+pub fn handle_undo(handle : Int) -> Bool raise Failure {
   @ffi.handle_undo(handle)
 }
 
 ///|
 /// Redo on the MoonBit editor directly and return whether it succeeded.
-pub fn handle_redo(handle : Int) -> Bool {
+pub fn handle_redo(handle : Int) -> Bool raise Failure {
   @ffi.handle_redo(handle)
 }
 
@@ -200,7 +207,7 @@ pub fn handle_structural_intent(
   node_id : String,
   timestamp_ms : Int,
   params_json : String,
-) -> String {
+) -> String raise {
   @ffi.handle_structural_intent(handle, op, node_id, timestamp_ms, params_json)
 }
 

--- a/apps/ideal/main/crdt_reexport.mbt
+++ b/apps/ideal/main/crdt_reexport.mbt
@@ -12,6 +12,16 @@ pub fn create_editor_with_undo(
 }
 
 ///|
+pub fn try_destroy_editor(handle : Int) -> Bool {
+  @ffi.try_destroy_editor(handle)
+}
+
+///|
+pub fn destroy_editor(handle : Int) -> Unit {
+  @ffi.destroy_editor(handle)
+}
+
+///|
 pub fn get_text(handle : Int) -> String {
   @ffi.get_text(handle)
 }

--- a/apps/ideal/main/init.mbt
+++ b/apps/ideal/main/init.mbt
@@ -102,13 +102,36 @@ fn root_update(
   msg : Msg,
   emit : Emit[Msg],
 ) -> (RootState, Cmd) {
-  let (cmd, model) = update(emit, msg, state.0)
+  let (cmd, model) = update(emit, msg, state.0) catch {
+    _ => (none, { ..state.0, sync_status: Error })
+  }
   (RootState(model, next_root_revision(state.1)), cmd)
 }
 
 ///|
 fn root_subscriptions(state : RootState, emit : Emit[Msg]) -> Sub {
   subscriptions(state.0, emit)
+}
+
+///|
+fn render_view_fallback(model : Model) -> Html {
+  let source = model.editor.get_text()
+  @html.div(attrs=@html.Attrs::build().role("alert"), [
+    @html.p([
+      @html.text(
+        "Derived views are unavailable. The current source is shown read-only.",
+      ),
+    ]),
+    @html.node(
+      "pre",
+      @html.Attrs::build()
+      .role("textbox")
+      .aria_label("Current source, read-only")
+      .aria_multiline("true")
+      .aria_readonly("true"),
+      [@html.text(source)],
+    ),
+  ])
 }
 
 ///|
@@ -119,7 +142,11 @@ fn main {
       update=root_update,
       subscriptions=root_subscriptions,
     )
-    model.map(state => view(emit, state.0))
+    model.map(state => {
+      view(emit, state.0) catch {
+        _ => render_view_fallback(state.0)
+      }
+    })
   })
   app.mount("app")
 }

--- a/apps/ideal/main/intent_log.mbt
+++ b/apps/ideal/main/intent_log.mbt
@@ -43,7 +43,7 @@ fn push_patch(
   model : Model,
   op : @lambda_edits.TreeEditOp,
   edits : Array[@canopy_core.SpanEdit],
-) -> Unit {
+) -> Unit raise Failure {
   if edits.is_empty() {
     return
   }

--- a/apps/ideal/main/internal/history_render/history_render_wbtest.mbt
+++ b/apps/ideal/main/internal/history_render/history_render_wbtest.mbt
@@ -7,7 +7,7 @@
 ///|
 /// Helper: build a fresh single-editor scenario with `n` sequential
 /// inserts of "a" by `agent`. LVs run 0..<n in append order.
-fn build_linear(agent : String, n : Int) -> @editor.SyncEditor[@ast.Term] {
+fn build_linear(agent : String, n : Int) -> @editor.SyncEditor[@ast.Term] raise {
   let (editor, _) = try! @lambda.new_lambda_editor(agent)
   for i in 0..<n {
     editor.insert_at(i, "a", 0)

--- a/apps/ideal/main/moon.pkg
+++ b/apps/ideal/main/moon.pkg
@@ -47,6 +47,8 @@ options(
     "js": {
       "exports": [
         "create_editor_with_undo",
+        "destroy_editor",
+        "try_destroy_editor",
         "get_text",
         "set_text",
         "set_text_and_record",

--- a/apps/ideal/main/pkg.generated.mbti
+++ b/apps/ideal/main/pkg.generated.mbti
@@ -23,6 +23,8 @@ pub fn create_editor_with_undo(String, Int) -> Int raise
 
 pub fn delete_at(Int, Int, Int) -> Bool raise
 
+pub fn destroy_editor(Int) -> Unit
+
 pub fn ephemeral_apply(Int, Bytes) -> Unit
 
 pub fn ephemeral_delete_presence(Int) -> Unit
@@ -72,6 +74,8 @@ pub fn save_file(Int, String) -> Unit
 pub fn set_text(Int, String) -> Unit raise
 
 pub fn set_text_and_record(Int, String, Int) -> Unit raise
+
+pub fn try_destroy_editor(Int) -> Bool
 
 pub fn undo_manager_can_redo(Int) -> Bool
 

--- a/apps/ideal/main/pkg.generated.mbti
+++ b/apps/ideal/main/pkg.generated.mbti
@@ -17,11 +17,11 @@ import {
 // Values
 pub fn apply_sync_json(Int, String) -> String
 
-pub fn apply_tree_edit_json(Int, String, Int) -> String
+pub fn apply_tree_edit_json(Int, String, Int) -> String raise
 
-pub fn create_editor_with_undo(String, Int) -> Int
+pub fn create_editor_with_undo(String, Int) -> Int raise
 
-pub fn delete_at(Int, Int, Int) -> Bool
+pub fn delete_at(Int, Int, Int) -> Bool raise
 
 pub fn ephemeral_apply(Int, Bytes) -> Unit
 
@@ -41,7 +41,7 @@ pub fn export_all_json(Int) -> String
 
 pub fn export_since_json(Int, String) -> String
 
-pub fn get_errors_json(Int) -> String
+pub fn get_errors_json(Int) -> String raise Failure
 
 pub fn get_proj_node_json(Int) -> String
 
@@ -51,17 +51,17 @@ pub fn get_text(Int) -> String
 
 pub fn get_version_json(Int) -> String
 
-pub fn handle_redo(Int) -> Bool
+pub fn handle_redo(Int) -> Bool raise Failure
 
-pub fn handle_structural_intent(Int, String, String, Int, String) -> String
+pub fn handle_structural_intent(Int, String, String, Int, String) -> String raise
 
-pub fn handle_text_intent(Int, Int, Int, String, Int) -> Unit
+pub fn handle_text_intent(Int, Int, Int, String, Int) -> Unit raise
 
-pub fn handle_text_intent_checked(Int, Int, Int, String, Int) -> Bool
+pub fn handle_text_intent_checked(Int, Int, Int, String, Int) -> Bool raise
 
-pub fn handle_undo(Int) -> Bool
+pub fn handle_undo(Int) -> Bool raise Failure
 
-pub fn insert_at(Int, Int, String, Int) -> Unit
+pub fn insert_at(Int, Int, String, Int) -> Unit raise
 
 pub fn load_file(Int) -> Unit
 
@@ -69,17 +69,17 @@ pub fn register_file_host(@js_ffi.Any) -> Unit
 
 pub fn save_file(Int, String) -> Unit
 
-pub fn set_text(Int, String) -> Unit
+pub fn set_text(Int, String) -> Unit raise
 
-pub fn set_text_and_record(Int, String, Int) -> Unit
+pub fn set_text_and_record(Int, String, Int) -> Unit raise
 
 pub fn undo_manager_can_redo(Int) -> Bool
 
 pub fn undo_manager_can_undo(Int) -> Bool
 
-pub fn undo_manager_redo(Int) -> Bool
+pub fn undo_manager_redo(Int) -> Bool raise Failure
 
-pub fn undo_manager_undo(Int) -> Bool
+pub fn undo_manager_undo(Int) -> Bool raise Failure
 
 // Errors
 

--- a/apps/ideal/main/update.mbt
+++ b/apps/ideal/main/update.mbt
@@ -3,7 +3,7 @@ fn apply_structural_edit_request(
   model : Model,
   op : String,
   node_id : String,
-) -> (Cmd, Model) {
+) -> (Cmd, Model) raise {
   let nid = match parse_node_id(node_id) {
     Some(id) => id
     None => return (none, model)
@@ -19,7 +19,7 @@ fn apply_structural_edit_request(
 }
 
 ///|
-fn update(emit : Emit[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
+fn update(emit : Emit[Msg], msg : Msg, model : Model) -> (Cmd, Model) raise {
   match handle_workspace(emit, msg, model) {
     Some(r) => return r
     None => ()

--- a/apps/ideal/main/update_codemirror.mbt
+++ b/apps/ideal/main/update_codemirror.mbt
@@ -3,7 +3,7 @@ fn handle_codemirror(
   emit : Emit[Msg],
   msg : Msg,
   model : Model,
-) -> (Cmd, Model)? {
+) -> (Cmd, Model)? raise {
   let _ = emit
   match msg {
     CmMounted => {

--- a/apps/ideal/main/update_file_io.mbt
+++ b/apps/ideal/main/update_file_io.mbt
@@ -1,5 +1,9 @@
 ///|
-fn handle_file_io(emit : Emit[Msg], msg : Msg, model : Model) -> (Cmd, Model)? {
+fn handle_file_io(
+  emit : Emit[Msg],
+  msg : Msg,
+  model : Model,
+) -> (Cmd, Model)? raise {
   let _ = emit
   match msg {
     LoadExample(example_text) => Some(load_text(model, example_text))

--- a/apps/ideal/main/update_outline.mbt
+++ b/apps/ideal/main/update_outline.mbt
@@ -1,5 +1,9 @@
 ///|
-fn handle_outline(emit : Emit[Msg], msg : Msg, model : Model) -> (Cmd, Model)? {
+fn handle_outline(
+  emit : Emit[Msg],
+  msg : Msg,
+  model : Model,
+) -> (Cmd, Model)? raise {
   let _ = emit
   match msg {
     OutlineNodeClicked(node_id) => {

--- a/apps/ideal/main/update_overlay.mbt
+++ b/apps/ideal/main/update_overlay.mbt
@@ -1,5 +1,9 @@
 ///|
-fn handle_overlay(emit : Emit[Msg], msg : Msg, model : Model) -> (Cmd, Model)? {
+fn handle_overlay(
+  emit : Emit[Msg],
+  msg : Msg,
+  model : Model,
+) -> (Cmd, Model)? raise {
   match msg {
     OpenActionOverlayFromOutline => {
       let node_id_str = match model.selected_node {

--- a/apps/ideal/main/update_structural.mbt
+++ b/apps/ideal/main/update_structural.mbt
@@ -3,7 +3,7 @@ fn handle_structural(
   emit : Emit[Msg],
   msg : Msg,
   model : Model,
-) -> (Cmd, Model)? {
+) -> (Cmd, Model)? raise {
   let _ = emit
   match msg {
     StructuralEditRequested(op~, node_id~) =>

--- a/apps/ideal/main/update_structure_mode.mbt
+++ b/apps/ideal/main/update_structure_mode.mbt
@@ -3,7 +3,7 @@ fn handle_structure_mode(
   emit : Emit[Msg],
   msg : Msg,
   model : Model,
-) -> (Cmd, Model)? {
+) -> (Cmd, Model)? raise {
   let _ = emit
   match msg {
     StructureNodeSelected(node_id) =>

--- a/apps/ideal/main/update_workspace.mbt
+++ b/apps/ideal/main/update_workspace.mbt
@@ -3,7 +3,7 @@
 // Some((Cmd, Model)). Returns None for unmatched variants.
 
 ///|
-fn sync_after_history_change(model : Model) -> (Cmd, Model) {
+fn sync_after_history_change(model : Model) -> (Cmd, Model) raise {
   let new_model = refresh(model)
   let text = new_model.editor.get_text()
   let cmd = sync_after_local_model_change(new_model, text)
@@ -15,7 +15,7 @@ fn handle_workspace(
   emit : Emit[Msg],
   msg : Msg,
   model : Model,
-) -> (Cmd, Model)? {
+) -> (Cmd, Model)? raise {
   let _ = emit
   match msg {
     SetMode(mode) => {

--- a/apps/ideal/main/view_bottom.mbt
+++ b/apps/ideal/main/view_bottom.mbt
@@ -258,7 +258,7 @@ fn view_history_panel(model : Model) -> Html {
 /// a `<section>` with `inner_html` rather than a `<div>` with vdom
 /// children, and for the `bottom_visible` gate.
 #warnings("-alert_xss_vulnerable")
-fn view_graphviz_panel(model : Model) -> Html {
+fn view_graphviz_panel(model : Model) -> Html raise {
   let html = if model.workspace.bottom_visible {
     render_graphviz_html(model)
   } else {
@@ -289,7 +289,7 @@ fn view_incr_graph_panel(model : Model) -> Html {
 }
 
 ///|
-fn view_bottom_content(dispatch : Emit[Msg], model : Model) -> Html {
+fn view_bottom_content(dispatch : Emit[Msg], model : Model) -> Html raise {
   let content : Html = match model.bottom_tab {
     Problems => view_problems(model)
     OpLog => view_op_log(model)

--- a/apps/ideal/main/view_bottom_graphviz.mbt
+++ b/apps/ideal/main/view_bottom_graphviz.mbt
@@ -29,7 +29,7 @@ fn render_dot_to_svg(dot : String) -> String {
 /// transition from `<section>` (SVG panels) to `<div>` (everything
 /// else), removes the old subtree wholesale, and rebuilds — so stale
 /// SVG can't leak past the diff and block sibling click handlers.
-fn render_graphviz_html(model : Model) -> String {
+fn render_graphviz_html(model : Model) -> String raise {
   let snap = model.editor.causal_snapshot()
   let key = render_cache_key(model.editor.identity(), snap)
   if cache_hit(graphviz_cache, key) {

--- a/apps/ideal/main/view_bottom_patch.mbt
+++ b/apps/ideal/main/view_bottom_patch.mbt
@@ -66,7 +66,7 @@ fn format_structured_change(
 /// so the user can cross-reference the matching Op Log entry, then each
 /// `SpanEdit` renders via its `Show` impl (`@<start> -<delete_len> +«…»`).
 /// Per-entry `changes` are rendered in a `<details>` block within each row.
-fn view_patch_log(model : Model) -> Html {
+fn view_patch_log(model : Model) -> Html raise {
   // See `view_op_log` for the rationale; Patch panel rows are heavier
   // (header + N `SpanEdit` rows per entry), so guarding here matters more.
   if !model.workspace.bottom_visible {

--- a/apps/ideal/main/view_bottom_problems.mbt
+++ b/apps/ideal/main/view_bottom_problems.mbt
@@ -1,5 +1,5 @@
 ///|
-fn view_problems(model : Model) -> Html {
+fn view_problems(model : Model) -> Html raise {
   guard model.workspace.bottom_visible else {
     return @html.div(
       class="bottom-content",

--- a/apps/ideal/main/view_inspector.mbt
+++ b/apps/ideal/main/view_inspector.mbt
@@ -27,7 +27,7 @@ fn find_node_by_id(
 fn resolve_selected_node(
   model : Model,
   target_id : String,
-) -> @proj.InteractiveTreeNode[@ast.Term]? {
+) -> @proj.InteractiveTreeNode[@ast.Term]? raise {
   let loaded = match model.outline_state.tree {
     Some(root) => find_node_by_id(root, target_id)
     None => None
@@ -76,7 +76,7 @@ fn inspector_row(key : String, value : String) -> Html {
 fn view_node_details(
   node : @proj.InteractiveTreeNode[@ast.Term],
   model : Model,
-) -> Html {
+) -> Html raise {
   let kind_tag = @lambda_proj.term_kind_tag(node.kind)
   let items : Array[Html] = [
     span(class=@ui.inspector_label_class(), [text("NODE")]),
@@ -166,7 +166,7 @@ fn view_crdt_info(model : Model) -> Html {
 
 ///|
 /// Render inspector content (without wrapper — wrapper is in view()).
-fn view_inspector_content(dispatch : Emit[Msg], model : Model) -> Html {
+fn view_inspector_content(dispatch : Emit[Msg], model : Model) -> Html raise {
   let node_section : Html = match model.selected_node {
     Some(sel_id) => {
       let found = resolve_selected_node(model, sel_id)

--- a/apps/ideal/main/view_outline.mbt
+++ b/apps/ideal/main/view_outline.mbt
@@ -254,7 +254,7 @@ fn view_outline_node(
 fn navigate_outline(
   model : Model,
   direction : @canopy_core.Direction,
-) -> String? {
+) -> String? raise {
   let node_id_str = match model.selected_node {
     Some(s) => s
     None => return None
@@ -292,7 +292,7 @@ fn get_selected_node_id(model : Model) -> @canopy_core.NodeId? {
 /// Maps eval results to ProjNode children by definition index.
 fn build_outline_eval_annotations(
   model : Model,
-) -> Map[@canopy_core.NodeId, Array[@lambda.EvalResult]] {
+) -> Map[@canopy_core.NodeId, Array[@lambda.EvalResult]] raise {
   let annotations : Map[@canopy_core.NodeId, Array[@lambda.EvalResult]] = Map([])
   let eval_results = model.companion.get_eval_results()
   if eval_results.is_empty() {
@@ -319,9 +319,10 @@ fn build_outline_eval_annotations(
 
 ///|
 /// Render outline tree view with keyboard navigation (original tree mode).
-fn view_outline_tree(dispatch : Emit[Msg], model : Model) -> Html {
+fn view_outline_tree(dispatch : Emit[Msg], model : Model) -> Html raise {
   let navigate = fn(direction : @canopy_core.Direction) {
-    match navigate_outline(model, direction) {
+    let next = navigate_outline(model, direction) catch { _ => None }
+    match next {
       Some(id) => dispatch(OutlineNavigate(id))
       None => @rabbita.none
     }
@@ -405,7 +406,7 @@ fn view_outline_tree(dispatch : Emit[Msg], model : Model) -> Html {
 
 ///|
 /// Render outline content.
-fn view_outline_content(dispatch : Emit[Msg], model : Model) -> Html {
+fn view_outline_content(dispatch : Emit[Msg], model : Model) -> Html raise {
   js_install_outline_drag_capture()
   view_outline_tree(dispatch, model)
 }

--- a/apps/ideal/main/view_root.mbt
+++ b/apps/ideal/main/view_root.mbt
@@ -155,7 +155,7 @@ fn view_outline_resize_handle(
 }
 
 ///|
-fn view(dispatch : Emit[Msg], model : Model) -> Html {
+fn view(dispatch : Emit[Msg], model : Model) -> Html raise {
   // Always render panels — toggle visibility via CSS class
   // so CSS transitions work for both enter and exit.
   let outline_class = if model.workspace.outline_visible {

--- a/apps/ideal/web/package-lock.json
+++ b/apps/ideal/web/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "canopy-ideal-editor",
       "dependencies": {
+        "@canopy/editor-adapter": "file:../../../adapters/editor",
         "@codemirror/commands": "^6.5.0",
         "@codemirror/language": "^6.10.0",
         "@codemirror/state": "^6.4.0",
@@ -35,6 +36,73 @@
       "optionalDependencies": {
         "better-sqlite3": "^11.0.0"
       }
+    },
+    "../../../adapters/editor": {
+      "name": "@canopy/editor-adapter",
+      "version": "0.1.0-alpha.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@codemirror/lint": "^6.9.7",
+        "@codemirror/state": "^6.5.0",
+        "@codemirror/view": "^6.35.0",
+        "@playwright/test": "1.61.1",
+        "@types/node": "^24.13.3",
+        "typescript": "^6.0.3",
+        "vite": "^6.0.0",
+        "vitest": "^4.1.10"
+      },
+      "peerDependencies": {
+        "@codemirror/commands": "^6.10.0",
+        "@codemirror/language": "^6.10.0",
+        "@codemirror/lint": "^6.9.7",
+        "@codemirror/state": "^6.5.0",
+        "@codemirror/view": "^6.35.0",
+        "prosemirror-commands": "^1.6.0",
+        "prosemirror-keymap": "^1.2.0",
+        "prosemirror-model": "^1.24.0",
+        "prosemirror-state": "^1.4.0",
+        "prosemirror-transform": "^1.10.0",
+        "prosemirror-view": "^1.37.0"
+      },
+      "peerDependenciesMeta": {
+        "@codemirror/commands": {
+          "optional": true
+        },
+        "@codemirror/language": {
+          "optional": true
+        },
+        "@codemirror/lint": {
+          "optional": true
+        },
+        "@codemirror/state": {
+          "optional": true
+        },
+        "@codemirror/view": {
+          "optional": true
+        },
+        "prosemirror-commands": {
+          "optional": true
+        },
+        "prosemirror-keymap": {
+          "optional": true
+        },
+        "prosemirror-model": {
+          "optional": true
+        },
+        "prosemirror-state": {
+          "optional": true
+        },
+        "prosemirror-transform": {
+          "optional": true
+        },
+        "prosemirror-view": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@canopy/editor-adapter": {
+      "resolved": "../../../adapters/editor",
+      "link": true
     },
     "node_modules/@codemirror/commands": {
       "version": "6.10.3",

--- a/apps/ideal/web/package.json
+++ b/apps/ideal/web/package.json
@@ -13,6 +13,7 @@
     "test:headed": "playwright test --headed"
   },
   "dependencies": {
+    "@canopy/editor-adapter": "file:../../../adapters/editor",
     "@codemirror/commands": "^6.5.0",
     "@codemirror/language": "^6.10.0",
     "@codemirror/state": "^6.4.0",

--- a/apps/ideal/web/src/main.ts
+++ b/apps/ideal/web/src/main.ts
@@ -1,4 +1,5 @@
 import './canopy-editor';
+import { adaptMoonBitModule } from '@canopy/editor-adapter/moonbit-result';
 import * as cmCommands from '@codemirror/commands';
 import { HighlightStyle, syntaxHighlighting } from '@codemirror/language';
 import * as cmState from '@codemirror/state';
@@ -87,7 +88,12 @@ function loadCrdtModule(): Promise<CrdtModule> {
     };
     canopyGlobal.__canopy_codemirror = { ...cmState, ...cmView, ...cmCommands };
     // Loading the MoonBit module also runs Rabbita's main(), which renders <canopy-editor>.
-    crdtPromise = import('@moonbit/ideal-editor') as Promise<CrdtModule>;
+    crdtPromise = import('@moonbit/ideal-editor').then((raw) => adaptMoonBitModule(raw, {
+      createFunctions: ['create_editor_with_undo'],
+      destroyFunctions: ['destroy_editor'],
+      tryDestroyFunctions: ['try_destroy_editor'],
+      initialHandles: [0],
+    }));
   }
   return crdtPromise;
 }

--- a/apps/loomark/archive/archive.mbt
+++ b/apps/loomark/archive/archive.mbt
@@ -89,12 +89,26 @@ pub fn LoomarkDocumentArchive::history(
 pub fn LoomarkDocumentArchive::capture(
   document_id~ : LoomarkDocumentId,
   editor~ : @markdown.MarkdownEditor,
-) -> LoomarkDocumentArchive raise LoomarkArchiveCaptureError {
+) -> LoomarkDocumentArchive raise {
   let portable_markdown = editor.portable_markdown()
   let history = editor.history_since() catch {
-    _ =>
+    @markdown.MarkdownArchiveError::ExportFailed(detail~) =>
+      raise LoomarkArchiveCaptureError::HistoryUnavailable(detail~)
+    @markdown.MarkdownArchiveError::HistoryAdmissionFailed(detail~) =>
+      raise LoomarkArchiveCaptureError::HistoryUnavailable(detail~)
+    @markdown.MarkdownArchiveError::IncompleteHistory =>
       raise LoomarkArchiveCaptureError::HistoryUnavailable(
-        detail="history export failed",
+        detail="history is incomplete",
+      )
+    @markdown.MarkdownArchiveError::InvalidAgentId =>
+      raise LoomarkArchiveCaptureError::HistoryUnavailable(
+        detail="invalid agent id",
+      )
+    @markdown.MarkdownArchiveError::WriterCreationFailed(detail~) =>
+      raise LoomarkArchiveCaptureError::HistoryUnavailable(detail~)
+    @markdown.MarkdownArchiveError::LimitExceeded(..) =>
+      raise LoomarkArchiveCaptureError::HistoryUnavailable(
+        detail="history export limit exceeded",
       )
   }
   { document_id, portable_markdown, history }
@@ -124,7 +138,7 @@ pub fn LoomarkDocumentArchive::from_json_string(
   json : String,
   validation_agent_id~ : String,
   open_limits~ : @markdown.MarkdownArchiveOpenLimits,
-) -> LoomarkDocumentArchive raise LoomarkArchiveDecodeError {
+) -> LoomarkDocumentArchive raise {
   let value = @json.parse(json) catch {
     _ =>
       raise LoomarkArchiveDecodeError::MalformedEnvelope(detail="invalid JSON")
@@ -235,12 +249,13 @@ fn validate_decoded(
   history : @markdown.MarkdownDocumentHistory,
   validation_agent_id : String,
   open_limits : @markdown.MarkdownArchiveOpenLimits,
-) -> Unit raise LoomarkArchiveDecodeError {
+) -> Unit raise {
   let reopened = @markdown.MarkdownEditor::open(
     agent_id=validation_agent_id,
     history~,
     open_limits~,
   ) catch {
+    Failure::Failure(_) as failure => raise failure
     @markdown.MarkdownArchiveError::InvalidAgentId =>
       raise LoomarkArchiveDecodeError::InvalidValidationAgentId
     @markdown.MarkdownArchiveError::WriterCreationFailed(detail~) =>
@@ -257,6 +272,7 @@ fn validate_decoded(
       raise LoomarkArchiveDecodeError::IncompleteHistory
     @markdown.MarkdownArchiveError::ExportFailed(detail~) =>
       raise LoomarkArchiveDecodeError::HistoryExportFailed(detail~)
+    error => raise error
   }
   if reopened.portable_markdown() != portable_markdown {
     raise LoomarkArchiveDecodeError::PortableTextHistoryMismatch

--- a/apps/loomark/archive/archive_wbtest.mbt
+++ b/apps/loomark/archive/archive_wbtest.mbt
@@ -53,7 +53,7 @@ test "archive decode error matrix" {
   let encoded = archive.to_json_string()
   assert_true(encoded.contains("\"schema_version\":\"1\""))
 
-  let capacity : Result[LoomarkDocumentArchive, LoomarkArchiveDecodeError] = Ok(
+  let capacity : Result[LoomarkDocumentArchive, Error] = Ok(
     LoomarkDocumentArchive::from_json_string(
       encoded,
       validation_agent_id="archive-errors-capacity",
@@ -73,7 +73,7 @@ test "archive decode error matrix" {
     _ => fail("expected archive limit failure")
   }
 
-  let newer : Result[LoomarkDocumentArchive, LoomarkArchiveDecodeError] = Ok(
+  let newer : Result[LoomarkDocumentArchive, Error] = Ok(
     LoomarkDocumentArchive::from_json_string(
       "{\"schema_version\":\"2\",\"document_id\":\"x\",\"portable_markdown\":42,\"history\":false,\"extensions\":{}}",
       validation_agent_id="archive-errors-newer",
@@ -88,7 +88,7 @@ test "archive decode error matrix" {
     _ => fail("expected version 2 to be unsupported")
   }
 
-  let too_large : Result[LoomarkDocumentArchive, LoomarkArchiveDecodeError] = Ok(
+  let too_large : Result[LoomarkDocumentArchive, Error] = Ok(
     LoomarkDocumentArchive::from_json_string(
       "{\"schema_version\":\"2147483648\"}",
       validation_agent_id="archive-errors-int-overflow",
@@ -103,7 +103,7 @@ test "archive decode error matrix" {
     _ => fail("expected 2147483648 to be unsupported")
   }
 
-  let much_too_large : Result[LoomarkDocumentArchive, LoomarkArchiveDecodeError] = Ok(
+  let much_too_large : Result[LoomarkDocumentArchive, Error] = Ok(
     LoomarkDocumentArchive::from_json_string(
       "{\"schema_version\":\"999999999999999999999999999999999999999999999999999\"}",
       validation_agent_id="archive-errors-huge-version",
@@ -127,7 +127,7 @@ test "archive decode error matrix" {
     "{\"schema_version\":null}", "{\"schema_version\":{}}", "{\"schema_version\":[]}",
   ]
   for schema_version_json in malformed_schema_versions {
-    let malformed : Result[LoomarkDocumentArchive, LoomarkArchiveDecodeError] = Ok(
+    let malformed : Result[LoomarkDocumentArchive, Error] = Ok(
       LoomarkDocumentArchive::from_json_string(
         schema_version_json,
         validation_agent_id="archive-errors-malformed-schema-version",
@@ -141,7 +141,7 @@ test "archive decode error matrix" {
     )
   }
 
-  let malformed : Result[LoomarkDocumentArchive, LoomarkArchiveDecodeError] = Ok(
+  let malformed : Result[LoomarkDocumentArchive, Error] = Ok(
     LoomarkDocumentArchive::from_json_string(
       "not-json",
       validation_agent_id="archive-errors-malformed",
@@ -152,7 +152,7 @@ test "archive decode error matrix" {
   }
   assert_true(malformed is Err(LoomarkArchiveDecodeError::MalformedEnvelope(_)))
 
-  let missing : Result[LoomarkDocumentArchive, LoomarkArchiveDecodeError] = Ok(
+  let missing : Result[LoomarkDocumentArchive, Error] = Ok(
     LoomarkDocumentArchive::from_json_string(
       "{\"schema_version\":\"1\"}",
       validation_agent_id="archive-errors-missing",
@@ -163,7 +163,7 @@ test "archive decode error matrix" {
   }
   assert_true(missing is Err(LoomarkArchiveDecodeError::MalformedEnvelope(_)))
 
-  let unknown : Result[LoomarkDocumentArchive, LoomarkArchiveDecodeError] = Ok(
+  let unknown : Result[LoomarkDocumentArchive, Error] = Ok(
     LoomarkDocumentArchive::from_json_string(
       encoded.replace(
         old="\"extensions\":{}",
@@ -177,7 +177,7 @@ test "archive decode error matrix" {
   }
   assert_true(unknown is Err(LoomarkArchiveDecodeError::MalformedEnvelope(_)))
 
-  let corrupt : Result[LoomarkDocumentArchive, LoomarkArchiveDecodeError] = Ok(
+  let corrupt : Result[LoomarkDocumentArchive, Error] = Ok(
     LoomarkDocumentArchive::from_json_string(
       encoded.replace(old="\"history\":\"", new="\"history\":\"not-history"),
       validation_agent_id="archive-errors-corrupt",
@@ -188,7 +188,7 @@ test "archive decode error matrix" {
   }
   assert_true(corrupt is Err(LoomarkArchiveDecodeError::CorruptHistory(_)))
 
-  let mismatch : Result[LoomarkDocumentArchive, LoomarkArchiveDecodeError] = Ok(
+  let mismatch : Result[LoomarkDocumentArchive, Error] = Ok(
     LoomarkDocumentArchive::from_json_string(
       encoded.replace(old="# Title\\n", new="# Other\\n"),
       validation_agent_id="archive-errors-mismatch",
@@ -201,7 +201,7 @@ test "archive decode error matrix" {
     mismatch is Err(LoomarkArchiveDecodeError::PortableTextHistoryMismatch),
   )
 
-  let empty_id : Result[LoomarkDocumentArchive, LoomarkArchiveDecodeError] = Ok(
+  let empty_id : Result[LoomarkDocumentArchive, Error] = Ok(
     LoomarkDocumentArchive::from_json_string(
       encoded.replace(old="doc-errors", new=""),
       validation_agent_id="archive-errors-empty-id",
@@ -212,10 +212,7 @@ test "archive decode error matrix" {
   }
   assert_true(empty_id is Err(LoomarkArchiveDecodeError::EmptyDocumentId))
 
-  let nonempty_extensions : Result[
-    LoomarkDocumentArchive,
-    LoomarkArchiveDecodeError,
-  ] = Ok(
+  let nonempty_extensions : Result[LoomarkDocumentArchive, Error] = Ok(
     LoomarkDocumentArchive::from_json_string(
       encoded.replace(
         old="\"extensions\":{}",
@@ -258,7 +255,7 @@ test "archive decode distinguishes incomplete history from limit-exceeded" {
     "extensions": Json::empty_object(),
   }).stringify()
 
-  let incomplete : Result[LoomarkDocumentArchive, LoomarkArchiveDecodeError] = Ok(
+  let incomplete : Result[LoomarkDocumentArchive, Error] = Ok(
     LoomarkDocumentArchive::from_json_string(
       encoded,
       validation_agent_id="archive-gap-incomplete",
@@ -269,7 +266,7 @@ test "archive decode distinguishes incomplete history from limit-exceeded" {
   }
   assert_true(incomplete is Err(LoomarkArchiveDecodeError::IncompleteHistory))
 
-  let capacity : Result[LoomarkDocumentArchive, LoomarkArchiveDecodeError] = Ok(
+  let capacity : Result[LoomarkDocumentArchive, Error] = Ok(
     LoomarkDocumentArchive::from_json_string(
       encoded,
       validation_agent_id="archive-gap-capacity",

--- a/apps/loomark/archive/pkg.generated.mbti
+++ b/apps/loomark/archive/pkg.generated.mbti
@@ -36,9 +36,9 @@ pub(all) suberror LoomarkDocumentIdError {
 pub struct LoomarkDocumentArchive {
   // private fields
 }
-pub fn LoomarkDocumentArchive::capture(document_id~ : LoomarkDocumentId, editor~ : @markdown.MarkdownEditor) -> Self raise LoomarkArchiveCaptureError
+pub fn LoomarkDocumentArchive::capture(document_id~ : LoomarkDocumentId, editor~ : @markdown.MarkdownEditor) -> Self raise
 pub fn LoomarkDocumentArchive::document_id(Self) -> LoomarkDocumentId
-pub fn LoomarkDocumentArchive::from_json_string(String, validation_agent_id~ : String, open_limits~ : @markdown.MarkdownArchiveOpenLimits) -> Self raise LoomarkArchiveDecodeError
+pub fn LoomarkDocumentArchive::from_json_string(String, validation_agent_id~ : String, open_limits~ : @markdown.MarkdownArchiveOpenLimits) -> Self raise
 pub fn LoomarkDocumentArchive::history(Self) -> @markdown.MarkdownDocumentHistory
 pub fn LoomarkDocumentArchive::portable_markdown(Self) -> String
 pub fn LoomarkDocumentArchive::to_json_string(Self) -> String

--- a/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
+++ b/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
@@ -109,6 +109,16 @@ async function forceEditorFailure(page: Page): Promise<void> {
     import(moduleUrl).then(module => module.dev_host_force_editor_failure()), moduleUrl)
 }
 
+async function forceParserFailure(page: Page): Promise<void> {
+  await page.evaluate(moduleUrl =>
+    import(moduleUrl).then(module => module.dev_host_force_parser_failure()), moduleUrl)
+}
+
+async function forceReconstructionFailure(page: Page): Promise<void> {
+  await page.evaluate(moduleUrl =>
+    import(moduleUrl).then(module => module.dev_host_force_reconstruction_failure()), moduleUrl)
+}
+
 async function focusPreview(page: Page): Promise<void> {
   await page.evaluate(moduleUrl =>
     import(moduleUrl).then(module => module.dev_host_focus_preview()), moduleUrl)
@@ -214,6 +224,68 @@ test("private development host remains independent of archive storage", async ({
     ).__loomarkStorageWrites)).toBe(0)
   } finally {
     await context.close()
+  }
+})
+
+test("post-acceptance parser Failure reopens once and resumes Raw editing", async ({ browser }) => {
+  const host = await mountHost(browser, "# Before\n")
+  try {
+    await toggleSplitPreview(host.page)
+    await selectPreview(host.page)
+    await expectPreviewSource(host.page, "# Before\n")
+
+    await forceParserFailure(host.page)
+    await expect.poll(async () => (await snapshot(host.page)).parser_failure_armed).toBe(true)
+    await requestSource(host.page, "# Accepted\n")
+
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("# Accepted\n")
+    await expect.poll(async () => (await snapshot(host.page)).runtime_state).toBe("healthy")
+    await expect.poll(async () => (await snapshot(host.page)).mode).toBe("raw")
+    await expect.poll(async () => (await snapshot(host.page)).error_code).toBe("editor-recovered")
+    await expect.poll(async () => (await snapshot(host.page)).parser_failure_armed).toBe(false)
+    await expect.poll(async () => (await snapshot(host.page)).committed_change_count).toBe(1)
+    await expect(host.page.locator("#loomark-input")).toHaveValue("# Accepted\n")
+    await expect(host.page.locator("#loomark-preview")).toHaveCount(0)
+    await expect(host.page.locator("#loomark-block")).toHaveCount(0)
+
+    await host.page.locator("#loomark-input").fill("# Continued\n")
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("# Continued\n")
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("failed reconstruction exposes exact Markdown in terminal Raw Recovery", async ({ browser }) => {
+  const host = await mountHost(browser, "# Before\n")
+  try {
+    await forceReconstructionFailure(host.page)
+    await forceParserFailure(host.page)
+    await requestSource(host.page, "# Accepted\n")
+
+    await expect.poll(async () => (await snapshot(host.page)).runtime_state).toBe("raw-recovery")
+    await expect.poll(async () => (await snapshot(host.page)).fatal).toBe(true)
+    await expect.poll(async () => (await snapshot(host.page)).reconstruction_attempt_count).toBe(1)
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("# Accepted\n")
+    await expect(host.page.locator("#loomark-recovery-source")).toHaveValue("# Accepted\n")
+    await expect(host.page.locator("#loomark-recovery-copy")).toBeVisible()
+    await expect(host.page.locator("#loomark-recovery-download")).toBeVisible()
+    await expect(host.page.locator("#loomark-recovery-reload")).toBeVisible()
+    await host.page.locator("#loomark-recovery-copy").click()
+    await expect.poll(async () => (await snapshot(host.page)).error_code).toBe(
+      "editor-recovery-failed",
+    )
+    const [download] = await Promise.all([
+      host.page.waitForEvent("download"),
+      host.page.locator("#loomark-recovery-download").click(),
+    ])
+    expect(download.suggestedFilename()).toBe("loomark-recovered.md")
+    await expect(host.page.locator("#loomark-preview")).toHaveCount(0)
+    await expect(host.page.locator("#loomark-block")).toHaveCount(0)
+
+    await requestSource(host.page, "# Must not land\n")
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("# Accepted\n")
+  } finally {
+    await host.context.close()
   }
 })
 

--- a/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
+++ b/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
@@ -379,15 +379,16 @@ test("Raw keeps focus and accepts consecutive keystrokes while split Preview upd
     let expectedSource = "start"
     for (const character of ["a", "b", "c"]) {
       expectedSource += character
-      await host.page.keyboard.type(character)
-      // Wait for each coalesced transaction to commit and re-render before
-      // checking focus, so this exercises the slow-CI ordering deterministically.
+      await expect(input).toBeFocused()
+      // Target the current textarea node so an already-scheduled split render
+      // cannot send the key to a detached predecessor between focus and input.
+      await input.pressSequentially(character)
+      // A canonical source commit plus focus on the re-resolved control is the
+      // explicit acknowledgement that the transaction rendered successfully.
       await expect.poll(async () => (await snapshot(host.page)).source).toBe(
         expectedSource,
       )
-      await expect.poll(() => host.page.evaluate(() => document.activeElement?.id)).toBe(
-        "loomark-input",
-      )
+      await expect(input).toBeFocused()
     }
 
     await expect(input).toHaveValue("startabc")
@@ -398,10 +399,8 @@ test("Raw keeps focus and accepts consecutive keystrokes while split Preview upd
       "data-orientation",
       "vertical",
     )
-    await expect.poll(() => host.page.evaluate(() => document.activeElement?.id)).toBe(
-      "loomark-input",
-    )
-    await host.page.keyboard.type("d")
+    await expect(input).toBeFocused()
+    await input.pressSequentially("d")
     await expect(input).toHaveValue("startabcd")
   } finally {
     await host.context.close()

--- a/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
+++ b/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
@@ -376,15 +376,21 @@ test("Raw keeps focus and accepts consecutive keystrokes while split Preview upd
       textarea.setSelectionRange(textarea.value.length, textarea.value.length)
     })
 
+    let expectedSource = "start"
     for (const character of ["a", "b", "c"]) {
+      expectedSource += character
       await host.page.keyboard.type(character)
+      // Wait for each coalesced transaction to commit and re-render before
+      // checking focus, so this exercises the slow-CI ordering deterministically.
+      await expect.poll(async () => (await snapshot(host.page)).source).toBe(
+        expectedSource,
+      )
       await expect.poll(() => host.page.evaluate(() => document.activeElement?.id)).toBe(
         "loomark-input",
       )
     }
 
     await expect(input).toHaveValue("startabc")
-    await expect.poll(async () => (await snapshot(host.page)).source).toBe("startabc")
     await expectPreviewSource(host.page, "startabc")
 
     await host.page.setViewportSize({ width: 390, height: 844 })

--- a/apps/loomark/internal/dev_host/dev_host.mbt
+++ b/apps/loomark/internal/dev_host/dev_host.mbt
@@ -44,6 +44,17 @@ pub fn dev_host_force_editor_failure() -> Unit {
 }
 
 ///|
+/// Arm only the private parser-publication recovery seam.
+pub fn dev_host_force_parser_failure() -> Unit {
+  @app.force_parser_failure()
+}
+
+///|
+pub fn dev_host_force_reconstruction_failure() -> Unit {
+  @app.force_reconstruction_failure()
+}
+
+///|
 pub fn dev_host_focus_preview() -> Unit {
   @app.focus_preview()
 }

--- a/apps/loomark/internal/dev_host/moon.pkg
+++ b/apps/loomark/internal/dev_host/moon.pkg
@@ -16,6 +16,8 @@ options(
         "dev_host_select_preview",
         "dev_host_restore_snapshot",
         "dev_host_force_editor_failure",
+        "dev_host_force_parser_failure",
+        "dev_host_force_reconstruction_failure",
         "dev_host_focus_preview",
         "dev_host_focus_raw",
         "dev_host_focus_block",

--- a/apps/loomark/internal/dev_host/pkg.generated.mbti
+++ b/apps/loomark/internal/dev_host/pkg.generated.mbti
@@ -14,6 +14,10 @@ pub fn dev_host_focus_raw() -> Unit
 
 pub fn dev_host_force_editor_failure() -> Unit
 
+pub fn dev_host_force_parser_failure() -> Unit
+
+pub fn dev_host_force_reconstruction_failure() -> Unit
+
 pub fn dev_host_measure_failure() -> Unit
 
 pub fn dev_host_measure_preview() -> Unit

--- a/apps/loomark/internal/rabbita/application.mbt
+++ b/apps/loomark/internal/rabbita/application.mbt
@@ -189,6 +189,23 @@ fn mode_name(mode : @core.ApplicationMode) -> String {
 }
 
 ///|
+fn runtime_state_name(state : EditorRuntimeState) -> String {
+  match state {
+    EditorRuntimeState::Healthy => "healthy"
+    EditorRuntimeState::Restarting => "restarting"
+    EditorRuntimeState::RawRecovery(_) => "raw-recovery"
+  }
+}
+
+///|
+fn runtime_source(model : DriverModel) -> String {
+  match model.runtime_state {
+    EditorRuntimeState::RawRecovery(source) => source
+    _ => model.document.source()
+  }
+}
+
+///|
 /// Render one decorative mode glyph; the owning tab supplies its accessible
 /// name and interaction semantics.
 fn mode_icon(path : String) -> @html.Html {
@@ -236,10 +253,11 @@ fn record_error(
 ///|
 fn publish(model : DriverModel) -> Unit {
   let fields : Map[String, Json] = {
-    "source": model.document.source().to_json(),
+    "source": runtime_source(model).to_json(),
     "replica_id": model.replica_id.to_json(),
     "version": @core.SNAPSHOT_VERSION.to_json(),
     "mode": mode_name(model.state.mode()).to_json(),
+    "runtime_state": runtime_state_name(model.runtime_state).to_json(),
     "split_preview_open": model.split_preview_open.to_json(),
     "source_revision": model.source_revision.to_json(),
     "semantic_read_count": model.semantic_read_count.to_json(),
@@ -255,6 +273,8 @@ fn publish(model : DriverModel) -> Unit {
     "error_count": model.error_count.to_json(),
     "committed_change_count": model.committed_change_count.to_json(),
     "editor_failure_armed": model.fail_next_editor_commit.to_json(),
+    "parser_failure_armed": model.force_parser_failure.to_json(),
+    "reconstruction_attempt_count": model.reconstruction_attempt_count.to_json(),
     "resize_count": model.resize_count.to_json(),
     "selection": match model.selection {
       Some(selection) => selection.to_json()
@@ -551,7 +571,10 @@ fn standalone_preview_view(
   emit : @cmd.Emit[DriverEvent],
   active_view : @rabbita_runtime.Html,
 ) -> @rabbita_runtime.Html {
-  preview_view(model, emit, active_view, @html.nothing)
+  match model.runtime_state {
+    EditorRuntimeState::RawRecovery(_) => raw_recovery_view(model, emit)
+    _ => preview_view(model, emit, active_view, @html.nothing)
+  }
 }
 
 ///|
@@ -560,6 +583,10 @@ fn private_dev_host_preview_view(
   emit : @cmd.Emit[DriverEvent],
   active_view : @rabbita_runtime.Html,
 ) -> @rabbita_runtime.Html {
+  match model.runtime_state {
+    EditorRuntimeState::RawRecovery(_) => return raw_recovery_view(model, emit)
+    _ => ()
+  }
   let driver_controls = @html.fragment([
     @html.button(
       id="loomark-event-target",
@@ -620,6 +647,12 @@ fn driver_event_name(event : DriverEvent) -> String {
     Lifecycle(life_event) =>
       match life_event {
         EditorFailure => "editor-failure"
+        ForceParserFailure => "force-parser-failure"
+        ForceReconstructionFailure => "force-reconstruction-failure"
+        RecoveryCopy => "recovery-copy"
+        RecoveryDownload => "recovery-download"
+        RecoveryReload => "recovery-reload"
+        RecoveryEffectFailed(_) => "recovery-effect-failed"
         RestoreSnapshot(..) => "restore-snapshot"
         CustomEvent(_) => "custom-event"
         ControlInstalled => "control-installed"
@@ -670,6 +703,16 @@ fn parse_driver_event(detail : String) -> DriverEvent {
     Editing(RawInput(detail["raw-input|".length():].to_owned(), None, None))
   } else if detail == "editor-failure" {
     Lifecycle(EditorFailure)
+  } else if detail == "force-parser-failure" {
+    Lifecycle(ForceParserFailure)
+  } else if detail == "force-reconstruction-failure" {
+    Lifecycle(ForceReconstructionFailure)
+  } else if detail == "recovery-copy" {
+    Lifecycle(RecoveryCopy)
+  } else if detail == "recovery-download" {
+    Lifecycle(RecoveryDownload)
+  } else if detail == "recovery-reload" {
+    Lifecycle(RecoveryReload)
   } else if detail.has_prefix("restore-focus|") {
     Navigation(RestoreFocus(detail["restore-focus|".length():].to_owned()))
   } else if detail.has_prefix("restore-snapshot|") {
@@ -801,7 +844,7 @@ fn update_editing(
   latest_model : @ref.Ref[DriverModel?],
   event : EditingEvent,
   emit : @cmd.Emit[DriverEvent],
-) -> (DriverModel, @cmd.Cmd) {
+) -> (DriverModel, @cmd.Cmd) raise {
   let raw_token_active = match event {
     RawInput(_, _, Some(token)) => raw_input_coordinator.is_active(token)
     _ => true
@@ -1638,6 +1681,21 @@ fn update_probe(
 }
 
 ///|
+/// Run a recovery action immediately in the originating activation turn and
+/// route boundary failures back through an allowed recovery event.
+fn recovery_effect_command(
+  effect : () -> Unit raise @dom_boundary.DomBoundaryError,
+  emit : @cmd.Emit[DriverEvent],
+) -> @cmd.Cmd {
+  @cmd.custom_cmd(scheduler => {
+    effect() catch {
+      error =>
+        scheduler.add(emit(Lifecycle(RecoveryEffectFailed(error.message()))))
+    }
+  })
+}
+
+///|
 /// Application-control dispatcher: failures, restore, subscriptions, fatal,
 /// resize, and driver protocol errors.
 fn update_lifecycle(
@@ -1647,12 +1705,53 @@ fn update_lifecycle(
   model : DriverModel,
   event : LifecycleEvent,
   emit : @cmd.Emit[DriverEvent],
-) -> (DriverModel, @cmd.Cmd) {
+) -> (DriverModel, @cmd.Cmd) raise {
   match event {
     EditorFailure => {
       let next = { ..model, fail_next_editor_commit: true }
       (next, @rabbita_runtime.none)
     }
+    ForceParserFailure => {
+      let next = { ..model, force_parser_failure: true }
+      (next, @rabbita_runtime.none)
+    }
+    ForceReconstructionFailure => {
+      let next = { ..model, force_reconstruction_failure: true }
+      (next, @rabbita_runtime.none)
+    }
+    RecoveryCopy =>
+      (
+        model,
+        recovery_effect_command(
+          () => @dom_boundary.copy_text(runtime_source(model)),
+          emit,
+        ),
+      )
+    RecoveryDownload =>
+      (
+        model,
+        recovery_effect_command(
+          () => {
+            @dom_boundary.download_text(
+              "loomark-recovered.md",
+              runtime_source(model),
+            )
+          },
+          emit,
+        ),
+      )
+    RecoveryReload =>
+      (model, recovery_effect_command(() => @dom_boundary.reload(), emit))
+    RecoveryEffectFailed(detail) =>
+      (
+        {
+          ..model,
+          error: Some("Recovery action failed: " + detail),
+          error_code: Some("recovery-effect-failed"),
+          error_operation: Some("recovery-action"),
+        },
+        @rabbita_runtime.none,
+      )
     RestoreSnapshot(version~, source~, mode~) => {
       let snapshot = @core.ApplicationStateSnapshot::ApplicationStateSnapshot(
         version~,
@@ -1767,9 +1866,22 @@ fn update_lifecycle(
 }
 
 ///|
+fn recovery_control_event(event : DriverEvent) -> Bool {
+  match event {
+    Lifecycle(
+      RecoveryCopy
+      | RecoveryDownload
+      | RecoveryReload
+      | RecoveryEffectFailed(_)
+    ) => true
+    _ => false
+  }
+}
+
+///|
 /// Total dispatch: the envelope constructor encodes the concern, so routing
-/// cannot misclassify. Archive completions land even in fatal state; the
-/// fatal rejection guard covers every other event.
+/// cannot misclassify. Archive completions land even in fatal state; recovery
+/// controls remain available while every editing event is rejected.
 fn update_model(
   editor : @markdown.MarkdownEditor,
   attachment : @md_markdown.MarkdownSemanticAttachment,
@@ -1778,10 +1890,10 @@ fn update_model(
   latest_model : @ref.Ref[DriverModel?],
   event : DriverEvent,
   emit : @cmd.Emit[DriverEvent],
-) -> (DriverModel, @cmd.Cmd) {
+) -> (DriverModel, @cmd.Cmd) raise {
   let (next, command) = match event {
     Archive(completion) => update_archive_tracker(model, completion)
-    _ if model.fatal => {
+    _ if model.fatal && !recovery_control_event(event) => {
       match event {
         Editing(RawInput(_, _, Some(token))) =>
           raw_input_coordinator.cancel(token)
@@ -1995,12 +2107,39 @@ fn build_application(
   subscriptions : (DriverModel, @cmd.Emit[DriverEvent]) -> @sub.Sub,
   view : (DriverModel, @cmd.Emit[DriverEvent], @rabbita_runtime.Html) -> @rabbita_runtime.Html,
 ) -> @rabbita_runtime.App {
+  let current_session : @ref.Ref[EditorSession] = {
+    val: { editor, attachment },
+  }
   let latest_model : @ref.Ref[DriverModel?] = { val: None }
   let raw_input_coordinator = RawInputCoordinator::RawInputCoordinator()
   let update = (model, event, emit) => {
+    let session = current_session.val
     update_model(
-      editor, attachment, raw_input_coordinator, model, latest_model, event, emit,
-    )
+      session.editor,
+      session.attachment,
+      raw_input_coordinator,
+      model,
+      latest_model,
+      event,
+      emit,
+    ) catch {
+      Failure::Failure(_) as failure => {
+        raw_input_coordinator.cancel_pending()
+        let (next, command) = recover_after_parser_failure(
+          current_session, model, failure, emit,
+        )
+        publish(next)
+        (next, command)
+      }
+      error => {
+        raw_input_coordinator.cancel_pending()
+        let (next, command) = quarantine_outer_error(
+          current_session, model, error,
+        )
+        publish(next)
+        (next, command)
+      }
+    }
   }
   @rabbita_runtime.new(() => {
     let (model, emit) = @rabbita_runtime.create_state_with_init(
@@ -2057,7 +2196,7 @@ fn initial_model(
   document_id : @archive.LoomarkDocumentId,
   replica_id : String,
   archive_persistence_enabled~ : Bool,
-) -> DriverModel {
+) -> DriverModel raise {
   let host_width = @dom_boundary.measure_element_id(host_id)
     .offset_width()
     .to_int() catch {
@@ -2065,7 +2204,9 @@ fn initial_model(
     }
   {
     state: @core.ApplicationState::ApplicationState(@core.Raw),
+    runtime_state: EditorRuntimeState::Healthy,
     document: editor.snapshot(),
+    document_version: editor.version(),
     document_id,
     archive_persistence_enabled,
     semantic_document: None,
@@ -2083,6 +2224,9 @@ fn initial_model(
     error_count: 0,
     committed_change_count: 0,
     fail_next_editor_commit: false,
+    force_parser_failure: false,
+    force_reconstruction_failure: false,
+    reconstruction_attempt_count: 0,
     resize_count: 0,
     selection: None,
     measurement: None,
@@ -2111,14 +2255,16 @@ fn mount_application(
     DriverModel,
     (@repository.LocalArchiveRequestId, String)?,
   ) -> @rabbita_runtime.App,
-) -> String {
+) -> String raise {
   if mounted.val {
     return "{\"ok\":false,\"error\":\"host-already-mounted\"}"
   }
   let replica_id = @archive_storage.fresh_id(replica_prefix)
-  let document_id = try! @archive.LoomarkDocumentId::from_string(
+  let document_id = @archive.LoomarkDocumentId::from_string(
     @archive_storage.fresh_id("loomark-document-"),
-  )
+  ) catch {
+    _ => return "{\"ok\":false,\"error\":\"document-id-allocation-failed\"}"
+  }
   let (editor, attachment) = @markdown.MarkdownEditor::with_semantic_attachment(
     agent_id=replica_id,
     source~,
@@ -2148,7 +2294,12 @@ pub fn mount_standalone(host_id : String, source : String) -> String {
   }
   mounted.val = true
   @archive_storage.load(loaded => {
-    finish_standalone_bootstrap(host_id, source, loaded)
+    finish_standalone_bootstrap(host_id, source, loaded) catch {
+      _ =>
+        recovery_application(RecoveryCategory::EditorInitializationFailed).mount(
+          host_id,
+        )
+    }
   })
   "{\"ok\":true}"
 }
@@ -2158,7 +2309,9 @@ pub fn mount_standalone(host_id : String, source : String) -> String {
 pub fn mount(host_id : String, source : String) -> String {
   mount_application(
     host_id, source, "loomark-dev-host-", private_dev_host_application,
-  )
+  ) catch {
+    _ => "{\"ok\":false,\"error\":\"editor-initialization-failed\"}"
+  }
 }
 
 ///|
@@ -2206,6 +2359,18 @@ pub fn restore_snapshot(version : Int, source : String, mode : String) -> Unit {
 /// Arm the next real editor transaction to use a failing editor request.
 pub fn force_editor_failure() -> Unit {
   dispatch_driver("editor-failure")
+}
+
+///|
+/// Private dev-host control: the next normal edit fails after CRDT acceptance.
+pub fn force_parser_failure() -> Unit {
+  dispatch_driver("force-parser-failure")
+}
+
+///|
+/// Private dev-host control: force the next recovery attempt into RawRecovery.
+pub fn force_reconstruction_failure() -> Unit {
+  dispatch_driver("force-reconstruction-failure")
 }
 
 ///|

--- a/apps/loomark/internal/rabbita/commit_classification.mbt
+++ b/apps/loomark/internal/rabbita/commit_classification.mbt
@@ -1,28 +1,89 @@
 ///|
-/// Classify one atomic editor commit into domain terms: an Applied result is
-/// a history-changing commit and advances both revision counters; an
-/// Unchanged result is a history no-op and leaves them untouched. The
-/// classification is independent of source equality — Applied advances
-/// history whether or not the resulting Markdown source differs.
+/// Classify one atomic commit by the explicit CRDT version frontier.
 ///
-/// Pure: no editor, no DOM, no commands. The calling shell owns selection
-/// extraction, preview demand, and the `@repository.history_trigger`
-/// persistence decision.
+/// Source equality is consulted only after the frontier advances: a real
+/// operation can preserve visible text while still counting as one accepted
+/// commit. The function is pure; the shell owns editor and archive effects.
 fn classify_commit(
   model : DriverModel,
-  result : @markdown.MarkdownCommitResult,
-) -> (DriverModel, Bool) {
-  match result {
-    @markdown.Applied(document, _) =>
-      (
-        {
-          ..model,
-          document,
-          source_revision: model.source_revision + 1,
-          committed_change_count: model.committed_change_count + 1,
-        },
-        true,
-      )
-    @markdown.Unchanged(document) => ({ ..model, document, }, false)
+  receipt : @markdown.MarkdownCommitReceipt,
+) -> (DriverModel, Bool, Bool) {
+  let document = match receipt.result() {
+    @markdown.Applied(document, _) => document
+    @markdown.Unchanged(document) => document
   }
+  let accepted = receipt.after_version() != model.document_version
+  if !accepted {
+    return ({ ..model, document, }, false, false)
+  }
+  let changed = document.source() != model.document.source()
+  (
+    {
+      ..model,
+      document,
+      document_version: receipt.after_version(),
+      source_revision: if changed {
+        model.source_revision + 1
+      } else {
+        model.source_revision
+      },
+      committed_change_count: model.committed_change_count + 1,
+    },
+    true,
+    changed,
+  )
+}
+
+///|
+/// Advance counters when reconstruction cannot provide a usable snapshot but
+/// the captured portable source/version still proves acceptance.
+fn classify_recovered_source(
+  model : DriverModel,
+  source : String,
+  version : @markdown.MarkdownDocumentVersion,
+) -> DriverModel {
+  let accepted = version != model.document_version
+  if !accepted {
+    return model
+  }
+  let changed = source != model.document.source()
+  {
+    ..model,
+    document_version: version,
+    source_revision: if changed {
+      model.source_revision + 1
+    } else {
+      model.source_revision
+    },
+    committed_change_count: model.committed_change_count + 1,
+  }
+}
+
+///|
+/// Install the fresh snapshot after reopening a failed editor. The failed
+/// editor itself is never queried for a snapshot.
+fn classify_recovered_frontier(
+  model : DriverModel,
+  document : @markdown.MarkdownDocumentSnapshot,
+  version : @markdown.MarkdownDocumentVersion,
+) -> (DriverModel, Bool) {
+  let accepted = version != model.document_version
+  if !accepted {
+    return ({ ..model, document, }, false)
+  }
+  let changed = document.source() != model.document.source()
+  (
+    {
+      ..model,
+      document,
+      document_version: version,
+      source_revision: if changed {
+        model.source_revision + 1
+      } else {
+        model.source_revision
+      },
+      committed_change_count: model.committed_change_count + 1,
+    },
+    changed,
+  )
 }

--- a/apps/loomark/internal/rabbita/commit_classification_wbtest.mbt
+++ b/apps/loomark/internal/rabbita/commit_classification_wbtest.mbt
@@ -1,21 +1,14 @@
 ///|
-/// Classification boundary matrix:
-///
-/// | receipt result | domain term | source_revision | committed_change_count | changed |
-/// | --- | --- | --- | --- | --- |
-/// | Applied | history-changing commit | +1 | +1 | true |
-/// | Unchanged | history no-op | unchanged | unchanged | false |
-///
-/// Unrelated model fields pass through untouched in both cases. The
-/// classification is independent of source equality: Applied advances
-/// history regardless of whether the resulting Markdown source differs.
-/// Selection extraction and preview demand stay in the calling shell.
-
-///|
-fn test_model(document : @markdown.MarkdownDocumentSnapshot) -> DriverModel {
+/// Version-frontier classification tests.
+fn test_model(
+  document : @markdown.MarkdownDocumentSnapshot,
+  version : @markdown.MarkdownDocumentVersion,
+) -> DriverModel {
   {
     state: @core.ApplicationState::ApplicationState(@core.Raw),
+    runtime_state: EditorRuntimeState::Healthy,
     document,
+    document_version: version,
     document_id: @archive.LoomarkDocumentId::from_string("test-doc") catch {
       _ => abort("test document id must construct")
     },
@@ -35,6 +28,9 @@ fn test_model(document : @markdown.MarkdownDocumentSnapshot) -> DriverModel {
     error_count: 0,
     committed_change_count: 3,
     fail_next_editor_commit: false,
+    force_parser_failure: false,
+    force_reconstruction_failure: false,
+    reconstruction_attempt_count: 0,
     resize_count: 0,
     selection: None,
     measurement: None,
@@ -51,37 +47,49 @@ fn test_model(document : @markdown.MarkdownDocumentSnapshot) -> DriverModel {
 }
 
 ///|
-test "history-changing commit advances both counters and reports changed" {
+test "history-changing commit advances counters and reports source change" {
   let editor = try! @markdown.MarkdownEditor(
     agent_id="agent-a",
     source="# Title",
   )
-  let document = editor.snapshot()
-  let model = test_model(document)
-  let (next, changed) = classify_commit(
-    model,
-    @markdown.MarkdownCommitResult::Applied(document, None),
-  )
+  let model = test_model(editor.snapshot(), editor.version())
+  let receipt = match
+    (try! editor.commit_with_receipt(
+      @markdown.MarkdownEditRequest::ReplaceSource("## Changed"),
+    )) {
+    Ok(receipt) => receipt
+    Err(_) => abort("expected receipt")
+  }
+  let (next, accepted, changed) = classify_commit(model, receipt)
   assert_eq(next.source_revision, 6)
   assert_eq(next.committed_change_count, 4)
+  assert_true(accepted)
   assert_true(changed)
-  assert_eq(next.document.source(), "# Title")
+  assert_eq(next.document.source(), "## Changed")
 }
 
 ///|
-test "history no-op leaves counters untouched and reports unchanged" {
+test "source-preserving commit still advances the frontier exactly once" {
   let editor = try! @markdown.MarkdownEditor(
     agent_id="agent-a",
     source="# Title",
   )
-  let document = editor.snapshot()
-  let model = test_model(document)
-  let (next, changed) = classify_commit(
-    model,
-    @markdown.MarkdownCommitResult::Unchanged(document),
-  )
+  let model = test_model(editor.snapshot(), editor.version())
+  let receipt = match
+    (try! editor.commit_with_receipt(
+      @markdown.MarkdownEditRequest::ReplaceText(
+        start=0,
+        delete_len=1,
+        inserted="#",
+      ),
+    )) {
+    Ok(receipt) => receipt
+    Err(_) => abort("expected receipt")
+  }
+  let (next, accepted, changed) = classify_commit(model, receipt)
   assert_eq(next.source_revision, 5)
-  assert_eq(next.committed_change_count, 3)
+  assert_eq(next.committed_change_count, 4)
+  assert_true(accepted)
   assert_false(changed)
   assert_eq(next.document.source(), "# Title")
 }
@@ -94,15 +102,19 @@ test "classification preserves unrelated model fields" {
   )
   let document = editor.snapshot()
   let model = {
-    ..test_model(document),
+    ..test_model(document, editor.version()),
     fatal: true,
     error: Some("boom"),
     split_preview_open: true,
   }
-  let (next, _) = classify_commit(
-    model,
-    @markdown.MarkdownCommitResult::Applied(document, None),
-  )
+  let receipt = match
+    (try! editor.commit_with_receipt(
+      @markdown.MarkdownEditRequest::ReplaceSource("changed"),
+    )) {
+    Ok(receipt) => receipt
+    Err(_) => abort("expected receipt")
+  }
+  let (next, _, _) = classify_commit(model, receipt)
   assert_true(next.fatal)
   assert_eq(next.error, Some("boom"))
   assert_true(next.split_preview_open)

--- a/apps/loomark/internal/rabbita/document_transaction.mbt
+++ b/apps/loomark/internal/rabbita/document_transaction.mbt
@@ -26,7 +26,7 @@ fn archive_replacement(
   editor : @markdown.MarkdownEditor,
   model : DriverModel,
   emit : @cmd.Emit[DriverEvent],
-) -> (DriverModel, @cmd.Cmd) {
+) -> (DriverModel, @cmd.Cmd) raise {
   guard model.archive_persistence_enabled else {
     return (model, @rabbita_runtime.none)
   }
@@ -34,7 +34,10 @@ fn archive_replacement(
     document_id=model.document_id,
     editor~,
   ) catch {
-    _ => return (record_local_persistence_failure(model), @rabbita_runtime.none)
+    Failure::Failure(_) as failure => raise failure
+    @repository.LocalArchivePreparationError::HistoryUnavailable(_) =>
+      return (record_local_persistence_failure(model), @rabbita_runtime.none)
+    error => raise error
   }
   let (archive_tracker, request_id) = model.archive_tracker.request()
   let command = @archive_storage.replace(request_id, prepared.encoded(), completed=completion => {
@@ -44,21 +47,64 @@ fn archive_replacement(
 }
 
 ///|
+/// Archive failures happen after the local CRDT operation may already have
+/// landed. They are storage errors, not parser failures, and use a healthy
+/// snapshot plus the explicit version frontier for their accepted counters.
+fn accept_after_archive_error(
+  editor : @markdown.MarkdownEditor,
+  model : DriverModel,
+) -> (DriverModel, Bool, Bool) raise {
+  let document = editor.snapshot()
+  let (accepted, changed) = classify_recovered_frontier(
+    model,
+    document,
+    editor.version(),
+  )
+  (
+    record_local_persistence_failure(accepted),
+    accepted.document_version != model.document_version,
+    changed,
+  )
+}
+
+///|
+/// Handle the typed archive errors raised while cutting a receipt. Unknown
+/// errors and Loom Failure are deliberately not converted here.
+fn commit_archive_error(
+  editor : @markdown.MarkdownEditor,
+  model : DriverModel,
+  error : @markdown.MarkdownArchiveError,
+) -> (DriverModel, Bool, Bool) raise {
+  match error {
+    @markdown.MarkdownArchiveError::ExportFailed(..)
+    | @markdown.MarkdownArchiveError::HistoryAdmissionFailed(..)
+    | @markdown.MarkdownArchiveError::IncompleteHistory
+    | @markdown.MarkdownArchiveError::InvalidAgentId
+    | @markdown.MarkdownArchiveError::WriterCreationFailed(..)
+    | @markdown.MarkdownArchiveError::LimitExceeded(..) =>
+      accept_after_archive_error(editor, model)
+  }
+}
+
+///|
 /// Shared atomic-commit shell: failure injection, editor commit, receipt
 /// classification, and persistence dispatch. Mode-specific concerns
 /// (selection extraction, preview demand, application state) stay with the
-/// caller. Returns (model, result?, accepted, changed, command) — `result`
-/// is present only on a successful Ok receipt so block callers can extract
-/// the deep selection outcome without reading SyncEditor cursor state.
+/// caller. The outer update wrapper owns the only parser-Failure recovery.
 fn commit_edit_request(
   editor : @markdown.MarkdownEditor,
   model : DriverModel,
   request : @markdown.MarkdownEditRequest,
   operation : String,
   emit : @cmd.Emit[DriverEvent],
-) -> (DriverModel, @markdown.MarkdownCommitResult?, Bool, Bool, @cmd.Cmd) {
+) -> (DriverModel, @markdown.MarkdownCommitResult?, Bool, Bool, @cmd.Cmd) raise {
   let fail_commit = model.fail_next_editor_commit
-  let next = { ..model, fail_next_editor_commit: false }
+  let inject_parser_failure = model.force_parser_failure
+  let next = {
+    ..model,
+    fail_next_editor_commit: false,
+    force_parser_failure: false,
+  }
   let request = if fail_commit {
     @markdown.MarkdownEditRequest::ReplaceText(
       start=-1,
@@ -69,31 +115,47 @@ fn commit_edit_request(
     request
   }
   let receipt = editor.commit_with_receipt(request) catch {
-    _ => {
-      let document = editor.snapshot()
-      let changed = document.source() != model.document.source()
-      let accepted = {
-        ..next,
-        document,
-        source_revision: if changed {
-          model.source_revision + 1
-        } else {
-          model.source_revision
-        },
-        committed_change_count: if changed {
-          model.committed_change_count + 1
-        } else {
-          model.committed_change_count
-        },
-      }
-      return (
-        record_local_persistence_failure(accepted),
-        None,
-        true,
-        changed,
-        @rabbita_runtime.none,
+    Failure::Failure(_) as failure => raise failure
+    @markdown.MarkdownArchiveError::ExportFailed(..) => {
+      let (accepted, frontier_advanced, changed) = accept_after_archive_error(
+        editor, next,
       )
+      return (accepted, None, frontier_advanced, changed, @rabbita_runtime.none)
     }
+    @markdown.MarkdownArchiveError::HistoryAdmissionFailed(..) as error => {
+      let (accepted, frontier_advanced, changed) = commit_archive_error(
+        editor, next, error,
+      )
+      return (accepted, None, frontier_advanced, changed, @rabbita_runtime.none)
+    }
+    @markdown.MarkdownArchiveError::IncompleteHistory as error => {
+      let (accepted, frontier_advanced, changed) = commit_archive_error(
+        editor, next, error,
+      )
+      return (accepted, None, frontier_advanced, changed, @rabbita_runtime.none)
+    }
+    @markdown.MarkdownArchiveError::InvalidAgentId as error => {
+      let (accepted, frontier_advanced, changed) = commit_archive_error(
+        editor, next, error,
+      )
+      return (accepted, None, frontier_advanced, changed, @rabbita_runtime.none)
+    }
+    @markdown.MarkdownArchiveError::WriterCreationFailed(..) as error => {
+      let (accepted, frontier_advanced, changed) = commit_archive_error(
+        editor, next, error,
+      )
+      return (accepted, None, frontier_advanced, changed, @rabbita_runtime.none)
+    }
+    @markdown.MarkdownArchiveError::LimitExceeded(..) as error => {
+      let (accepted, frontier_advanced, changed) = commit_archive_error(
+        editor, next, error,
+      )
+      return (accepted, None, frontier_advanced, changed, @rabbita_runtime.none)
+    }
+    error => raise error
+  }
+  if inject_parser_failure && receipt is Ok(_) {
+    raise Failure::Failure("dev-host injected parser publication failure")
   }
   match receipt {
     Err(error) => {
@@ -107,16 +169,16 @@ fn commit_edit_request(
     }
     Ok(receipt) => {
       let result = receipt.result()
-      let (committed, changed) = classify_commit(next, result)
+      let (committed, accepted, changed) = classify_commit(next, receipt)
       match @repository.history_trigger(receipt) {
         @repository.LocalArchivePersistenceDecision::Replace => {
           let (persisted, command) = archive_replacement(
             editor, committed, emit,
           )
-          (persisted, Some(result), true, changed, command)
+          (persisted, Some(result), accepted, changed, command)
         }
         @repository.LocalArchivePersistenceDecision::Skip =>
-          (committed, Some(result), true, changed, @rabbita_runtime.none)
+          (committed, Some(result), accepted, changed, @rabbita_runtime.none)
       }
     }
   }
@@ -131,7 +193,7 @@ fn commit_source(
   source : String,
   operation : String,
   emit : @cmd.Emit[DriverEvent],
-) -> (DriverModel, Bool, Bool, @cmd.Cmd) {
+) -> (DriverModel, Bool, Bool, @cmd.Cmd) raise {
   let (committed, _, accepted, changed, command) = commit_edit_request(
     editor,
     model,
@@ -145,8 +207,6 @@ fn commit_source(
 
 ///|
 /// Commit one typed block request through the atomic façade boundary.
-/// Structural callers receive the deep selection outcome without reading
-/// SyncEditor cursor state in this shell.
 fn commit_block_request(
   editor : @markdown.MarkdownEditor,
   attachment : @md_markdown.MarkdownSemanticAttachment,
@@ -154,7 +214,7 @@ fn commit_block_request(
   request : @markdown.MarkdownEditRequest,
   operation : String,
   emit : @cmd.Emit[DriverEvent],
-) -> (DriverModel, @markdown.MarkdownBlockSelection?, Bool, @cmd.Cmd) {
+) -> (DriverModel, @markdown.MarkdownBlockSelection?, Bool, @cmd.Cmd) raise {
   let (committed, result, accepted, changed, persistence_command) = commit_edit_request(
     editor, model, request, operation, emit,
   )
@@ -186,7 +246,7 @@ fn commit_block_toolbar_request(
   originating_selection : BlockSelection?,
   control_id : String,
   emit : @cmd.Emit[DriverEvent],
-) -> (DriverModel, Bool, @cmd.Cmd) {
+) -> (DriverModel, Bool, @cmd.Cmd) raise {
   let (committed, committed_selection, _, persistence_command) = commit_block_request(
     editor, attachment, model, request, "editor-dispatch", emit,
   )

--- a/apps/loomark/internal/rabbita/driver_types.mbt
+++ b/apps/loomark/internal/rabbita/driver_types.mbt
@@ -51,10 +51,24 @@ priv enum ProbeEvent {
 }
 
 ///|
+/// The editor/semantic resources currently owned by the application shell.
+/// The holder is swapped only after a complete archive reopen succeeds.
+priv struct EditorSession {
+  editor : @markdown.MarkdownEditor
+  attachment : @md_markdown.MarkdownSemanticAttachment
+}
+
+///|
 /// Application-control events: failures, restore, subscriptions, fatal,
 /// resize, and driver protocol errors.
 priv enum LifecycleEvent {
   EditorFailure
+  ForceParserFailure
+  ForceReconstructionFailure
+  RecoveryCopy
+  RecoveryDownload
+  RecoveryReload
+  RecoveryEffectFailed(String)
   RestoreSnapshot(
     version~ : Int,
     source~ : String,
@@ -91,7 +105,9 @@ priv suberror DriverSubscription {
 ///|
 priv struct DriverModel {
   state : @core.ApplicationState
+  runtime_state : EditorRuntimeState
   document : @markdown.MarkdownDocumentSnapshot
+  document_version : @markdown.MarkdownDocumentVersion
   document_id : @archive.LoomarkDocumentId
   archive_persistence_enabled : Bool
   semantic_document : @md_markdown.MarkdownIR?
@@ -109,6 +125,9 @@ priv struct DriverModel {
   error_count : Int
   committed_change_count : Int
   fail_next_editor_commit : Bool
+  force_parser_failure : Bool
+  force_reconstruction_failure : Bool
+  reconstruction_attempt_count : Int
   resize_count : Int
   selection : String?
   measurement : String?

--- a/apps/loomark/internal/rabbita/editing_mode_wbtest.mbt
+++ b/apps/loomark/internal/rabbita/editing_mode_wbtest.mbt
@@ -66,7 +66,7 @@ fn block_variants() -> Array[EditingEvent] {
     agent_id="agent-a",
     source="# Title\n\nParagraph",
   )
-  let node_id = editor.snapshot().blocks()[0].node_id()
+  let node_id = (try! editor.snapshot()).blocks()[0].node_id()
   [
     BlockFocused("key"),
     BlockHeading(2, None),
@@ -101,7 +101,11 @@ test "selection read applies the driver probe result to the model" {
     agent_id="agent-a",
     source="# Title",
   )
-  let next = apply_selection_read(test_model(editor.snapshot()), 3, 5)
+  let next = apply_selection_read(
+    test_model(try! editor.snapshot(), editor.version()),
+    3,
+    5,
+  )
   assert_eq(next.selection, Some("3:5"))
 }
 
@@ -111,10 +115,14 @@ test "measurement applies the driver probe result to the model" {
     agent_id="agent-a",
     source="# Title",
   )
-  let next = apply_measurement(test_model(editor.snapshot()), 640.0, 480.0)
+  let next = apply_measurement(
+    test_model(try! editor.snapshot(), editor.version()),
+    640.0,
+    480.0,
+  )
   assert_eq(next.measurement, Some("640:480"))
   let fractional = apply_measurement(
-    test_model(editor.snapshot()),
+    test_model(try! editor.snapshot(), editor.version()),
     120.5,
     48.25,
   )

--- a/apps/loomark/internal/rabbita/editor_session.mbt
+++ b/apps/loomark/internal/rabbita/editor_session.mbt
@@ -1,0 +1,37 @@
+///|
+/// Canonical data captured from an editor whose parser is no longer usable.
+/// Every field is obtained from parser-independent façade/archive APIs.
+priv struct RecoveryDocument {
+  document_id : @archive.LoomarkDocumentId
+  source : String
+  version : @markdown.MarkdownDocumentVersion
+  history : @markdown.MarkdownDocumentHistory
+}
+
+///|
+fn capture_recovery_document(
+  document_id : @archive.LoomarkDocumentId,
+  editor : @markdown.MarkdownEditor,
+) -> RecoveryDocument raise {
+  let source = editor.portable_markdown()
+  let version = editor.version()
+  let history = editor.history_since()
+  { document_id, source, version, history }
+}
+
+///|
+/// Make exactly one fresh writer/parser pair from the captured complete
+/// archive. The caller swaps the session only after this function succeeds.
+fn reopen_recovery_document(
+  recovery : RecoveryDocument,
+  writer_prefix : String,
+) -> (@markdown.MarkdownEditor, @md_markdown.MarkdownSemanticAttachment) raise {
+  let writer_id = @archive_storage.fresh_id(writer_prefix)
+  let reopened = @repository.reopen_local_history(
+    recovery.history,
+    document_id=recovery.document_id,
+    agent_id=writer_id,
+    policy=@repository.LocalRestorePolicy::trusted(),
+  )
+  (reopened.editor(), reopened.attachment())
+}

--- a/apps/loomark/internal/rabbita/effect_decision_wbtest.mbt
+++ b/apps/loomark/internal/rabbita/effect_decision_wbtest.mbt
@@ -31,7 +31,7 @@ test "repair_eligible requires mode, generation, and revision to match" {
     source="# Title",
   )
   let model = {
-    ..test_model(editor.snapshot()),
+    ..test_model(try! editor.snapshot(), editor.version()),
     text_input_generation: 3,
     source_revision: 7,
   }
@@ -62,7 +62,7 @@ test "raw repair requires a rendered Raw control" {
     source="# Title",
   )
   let model = {
-    ..test_model(editor.snapshot()),
+    ..test_model(editor.snapshot(), editor.version()),
     text_input_generation: 3,
     source_revision: 7,
   }
@@ -111,7 +111,7 @@ test "block selection decision applies when mode and revision match and target r
   let key = document.blocks()[0].key()
   let selection = BlockSelection::{ key, index: 0, start: 0, end: 0 }
   let model = {
-    ..test_model(document),
+    ..test_model(document, editor.version()),
     state: @core.ApplicationState::ApplicationState(@core.Block),
     source_revision: 7,
   }
@@ -131,7 +131,7 @@ test "block selection decision classifies stale mode, superseded revision, missi
   let key = document.blocks()[0].key()
   let selection = BlockSelection::{ key, index: 0, start: 0, end: 0 }
   let model = {
-    ..test_model(document),
+    ..test_model(document, editor.version()),
     state: @core.ApplicationState::ApplicationState(@core.Block),
     source_revision: 7,
   }

--- a/apps/loomark/internal/rabbita/pkg.generated.mbti
+++ b/apps/loomark/internal/rabbita/pkg.generated.mbti
@@ -18,6 +18,10 @@ pub fn focus_raw() -> Unit
 
 pub fn force_editor_failure() -> Unit
 
+pub fn force_parser_failure() -> Unit
+
+pub fn force_reconstruction_failure() -> Unit
+
 pub fn measure_failure() -> Unit
 
 pub fn measure_preview() -> Unit

--- a/apps/loomark/internal/rabbita/recovery_raw_view.mbt
+++ b/apps/loomark/internal/rabbita/recovery_raw_view.mbt
@@ -1,0 +1,87 @@
+///|
+/// Read-only recovery surface for an accepted document whose editor session
+/// could not be reopened. It has no editing callback; controls are effects
+/// over the exact captured source only.
+fn raw_recovery_view(
+  model : DriverModel,
+  emit : @cmd.Emit[DriverEvent],
+) -> @rabbita_runtime.Html {
+  let source = match model.runtime_state {
+    EditorRuntimeState::RawRecovery(source) => source
+    _ => model.document.source()
+  }
+  @html.div(
+    id="loomark-recovery-root",
+    attrs=@html.Attrs::build()
+      .role("alert")
+      .aria_label("Markdown document recovery")
+      .data_set("loomark-recovery", "raw"),
+    style=[
+      "min-height:100vh;box-sizing:border-box;display:grid;place-items:center;padding:2rem;background:oklch(0.968 0.008 85);color:oklch(0.24 0.018 265)",
+    ],
+    @html.div(
+      id="loomark-recovery-panel",
+      style=[
+        "width:min(100%,48rem);display:grid;gap:0.75rem;padding:2rem;border:1px solid oklch(0.86 0.012 85);border-radius:0.5rem;background:oklch(0.991 0.004 85)",
+      ],
+      [
+        @html.h1(id="loomark-recovery-title", "Your document is safe to copy"),
+        @html.p(
+          id="loomark-recovery-message",
+          "Editing is paused. Copy or download the exact accepted Markdown, then reload to try again.",
+        ),
+        match model.error {
+          Some(error) =>
+            @html.p(
+              id="loomark-recovery-status",
+              attrs=@html.Attrs::build().role("status"),
+              error,
+            )
+          None => @html.nothing
+        },
+        @html.textarea(
+          id="loomark-recovery-source",
+          attrs=@html.Attrs::build().aria_label("Recovered Markdown source"),
+          rows=18,
+          value=source,
+          read_only=true,
+          "",
+        ),
+        @html.pre(
+          id="loomark-recovery-source-pre",
+          attrs=@html.Attrs::build().aria_label(
+            "Recovered Markdown source preview",
+          ),
+          source,
+        ),
+        @html.div(
+          attrs=@html.Attrs::build()
+            .role("group")
+            .aria_label("Recovery actions"),
+          [
+            @rui.button(
+              id="loomark-recovery-copy",
+              attrs=@html.Attrs::build().aria_label("Copy recovered Markdown"),
+              on_click=emit(Lifecycle(RecoveryCopy)),
+              "Copy",
+            ),
+            @rui.button(
+              id="loomark-recovery-download",
+              attrs=@html.Attrs::build().aria_label(
+                "Download recovered Markdown",
+              ),
+              on_click=emit(Lifecycle(RecoveryDownload)),
+              "Download .md",
+            ),
+            @rui.button(
+              id="loomark-recovery-reload",
+              attrs=@html.Attrs::build().aria_label("Reload editor"),
+              on_click=emit(Lifecycle(RecoveryReload)),
+              "Reload",
+            ),
+          ],
+        ),
+      ],
+    ),
+  )
+}

--- a/apps/loomark/internal/rabbita/recovery_shell.mbt
+++ b/apps/loomark/internal/rabbita/recovery_shell.mbt
@@ -1,0 +1,216 @@
+///|
+/// Enter terminal recovery without reading the failed editor again.
+fn terminal_raw_recovery(
+  model : DriverModel,
+  source : String,
+  message : String,
+) -> (DriverModel, @cmd.Cmd) {
+  let next = {
+    ..model,
+    runtime_state: EditorRuntimeState::RawRecovery(source),
+    state: @core.ApplicationState::ApplicationState(@core.Raw),
+    semantic_document: None,
+    split_preview_open: false,
+    active_block_key: None,
+    selection: None,
+    fatal: true,
+    force_parser_failure: false,
+    force_reconstruction_failure: false,
+    error: Some(message),
+    error_code: Some("editor-recovery-failed"),
+    error_operation: Some("editor-recovery"),
+    rejection: None,
+  }
+  (next, @rabbita_runtime.none)
+}
+
+///|
+/// Persist through the fresh healthy editor after reconstruction. Failure to
+/// prepare storage does not roll back the accepted in-memory document.
+fn persist_recovered_editor(
+  editor : @markdown.MarkdownEditor,
+  model : DriverModel,
+  emit : @cmd.Emit[DriverEvent],
+) -> (DriverModel, @cmd.Cmd) {
+  archive_replacement(editor, model, emit) catch {
+    _ => (record_local_persistence_failure(model), @rabbita_runtime.none)
+  }
+}
+
+///|
+/// Rebuild once from the accepted archive. This is the only shell that may
+/// catch parser Failure; the old session is never retried or reset.
+fn recover_after_parser_failure(
+  session_ref : @ref.Ref[EditorSession],
+  model : DriverModel,
+  failure : Failure,
+  emit : @cmd.Emit[DriverEvent],
+) -> (DriverModel, @cmd.Cmd) {
+  ignore(failure)
+  let (state, decision) = reduce_editor_runtime(
+    model.runtime_state,
+    EditorRecoveryEvent::Failure,
+  )
+  match decision {
+    EditorRecoveryDecision::Reject => {
+      session_ref.val.attachment.dispose()
+      terminal_raw_recovery(
+        model,
+        runtime_source(model),
+        "Editing is paused. Copy your Markdown and reload to continue.",
+      )
+    }
+    EditorRecoveryDecision::Continue => {
+      let editor = session_ref.val.editor
+      let source = editor.portable_markdown()
+      let advanced = classify_recovered_source(model, source, editor.version())
+      session_ref.val.attachment.dispose()
+      terminal_raw_recovery(
+        { ..advanced, runtime_state: state },
+        source,
+        "Editing is paused. Copy your Markdown and reload to continue.",
+      )
+    }
+    EditorRecoveryDecision::Reconstruct => {
+      let model = {
+        ..model,
+        reconstruction_attempt_count: model.reconstruction_attempt_count + 1,
+      }
+      let old_session = session_ref.val
+      let recovery_source = old_session.editor.portable_markdown()
+      let recovery_version = old_session.editor.version()
+      let recovery = capture_recovery_document(
+        model.document_id,
+        old_session.editor,
+      ) catch {
+        _ => {
+          old_session.attachment.dispose()
+          let (failed_state, _) = reduce_editor_runtime(
+            state,
+            EditorRecoveryEvent::ReconstructionFailed(recovery_source),
+          )
+          let advanced = classify_recovered_source(
+            model, recovery_source, recovery_version,
+          )
+          return terminal_raw_recovery(
+            { ..advanced, runtime_state: failed_state },
+            recovery_source,
+            "Your document could not be reopened. Copy it and reload to try again.",
+          )
+        }
+      }
+      if model.force_reconstruction_failure {
+        old_session.attachment.dispose()
+        let (failed_state, _) = reduce_editor_runtime(
+          state,
+          EditorRecoveryEvent::ReconstructionFailed(recovery.source),
+        )
+        let advanced = classify_recovered_source(
+          model,
+          recovery.source,
+          recovery.version,
+        )
+        return terminal_raw_recovery(
+          { ..advanced, runtime_state: failed_state },
+          recovery.source,
+          "Your document could not be reopened. Copy it and reload to try again.",
+        )
+      }
+      let (fresh_editor, fresh_attachment) = reopen_recovery_document(
+        recovery, "loomark-recovery-writer-",
+      ) catch {
+        _ => {
+          old_session.attachment.dispose()
+          let (failed_state, _) = reduce_editor_runtime(
+            state,
+            EditorRecoveryEvent::ReconstructionFailed(recovery.source),
+          )
+          let advanced = classify_recovered_source(
+            model,
+            recovery.source,
+            recovery.version,
+          )
+          let (terminal, _) = terminal_raw_recovery(
+            { ..advanced, runtime_state: failed_state },
+            recovery.source,
+            "Your document could not be reopened. Copy it and reload to try again.",
+          )
+          return (terminal, @rabbita_runtime.none)
+        }
+      }
+      let fresh_document = fresh_editor.snapshot() catch {
+        _ => {
+          old_session.attachment.dispose()
+          fresh_attachment.dispose()
+          let (failed_state, _) = reduce_editor_runtime(
+            state,
+            EditorRecoveryEvent::ReconstructionFailed(recovery.source),
+          )
+          let advanced = classify_recovered_source(
+            model,
+            recovery.source,
+            recovery.version,
+          )
+          let (terminal, _) = terminal_raw_recovery(
+            { ..advanced, runtime_state: failed_state },
+            recovery.source,
+            "Your document could not be reopened. Copy it and reload to try again.",
+          )
+          return (terminal, @rabbita_runtime.none)
+        }
+      }
+      let (healthy_state, healthy_decision) = reduce_editor_runtime(
+        state,
+        EditorRecoveryEvent::ReconstructionSucceeded,
+      )
+      guard healthy_decision is EditorRecoveryDecision::Continue else {
+        return terminal_raw_recovery(
+          { ..model, runtime_state: healthy_state },
+          recovery.source,
+          "Editing is paused. Copy your Markdown and reload to continue.",
+        )
+      }
+      old_session.attachment.dispose()
+      session_ref.val = { editor: fresh_editor, attachment: fresh_attachment }
+      let (advanced, _) = classify_recovered_frontier(
+        model,
+        fresh_document,
+        fresh_editor.version(),
+      )
+      let next = {
+        ..advanced,
+        runtime_state: EditorRuntimeState::Healthy,
+        state: @core.ApplicationState::ApplicationState(@core.Raw),
+        semantic_document: None,
+        split_preview_open: false,
+        active_block_key: None,
+        selection: None,
+        fatal: false,
+        force_parser_failure: false,
+        force_reconstruction_failure: false,
+        error: Some("Your document was recovered and editing can continue."),
+        error_code: Some("editor-recovered"),
+        error_operation: Some("editor-recovery"),
+        rejection: None,
+      }
+      persist_recovered_editor(fresh_editor, next, emit)
+    }
+  }
+}
+
+///|
+/// Quarantine an unexpected outer-shell error without calling it a parser
+/// failure. This branch is intentionally outside document transactions.
+fn quarantine_outer_error(
+  session_ref : @ref.Ref[EditorSession],
+  model : DriverModel,
+  _error : Error,
+) -> (DriverModel, @cmd.Cmd) {
+  let editor = session_ref.val.editor
+  let source = editor.portable_markdown()
+  let advanced = classify_recovered_source(model, source, editor.version())
+  session_ref.val.attachment.dispose()
+  terminal_raw_recovery(
+    advanced, source, "Editing is paused. Copy your Markdown and reload to continue.",
+  )
+}

--- a/apps/loomark/internal/rabbita/recovery_state.mbt
+++ b/apps/loomark/internal/rabbita/recovery_state.mbt
@@ -1,0 +1,50 @@
+///|
+/// Runtime health of the mutable editor session. RawRecovery is terminal for
+/// this mount: the user must explicitly reload before another editor exists.
+priv enum EditorRuntimeState {
+  Healthy
+  Restarting
+  RawRecovery(String)
+} derive(Eq)
+
+///|
+/// Events produced by the imperative recovery shell.
+priv enum EditorRecoveryEvent {
+  Failure
+  ReconstructionSucceeded
+  ReconstructionFailed(String)
+}
+
+///|
+/// Pure decisions returned by the runtime-state reducer.
+priv enum EditorRecoveryDecision {
+  Reconstruct
+  Continue
+  Reject
+}
+
+///|
+/// Reduce one recovery event without touching the editor, DOM, or storage.
+/// There is deliberately no transition out of RawRecovery: it cannot retry
+/// the failed parser or reconstruct a second session.
+fn reduce_editor_runtime(
+  state : EditorRuntimeState,
+  event : EditorRecoveryEvent,
+) -> (EditorRuntimeState, EditorRecoveryDecision) {
+  match (state, event) {
+    (Healthy, EditorRecoveryEvent::Failure) =>
+      (EditorRuntimeState::Restarting, EditorRecoveryDecision::Reconstruct)
+    (Restarting, EditorRecoveryEvent::ReconstructionSucceeded) =>
+      (EditorRuntimeState::Healthy, EditorRecoveryDecision::Continue)
+    (Restarting, EditorRecoveryEvent::ReconstructionFailed(source)) =>
+      (
+        EditorRuntimeState::RawRecovery(source),
+        EditorRecoveryDecision::Continue,
+      )
+    (Restarting, EditorRecoveryEvent::Failure) =>
+      (EditorRuntimeState::RawRecovery(""), EditorRecoveryDecision::Continue)
+    (RawRecovery(source), _) =>
+      (EditorRuntimeState::RawRecovery(source), EditorRecoveryDecision::Reject)
+    _ => (state, EditorRecoveryDecision::Reject)
+  }
+}

--- a/apps/loomark/internal/rabbita/recovery_state_wbtest.mbt
+++ b/apps/loomark/internal/rabbita/recovery_state_wbtest.mbt
@@ -1,0 +1,73 @@
+///|
+test "editor recovery state starts one reconstruction" {
+  let (state, decision) = reduce_editor_runtime(
+    EditorRuntimeState::Healthy,
+    EditorRecoveryEvent::Failure,
+  )
+  match state {
+    EditorRuntimeState::Restarting => ()
+    _ => fail("expected Restarting")
+  }
+  match decision {
+    EditorRecoveryDecision::Reconstruct => ()
+    _ => fail("expected one reconstruction")
+  }
+}
+
+///|
+test "successful reconstruction returns to healthy editing" {
+  let (state, decision) = reduce_editor_runtime(
+    EditorRuntimeState::Restarting,
+    EditorRecoveryEvent::ReconstructionSucceeded,
+  )
+  match state {
+    EditorRuntimeState::Healthy => ()
+    _ => fail("expected Healthy")
+  }
+  match decision {
+    EditorRecoveryDecision::Continue => ()
+    _ => fail("expected continuation")
+  }
+}
+
+///|
+test "failed reconstruction enters terminal raw recovery" {
+  let (state, decision) = reduce_editor_runtime(
+    EditorRuntimeState::Restarting,
+    EditorRecoveryEvent::ReconstructionFailed("accepted"),
+  )
+  match state {
+    EditorRuntimeState::RawRecovery(source) => assert_eq(source, "accepted")
+    _ => fail("expected RawRecovery")
+  }
+  match decision {
+    EditorRecoveryDecision::Continue => ()
+    _ => fail("expected terminal continuation")
+  }
+}
+
+///|
+test "raw recovery never retries or leaves the terminal state" {
+  let (after_failure, failure_decision) = reduce_editor_runtime(
+    EditorRuntimeState::RawRecovery("accepted"),
+    EditorRecoveryEvent::Failure,
+  )
+  let (after_success, success_decision) = reduce_editor_runtime(
+    EditorRuntimeState::RawRecovery("accepted"),
+    EditorRecoveryEvent::ReconstructionSucceeded,
+  )
+  match (after_failure, after_success) {
+    (
+      EditorRuntimeState::RawRecovery(first),
+      EditorRuntimeState::RawRecovery(second),
+    ) => {
+      assert_eq(first, "accepted")
+      assert_eq(second, "accepted")
+    }
+    _ => fail("expected terminal RawRecovery")
+  }
+  match (failure_decision, success_decision) {
+    (EditorRecoveryDecision::Reject, EditorRecoveryDecision::Reject) => ()
+    _ => fail("expected both events to be rejected")
+  }
+}

--- a/apps/loomark/internal/rabbita/recovery_view.mbt
+++ b/apps/loomark/internal/rabbita/recovery_view.mbt
@@ -12,7 +12,7 @@ priv enum RecoveryCategory {
 
 ///|
 /// Stable, non-editable recovery application for an unreadable local archive.
-fn recovery_view(category : RecoveryCategory) -> @rabbita_runtime.Html {
+fn archive_recovery_view(category : RecoveryCategory) -> @rabbita_runtime.Html {
   let (title, message, name) = match category {
     RecoveryCategory::StorageUnavailable =>
       (
@@ -76,6 +76,6 @@ fn recovery_view(category : RecoveryCategory) -> @rabbita_runtime.Html {
 /// Build a static recovery app without an editor or storage command.
 fn recovery_application(category : RecoveryCategory) -> @rabbita_runtime.App {
   @rabbita_runtime.new(() => {
-    @rabbita_runtime.Val::constant(recovery_view(category))
+    @rabbita_runtime.Val::constant(archive_recovery_view(category))
   })
 }

--- a/apps/loomark/internal/rabbita/semantic_preview_view_benchmark_wbtest.mbt
+++ b/apps/loomark/internal/rabbita/semantic_preview_view_benchmark_wbtest.mbt
@@ -27,7 +27,7 @@ fn preview_view_benchmark_replace_middle(source : String) -> String {
 fn wbtest_markdown_ir(
   source_id : @loom.SourceId,
   source : String,
-) -> @md_markdown.MarkdownIR {
+) -> @md_markdown.MarkdownIR raise {
   let parser = @loom.new_parser(
     source_id, source, @md_markdown.markdown_grammar,
   )
@@ -48,7 +48,7 @@ priv struct PreviewViewBenchmarkInput {
 }
 
 ///|
-fn preview_view_benchmark_input() -> PreviewViewBenchmarkInput {
+fn preview_view_benchmark_input() -> PreviewViewBenchmarkInput raise {
   let source = preview_view_benchmark_source(2500)
   let edited = preview_view_benchmark_replace_middle(source)
   {

--- a/apps/loomark/internal/rabbita/semantic_preview_view_wbtest.mbt
+++ b/apps/loomark/internal/rabbita/semantic_preview_view_wbtest.mbt
@@ -1,6 +1,6 @@
 ///|
 #warnings("-alert_unstable")
-fn render_preview(source : String) -> String {
+fn render_preview(source : String) -> String raise {
   let preview = semantic_preview_view(
     source,
     wbtest_markdown_ir(@loom.SourceId("loomark-preview-ssr"), source),

--- a/apps/loomark/internal/rabbita/standalone_bootstrap.mbt
+++ b/apps/loomark/internal/rabbita/standalone_bootstrap.mbt
@@ -32,7 +32,7 @@ fn mount_standalone_editor(
   baseline : (@repository.LocalArchiveRequestId, String)?,
   archive_tracker : @repository.LocalArchiveRequestTracker,
   local_storage_warning : Bool,
-) -> Unit {
+) -> Unit raise {
   let initial = {
     ..initial_model(
       host_id,
@@ -52,11 +52,21 @@ fn mount_standalone_editor(
 
 ///|
 /// Construct a new local document and schedule its complete baseline archive.
-fn mount_new_standalone_document(host_id : String, source : String) -> Unit {
+fn mount_new_standalone_document(
+  host_id : String,
+  source : String,
+) -> Unit raise {
   let replica_id = @archive_storage.fresh_id("loomark-standalone-writer-")
-  let document_id = try! @archive.LoomarkDocumentId::from_string(
+  let document_id = @archive.LoomarkDocumentId::from_string(
     @archive_storage.fresh_id("loomark-document-"),
-  )
+  ) catch {
+    _ => {
+      recovery_application(RecoveryCategory::EditorInitializationFailed).mount(
+        host_id,
+      )
+      return
+    }
+  }
   let (editor, attachment) = @markdown.MarkdownEditor::with_semantic_attachment(
     agent_id=replica_id,
     source~,
@@ -102,7 +112,7 @@ fn mount_new_standalone_document(host_id : String, source : String) -> Unit {
 fn mount_reopened_standalone_document(
   host_id : String,
   archive : @archive.LoomarkDocumentArchive,
-) -> Unit {
+) -> Unit raise {
   let policy = @repository.LocalRestorePolicy::trusted()
   let replica_id = @archive_storage.fresh_id("loomark-standalone-writer-")
   let reopened = @repository.reopen_local_archive(
@@ -133,7 +143,7 @@ fn finish_standalone_bootstrap(
   host_id : String,
   source : String,
   loaded : @archive_storage.LocalArchiveStorageRead,
-) -> Unit {
+) -> Unit raise {
   match loaded {
     @archive_storage.LocalArchiveStorageRead::Missing =>
       mount_new_standalone_document(host_id, source)

--- a/apps/loomark/repository/pkg.generated.mbti
+++ b/apps/loomark/repository/pkg.generated.mbti
@@ -7,13 +7,15 @@ import {
 }
 
 // Values
-pub fn classify_local_archive_record(String?, validation_agent_id~ : String, policy~ : LocalRestorePolicy) -> LocalArchiveLoad
+pub fn classify_local_archive_record(String?, validation_agent_id~ : String, policy~ : LocalRestorePolicy) -> LocalArchiveLoad raise
 
 pub fn history_trigger(@dowdiness/canopy/editor/markdown.MarkdownCommitReceipt) -> LocalArchivePersistenceDecision
 
-pub fn prepare_local_archive(document_id~ : @archive.LoomarkDocumentId, editor~ : @dowdiness/canopy/editor/markdown.MarkdownEditor) -> PreparedLocalArchive raise LocalArchivePreparationError
+pub fn prepare_local_archive(document_id~ : @archive.LoomarkDocumentId, editor~ : @dowdiness/canopy/editor/markdown.MarkdownEditor) -> PreparedLocalArchive raise
 
-pub fn reopen_local_archive(@archive.LoomarkDocumentArchive, agent_id~ : String, policy~ : LocalRestorePolicy) -> ReopenedLocalArchive raise @dowdiness/canopy/editor/markdown.MarkdownArchiveError
+pub fn reopen_local_archive(@archive.LoomarkDocumentArchive, agent_id~ : String, policy~ : LocalRestorePolicy) -> ReopenedLocalArchive raise
+
+pub fn reopen_local_history(@dowdiness/canopy/editor/markdown.MarkdownDocumentHistory, document_id~ : @archive.LoomarkDocumentId, agent_id~ : String, policy~ : LocalRestorePolicy) -> ReopenedLocalArchive raise
 
 // Errors
 pub(all) suberror LocalArchivePreparationError {

--- a/apps/loomark/repository/repository.mbt
+++ b/apps/loomark/repository/repository.mbt
@@ -25,12 +25,14 @@ const TRUSTED_LOCAL_ADMISSION_MAXIMUM : Int = 2147483647
 ///|
 /// Construct the explicit policy for a device-owned local archive.
 pub fn LocalRestorePolicy::trusted() -> LocalRestorePolicy {
-  let open_limits = try! @markdown.MarkdownArchiveOpenLimits(
+  let open_limits = @markdown.MarkdownArchiveOpenLimits(
     max_encoded_bytes=TRUSTED_LOCAL_ADMISSION_MAXIMUM,
     max_decoded_operations=TRUSTED_LOCAL_ADMISSION_MAXIMUM,
     max_pending_operations=TRUSTED_LOCAL_ADMISSION_MAXIMUM,
     max_parents_per_operation=TRUSTED_LOCAL_ADMISSION_MAXIMUM,
-  )
+  ) catch {
+    _ => abort("trusted local archive limits must be valid")
+  }
   LocalRestorePolicy(open_limits)
 }
 
@@ -102,7 +104,7 @@ pub fn classify_local_archive_record(
   raw_record : String?,
   validation_agent_id~ : String,
   policy~ : LocalRestorePolicy,
-) -> LocalArchiveLoad {
+) -> LocalArchiveLoad raise {
   match raw_record {
     None => LocalArchiveLoad::Missing
     Some(encoded) => {
@@ -111,7 +113,30 @@ pub fn classify_local_archive_record(
         validation_agent_id~,
         open_limits=policy.open_limits,
       ) catch {
-        error => return LocalArchiveLoad::Rejected(map_decode_failure(error))
+        Failure::Failure(_) as failure => raise failure
+        @archive.LoomarkArchiveDecodeError::UnsupportedNewerVersion(..) as error =>
+          return LocalArchiveLoad::Rejected(map_decode_failure(error))
+        @archive.LoomarkArchiveDecodeError::MalformedEnvelope(..) as error =>
+          return LocalArchiveLoad::Rejected(map_decode_failure(error))
+        @archive.LoomarkArchiveDecodeError::EmptyDocumentId as error =>
+          return LocalArchiveLoad::Rejected(map_decode_failure(error))
+        @archive.LoomarkArchiveDecodeError::CorruptHistory(..) as error =>
+          return LocalArchiveLoad::Rejected(map_decode_failure(error))
+        @archive.LoomarkArchiveDecodeError::PortableTextHistoryMismatch as error =>
+          return LocalArchiveLoad::Rejected(map_decode_failure(error))
+        @archive.LoomarkArchiveDecodeError::InvalidValidationAgentId as error =>
+          return LocalArchiveLoad::Rejected(map_decode_failure(error))
+        @archive.LoomarkArchiveDecodeError::WriterCreationFailed(..) as error =>
+          return LocalArchiveLoad::Rejected(map_decode_failure(error))
+        @archive.LoomarkArchiveDecodeError::LimitExceeded(..) as error =>
+          return LocalArchiveLoad::Rejected(map_decode_failure(error))
+        @archive.LoomarkArchiveDecodeError::HistoryAdmissionFailed(..) as error =>
+          return LocalArchiveLoad::Rejected(map_decode_failure(error))
+        @archive.LoomarkArchiveDecodeError::HistoryExportFailed(..) as error =>
+          return LocalArchiveLoad::Rejected(map_decode_failure(error))
+        @archive.LoomarkArchiveDecodeError::IncompleteHistory as error =>
+          return LocalArchiveLoad::Rejected(map_decode_failure(error))
+        error => raise error
       }
       LocalArchiveLoad::Valid(archive)
     }
@@ -135,10 +160,12 @@ pub struct PreparedLocalArchive {
 pub fn prepare_local_archive(
   document_id~ : @archive.LoomarkDocumentId,
   editor~ : @markdown.MarkdownEditor,
-) -> PreparedLocalArchive raise LocalArchivePreparationError {
+) -> PreparedLocalArchive raise {
   let archive = @archive.LoomarkDocumentArchive::capture(document_id~, editor~) catch {
+    Failure::Failure(_) as failure => raise failure
     @archive.LoomarkArchiveCaptureError::HistoryUnavailable(detail~) =>
       raise LocalArchivePreparationError::HistoryUnavailable(detail~)
+    error => raise error
   }
   { encoded: archive.to_json_string() }
 }
@@ -264,13 +291,31 @@ pub fn reopen_local_archive(
   archive : @archive.LoomarkDocumentArchive,
   agent_id~ : String,
   policy~ : LocalRestorePolicy,
-) -> ReopenedLocalArchive raise @markdown.MarkdownArchiveError {
+) -> ReopenedLocalArchive raise {
   let (editor, attachment) = @markdown.MarkdownEditor::open_with_semantic_attachment(
     agent_id~,
     history=archive.history(),
     open_limits=policy.open_limits,
   )
   { document_id: archive.document_id(), editor, attachment }
+}
+
+///|
+/// Reopen parser-independent complete history captured from a terminal editor.
+/// Unlike archive admission, this does not compare a parser-derived portable
+/// text summary; the fresh editor becomes the authority after history replay.
+pub fn reopen_local_history(
+  history : @markdown.MarkdownDocumentHistory,
+  document_id~ : @archive.LoomarkDocumentId,
+  agent_id~ : String,
+  policy~ : LocalRestorePolicy,
+) -> ReopenedLocalArchive raise {
+  let (editor, attachment) = @markdown.MarkdownEditor::open_with_semantic_attachment(
+    agent_id~,
+    history~,
+    open_limits=policy.open_limits,
+  )
+  { document_id, editor, attachment }
 }
 
 ///|

--- a/apps/relay-server/package-lock.json
+++ b/apps/relay-server/package-lock.json
@@ -7,6 +7,7 @@
       "name": "canopy-relay-server",
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20240725.0",
+        "typescript": "^5.4.0",
         "wrangler": "^3.72.0"
       }
     },
@@ -1447,6 +1448,20 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "node_modules/ufo": {
       "version": "1.6.3",

--- a/apps/relay-server/package.json
+++ b/apps/relay-server/package.json
@@ -3,10 +3,12 @@
   "private": true,
   "scripts": {
     "dev": "wrangler dev",
-    "deploy": "wrangler deploy"
+    "deploy": "wrangler deploy",
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240725.0",
+    "typescript": "^5.4.0",
     "wrangler": "^3.72.0"
   }
 }

--- a/apps/relay-server/src/index.ts
+++ b/apps/relay-server/src/index.ts
@@ -9,11 +9,16 @@ export interface Env {
   RELAY: DurableObjectNamespace;
 }
 
-// Lazy-loaded MoonBit module (deferred to handler scope)
-let relay: any = null;
-async function loadRelay() {
-  if (relay) return relay;
-  relay = await import("../../../_build/js/release/build/dowdiness/canopy/ffi/lambda/lambda.js");
+// Lazy-loaded MoonBit module (deferred to handler scope).
+type RelayModule = typeof import(
+  "../../../_build/js/release/build/dowdiness/canopy/ffi/lambda/lambda.js"
+);
+let relay: RelayModule | null = null;
+async function loadRelay(): Promise<RelayModule> {
+  if (relay !== null) return relay;
+  relay = await import(
+    "../../../_build/js/release/build/dowdiness/canopy/ffi/lambda/lambda.js"
+  );
   return relay;
 }
 
@@ -51,7 +56,8 @@ export class RelayRoom implements DurableObject {
     // Pass a send callback to MoonBit — relay manages sessions + broadcast.
     // relay_on_connect returns false if the peer_id is empty or already in
     // the room; close the duplicate transport rather than leaving a zombie.
-    const accepted = relay.relay_on_connect(
+    const relayModule = await loadRelay();
+    const accepted = relayModule.relay_on_connect(
       this.roomId,
       peerId,
       (data: Uint8Array) => {
@@ -70,15 +76,15 @@ export class RelayRoom implements DurableObject {
       const data = e.data instanceof ArrayBuffer
         ? new Uint8Array(e.data)
         : new TextEncoder().encode(e.data as string);
-      relay.relay_on_message(this.roomId, peerId, data);
+      relayModule.relay_on_message(this.roomId, peerId, data);
     });
 
     server.addEventListener("close", () => {
-      relay.relay_on_disconnect(this.roomId, peerId);
+      relayModule.relay_on_disconnect(this.roomId, peerId);
     });
 
     server.addEventListener("error", () => {
-      relay.relay_on_disconnect(this.roomId, peerId);
+      relayModule.relay_on_disconnect(this.roomId, peerId);
     });
 
     return new Response(null, { status: 101, webSocket: client });

--- a/apps/relay-server/tsconfig.json
+++ b/apps/relay-server/tsconfig.json
@@ -3,7 +3,9 @@
     "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "lib": ["ESNext"],
     "strict": true,
+    "skipLibCheck": true,
     "types": ["@cloudflare/workers-types"],
     "paths": {
       "../../../_build/js/release/build/dowdiness/canopy/ffi/lambda/lambda.js": ["../../_build/js/release/build/dowdiness/canopy/ffi/lambda/lambda.d.ts"]

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -44,9 +44,20 @@
       "name": "@canopy/editor-adapter",
       "version": "0.1.0-alpha.0",
       "license": "Apache-2.0",
+      "devDependencies": {
+        "@codemirror/lint": "^6.9.7",
+        "@codemirror/state": "^6.5.0",
+        "@codemirror/view": "^6.35.0",
+        "@playwright/test": "1.61.1",
+        "@types/node": "^24.13.3",
+        "typescript": "^6.0.3",
+        "vite": "^6.0.0",
+        "vitest": "^4.1.10"
+      },
       "peerDependencies": {
         "@codemirror/commands": "^6.10.0",
         "@codemirror/language": "^6.10.0",
+        "@codemirror/lint": "^6.9.7",
         "@codemirror/state": "^6.5.0",
         "@codemirror/view": "^6.35.0",
         "prosemirror-commands": "^1.6.0",
@@ -61,6 +72,9 @@
           "optional": true
         },
         "@codemirror/language": {
+          "optional": true
+        },
+        "@codemirror/lint": {
           "optional": true
         },
         "@codemirror/state": {

--- a/apps/web/scripts/check-waku-bundles.mjs
+++ b/apps/web/scripts/check-waku-bundles.mjs
@@ -3,9 +3,9 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const generatedModules = [
-  { id: '@moonbit/crdt-lambda', fingerprint: 'assemble_lambda_handle' },
-  { id: '@moonbit/crdt-json', fingerprint: 'assemble_json_handle' },
-  { id: '@moonbit/crdt-markdown', fingerprint: 'assemble_markdown_handle' },
+  { id: '@moonbit/crdt-lambda', fingerprint: 'try_destroy_editor' },
+  { id: '@moonbit/crdt-json', fingerprint: 'try_destroy_json_editor' },
+  { id: '@moonbit/crdt-markdown', fingerprint: 'try_destroy_markdown_editor' },
   { id: '@moonbit/crdt-jsx', fingerprint: 'jsx_session_new' },
   { id: '@moonbit/graphviz', fingerprint: 'render_dot_to_svg' },
 ];
@@ -42,17 +42,17 @@ const forbiddenProductionClientArtifacts = [
   {
     capability: 'Memo provider URL',
     fingerprint: 'https://generativelanguage.googleapis.com/v1beta/models/',
-    allowedBundleFingerprint: 'assemble_lambda_handle',
+    allowedBundleFingerprint: 'try_destroy_editor',
   },
   {
     capability: 'Memo provider function',
     fingerprint: 'canopy_llm_fix_typos',
-    allowedBundleFingerprint: 'assemble_lambda_handle',
+    allowedBundleFingerprint: 'try_destroy_editor',
   },
   {
     capability: 'Memo provider function',
     fingerprint: 'canopy_llm_edit',
-    allowedBundleFingerprint: 'assemble_lambda_handle',
+    allowedBundleFingerprint: 'try_destroy_editor',
   },
   ...forbiddenProductionResumeArtifacts,
   ...forbiddenProductionGenuiArtifacts,

--- a/apps/web/scripts/waku-foundation.test.mjs
+++ b/apps/web/scripts/waku-foundation.test.mjs
@@ -87,9 +87,9 @@ test('invalidates generated importers and fully reloads after an output write', 
 
 test('detects each generated runtime fingerprint in a server/RSC bundle', () => {
   const bundles = [
-    ['crdt-lambda', '@moonbit/crdt-lambda', 'assemble_lambda_handle'],
-    ['crdt-json', '@moonbit/crdt-json', 'assemble_json_handle'],
-    ['crdt-markdown', '@moonbit/crdt-markdown', 'assemble_markdown_handle'],
+    ['crdt-lambda', '@moonbit/crdt-lambda', 'try_destroy_editor'],
+    ['crdt-json', '@moonbit/crdt-json', 'try_destroy_json_editor'],
+    ['crdt-markdown', '@moonbit/crdt-markdown', 'try_destroy_markdown_editor'],
     ['crdt-jsx', '@moonbit/crdt-jsx', 'jsx_session_new'],
     ['graphviz', '@moonbit/graphviz', 'render_dot_to_svg'],
   ];
@@ -199,7 +199,7 @@ test('rejects Memo development and provider capabilities outside the shared Lamb
       ].join('\n'),
     }, {
       name: 'dist/public/assets/crdt-lambda-a.js',
-      source: ['assemble_lambda_handle', ...providerFingerprints].join('\n'),
+      source: ['try_destroy_editor', ...providerFingerprints].join('\n'),
     }],
   });
   assert.deepEqual(result.productionClientArtifactLeaks, [

--- a/apps/web/src/features/genui/browser/mount.js
+++ b/apps/web/src/features/genui/browser/mount.js
@@ -1,4 +1,5 @@
 'use client';
+import { adaptMoonBitModule } from '@canopy/editor-adapter/moonbit-result';
 import './styles.css';
 import {
   ORDER_ROWS,
@@ -336,7 +337,7 @@ async function ensureJsxModule() {
     throw error
   }
   if (disposed) throw new Error('GenUI session was disposed before the JSX runtime loaded.')
-  jsxModule = loaded
+  jsxModule = adaptMoonBitModule(loaded)
 }
 
 async function ensureFeasibilitySession() {

--- a/apps/web/src/features/json/browser/editor.ts
+++ b/apps/web/src/features/json/browser/editor.ts
@@ -1,5 +1,6 @@
 'use client';
 import { HTMLAdapter } from '@canopy/editor-adapter/html-adapter';
+import type { AdaptedMoonBitModule } from '@canopy/editor-adapter/moonbit-result';
 import { DecorationOverlay } from '../../../shared/decoration-overlay';
 import type { Decoration } from '@canopy/editor-adapter/types';
 import type { ViewPatch, ViewNode } from '@canopy/editor-adapter/types';
@@ -11,7 +12,9 @@ declare global {
   interface Window { getJsonRoleSpans: () => JsonRoleSpanData[]; }
 }
 
-export type JsonEditorRuntime = typeof import('@moonbit/crdt-json');
+export type JsonEditorRuntime = AdaptedMoonBitModule<
+  typeof import('@moonbit/crdt-json')
+>;
 
 export function mountJsonEditor(
   root: Document | HTMLElement = globalThis.document,

--- a/apps/web/src/features/json/route/json-client.tsx
+++ b/apps/web/src/features/json/route/json-client.tsx
@@ -1,14 +1,13 @@
 'use client';
 
 import { type ReactNode, useCallback, useState } from 'react';
+import { adaptMoonBitModule } from '@canopy/editor-adapter/moonbit-result';
 import { ImperativeDemoHost } from '../../../shared/route-lifecycle/browser/imperative-host';
-import {
-  mountJsonEditor,
-  type JsonEditorRuntime,
-} from '../browser/editor';
+import { mountJsonEditor } from '../browser/editor';
 import '../browser/styles.css';
 
-const loadJsonRuntime: (() => Promise<JsonEditorRuntime>) | null = import.meta.env.SSR
+type RawJsonEditorRuntime = typeof import('@moonbit/crdt-json');
+const loadJsonRuntime: (() => Promise<RawJsonEditorRuntime>) | null = import.meta.env.SSR
   ? null
   : () => import('@moonbit/crdt-json');
 
@@ -34,7 +33,12 @@ function mountJsonRoute(
   void loadJsonRuntime()
     .then((runtime) => {
       if (disposed) return;
-      controller = mountJsonEditor(container, restoredSnapshot, runtime);
+      const adaptedRuntime = adaptMoonBitModule(runtime, {
+        createFunctions: ['create_json_editor'],
+        destroyFunctions: ['destroy_json_editor'],
+        tryDestroyFunctions: ['try_destroy_json_editor'],
+      });
+      controller = mountJsonEditor(container, restoredSnapshot, adaptedRuntime);
       if (
         pendingFocusToken !== null &&
         !controller.restoreFocus(pendingFocusToken)

--- a/apps/web/src/features/lambda/browser/editor.ts
+++ b/apps/web/src/features/lambda/browser/editor.ts
@@ -3,12 +3,15 @@
 // Mini-ML editor — imperative DOM shell over the MoonBit CRDT core.
 
 import { HTMLAdapter } from '@canopy/editor-adapter/html-adapter';
+import type { AdaptedMoonBitModule } from '@canopy/editor-adapter/moonbit-result';
 import type { ViewPatch } from '@canopy/editor-adapter/types';
 import type { MountedImperativeSession } from '../../../shared/route-lifecycle/browser/imperative-session';
 import { DecorationOverlay } from '../../../shared/decoration-overlay';
 import { runAnalysis } from './ast-grep-runner';
 
-export type LambdaEditorRuntime = typeof import('@moonbit/crdt-lambda');
+export type LambdaEditorRuntime = AdaptedMoonBitModule<
+  typeof import('@moonbit/crdt-lambda')
+>;
 export type GraphvizRuntime = typeof import('@moonbit/graphviz');
 
 type PatternMatchEntry = {
@@ -101,11 +104,7 @@ export function mountLambdaEditor(
     releasePrettyAdapter = () => prettyAdapter.destroy();
     const decorationOverlay = new DecorationOverlay(editorEl);
     releaseDecorationOverlay = () => decorationOverlay.dispose();
-    const analysisApi = crdt as LambdaEditorRuntime & {
-      apply_ast_grep_results_json(handle: number, matchesJson: string): string;
-      compute_view_patches_json(handle: number): string;
-      get_pattern_matches_json(handle: number): string;
-    };
+    const analysisApi = crdt;
     let lastText = '';
 
     function renderStructuralSearchState(message: string): void {

--- a/apps/web/src/features/lambda/route/lambda-client.tsx
+++ b/apps/web/src/features/lambda/route/lambda-client.tsx
@@ -1,16 +1,17 @@
 'use client';
 
 import { type ReactNode, useCallback, useState } from 'react';
+import { adaptMoonBitModule } from '@canopy/editor-adapter/moonbit-result';
 import { ImperativeDemoHost } from '../../../shared/route-lifecycle/browser/imperative-host';
 import {
   mountLambdaEditor,
   type GraphvizRuntime,
-  type LambdaEditorRuntime,
 } from '../browser/editor';
 import '../browser/styles.css';
 
+type RawLambdaEditorRuntime = typeof import('@moonbit/crdt-lambda');
 const loadLambdaRuntime: (() => Promise<[
-  LambdaEditorRuntime,
+  RawLambdaEditorRuntime,
   GraphvizRuntime,
 ]>) | null = import.meta.env.SSR
   ? null
@@ -41,10 +42,15 @@ function mountLambdaRoute(
   void loadLambdaRuntime()
     .then(([crdt, graphviz]) => {
       if (disposed) return;
+      const adaptedRuntime = adaptMoonBitModule(crdt, {
+        createFunctions: ['create_editor', 'create_editor_with_undo'],
+        destroyFunctions: ['destroy_editor'],
+        tryDestroyFunctions: ['try_destroy_editor'],
+      });
       controller = mountLambdaEditor(
         container,
         restoredSnapshot,
-        crdt,
+        adaptedRuntime,
         graphviz,
       );
       if (

--- a/apps/web/src/features/markdown/browser/app.ts
+++ b/apps/web/src/features/markdown/browser/app.ts
@@ -3,13 +3,16 @@
 // Markdown Block Editor — three-mode page wiring FFI → adapters.
 
 import { BlockInput, type BlockSelection } from '@canopy/editor-adapter/block-input';
+import type { AdaptedMoonBitModule } from '@canopy/editor-adapter/moonbit-result';
 import { MarkdownPreview } from '@canopy/editor-adapter/markdown-preview';
 import '@canopy/editor-adapter/block-input.css';
 import type { ViewPatch, UserIntent } from '@canopy/editor-adapter/types';
 import type { MountedImperativeSession } from '../../../shared/route-lifecycle/browser/imperative-session';
 import { stripParagraphSentinels } from './sentinels';
 
-export type MarkdownEditorRuntime = typeof import('@moonbit/crdt-markdown');
+export type MarkdownEditorRuntime = AdaptedMoonBitModule<
+  typeof import('@moonbit/crdt-markdown')
+>;
 
 export function mountMarkdownApp(
   root: Document | HTMLElement = globalThis.document,

--- a/apps/web/src/features/markdown/route/markdown-client.tsx
+++ b/apps/web/src/features/markdown/route/markdown-client.tsx
@@ -1,14 +1,13 @@
 'use client';
 
 import { type ReactNode, useCallback, useState } from 'react';
+import { adaptMoonBitModule } from '@canopy/editor-adapter/moonbit-result';
 import { ImperativeDemoHost } from '../../../shared/route-lifecycle/browser/imperative-host';
-import {
-  mountMarkdownApp,
-  type MarkdownEditorRuntime,
-} from '../browser/app';
+import { mountMarkdownApp } from '../browser/app';
 import '../browser/styles.css';
 
-const loadMarkdownRuntime: (() => Promise<MarkdownEditorRuntime>) | null = import.meta.env.SSR
+type RawMarkdownEditorRuntime = typeof import('@moonbit/crdt-markdown');
+const loadMarkdownRuntime: (() => Promise<RawMarkdownEditorRuntime>) | null = import.meta.env.SSR
   ? null
   : () => import('@moonbit/crdt-markdown');
 
@@ -34,7 +33,12 @@ function mountMarkdownRoute(
   void loadMarkdownRuntime()
     .then((runtime) => {
       if (disposed) return;
-      controller = mountMarkdownApp(container, restoredSnapshot, runtime);
+      const adaptedRuntime = adaptMoonBitModule(runtime, {
+        createFunctions: ['create_markdown_editor'],
+        destroyFunctions: ['destroy_markdown_editor'],
+        tryDestroyFunctions: ['try_destroy_markdown_editor'],
+      });
+      controller = mountMarkdownApp(container, restoredSnapshot, adaptedRuntime);
       if (
         pendingFocusToken !== null &&
         !controller.restoreFocus(pendingFocusToken)

--- a/examples/demo-react/package-lock.json
+++ b/examples/demo-react/package-lock.json
@@ -8,6 +8,7 @@
       "name": "lambda-crdt-editor-react",
       "version": "0.1.0",
       "dependencies": {
+        "@canopy/editor-adapter": "file:../../adapters/editor",
         "react": "^19.2.4",
         "react-dom": "^19.2.7"
       },
@@ -27,6 +28,69 @@
         "vite": "^8.0.14",
         "vitest": "^4.1.10",
         "ws": "^8.20.0"
+      }
+    },
+    "../../adapters/editor": {
+      "name": "@canopy/editor-adapter",
+      "version": "0.1.0-alpha.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@codemirror/lint": "^6.9.7",
+        "@codemirror/state": "^6.5.0",
+        "@codemirror/view": "^6.35.0",
+        "@playwright/test": "1.61.1",
+        "@types/node": "^24.13.3",
+        "typescript": "^6.0.3",
+        "vite": "^6.0.0",
+        "vitest": "^4.1.10"
+      },
+      "peerDependencies": {
+        "@codemirror/commands": "^6.10.0",
+        "@codemirror/language": "^6.10.0",
+        "@codemirror/lint": "^6.9.7",
+        "@codemirror/state": "^6.5.0",
+        "@codemirror/view": "^6.35.0",
+        "prosemirror-commands": "^1.6.0",
+        "prosemirror-keymap": "^1.2.0",
+        "prosemirror-model": "^1.24.0",
+        "prosemirror-state": "^1.4.0",
+        "prosemirror-transform": "^1.10.0",
+        "prosemirror-view": "^1.37.0"
+      },
+      "peerDependenciesMeta": {
+        "@codemirror/commands": {
+          "optional": true
+        },
+        "@codemirror/language": {
+          "optional": true
+        },
+        "@codemirror/lint": {
+          "optional": true
+        },
+        "@codemirror/state": {
+          "optional": true
+        },
+        "@codemirror/view": {
+          "optional": true
+        },
+        "prosemirror-commands": {
+          "optional": true
+        },
+        "prosemirror-keymap": {
+          "optional": true
+        },
+        "prosemirror-model": {
+          "optional": true
+        },
+        "prosemirror-state": {
+          "optional": true
+        },
+        "prosemirror-transform": {
+          "optional": true
+        },
+        "prosemirror-view": {
+          "optional": true
+        }
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -136,6 +200,10 @@
       "bin": {
         "specificity": "bin/cli.js"
       }
+    },
+    "node_modules/@canopy/editor-adapter": {
+      "resolved": "../../adapters/editor",
+      "link": true
     },
     "node_modules/@csstools/color-helpers": {
       "version": "6.0.2",

--- a/examples/demo-react/package.json
+++ b/examples/demo-react/package.json
@@ -17,6 +17,7 @@
     "test:headed": "playwright test --headed"
   },
   "dependencies": {
+    "@canopy/editor-adapter": "file:../../adapters/editor",
     "react": "^19.2.4",
     "react-dom": "^19.2.7"
   },

--- a/examples/demo-react/src/features/editor/crdt-api.ts
+++ b/examples/demo-react/src/features/editor/crdt-api.ts
@@ -8,11 +8,13 @@
 // The import is static, so the module is available synchronously.
 
 import * as crdtRaw from '@moonbit/crdt';
+import { adaptMoonBitModule } from '@canopy/editor-adapter/moonbit-result';
 
 export interface CrdtModule {
   create_editor_with_undo(agent_id: string, capture_timeout_ms: number): number;
   create_editor(agent_id: string): number;
   destroy_editor(handle: number): void;
+  try_destroy_editor(handle: number): boolean;
   get_text(handle: number): string;
   set_text(handle: number, new_text: string): void;
   set_text_and_record(handle: number, new_text: string, timestamp_ms: number): void;
@@ -33,7 +35,11 @@ export interface CrdtModule {
   redo_and_export_json(handle: number): string;
 }
 
-const crdtModule: CrdtModule = crdtRaw as unknown as CrdtModule;
+const crdtModule: CrdtModule = adaptMoonBitModule(crdtRaw, {
+  createFunctions: ['create_editor', 'create_editor_with_undo'],
+  destroyFunctions: ['destroy_editor'],
+  tryDestroyFunctions: ['try_destroy_editor'],
+});
 
 /**
  * Get the CRDT module (synchronous — available immediately).

--- a/examples/demo-react/src/features/editor/crdt-stub-module.ts
+++ b/examples/demo-react/src/features/editor/crdt-stub-module.ts
@@ -7,6 +7,7 @@ export const {
   create_editor_with_undo,
   create_editor,
   destroy_editor,
+  try_destroy_editor,
   get_text,
   set_text,
   set_text_and_record,

--- a/examples/demo-react/src/features/editor/crdt-stub.ts
+++ b/examples/demo-react/src/features/editor/crdt-stub.ts
@@ -49,6 +49,11 @@ export const stubCrdtModule: CrdtModule = {
     editors.delete(handle);
   },
 
+  try_destroy_editor(handle: number): boolean {
+    editors.delete(handle);
+    return true;
+  },
+
   get_text(handle: number): string {
     return getEditor(handle)?.text ?? '';
   },

--- a/examples/demo-react/src/moonbit-crdt.d.ts
+++ b/examples/demo-react/src/moonbit-crdt.d.ts
@@ -5,6 +5,7 @@ declare module '@moonbit/crdt' {
   export function create_editor_with_undo(agent_id: string, capture_timeout_ms: number): number;
   export function create_editor(agent_id: string): number;
   export function destroy_editor(handle: number): void;
+  export function try_destroy_editor(handle: number): boolean;
   export function get_text(handle: number): string;
   export function set_text(handle: number, new_text: string): void;
   export function set_text_and_record(handle: number, new_text: string, timestamp_ms: number): void;

--- a/examples/prosemirror/src/main.ts
+++ b/examples/prosemirror/src/main.ts
@@ -1,13 +1,20 @@
 // Canopy ProseMirror example — structural editor powered by EditorProtocol.
 
-import * as crdt from "@moonbit/canopy";
+import * as crdtRaw from "@moonbit/canopy";
 import { EditorState as PmState } from "prosemirror-state";
 import { PMAdapter } from "@canopy/editor-adapter/pm-adapter";
+import { adaptMoonBitModule } from "@canopy/editor-adapter/moonbit-result";
 import type { ViewPatch, ViewNode, UserIntent } from "@canopy/editor-adapter/types";
 import { connectWebSocket } from "./ws-glue";
 import { structuralKeymap } from "./keymap";
 
 // ── CRDT setup ──────────────────────────────────────────────
+
+const crdt = adaptMoonBitModule(crdtRaw, {
+  createFunctions: ["create_editor", "create_editor_with_undo"],
+  destroyFunctions: ["destroy_editor"],
+  tryDestroyFunctions: ["try_destroy_editor"],
+});
 
 const agentId = "pm-agent-" + Math.random().toString(36).slice(2, 8);
 const handle = crdt.create_editor_with_undo(agentId, 300);
@@ -128,7 +135,7 @@ let broadcastEdit: (() => void) | null = null;
 const WS_URL = "ws://localhost:8787?room=main&peer_id=" + encodeURIComponent(agentId);
 const sync = connectWebSocket(
   handle,
-  crdt as any,
+  crdt,
   WS_URL,
   () => {
     reconcile();

--- a/examples/prosemirror/src/ws-glue.ts
+++ b/examples/prosemirror/src/ws-glue.ts
@@ -8,7 +8,6 @@ interface WsCrdtModule {
   ws_on_close(handle: number): void;
   ws_broadcast_edit(handle: number): void;
   ws_broadcast_cursor(handle: number): void;
-  [key: string]: any;
 }
 
 const RECONNECT_DELAY_MS = 2000;

--- a/modules/canopy/core/test_expr_wbtest.mbt
+++ b/modules/canopy/core/test_expr_wbtest.mbt
@@ -116,7 +116,7 @@ test "ProjNode[TestExpr] — construction and field access" {
 ///|
 test "ProjNode::leaf allocates a fresh id from syntax span" {
   let syntax_node = @seam.SyntaxNode::from_cst(
-    @seam.CstNode::new(@seam.RawKind(1), [
+    @seam.CstNode::new_unclassified(@seam.RawKind(1), [
       @seam.CstElement::Token(
         @seam.CstToken::CstToken(@seam.RawKind(2), "text"),
       ),

--- a/modules/canopy/editor/diagnostic_publication_input.mbt
+++ b/modules/canopy/editor/diagnostic_publication_input.mbt
@@ -129,7 +129,7 @@ pub fn DiagnosticPublicationInputSnapshot::configuration(
 /// only to establish invalidation; the returned value carries no source text.
 pub fn[T] SyncEditor::diagnostic_publication_source_revision(
   self : SyncEditor[T],
-) -> @incr.Derived[DiagnosticPublicationSourceRevision] {
+) -> @incr.Derived[DiagnosticPublicationSourceRevision] raise Failure {
   let source_id = self.parser_source_id()
   @incr.Derived::Derived(
     self.parser_runtime(),

--- a/modules/canopy/editor/markdown/editor.mbt
+++ b/modules/canopy/editor/markdown/editor.mbt
@@ -492,11 +492,35 @@ pub struct MarkdownEditor {
 pub fn MarkdownEditor::MarkdownEditor(
   agent_id~ : String,
   source~ : String,
-) -> MarkdownEditor raise MarkdownEditorError {
+) -> MarkdownEditor raise {
   let editor = @md_companion.new_markdown_editor(agent_id) catch {
+    Failure::Failure(_) as failure => raise failure
     @text.TextError::EmptyReplicaId => raise MarkdownEditorError::InvalidAgentId
-    error =>
-      raise MarkdownEditorError::InitializationFailed(detail=error.message())
+    @text.TextError::InvalidPosition(..) =>
+      raise MarkdownEditorError::InitializationFailed(
+        detail="text editor construction failed",
+      )
+    @text.TextError::InvalidText(..) =>
+      raise MarkdownEditorError::InitializationFailed(
+        detail="text editor construction failed",
+      )
+    @text.TextError::InvalidRange(..) =>
+      raise MarkdownEditorError::InitializationFailed(
+        detail="text editor construction failed",
+      )
+    @text.TextError::SyncFailed(_) =>
+      raise MarkdownEditorError::InitializationFailed(
+        detail="text editor construction failed",
+      )
+    @text.TextError::VersionNotFound =>
+      raise MarkdownEditorError::InitializationFailed(
+        detail="text editor construction failed",
+      )
+    @text.TextError::Internal(..) =>
+      raise MarkdownEditorError::InitializationFailed(
+        detail="text editor construction failed",
+      )
+    error => raise error
   }
   initialize_markdown_editor(editor, source)
 }
@@ -507,13 +531,37 @@ pub fn MarkdownEditor::MarkdownEditor(
 pub fn MarkdownEditor::with_semantic_attachment(
   agent_id~ : String,
   source~ : String,
-) -> (MarkdownEditor, @md_markdown.MarkdownSemanticAttachment) raise MarkdownEditorError {
+) -> (MarkdownEditor, @md_markdown.MarkdownSemanticAttachment) raise {
   let (editor, attachment) = @md_companion.new_markdown_editor_with_semantic_attachment(
     agent_id,
   ) catch {
+    Failure::Failure(_) as failure => raise failure
     @text.TextError::EmptyReplicaId => raise MarkdownEditorError::InvalidAgentId
-    error =>
-      raise MarkdownEditorError::InitializationFailed(detail=error.message())
+    @text.TextError::InvalidPosition(..) =>
+      raise MarkdownEditorError::InitializationFailed(
+        detail="text editor construction failed",
+      )
+    @text.TextError::InvalidText(..) =>
+      raise MarkdownEditorError::InitializationFailed(
+        detail="text editor construction failed",
+      )
+    @text.TextError::InvalidRange(..) =>
+      raise MarkdownEditorError::InitializationFailed(
+        detail="text editor construction failed",
+      )
+    @text.TextError::SyncFailed(_) =>
+      raise MarkdownEditorError::InitializationFailed(
+        detail="text editor construction failed",
+      )
+    @text.TextError::VersionNotFound =>
+      raise MarkdownEditorError::InitializationFailed(
+        detail="text editor construction failed",
+      )
+    @text.TextError::Internal(..) =>
+      raise MarkdownEditorError::InitializationFailed(
+        detail="text editor construction failed",
+      )
+    error => raise error
   }
   (initialize_markdown_editor(editor, source), attachment)
 }
@@ -523,7 +571,7 @@ pub fn MarkdownEditor::with_semantic_attachment(
 fn initialize_markdown_editor(
   editor : @editor.SyncEditor[@md_markdown.Block],
   source : String,
-) -> MarkdownEditor {
+) -> MarkdownEditor raise {
   editor.set_text(source)
   editor.refresh()
   { editor, }
@@ -554,12 +602,36 @@ pub fn MarkdownEditor::open(
   agent_id~ : String,
   history~ : MarkdownDocumentHistory,
   open_limits~ : MarkdownArchiveOpenLimits,
-) -> MarkdownEditor raise MarkdownArchiveError {
+) -> MarkdownEditor raise {
   let editor = @md_companion.new_markdown_editor(agent_id) catch {
+    Failure::Failure(_) as failure => raise failure
     @text.TextError::EmptyReplicaId =>
       raise MarkdownArchiveError::InvalidAgentId
-    error =>
-      raise MarkdownArchiveError::WriterCreationFailed(detail=error.message())
+    @text.TextError::InvalidPosition(..) =>
+      raise MarkdownArchiveError::WriterCreationFailed(
+        detail="text editor construction failed",
+      )
+    @text.TextError::InvalidText(..) =>
+      raise MarkdownArchiveError::WriterCreationFailed(
+        detail="text editor construction failed",
+      )
+    @text.TextError::InvalidRange(..) =>
+      raise MarkdownArchiveError::WriterCreationFailed(
+        detail="text editor construction failed",
+      )
+    @text.TextError::SyncFailed(_) =>
+      raise MarkdownArchiveError::WriterCreationFailed(
+        detail="text editor construction failed",
+      )
+    @text.TextError::VersionNotFound =>
+      raise MarkdownArchiveError::WriterCreationFailed(
+        detail="text editor construction failed",
+      )
+    @text.TextError::Internal(..) =>
+      raise MarkdownArchiveError::WriterCreationFailed(
+        detail="text editor construction failed",
+      )
+    error => raise error
   }
   open_markdown_editor(editor, history, open_limits)
 }
@@ -571,14 +643,38 @@ pub fn MarkdownEditor::open_with_semantic_attachment(
   agent_id~ : String,
   history~ : MarkdownDocumentHistory,
   open_limits~ : MarkdownArchiveOpenLimits,
-) -> (MarkdownEditor, @md_markdown.MarkdownSemanticAttachment) raise MarkdownArchiveError {
+) -> (MarkdownEditor, @md_markdown.MarkdownSemanticAttachment) raise {
   let (editor, attachment) = @md_companion.new_markdown_editor_with_semantic_attachment(
     agent_id,
   ) catch {
+    Failure::Failure(_) as failure => raise failure
     @text.TextError::EmptyReplicaId =>
       raise MarkdownArchiveError::InvalidAgentId
-    error =>
-      raise MarkdownArchiveError::WriterCreationFailed(detail=error.message())
+    @text.TextError::InvalidPosition(..) =>
+      raise MarkdownArchiveError::WriterCreationFailed(
+        detail="text editor construction failed",
+      )
+    @text.TextError::InvalidText(..) =>
+      raise MarkdownArchiveError::WriterCreationFailed(
+        detail="text editor construction failed",
+      )
+    @text.TextError::InvalidRange(..) =>
+      raise MarkdownArchiveError::WriterCreationFailed(
+        detail="text editor construction failed",
+      )
+    @text.TextError::SyncFailed(_) =>
+      raise MarkdownArchiveError::WriterCreationFailed(
+        detail="text editor construction failed",
+      )
+    @text.TextError::VersionNotFound =>
+      raise MarkdownArchiveError::WriterCreationFailed(
+        detail="text editor construction failed",
+      )
+    @text.TextError::Internal(..) =>
+      raise MarkdownArchiveError::WriterCreationFailed(
+        detail="text editor construction failed",
+      )
+    error => raise error
   }
   (open_markdown_editor(editor, history, open_limits), attachment)
 }
@@ -590,8 +686,9 @@ fn open_markdown_editor(
   editor : @editor.SyncEditor[@md_markdown.Block],
   history : MarkdownDocumentHistory,
   open_limits : MarkdownArchiveOpenLimits,
-) -> MarkdownEditor raise MarkdownArchiveError {
+) -> MarkdownEditor raise {
   let report = editor.admit_with_limits(history.message, open_limits.limits) catch {
+    Failure::Failure(_) as failure => raise failure
     @text.TextError::SyncFailed(
       @sync.Failure::LimitExceeded(kind~, limit~, actual~)
     ) =>
@@ -600,8 +697,47 @@ fn open_markdown_editor(
         maximum=limit,
         actual~,
       )
-    error =>
-      raise MarkdownArchiveError::HistoryAdmissionFailed(detail=error.message())
+    @text.TextError::EmptyReplicaId =>
+      raise MarkdownArchiveError::HistoryAdmissionFailed(
+        detail="history admission failed",
+      )
+    @text.TextError::InvalidPosition(..) =>
+      raise MarkdownArchiveError::HistoryAdmissionFailed(
+        detail="history admission failed",
+      )
+    @text.TextError::InvalidText(..) =>
+      raise MarkdownArchiveError::HistoryAdmissionFailed(
+        detail="history admission failed",
+      )
+    @text.TextError::InvalidRange(..) =>
+      raise MarkdownArchiveError::HistoryAdmissionFailed(
+        detail="history admission failed",
+      )
+    @text.TextError::SyncFailed(@sync.Failure::MissingDependency(..)) =>
+      raise MarkdownArchiveError::HistoryAdmissionFailed(
+        detail="history admission failed",
+      )
+    @text.TextError::SyncFailed(@sync.Failure::MalformedMessage(..)) =>
+      raise MarkdownArchiveError::HistoryAdmissionFailed(
+        detail="history admission failed",
+      )
+    @text.TextError::SyncFailed(@sync.Failure::InvalidContent(..)) =>
+      raise MarkdownArchiveError::HistoryAdmissionFailed(
+        detail="history admission failed",
+      )
+    @text.TextError::SyncFailed(@sync.Failure::ConflictingIdentity(..)) =>
+      raise MarkdownArchiveError::HistoryAdmissionFailed(
+        detail="history admission failed",
+      )
+    @text.TextError::VersionNotFound =>
+      raise MarkdownArchiveError::HistoryAdmissionFailed(
+        detail="history admission failed",
+      )
+    @text.TextError::Internal(..) =>
+      raise MarkdownArchiveError::HistoryAdmissionFailed(
+        detail="history admission failed",
+      )
+    error => raise error
   }
   editor.refresh()
   if report.pending_operations() > 0 {
@@ -621,10 +757,38 @@ fn open_markdown_editor(
 pub fn MarkdownEditor::admit(
   self : Self,
   history : MarkdownDocumentHistory,
-) -> MarkdownAdmitReport raise MarkdownArchiveError {
+) -> MarkdownAdmitReport raise {
   let report = self.editor.admit(history.message) catch {
-    error =>
-      raise MarkdownArchiveError::HistoryAdmissionFailed(detail=error.message())
+    Failure::Failure(_) as failure => raise failure
+    @text.TextError::EmptyReplicaId =>
+      raise MarkdownArchiveError::HistoryAdmissionFailed(
+        detail="history admission failed",
+      )
+    @text.TextError::InvalidPosition(..) =>
+      raise MarkdownArchiveError::HistoryAdmissionFailed(
+        detail="history admission failed",
+      )
+    @text.TextError::InvalidText(..) =>
+      raise MarkdownArchiveError::HistoryAdmissionFailed(
+        detail="history admission failed",
+      )
+    @text.TextError::InvalidRange(..) =>
+      raise MarkdownArchiveError::HistoryAdmissionFailed(
+        detail="history admission failed",
+      )
+    @text.TextError::SyncFailed(_) =>
+      raise MarkdownArchiveError::HistoryAdmissionFailed(
+        detail="history admission failed",
+      )
+    @text.TextError::VersionNotFound =>
+      raise MarkdownArchiveError::HistoryAdmissionFailed(
+        detail="history admission failed",
+      )
+    @text.TextError::Internal(..) =>
+      raise MarkdownArchiveError::HistoryAdmissionFailed(
+        detail="history admission failed",
+      )
+    error => raise error
   }
   // Applicable operations are committed before the withheld ones are counted,
   // so the projection is rebuilt on both paths.
@@ -641,7 +805,9 @@ pub fn MarkdownEditor::admit(
 
 ///|
 /// Read the last committed canonical source without exposing editor state.
-pub fn MarkdownEditor::snapshot(self : Self) -> MarkdownDocumentSnapshot {
+pub fn MarkdownEditor::snapshot(
+  self : Self,
+) -> MarkdownDocumentSnapshot raise Failure {
   document_snapshot(self.editor)
 }
 
@@ -694,7 +860,7 @@ pub fn MarkdownEditor::history_since(
 pub fn MarkdownEditor::commit(
   self : Self,
   request : MarkdownEditRequest,
-) -> Result[MarkdownCommitResult, MarkdownEditorError] {
+) -> Result[MarkdownCommitResult, MarkdownEditorError] raise {
   self.commit_recording_transforms(request).map(pair => pair.0)
 }
 
@@ -707,7 +873,7 @@ pub fn MarkdownEditor::commit(
 pub fn MarkdownEditor::commit_with_receipt(
   self : Self,
   request : MarkdownEditRequest,
-) -> Result[MarkdownCommitReceipt, MarkdownEditorError] raise MarkdownArchiveError {
+) -> Result[MarkdownCommitReceipt, MarkdownEditorError] raise {
   let before_version = self.version()
   match self.commit_recording_transforms(request) {
     Err(error) => Err(error)
@@ -744,7 +910,7 @@ fn MarkdownEditor::commit_recording_transforms(
 ) -> Result[
   (MarkdownCommitResult, @vector.Vector[MarkdownTextTransform]),
   MarkdownEditorError,
-] {
+] raise {
   match request {
     ReplaceSource(source) => {
       let before = self.editor.get_text()
@@ -903,7 +1069,7 @@ fn MarkdownEditor::commit_structural_recording_transforms(
 ) -> Result[
   (MarkdownCommitResult, @vector.Vector[MarkdownTextTransform]),
   MarkdownEditorError,
-] {
+] raise {
   let source = self.editor.get_text()
   guard self.editor.get_proj_node() is Some(proj) else {
     return Err(MarkdownEditorError::ProjectionUnavailable)
@@ -917,13 +1083,9 @@ fn MarkdownEditor::commit_structural_recording_transforms(
       .search_by(block => block.node_id().value == node_id)
     _ => None
   }
+  let source_map = self.editor.get_source_map()
   let computed = Ok(
-    @md_edits.compute_markdown_edit(
-      op,
-      source,
-      proj,
-      self.editor.get_source_map(),
-    ),
+    @md_edits.compute_markdown_edit(op, source, proj, source_map),
   ) catch {
     error => Err(error.message())
   }
@@ -993,7 +1155,7 @@ fn sequential_text_transforms(
 fn MarkdownEditor::editable_block_target(
   self : Self,
   node_id : MarkdownNodeId,
-) -> Bool {
+) -> Bool raise Failure {
   for block in self.snapshot().blocks().to_array() {
     if block.node_id() == node_id {
       return match block.kind() {
@@ -1010,7 +1172,7 @@ fn MarkdownEditor::editable_block_target(
 fn MarkdownEditor::editable_block_text(
   self : Self,
   node_id : MarkdownNodeId,
-) -> String? {
+) -> String? raise Failure {
   for block in self.snapshot().blocks().to_array() {
     if block.node_id() == node_id {
       return Some(block.canonical_text())
@@ -1114,7 +1276,7 @@ fn selection_for_cursor(
 /// Copy only stable node identities into the façade snapshot.
 fn projection_snapshot(
   editor : @editor.SyncEditor[@md_markdown.Block],
-) -> MarkdownProjectionSnapshot {
+) -> MarkdownProjectionSnapshot raise Failure {
   match editor.get_proj_node() {
     None => { root_id: None, node_ids: @vector.new() }
     Some(root) => {
@@ -1131,7 +1293,7 @@ fn projection_snapshot(
 /// the editable block view, preserving the #1045 alignment policy.
 fn document_snapshot(
   editor : @editor.SyncEditor[@md_markdown.Block],
-) -> MarkdownDocumentSnapshot {
+) -> MarkdownDocumentSnapshot raise Failure {
   let source = editor.get_text()
   {
     source,
@@ -1144,7 +1306,7 @@ fn document_snapshot(
 fn editable_block_snapshots(
   editor : @editor.SyncEditor[@md_markdown.Block],
   source : String,
-) -> @vector.Vector[MarkdownBlockSnapshot] {
+) -> @vector.Vector[MarkdownBlockSnapshot] raise Failure {
   match editor.get_proj_node() {
     None => @vector.new()
     Some(root) => {

--- a/modules/canopy/editor/markdown/markdown_editor_wbtest.mbt
+++ b/modules/canopy/editor/markdown/markdown_editor_wbtest.mbt
@@ -16,7 +16,7 @@ fn archive_open_limits(
 }
 
 ///|
-fn fresh_markdown_ir(source : String) -> @md_markdown.MarkdownIR {
+fn fresh_markdown_ir(source : String) -> @md_markdown.MarkdownIR raise {
   let parser = @loom.new_parser(
     @loom.SourceId("markdown-editor-semantic-fresh"),
     source,
@@ -1255,7 +1255,7 @@ test "typed delete selects the adjacent survivor instead of a stale cursor" {
 
 ///|
 test "empty replica identity is a categorized construction failure" {
-  let result : Result[MarkdownEditor, MarkdownEditorError] = Ok(
+  let result : Result[MarkdownEditor, Error] = Ok(
     MarkdownEditor(agent_id="", source=""),
   ) catch {
     error => Err(error)
@@ -1301,7 +1301,7 @@ test "archive open enforces the exact encoded-byte limit atomically" {
     max_pending_operations=10,
     max_parents_per_operation=16,
   )
-  let refused : Result[MarkdownEditor, MarkdownArchiveError] = Ok(
+  let refused : Result[MarkdownEditor, Error] = Ok(
     MarkdownEditor::open(
       agent_id="archive-policy-over",
       history~,
@@ -1476,7 +1476,7 @@ test "open categorizes a bad writer identity as such" {
   let document = try! MarkdownEditor(agent_id="identity-source", source="# T\n")
   let history = try! document.history_since()
 
-  let refused : Result[MarkdownEditor, MarkdownArchiveError] = Ok(
+  let refused : Result[MarkdownEditor, Error] = Ok(
     MarkdownEditor::open(
       agent_id="",
       history~,
@@ -1549,7 +1549,7 @@ test "withheld operations are reported by admit and refused by open" {
     MarkdownAdmitReport::Withheld(applied=0, withheld=1),
   )
 
-  let refused : Result[MarkdownEditor, MarkdownArchiveError] = Ok(
+  let refused : Result[MarkdownEditor, Error] = Ok(
     MarkdownEditor::open(
       agent_id="gap-open",
       history=gapped,
@@ -1563,7 +1563,7 @@ test "withheld operations are reported by admit and refused by open" {
     _ => fail("expected IncompleteHistory")
   }
 
-  let capacity_refused : Result[MarkdownEditor, MarkdownArchiveError] = Ok(
+  let capacity_refused : Result[MarkdownEditor, Error] = Ok(
     MarkdownEditor::open(
       agent_id="gap-capacity-open",
       history=gapped,

--- a/modules/canopy/editor/markdown/pkg.generated.mbti
+++ b/modules/canopy/editor/markdown/pkg.generated.mbti
@@ -131,17 +131,17 @@ pub(all) enum MarkdownEditRequest {
 pub struct MarkdownEditor {
   // private fields
 }
-pub fn MarkdownEditor::MarkdownEditor(agent_id~ : String, source~ : String) -> Self raise MarkdownEditorError
-pub fn MarkdownEditor::admit(Self, MarkdownDocumentHistory) -> MarkdownAdmitReport raise MarkdownArchiveError
-pub fn MarkdownEditor::commit(Self, MarkdownEditRequest) -> Result[MarkdownCommitResult, MarkdownEditorError]
-pub fn MarkdownEditor::commit_with_receipt(Self, MarkdownEditRequest) -> Result[MarkdownCommitReceipt, MarkdownEditorError] raise MarkdownArchiveError
+pub fn MarkdownEditor::MarkdownEditor(agent_id~ : String, source~ : String) -> Self raise
+pub fn MarkdownEditor::admit(Self, MarkdownDocumentHistory) -> MarkdownAdmitReport raise
+pub fn MarkdownEditor::commit(Self, MarkdownEditRequest) -> Result[MarkdownCommitResult, MarkdownEditorError] raise
+pub fn MarkdownEditor::commit_with_receipt(Self, MarkdownEditRequest) -> Result[MarkdownCommitReceipt, MarkdownEditorError] raise
 pub fn MarkdownEditor::history_since(Self, version? : MarkdownDocumentVersion) -> MarkdownDocumentHistory raise MarkdownArchiveError
-pub fn MarkdownEditor::open(agent_id~ : String, history~ : MarkdownDocumentHistory, open_limits~ : MarkdownArchiveOpenLimits) -> Self raise MarkdownArchiveError
-pub fn MarkdownEditor::open_with_semantic_attachment(agent_id~ : String, history~ : MarkdownDocumentHistory, open_limits~ : MarkdownArchiveOpenLimits) -> (Self, @dowdiness/markdown.MarkdownSemanticAttachment) raise MarkdownArchiveError
+pub fn MarkdownEditor::open(agent_id~ : String, history~ : MarkdownDocumentHistory, open_limits~ : MarkdownArchiveOpenLimits) -> Self raise
+pub fn MarkdownEditor::open_with_semantic_attachment(agent_id~ : String, history~ : MarkdownDocumentHistory, open_limits~ : MarkdownArchiveOpenLimits) -> (Self, @dowdiness/markdown.MarkdownSemanticAttachment) raise
 pub fn MarkdownEditor::portable_markdown(Self) -> String
-pub fn MarkdownEditor::snapshot(Self) -> MarkdownDocumentSnapshot
+pub fn MarkdownEditor::snapshot(Self) -> MarkdownDocumentSnapshot raise Failure
 pub fn MarkdownEditor::version(Self) -> MarkdownDocumentVersion
-pub fn MarkdownEditor::with_semantic_attachment(agent_id~ : String, source~ : String) -> (Self, @dowdiness/markdown.MarkdownSemanticAttachment) raise MarkdownEditorError
+pub fn MarkdownEditor::with_semantic_attachment(agent_id~ : String, source~ : String) -> (Self, @dowdiness/markdown.MarkdownSemanticAttachment) raise
 
 pub struct MarkdownNodeId {
   // private fields

--- a/modules/canopy/editor/pkg.generated.mbti
+++ b/modules/canopy/editor/pkg.generated.mbti
@@ -25,9 +25,9 @@ pub fn adjust_position(Int, Int, Int, Int) -> Int
 
 pub fn compute_edit(String, String) -> @dowdiness/loom/core.Edit
 
-pub fn[T : @pretty.Pretty] compute_pretty_patches(ViewUpdateState, SyncEditor[T]) -> Array[@protocol.ViewPatch]
+pub fn[T : @pretty.Pretty] compute_pretty_patches(ViewUpdateState, SyncEditor[T]) -> Array[@protocol.ViewPatch] raise Failure
 
-pub fn[T : @dowdiness/loom/core.Renderable] compute_view_patches(ViewUpdateState, SyncEditor[T]) -> Array[@protocol.ViewPatch]
+pub fn[T : @dowdiness/loom/core.Renderable] compute_view_patches(ViewUpdateState, SyncEditor[T]) -> Array[@protocol.ViewPatch] raise Failure
 
 pub fn project_diagnostics_for_source(@diagnostic.SourceId, @dowdiness/loom/core.DiagnosticSet) -> Array[@protocol.Diagnostic]
 
@@ -132,88 +132,89 @@ pub fn[T] LanguageCapabilities::with_to_view_node(Self[T], (@dowdiness/canopy/co
 pub struct SyncEditor[T] {
   // private fields
 }
-pub fn[T : Eq] SyncEditor::admit(Self[T], @text.SyncMessage) -> @text.SyncReport raise @text.TextError
-pub fn[T : Eq] SyncEditor::admit_with_limits(Self[T], @text.SyncMessage, @sync.Limits) -> @text.SyncReport raise @text.TextError
+pub fn[T : Eq] SyncEditor::admit(Self[T], @text.SyncMessage) -> @text.SyncReport raise
+pub fn[T : Eq] SyncEditor::admit_with_limits(Self[T], @text.SyncMessage, @sync.Limits) -> @text.SyncReport raise
 pub fn[T] SyncEditor::apply_ephemeral(Self[T], Bytes) -> Unit
-pub fn[T : Eq] SyncEditor::apply_span_edits(Self[T], Array[@dowdiness/canopy/core.SpanEdit], @dowdiness/canopy/core.FocusHint, Int, hint? : @dowdiness/canopy/core.IdentityTransform) -> Unit
+pub fn[T : Eq] SyncEditor::apply_span_edits(Self[T], Array[@dowdiness/canopy/core.SpanEdit], @dowdiness/canopy/core.FocusHint, Int, hint? : @dowdiness/canopy/core.IdentityTransform) -> Unit raise Failure
 pub fn[T : Eq] SyncEditor::apply_sync(Self[T], @text.SyncMessage) -> Unit raise
-pub fn[T : Eq] SyncEditor::apply_text_edit(Self[T], Int, Int, String, Int) -> Unit
-pub fn[T : Eq] SyncEditor::apply_text_edit_exact(Self[T], Int, Int, String, Int) -> Bool
-pub fn[T : Eq] SyncEditor::apply_text_transform(Self[T], @dowdiness/canopy/core.NodeId, (String, Int, Int) -> Result[String, String], Int) -> Result[Unit, TreeEditError]
-pub fn[T : Eq] SyncEditor::backspace(Self[T]) -> Bool
-pub fn[T : Eq] SyncEditor::backspace_and_record(Self[T], Int) -> Bool
-pub fn[T] SyncEditor::cached_proj_node(Self[T]) -> @cells.Derived[@dowdiness/canopy/core.ProjNode[T]?]
+pub fn[T : Eq] SyncEditor::apply_text_edit(Self[T], Int, Int, String, Int) -> Unit raise Failure
+pub fn[T : Eq] SyncEditor::apply_text_edit_exact(Self[T], Int, Int, String, Int) -> Bool raise Failure
+pub fn[T : Eq] SyncEditor::apply_text_transform(Self[T], @dowdiness/canopy/core.NodeId, (String, Int, Int) -> Result[String, String], Int) -> Result[Unit, TreeEditError] raise
+pub fn[T : Eq] SyncEditor::backspace(Self[T]) -> Bool raise Failure
+pub fn[T : Eq] SyncEditor::backspace_and_record(Self[T], Int) -> Bool raise Failure
+pub fn[T] SyncEditor::cached_proj_node(Self[T]) -> @cells.Derived[@dowdiness/canopy/core.ProjNode[T]?] raise Failure
 pub fn[T] SyncEditor::can_redo(Self[T]) -> Bool
 pub fn[T] SyncEditor::can_undo(Self[T]) -> Bool
 pub fn[T] SyncEditor::causal_snapshot(Self[T]) -> @history.CausalSnapshot
-pub fn[T] SyncEditor::clear_undo(Self[T]) -> Unit
-pub fn[T : Eq] SyncEditor::commit_edit(Self[T], @dowdiness/canopy/core.NodeId, String, Int) -> Result[Unit, TreeEditError]
-pub fn[T : Eq] SyncEditor::delete(Self[T]) -> Bool
-pub fn[T : Eq] SyncEditor::delete_and_record(Self[T], Int) -> Bool
-pub fn[T : Eq] SyncEditor::delete_at(Self[T], Int, Int) -> Bool
+pub fn[T] SyncEditor::clear_undo(Self[T]) -> Unit raise Failure
+pub fn[T : Eq] SyncEditor::commit_edit(Self[T], @dowdiness/canopy/core.NodeId, String, Int) -> Result[Unit, TreeEditError] raise
+pub fn[T : Eq] SyncEditor::delete(Self[T]) -> Bool raise Failure
+pub fn[T : Eq] SyncEditor::delete_and_record(Self[T], Int) -> Bool raise Failure
+pub fn[T : Eq] SyncEditor::delete_at(Self[T], Int, Int) -> Bool raise Failure
 pub fn[T] SyncEditor::delete_local_presence(Self[T]) -> Unit
-pub fn[T : Eq + @dowdiness/loom/core.Renderable] SyncEditor::delete_node(Self[T], @dowdiness/canopy/core.NodeId, Int) -> Result[Unit, TreeEditError]
-pub fn[T] SyncEditor::diagnostic_publication_source_revision(Self[T]) -> @cells.Derived[DiagnosticPublicationSourceRevision]
+pub fn[T : Eq + @dowdiness/loom/core.Renderable] SyncEditor::delete_node(Self[T], @dowdiness/canopy/core.NodeId, Int) -> Result[Unit, TreeEditError] raise
+pub fn[T] SyncEditor::diagnostic_publication_source_revision(Self[T]) -> @cells.Derived[DiagnosticPublicationSourceRevision] raise Failure
 pub fn[T] SyncEditor::encode_ephemeral_all(Self[T]) -> Bytes
 pub fn[T] SyncEditor::export_all(Self[T]) -> @text.SyncMessage raise
 pub fn[T] SyncEditor::export_since(Self[T], @text.Version) -> @text.SyncMessage raise
 pub fn[T] SyncEditor::get_cursor(Self[T]) -> Int
-pub fn[T] SyncEditor::get_errors(Self[T]) -> Array[String]
+pub fn[T] SyncEditor::get_errors(Self[T]) -> Array[String] raise Failure
 pub fn[T] SyncEditor::get_hub(Self[T]) -> @ephemeral.EphemeralHub
-pub fn[T] SyncEditor::get_node(Self[T], @dowdiness/canopy/core.NodeId) -> @dowdiness/canopy/core.ProjNode[T]?
-pub fn[T] SyncEditor::get_node_range(Self[T], @dowdiness/canopy/core.NodeId) -> @dowdiness/loom/core.Range?
+pub fn[T] SyncEditor::get_node(Self[T], @dowdiness/canopy/core.NodeId) -> @dowdiness/canopy/core.ProjNode[T]? raise Failure
+pub fn[T] SyncEditor::get_node_range(Self[T], @dowdiness/canopy/core.NodeId) -> @dowdiness/loom/core.Range? raise Failure
 pub fn[T] SyncEditor::get_peer_cursors(Self[T]) -> Map[String, @ephemeral.PeerCursor]
 pub fn[T] SyncEditor::get_peer_id(Self[T]) -> String
-pub fn[T : @pretty.Pretty] SyncEditor::get_pretty_view(Self[T]) -> @protocol.ViewNode
-pub fn[T] SyncEditor::get_proj_node(Self[T]) -> @dowdiness/canopy/core.ProjNode[T]?
-pub fn[T] SyncEditor::get_registry(Self[T]) -> Map[@dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.ProjNode[T]]
-pub fn[T] SyncEditor::get_source_map(Self[T]) -> @dowdiness/canopy/core.SourceMap
+pub fn[T : @pretty.Pretty] SyncEditor::get_pretty_view(Self[T]) -> @protocol.ViewNode raise Failure
+pub fn[T] SyncEditor::get_proj_node(Self[T]) -> @dowdiness/canopy/core.ProjNode[T]? raise Failure
+pub fn[T] SyncEditor::get_registry(Self[T]) -> Map[@dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.ProjNode[T]] raise Failure
+pub fn[T] SyncEditor::get_source_map(Self[T]) -> @dowdiness/canopy/core.SourceMap raise Failure
 pub fn[T] SyncEditor::get_sync_status(Self[T]) -> @sync_session.SyncStatus
 pub fn[T] SyncEditor::get_text(Self[T]) -> String
-pub fn[T] SyncEditor::get_tree(Self[T]) -> T?
+pub fn[T] SyncEditor::get_tree(Self[T]) -> T? raise Failure
 pub fn[T] SyncEditor::get_version(Self[T]) -> @text.Version
-pub fn[T : @dowdiness/loom/core.Renderable] SyncEditor::get_view_tree(Self[T]) -> @protocol.ViewNode?
+pub fn[T : @dowdiness/loom/core.Renderable] SyncEditor::get_view_tree(Self[T]) -> @protocol.ViewNode? raise Failure
 pub fn[T] SyncEditor::identity(Self[T]) -> Int
 pub fn[T : Eq] SyncEditor::insert(Self[T], String) -> Unit raise
 pub fn[T : Eq] SyncEditor::insert_and_record(Self[T], String, Int) -> Unit raise
-pub fn[T : Eq] SyncEditor::insert_at(Self[T], Int, String, Int) -> Unit
-pub fn[T] SyncEditor::invalidate_pending_identity_hints(Self[T]) -> Unit
+pub fn[T : Eq] SyncEditor::insert_at(Self[T], Int, String, Int) -> Unit raise Failure
+pub fn[T] SyncEditor::invalidate_pending_identity_hints(Self[T]) -> Unit raise Failure
 pub fn[T] SyncEditor::is_dirty(Self[T]) -> Bool
-pub fn[T] SyncEditor::is_parse_valid(Self[T]) -> Bool
-pub fn[T : Eq] SyncEditor::mark_dirty(Self[T]) -> Unit
+pub fn[T] SyncEditor::is_parse_valid(Self[T]) -> Bool raise Failure
+pub fn[T] SyncEditor::is_parser_healthy(Self[T]) -> Bool
+pub fn[T : Eq] SyncEditor::mark_dirty(Self[T]) -> Unit raise Failure
 pub fn[T] SyncEditor::move_cursor(Self[T], Int) -> Unit
 pub fn[T] SyncEditor::move_cursor_left_grapheme(Self[T]) -> Unit
 pub fn[T] SyncEditor::move_cursor_left_word(Self[T]) -> Unit
 pub fn[T] SyncEditor::move_cursor_right_grapheme(Self[T]) -> Unit
 pub fn[T] SyncEditor::move_cursor_right_word(Self[T]) -> Unit
-pub fn[T : Eq + @dowdiness/loom/core.Renderable] SyncEditor::move_node(Self[T], @dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.DropPosition, Int) -> Result[Array[@dowdiness/canopy/core.SpanEdit], TreeEditError]
-pub fn[T, E] SyncEditor::new_with_builder(String, (@diagnostic.SourceId, String, @cells.Runtime?) -> @pipeline.Parser[T], (@pipeline.Parser[T], @dowdiness/canopy/core.IdentityHintConsumer) -> (@cells.Derived[@dowdiness/canopy/core.ProjNode[T]?], @cells.Derived[Map[@dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.ProjNode[T]]], @cells.Derived[@dowdiness/canopy/core.SourceMap], LanguageCapabilities[T], E), capture_timeout_ms? : Int, parent_runtime? : @cells.Runtime) -> (Self[T], E) raise @text.TextError
-pub fn[T] SyncEditor::node_at_position(Self[T], Int) -> @dowdiness/canopy/core.NodeId?
+pub fn[T : Eq + @dowdiness/loom/core.Renderable] SyncEditor::move_node(Self[T], @dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.DropPosition, Int) -> Result[Array[@dowdiness/canopy/core.SpanEdit], TreeEditError] raise
+pub fn[T, E] SyncEditor::new_with_builder(String, (@diagnostic.SourceId, String, @cells.Runtime?) -> @pipeline.Parser[T] raise Failure, (@pipeline.Parser[T], @dowdiness/canopy/core.IdentityHintConsumer) -> (@cells.Derived[@dowdiness/canopy/core.ProjNode[T]?], @cells.Derived[Map[@dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.ProjNode[T]]], @cells.Derived[@dowdiness/canopy/core.SourceMap], LanguageCapabilities[T], E), capture_timeout_ms? : Int, parent_runtime? : @cells.Runtime) -> (Self[T], E) raise
+pub fn[T] SyncEditor::node_at_position(Self[T], Int) -> @dowdiness/canopy/core.NodeId? raise Failure
 pub fn[T] SyncEditor::on_watchdog_fire(Self[T], Int) -> Unit
-pub fn[T] SyncEditor::parser_ast(Self[T]) -> @cells.Derived[T]
-pub fn[T] SyncEditor::parser_diagnostics(Self[T]) -> @cells.Derived[@dowdiness/loom/core.DiagnosticSet]
-pub fn[T] SyncEditor::parser_runtime(Self[T]) -> @cells.Runtime
-pub fn[T] SyncEditor::parser_snapshot(Self[T]) -> @cells.Derived[@incremental.ParseSnapshot[T]]
-pub fn[T] SyncEditor::parser_source(Self[T]) -> @cells.Derived[String]
+pub fn[T] SyncEditor::parser_ast(Self[T]) -> @cells.Derived[T] raise Failure
+pub fn[T] SyncEditor::parser_diagnostics(Self[T]) -> @cells.Derived[@dowdiness/loom/core.DiagnosticSet] raise Failure
+pub fn[T] SyncEditor::parser_runtime(Self[T]) -> @cells.Runtime raise Failure
+pub fn[T] SyncEditor::parser_snapshot(Self[T]) -> @cells.Derived[@incremental.ParseSnapshot[T]] raise Failure
+pub fn[T] SyncEditor::parser_source(Self[T]) -> @cells.Derived[String] raise Failure
 pub fn[T] SyncEditor::parser_source_id(Self[T]) -> @diagnostic.SourceId
-pub fn[T] SyncEditor::parser_syntax_tree(Self[T]) -> @cells.Derived[@seam.SyntaxNode]
-pub fn[T : Eq] SyncEditor::redo(Self[T]) -> Bool
-pub fn[T : Eq] SyncEditor::redo_and_export(Self[T]) -> @text.SyncMessage?
-pub fn[T] SyncEditor::refresh(Self[T]) -> Unit
-pub fn[T] SyncEditor::registry_memo(Self[T]) -> @cells.Derived[Map[@dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.ProjNode[T]]]
+pub fn[T] SyncEditor::parser_syntax_tree(Self[T]) -> @cells.Derived[@seam.SyntaxNode] raise Failure
+pub fn[T : Eq] SyncEditor::redo(Self[T]) -> Bool raise Failure
+pub fn[T : Eq] SyncEditor::redo_and_export(Self[T]) -> @text.SyncMessage? raise Failure
+pub fn[T] SyncEditor::refresh(Self[T]) -> Unit raise Failure
+pub fn[T] SyncEditor::registry_memo(Self[T]) -> @cells.Derived[Map[@dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.ProjNode[T]]] raise Failure
 pub fn[T] SyncEditor::remove_ephemeral_outdated(Self[T]) -> Unit
 pub fn[T] SyncEditor::set_local_presence(Self[T], String, String, selection? : (Int, Int)?) -> Unit
 pub fn[T] SyncEditor::set_on_status_change(Self[T], ((@sync_session.SyncStatus) -> Unit)?) -> Unit
-pub fn[T : Eq] SyncEditor::set_text(Self[T], String) -> Unit
-pub fn[T : Eq] SyncEditor::set_text_and_record(Self[T], String, Int) -> Unit
-pub fn[T : Eq] SyncEditor::set_text_with_change(Self[T], String) -> (@text_change.TextChange, Bool)
-pub fn[T] SyncEditor::set_tracking(Self[T], Bool) -> Unit
+pub fn[T : Eq] SyncEditor::set_text(Self[T], String) -> Unit raise Failure
+pub fn[T : Eq] SyncEditor::set_text_and_record(Self[T], String, Int) -> Unit raise Failure
+pub fn[T : Eq] SyncEditor::set_text_with_change(Self[T], String) -> (@text_change.TextChange, Bool) raise Failure
+pub fn[T] SyncEditor::set_tracking(Self[T], Bool) -> Unit raise Failure
 pub fn[T] SyncEditor::set_watchdog_scheduler(Self[T], ((Int, Int) -> Unit)?) -> Unit
 pub fn[T] SyncEditor::set_watchdog_timeout(Self[T], Int) -> Unit
-pub fn[T] SyncEditor::source_map_memo(Self[T]) -> @cells.Derived[@dowdiness/canopy/core.SourceMap]
+pub fn[T] SyncEditor::source_map_memo(Self[T]) -> @cells.Derived[@dowdiness/canopy/core.SourceMap] raise Failure
 pub fn[T] SyncEditor::subscribe_ephemeral_local(Self[T], (Bytes) -> Bool) -> @ephemeral.EphemeralSubscription
-pub fn[T : Eq] SyncEditor::undo(Self[T]) -> Bool
-pub fn[T : Eq] SyncEditor::undo_and_export(Self[T]) -> @text.SyncMessage?
+pub fn[T : Eq] SyncEditor::undo(Self[T]) -> Bool raise Failure
+pub fn[T : Eq] SyncEditor::undo_and_export(Self[T]) -> @text.SyncMessage? raise Failure
 pub fn[T] SyncEditor::ws_broadcast_cursor(Self[T]) -> Unit
 pub fn[T] SyncEditor::ws_broadcast_edit(Self[T]) -> Unit
 pub fn[T] SyncEditor::ws_on_close(Self[T]) -> Unit
@@ -228,7 +229,7 @@ pub struct ViewUpdateState {
   // private fields
 } derive(@debug.Debug)
 pub fn ViewUpdateState::ViewUpdateState() -> Self
-pub fn[T : Eq] ViewUpdateState::apply_diagnostic_fix(Self, SyncEditor[T], snapshot_id~ : Int, diagnostic_id~ : Int, fix_id~ : Int, timestamp_ms~ : Int) -> Bool
+pub fn[T : Eq] ViewUpdateState::apply_diagnostic_fix(Self, SyncEditor[T], snapshot_id~ : Int, diagnostic_id~ : Int, fix_id~ : Int, timestamp_ms~ : Int) -> Bool raise Failure
 pub fn ViewUpdateState::set_had_errors(Self, Bool) -> Unit
 pub fn ViewUpdateState::set_previous(Self, @protocol.ViewNode?) -> Unit
 

--- a/modules/canopy/editor/sync_editor.mbt
+++ b/modules/canopy/editor/sync_editor.mbt
@@ -27,6 +27,10 @@ pub struct SyncEditor[T] {
   priv mut ws : JsWebSocket?
   priv session : @sync_session.SyncSession
   priv mut projection_dirty : Bool
+  // Once Loom raises Failure, its engine source and published snapshot may no
+  // longer agree. Preserve that exact value and reject every later parser or
+  // projection operation before it can observe or mutate stale state.
+  priv mut parser_failure : Failure?
   // Structural-edit identity hints accumulated since the last reconcile.
   // Structural edits push their IdentityTransform here; raw-text edits push
   // Opaque (taint) when non-empty. Consumed and cleared once per reparse by
@@ -56,7 +60,7 @@ pub struct SyncEditor[T] {
 /// constructed extras, and the extras value `E` itself.
 pub fn[T, E] SyncEditor::new_with_builder(
   agent_id : String,
-  make_parser : (@loom_core.SourceId, String, @incr.Runtime?) -> @loom.Parser[T],
+  make_parser : (@loom_core.SourceId, String, @incr.Runtime?) -> @loom.Parser[T] raise Failure,
   build_parts : (@loom.Parser[T], @core.IdentityHintConsumer) -> (
     @incr.Derived[@core.ProjNode[T]?],
     @incr.Derived[Map[@core.NodeId, @core.ProjNode[T]]],
@@ -66,7 +70,7 @@ pub fn[T, E] SyncEditor::new_with_builder(
   ),
   capture_timeout_ms? : Int = 500,
   parent_runtime? : @incr.Runtime,
-) -> (SyncEditor[T], E) raise @text.TextError {
+) -> (SyncEditor[T], E) raise {
   let doc = @text.TextState::new(agent_id)
   let pending_transforms : Ref[Array[@core.IdentityTransform]] = Ref([])
   let identity_hint_consumer = @core.IdentityHintConsumer(fn() {
@@ -133,6 +137,7 @@ fn[T] finish_editor(
     ws: None,
     session: @sync_session.SyncSession::SyncSession(),
     projection_dirty: false,
+    parser_failure: None,
     pending_transforms,
     identity,
   }
@@ -329,13 +334,19 @@ pub fn[T] SyncEditor::on_watchdog_fire(
 ///|
 /// Returns the cached projection tree.
 /// Safe to call both inside and outside tracked context.
-pub fn[T] SyncEditor::get_proj_node(self : SyncEditor[T]) -> @core.ProjNode[T]? {
+pub fn[T] SyncEditor::get_proj_node(
+  self : SyncEditor[T],
+) -> @core.ProjNode[T]? raise Failure {
+  self.ensure_parser_healthy()
   self.cached_proj_node.read_or_abort()
 }
 
 ///|
 /// Safe to call both inside and outside tracked context.
-pub fn[T] SyncEditor::get_source_map(self : SyncEditor[T]) -> @core.SourceMap {
+pub fn[T] SyncEditor::get_source_map(
+  self : SyncEditor[T],
+) -> @core.SourceMap raise Failure {
+  self.ensure_parser_healthy()
   self.source_map_memo.read_or_abort()
 }
 
@@ -344,7 +355,8 @@ pub fn[T] SyncEditor::get_source_map(self : SyncEditor[T]) -> @core.SourceMap {
 /// Safe to call both inside and outside tracked context.
 pub fn[T] SyncEditor::get_registry(
   self : SyncEditor[T],
-) -> Map[@core.NodeId, @core.ProjNode[T]] {
+) -> Map[@core.NodeId, @core.ProjNode[T]] raise Failure {
+  self.ensure_parser_healthy()
   self.registry_memo.read_or_abort()
 }
 
@@ -355,7 +367,8 @@ pub fn[T] SyncEditor::get_registry(
 /// subscribers that need to react to changes rather than read eagerly.
 pub fn[T] SyncEditor::cached_proj_node(
   self : SyncEditor[T],
-) -> @incr.Derived[@core.ProjNode[T]?] {
+) -> @incr.Derived[@core.ProjNode[T]?] raise Failure {
+  self.ensure_parser_healthy()
   self.cached_proj_node
 }
 
@@ -363,7 +376,8 @@ pub fn[T] SyncEditor::cached_proj_node(
 /// Reactive view of the node-id → projection-node registry.
 pub fn[T] SyncEditor::registry_memo(
   self : SyncEditor[T],
-) -> @incr.Derived[Map[@core.NodeId, @core.ProjNode[T]]] {
+) -> @incr.Derived[Map[@core.NodeId, @core.ProjNode[T]]] raise Failure {
+  self.ensure_parser_healthy()
   self.registry_memo
 }
 
@@ -371,7 +385,8 @@ pub fn[T] SyncEditor::registry_memo(
 /// Reactive view of the source-position → node-id map.
 pub fn[T] SyncEditor::source_map_memo(
   self : SyncEditor[T],
-) -> @incr.Derived[@core.SourceMap] {
+) -> @incr.Derived[@core.SourceMap] raise Failure {
+  self.ensure_parser_healthy()
   self.source_map_memo
 }
 
@@ -381,7 +396,8 @@ pub fn[T] SyncEditor::source_map_memo(
 /// and malformed input propagates through recovered syntax plus diagnostics,
 /// not as `None`. The `?` is kept so this API doesn't need to churn if we later
 /// separate "never parsed" from "parse failed".
-pub fn[T] SyncEditor::get_tree(self : SyncEditor[T]) -> T? {
+pub fn[T] SyncEditor::get_tree(self : SyncEditor[T]) -> T? raise Failure {
+  self.ensure_parser_healthy()
   Some(self.parser.ast().read_or_abort())
 }
 
@@ -389,7 +405,8 @@ pub fn[T] SyncEditor::get_tree(self : SyncEditor[T]) -> T? {
 pub fn[T] SyncEditor::get_node(
   self : SyncEditor[T],
   id : @core.NodeId,
-) -> @core.ProjNode[T]? {
+) -> @core.ProjNode[T]? raise Failure {
+  self.ensure_parser_healthy()
   self.registry_memo.read_or_abort().get(id)
 }
 
@@ -401,7 +418,8 @@ pub fn[T] SyncEditor::get_node(
 pub fn[T] SyncEditor::node_at_position(
   self : SyncEditor[T],
   position : Int,
-) -> @core.NodeId? {
+) -> @core.NodeId? raise Failure {
+  self.ensure_parser_healthy()
   self.source_map_memo.read_or_abort().innermost_node_at(position)
 }
 
@@ -409,7 +427,8 @@ pub fn[T] SyncEditor::node_at_position(
 pub fn[T] SyncEditor::get_node_range(
   self : SyncEditor[T],
   id : @core.NodeId,
-) -> @loom_core.Range? {
+) -> @loom_core.Range? raise Failure {
+  self.ensure_parser_healthy()
   self.source_map_memo.read_or_abort().get_range(id)
 }
 
@@ -422,7 +441,8 @@ pub fn[T] SyncEditor::get_node_range(
 /// untouched. No-op when no hint is pending.
 pub fn[T] SyncEditor::invalidate_pending_identity_hints(
   self : SyncEditor[T],
-) -> Unit {
+) -> Unit raise Failure {
+  self.ensure_parser_healthy()
   self.taint_pending_transforms()
 }
 
@@ -452,7 +472,8 @@ pub fn[T : Eq] SyncEditor::apply_span_edits(
   focus_hint : @core.FocusHint,
   timestamp_ms : Int,
   hint? : @core.IdentityTransform,
-) -> Unit {
+) -> Unit raise Failure {
+  self.ensure_parser_healthy()
   if edits.is_empty() {
     return
   }
@@ -511,7 +532,8 @@ fn[T : Eq] SyncEditor::admit_with_policy(
   self : SyncEditor[T],
   msg : @text.SyncMessage,
   limits : @sync.Limits?,
-) -> @text.SyncReport raise @text.TextError {
+) -> @text.SyncReport raise {
+  self.ensure_parser_healthy()
   self.taint_pending_transforms()
   let old_source = self.doc.text()
   self.undo.set_tracking(false)
@@ -553,7 +575,7 @@ fn[T : Eq] SyncEditor::admit_with_policy(
 pub fn[T : Eq] SyncEditor::admit(
   self : SyncEditor[T],
   msg : @text.SyncMessage,
-) -> @text.SyncReport raise @text.TextError {
+) -> @text.SyncReport raise {
   self.admit_with_policy(msg, None)
 }
 
@@ -566,7 +588,7 @@ pub fn[T : Eq] SyncEditor::admit_with_limits(
   self : SyncEditor[T],
   msg : @text.SyncMessage,
   limits : @sync.Limits,
-) -> @text.SyncReport raise @text.TextError {
+) -> @text.SyncReport raise {
   self.admit_with_policy(msg, Some(limits))
 }
 
@@ -613,7 +635,7 @@ pub fn[T] SyncEditor::export_since(
 /// (e.g. to inject eval annotations).
 pub fn[T : @pretty.Pretty] SyncEditor::get_pretty_view(
   self : SyncEditor[T],
-) -> @protocol.ViewNode {
+) -> @protocol.ViewNode raise Failure {
   guard self.get_tree() is Some(tree) else {
     return @protocol.layout_to_view_tree(@pretty.text(""), width=80)
   }
@@ -631,7 +653,7 @@ pub fn[T : @pretty.Pretty] SyncEditor::get_pretty_view(
 pub fn[T : @pretty.Pretty] compute_pretty_patches(
   state : ViewUpdateState,
   editor : SyncEditor[T],
-) -> Array[@protocol.ViewPatch] {
+) -> Array[@protocol.ViewPatch] raise Failure {
   let patches : Array[@protocol.ViewPatch] = []
   let current = editor.get_pretty_view()
   match state.previous {

--- a/modules/canopy/editor/sync_editor_parser.mbt
+++ b/modules/canopy/editor/sync_editor_parser.mbt
@@ -11,23 +11,50 @@ fn[T] SyncEditor::mark_projection_dirty(self : SyncEditor[T]) -> Unit {
 }
 
 ///|
+/// Reject parser and projection work after Loom has raised Failure. The stored
+/// value is re-raised unchanged so callers can quarantine the owning editor.
+fn[T] SyncEditor::ensure_parser_healthy(
+  self : SyncEditor[T],
+) -> Unit raise Failure {
+  match self.parser_failure {
+    Some(failure) => raise failure
+    None => ()
+  }
+}
+
+///|
+/// Whether parser-derived operations are still safe on this editor. Canonical
+/// CRDT text/version/history access remains available after this becomes false.
+pub fn[T] SyncEditor::is_parser_healthy(self : SyncEditor[T]) -> Bool {
+  self.parser_failure is None
+}
+
+///|
 fn[T : Eq] SyncEditor::sync_parser_after_text_change(
   self : SyncEditor[T],
   old_source : String,
   new_source : String,
   known_edit : @loom_core.Edit?,
-) -> Unit {
+) -> Unit raise Failure {
+  self.ensure_parser_healthy()
   self.document_version.set(self.doc.version())
   // Short-circuits mark_projection_dirty; Parser does its own identity check.
   guard old_source != new_source else { return }
-  if new_source == "" {
-    self.parser.set_source(new_source)
-  } else {
-    let edit = match known_edit {
-      Some(edit) => edit
-      None => compute_edit(old_source, new_source)
+  try {
+    if new_source == "" {
+      self.parser.set_source(new_source)
+    } else {
+      let edit = match known_edit {
+        Some(edit) => edit
+        None => compute_edit(old_source, new_source)
+      }
+      self.parser.apply_edit(edit, new_source)
     }
-    self.parser.apply_edit(edit, new_source)
+  } catch {
+    Failure::Failure(_) as failure => {
+      self.parser_failure = Some(failure)
+      raise failure
+    }
   }
   self.mark_projection_dirty()
 }
@@ -90,7 +117,7 @@ fn[T : Eq] SyncEditor::apply_local_text_change(
   old_source : String,
   new_source : String,
   known_edit : @loom_core.Edit?,
-) -> Unit {
+) -> Unit raise Failure {
   let applied_edit = resolve_applied_edit(old_source, new_source, known_edit)
   self.adjust_peer_cursors_after_text_change(
     old_source, new_source, applied_edit,
@@ -99,14 +126,20 @@ fn[T : Eq] SyncEditor::apply_local_text_change(
 }
 
 ///|
-pub fn[T : Eq] SyncEditor::mark_dirty(self : SyncEditor[T]) -> Unit {
+pub fn[T : Eq] SyncEditor::mark_dirty(
+  self : SyncEditor[T],
+) -> Unit raise Failure {
+  self.ensure_parser_healthy()
   self.document_version.set(self.doc.version())
   self.parser.set_source(self.doc.text())
   self.mark_projection_dirty()
 }
 
 ///|
-pub fn[T] SyncEditor::get_errors(self : SyncEditor[T]) -> Array[String] {
+pub fn[T] SyncEditor::get_errors(
+  self : SyncEditor[T],
+) -> Array[String] raise Failure {
+  self.ensure_parser_healthy()
   if self.doc.text() == "" {
     return []
   }
@@ -114,7 +147,9 @@ pub fn[T] SyncEditor::get_errors(self : SyncEditor[T]) -> Array[String] {
 }
 
 ///|
-pub fn[T] SyncEditor::is_parse_valid(self : SyncEditor[T]) -> Bool {
+pub fn[T] SyncEditor::is_parse_valid(
+  self : SyncEditor[T],
+) -> Bool raise Failure {
   self.get_errors().is_empty()
 }
 
@@ -122,7 +157,10 @@ pub fn[T] SyncEditor::is_parse_valid(self : SyncEditor[T]) -> Bool {
 /// The reactive runtime owned by the parser. Exposed so downstream
 /// consumers (e.g. the FFI typecheck bundle) can join the same graph
 /// and react to edits without a second parse of the editor's text.
-pub fn[T] SyncEditor::parser_runtime(self : SyncEditor[T]) -> @incr.Runtime {
+pub fn[T] SyncEditor::parser_runtime(
+  self : SyncEditor[T],
+) -> @incr.Runtime raise Failure {
+  self.ensure_parser_healthy()
   self.parser.runtime()
 }
 
@@ -138,7 +176,8 @@ pub fn[T] SyncEditor::parser_source_id(
 /// Reactive view of the parser's complete coherent snapshot.
 pub fn[T] SyncEditor::parser_snapshot(
   self : SyncEditor[T],
-) -> @incr.Derived[@loom.ParseSnapshot[T]] {
+) -> @incr.Derived[@loom.ParseSnapshot[T]] raise Failure {
+  self.ensure_parser_healthy()
   self.parser.snapshot()
 }
 
@@ -147,14 +186,18 @@ pub fn[T] SyncEditor::parser_snapshot(
 /// inside a memo closure.
 pub fn[T] SyncEditor::parser_syntax_tree(
   self : SyncEditor[T],
-) -> @incr.Derived[@seam.SyntaxNode] {
+) -> @incr.Derived[@seam.SyntaxNode] raise Failure {
+  self.ensure_parser_healthy()
   self.parser.syntax_tree()
 }
 
 ///|
 /// Reactive view of the parser's recovered AST. Tracked when read via
 /// `.get_or_abort()` inside a memo closure.
-pub fn[T] SyncEditor::parser_ast(self : SyncEditor[T]) -> @incr.Derived[T] {
+pub fn[T] SyncEditor::parser_ast(
+  self : SyncEditor[T],
+) -> @incr.Derived[T] raise Failure {
+  self.ensure_parser_healthy()
   self.parser.ast()
 }
 
@@ -162,7 +205,8 @@ pub fn[T] SyncEditor::parser_ast(self : SyncEditor[T]) -> @incr.Derived[T] {
 /// Reactive view of the parser's source text.
 pub fn[T] SyncEditor::parser_source(
   self : SyncEditor[T],
-) -> @incr.Derived[String] {
+) -> @incr.Derived[String] raise Failure {
+  self.ensure_parser_healthy()
   self.parser.source()
 }
 
@@ -170,7 +214,8 @@ pub fn[T] SyncEditor::parser_source(
 /// Reactive view of the parser's diagnostic set.
 pub fn[T] SyncEditor::parser_diagnostics(
   self : SyncEditor[T],
-) -> @incr.Derived[@loom.DiagnosticSet] {
+) -> @incr.Derived[@loom.DiagnosticSet] raise Failure {
+  self.ensure_parser_healthy()
   self.parser.diagnostics()
 }
 

--- a/modules/canopy/editor/sync_editor_parser_test.mbt
+++ b/modules/canopy/editor/sync_editor_parser_test.mbt
@@ -192,3 +192,79 @@ test "sync: version advances after insert" {
   // Version should have changed after insert
   inspect(v1 == v2, content="false")
 }
+
+///|
+fn assert_terminal_operation_rejected(
+  operation : () -> Unit raise,
+  expected_detail : String,
+) -> Unit raise {
+  let result : Result[Unit, Error] = Ok(operation()) catch {
+    error => Err(error)
+  }
+  match result {
+    Err(Failure::Failure(detail)) => assert_eq(detail, expected_detail)
+    Err(_) => fail("expected stored parser Failure")
+    Ok(_) => fail("expected terminal parser operation to fail")
+  }
+}
+
+///|
+/// A Loom Failure occurs after the CRDT mutation but before parser publication.
+/// Canonical text stays accepted, while the failed parser and every derived
+/// read become terminal. A later edit must fail before mutating the CRDT again.
+test "parser Failure preserves accepted text and terminalizes derived reads" {
+  let editor = try! @probe.new_parser_failure_test_editor("failure-agent")
+  let first : Result[Unit, Error] = Ok(editor.set_text("accepted")) catch {
+    error => Err(error)
+  }
+  let detail = match first {
+    Err(Failure::Failure(detail)) => detail
+    Err(_) => fail("expected parser publication Failure")
+    Ok(_) => fail("expected parser publication Failure")
+  }
+  assert_true(detail.contains("injected parser publication failure"))
+  assert_eq(editor.get_text(), "accepted")
+  assert_false(editor.is_parser_healthy())
+
+  let second : Result[Unit, Error] = Ok(editor.set_text("must-not-land")) catch {
+    error => Err(error)
+  }
+  match second {
+    Err(Failure::Failure(next_detail)) => assert_eq(next_detail, detail)
+    Err(_) => fail("expected stored parser Failure")
+    Ok(_) => fail("expected terminal parser to reject the edit")
+  }
+  assert_eq(editor.get_text(), "accepted")
+
+  let accepted_version = editor.get_version()
+  assert_terminal_operation_rejected(
+    fn() raise { editor.insert_and_record("x", 1) },
+    detail,
+  )
+  editor.move_cursor(0)
+  assert_terminal_operation_rejected(
+    fn() raise { ignore(editor.delete_and_record(2)) },
+    detail,
+  )
+  editor.move_cursor(editor.get_text().length())
+  assert_terminal_operation_rejected(
+    fn() raise { ignore(editor.backspace_and_record(3)) },
+    detail,
+  )
+  assert_eq(editor.get_text(), "accepted")
+  assert_eq(editor.get_version(), accepted_version)
+
+  let derived_read : Result[Unit, Error] = Ok(
+    {
+      ignore(editor.get_proj_node())
+      ()
+    },
+  ) catch {
+    error => Err(error)
+  }
+  match derived_read {
+    Err(Failure::Failure(next_detail)) => assert_eq(next_detail, detail)
+    Err(_) => fail("expected stored parser Failure")
+    Ok(_) => fail("expected terminal parser to reject derived reads")
+  }
+}

--- a/modules/canopy/editor/sync_editor_text.mbt
+++ b/modules/canopy/editor/sync_editor_text.mbt
@@ -41,6 +41,7 @@ pub fn[T : Eq] SyncEditor::insert(
   self : SyncEditor[T],
   text : String,
 ) -> Unit raise {
+  self.ensure_parser_healthy()
   self.taint_pending_transforms()
   let old_source = self.doc.text()
   self.cursor = @moji.prev_grapheme_boundary(old_source, self.cursor)
@@ -59,7 +60,8 @@ pub fn[T : Eq] SyncEditor::insert(
 }
 
 ///|
-pub fn[T : Eq] SyncEditor::delete(self : SyncEditor[T]) -> Bool {
+pub fn[T : Eq] SyncEditor::delete(self : SyncEditor[T]) -> Bool raise Failure {
+  self.ensure_parser_healthy()
   self.taint_pending_transforms()
   let old_source = self.doc.text()
   if !@moji.is_grapheme_boundary(old_source, self.cursor) {
@@ -97,7 +99,10 @@ pub fn[T : Eq] SyncEditor::delete(self : SyncEditor[T]) -> Bool {
 }
 
 ///|
-pub fn[T : Eq] SyncEditor::backspace(self : SyncEditor[T]) -> Bool {
+pub fn[T : Eq] SyncEditor::backspace(
+  self : SyncEditor[T],
+) -> Bool raise Failure {
+  self.ensure_parser_healthy()
   self.taint_pending_transforms()
   let old_source = self.doc.text()
   if !@moji.is_grapheme_boundary(old_source, self.cursor) {
@@ -213,7 +218,8 @@ fn[T : Eq] SyncEditor::apply_diagnostic_fix_candidate(
   source_id : @loom_core.SourceId,
   fix : @loom_core.DiagnosticFix,
   timestamp_ms : Int,
-) -> Bool {
+) -> Bool raise Failure {
+  self.ensure_parser_healthy()
   let old_source = self.doc.text()
   let expected_source = fix.apply(source_id, old_source) catch {
     _ => return false
@@ -256,7 +262,8 @@ fn[T : Eq] SyncEditor::apply_text_edit_with_policy(
   record_undo : Bool,
   move_cursor_to_edit_end : Bool,
   policy : SplicePolicy,
-) -> Bool {
+) -> Bool raise Failure {
+  self.ensure_parser_healthy()
   let old_source = self.doc.text()
   let text_len = old_source.length()
   let (safe_start, safe_delete_len) = match policy {
@@ -335,7 +342,7 @@ fn[T : Eq] SyncEditor::apply_text_edit_internal(
   timestamp_ms : Int,
   record_undo : Bool,
   move_cursor_to_edit_end : Bool,
-) -> Bool {
+) -> Bool raise Failure {
   self.apply_text_edit_with_policy(
     start,
     deleted_len,
@@ -354,7 +361,8 @@ pub fn[T : Eq] SyncEditor::apply_text_edit(
   deleted_len : Int,
   inserted : String,
   timestamp_ms : Int,
-) -> Unit {
+) -> Unit raise Failure {
+  self.ensure_parser_healthy()
   self.taint_pending_transforms()
   ignore(
     self.apply_text_edit_internal(
@@ -370,7 +378,8 @@ pub fn[T : Eq] SyncEditor::apply_text_edit_exact(
   deleted_len : Int,
   inserted : String,
   timestamp_ms : Int,
-) -> Bool {
+) -> Bool raise Failure {
+  self.ensure_parser_healthy()
   self.taint_pending_transforms()
   self.apply_text_edit_with_policy(
     start,
@@ -394,7 +403,8 @@ pub fn[T : Eq] SyncEditor::apply_text_edit_exact(
 pub fn[T : Eq] SyncEditor::set_text_with_change(
   self : SyncEditor[T],
   new_text : String,
-) -> (@text_change.TextChange, Bool) {
+) -> (@text_change.TextChange, Bool) raise Failure {
+  self.ensure_parser_healthy()
   let old_text = self.doc.text()
   let splice = @text_change.compute_text_change(old_text, new_text)
   if splice.is_noop() {
@@ -428,7 +438,7 @@ pub fn[T : Eq] SyncEditor::set_text_with_change(
 pub fn[T : Eq] SyncEditor::set_text(
   self : SyncEditor[T],
   new_text : String,
-) -> Unit {
+) -> Unit raise Failure {
   ignore(self.set_text_with_change(new_text))
 }
 
@@ -440,7 +450,8 @@ pub fn[T : Eq] SyncEditor::insert_at(
   position : Int,
   text : String,
   timestamp_ms : Int,
-) -> Unit {
+) -> Unit raise Failure {
+  self.ensure_parser_healthy()
   let text_len = self.doc.len()
   if position < 0 || position > text_len {
     return
@@ -459,7 +470,8 @@ pub fn[T : Eq] SyncEditor::delete_at(
   self : SyncEditor[T],
   position : Int,
   timestamp_ms : Int,
-) -> Bool {
+) -> Bool raise Failure {
+  self.ensure_parser_healthy()
   let text_len = self.doc.len()
   if position < 0 || position >= text_len {
     return false
@@ -476,7 +488,8 @@ pub fn[T : Eq] SyncEditor::set_text_and_record(
   self : SyncEditor[T],
   new_text : String,
   timestamp_ms : Int,
-) -> Unit {
+) -> Unit raise Failure {
+  self.ensure_parser_healthy()
   let old_text = self.doc.text()
   if old_text == new_text {
     return

--- a/modules/canopy/editor/sync_editor_tree_edit.mbt
+++ b/modules/canopy/editor/sync_editor_tree_edit.mbt
@@ -16,7 +16,8 @@ pub fn[T] SyncEditor::is_dirty(self : SyncEditor[T]) -> Bool {
 /// want to batch edits and trigger a single projection pass at a known
 /// point (e.g., on animation frame) rather than paying the cost lazily
 /// inside a getter.
-pub fn[T] SyncEditor::refresh(self : SyncEditor[T]) -> Unit {
+pub fn[T] SyncEditor::refresh(self : SyncEditor[T]) -> Unit raise Failure {
+  self.ensure_parser_healthy()
   self.projection_dirty = false
   let _ = self.cached_proj_node.read_or_abort()
 }
@@ -30,7 +31,7 @@ pub fn[T : Eq + @loom_core.Renderable] SyncEditor::delete_node(
   self : SyncEditor[T],
   node_id : @core.NodeId,
   timestamp_ms : Int,
-) -> Result[Unit, TreeEditError] {
+) -> Result[Unit, TreeEditError] raise {
   let range = match self.get_node_range(node_id) {
     None =>
       return Err(
@@ -71,7 +72,7 @@ pub fn[T : Eq] SyncEditor::commit_edit(
   node_id : @core.NodeId,
   new_text : String,
   timestamp_ms : Int,
-) -> Result[Unit, TreeEditError] {
+) -> Result[Unit, TreeEditError] raise {
   let range = match self.get_node_range(node_id) {
     None =>
       return Err(
@@ -107,7 +108,7 @@ pub fn[T : Eq] SyncEditor::apply_text_transform(
   node_id : @core.NodeId,
   compute_replacement : (String, Int, Int) -> Result[String, String],
   timestamp_ms : Int,
-) -> Result[Unit, TreeEditError] {
+) -> Result[Unit, TreeEditError] raise {
   let range = match self.get_node_range(node_id) {
     None =>
       return Err(
@@ -157,7 +158,7 @@ pub fn[T : Eq + @loom_core.Renderable] SyncEditor::move_node(
   target_id : @core.NodeId,
   position : @core.DropPosition,
   timestamp_ms : Int,
-) -> Result[Array[@core.SpanEdit], TreeEditError] {
+) -> Result[Array[@core.SpanEdit], TreeEditError] raise {
   // Resolve source
   let src_range = match self.get_node_range(source_id) {
     None =>

--- a/modules/canopy/editor/sync_editor_undo.mbt
+++ b/modules/canopy/editor/sync_editor_undo.mbt
@@ -6,6 +6,7 @@ pub fn[T : Eq] SyncEditor::insert_and_record(
   text : String,
   timestamp_ms : Int,
 ) -> Unit raise {
+  self.ensure_parser_healthy()
   self.taint_pending_transforms()
   let old_source = self.doc.text()
   self.cursor = @moji.prev_grapheme_boundary(old_source, self.cursor)
@@ -32,7 +33,8 @@ pub fn[T : Eq] SyncEditor::insert_and_record(
 pub fn[T : Eq] SyncEditor::delete_and_record(
   self : SyncEditor[T],
   timestamp_ms : Int,
-) -> Bool {
+) -> Bool raise Failure {
+  self.ensure_parser_healthy()
   self.taint_pending_transforms()
   let old_source = self.doc.text()
   if !@moji.is_grapheme_boundary(old_source, self.cursor) {
@@ -66,6 +68,7 @@ pub fn[T : Eq] SyncEditor::delete_and_record(
     )
     true
   } catch {
+    Failure::Failure(_) as failure => raise failure
     _ => false
   }
 }
@@ -74,7 +77,8 @@ pub fn[T : Eq] SyncEditor::delete_and_record(
 pub fn[T : Eq] SyncEditor::backspace_and_record(
   self : SyncEditor[T],
   timestamp_ms : Int,
-) -> Bool {
+) -> Bool raise Failure {
+  self.ensure_parser_healthy()
   self.taint_pending_transforms()
   let old_source = self.doc.text()
   if !@moji.is_grapheme_boundary(old_source, self.cursor) {
@@ -99,6 +103,7 @@ pub fn[T : Eq] SyncEditor::backspace_and_record(
       )
       true
     } catch {
+      Failure::Failure(_) as failure => raise failure
       _ => false
     }
   } else {
@@ -107,7 +112,8 @@ pub fn[T : Eq] SyncEditor::backspace_and_record(
 }
 
 ///|
-pub fn[T : Eq] SyncEditor::undo(self : SyncEditor[T]) -> Bool {
+pub fn[T : Eq] SyncEditor::undo(self : SyncEditor[T]) -> Bool raise Failure {
+  self.ensure_parser_healthy()
   self.taint_pending_transforms()
   let old_source = self.doc.text()
   try {
@@ -120,12 +126,14 @@ pub fn[T : Eq] SyncEditor::undo(self : SyncEditor[T]) -> Bool {
     self.mark_dirty()
     true
   } catch {
+    Failure::Failure(_) as failure => raise failure
     _ => false
   }
 }
 
 ///|
-pub fn[T : Eq] SyncEditor::redo(self : SyncEditor[T]) -> Bool {
+pub fn[T : Eq] SyncEditor::redo(self : SyncEditor[T]) -> Bool raise Failure {
+  self.ensure_parser_healthy()
   self.taint_pending_transforms()
   let old_source = self.doc.text()
   try {
@@ -138,6 +146,7 @@ pub fn[T : Eq] SyncEditor::redo(self : SyncEditor[T]) -> Bool {
     self.mark_dirty()
     true
   } catch {
+    Failure::Failure(_) as failure => raise failure
     _ => false
   }
 }
@@ -147,7 +156,8 @@ pub fn[T : Eq] SyncEditor::redo(self : SyncEditor[T]) -> Bool {
 /// Returns None if undo stack is empty or undo fails.
 pub fn[T : Eq] SyncEditor::undo_and_export(
   self : SyncEditor[T],
-) -> @text.SyncMessage? {
+) -> @text.SyncMessage? raise Failure {
+  self.ensure_parser_healthy()
   self.taint_pending_transforms()
   let ver_before = self.doc.version()
   let old_source = self.doc.text()
@@ -162,6 +172,7 @@ pub fn[T : Eq] SyncEditor::undo_and_export(
       true
     }
   } catch {
+    Failure::Failure(_) as failure => raise failure
     _ => false
   }
   if !success {
@@ -177,7 +188,8 @@ pub fn[T : Eq] SyncEditor::undo_and_export(
 /// Returns None if redo stack is empty or redo fails.
 pub fn[T : Eq] SyncEditor::redo_and_export(
   self : SyncEditor[T],
-) -> @text.SyncMessage? {
+) -> @text.SyncMessage? raise Failure {
+  self.ensure_parser_healthy()
   self.taint_pending_transforms()
   let ver_before = self.doc.version()
   let old_source = self.doc.text()
@@ -192,6 +204,7 @@ pub fn[T : Eq] SyncEditor::redo_and_export(
       true
     }
   } catch {
+    Failure::Failure(_) as failure => raise failure
     _ => false
   }
   if !success {
@@ -216,11 +229,13 @@ pub fn[T] SyncEditor::can_redo(self : SyncEditor[T]) -> Bool {
 pub fn[T] SyncEditor::set_tracking(
   self : SyncEditor[T],
   enabled : Bool,
-) -> Unit {
+) -> Unit raise Failure {
+  self.ensure_parser_healthy()
   self.undo.set_tracking(enabled)
 }
 
 ///|
-pub fn[T] SyncEditor::clear_undo(self : SyncEditor[T]) -> Unit {
+pub fn[T] SyncEditor::clear_undo(self : SyncEditor[T]) -> Unit raise Failure {
+  self.ensure_parser_healthy()
   self.undo.clear()
 }

--- a/modules/canopy/editor/view_updater.mbt
+++ b/modules/canopy/editor/view_updater.mbt
@@ -250,7 +250,7 @@ pub fn[T : Eq] ViewUpdateState::apply_diagnostic_fix(
   diagnostic_id~ : Int,
   fix_id~ : Int,
   timestamp_ms~ : Int,
-) -> Bool {
+) -> Bool raise Failure {
   guard snapshot_id >= 0 && diagnostic_id >= 0 && fix_id >= 0 else {
     return false
   }
@@ -291,7 +291,7 @@ pub fn[T : Eq] ViewUpdateState::apply_diagnostic_fix(
 ///|
 pub fn[T : @loom_core.Renderable] SyncEditor::get_view_tree(
   self : SyncEditor[T],
-) -> @protocol.ViewNode? {
+) -> @protocol.ViewNode? raise Failure {
   match self.get_proj_node() {
     Some(proj_node) => {
       let source_map = self.get_source_map()
@@ -387,7 +387,7 @@ fn merge_current_diagnostics(
 pub fn[T : @loom_core.Renderable] compute_view_patches(
   state : ViewUpdateState,
   editor : SyncEditor[T],
-) -> Array[@protocol.ViewPatch] {
+) -> Array[@protocol.ViewPatch] raise Failure {
   let patches : Array[@protocol.ViewPatch] = []
   let current = editor.get_view_tree()
   let current_decorations = match editor.capabilities.get_decorations {

--- a/modules/canopy/editor/view_updater_benchmark_wbtest.mbt
+++ b/modules/canopy/editor/view_updater_benchmark_wbtest.mbt
@@ -22,9 +22,9 @@ fn bench_source(def_count : Int) -> String {
 ///|
 fn bench_setup(let_count : Int) -> @protocol.ViewNode {
   let editor = try! @probe.new_test_editor("bench")
-  editor.set_text(bench_source(let_count))
-  let proj_node = editor.get_proj_node().unwrap()
-  let source_map = editor.get_source_map()
+  try! editor.set_text(bench_source(let_count))
+  let proj_node = (try! editor.get_proj_node()).unwrap()
+  let source_map = try! editor.get_source_map()
   @protocol.proj_to_view_node(proj_node, source_map)
 }
 
@@ -64,13 +64,13 @@ test "viewnode serialization (500 defs)" (b : @bench.T) {
 ///|
 test "compute_view_patches (100 defs, single edit)" (b : @bench.T) {
   let editor = try! @probe.new_test_editor("bench")
-  editor.set_text(bench_source(100))
+  try! editor.set_text(bench_source(100))
   let state = ViewUpdateState::ViewUpdateState()
   // Initial full tree
   let _ = compute_view_patches(state, editor)
   // Benchmark: single character edit + patch computation
   b.bench(() => {
-    editor.set_text(bench_source(100))
-    b.keep(compute_view_patches(state, editor))
+    try! editor.set_text(bench_source(100))
+    b.keep(try! compute_view_patches(state, editor))
   })
 }

--- a/modules/canopy/ffi/json/edit.mbt
+++ b/modules/canopy/ffi/json/edit.mbt
@@ -7,7 +7,7 @@ pub fn json_apply_edit(
   handle : Int,
   op_json : String,
   timestamp_ms : Int,
-) -> String {
+) -> String raise {
   match json_registry.get(handle) {
     Some(h) => {
       let json = @core_json.parse(op_json) catch {

--- a/modules/canopy/ffi/json/json_ffi.mbt
+++ b/modules/canopy/ffi/json/json_ffi.mbt
@@ -32,15 +32,20 @@ let json_registry : @host.HostRegistry[JsonHandle] = @host.HostRegistry::HostReg
 /// `EditorId`, or `EditorId(-1)` when construction fails. A failed
 /// construction leaves `json_registry` untouched
 /// (atomic-boundary observation, spec §3.6).
-fn assemble_json_handle(agent_id : String) -> @workspace.EditorId {
+fn assemble_json_handle(agent_id : String) -> @workspace.EditorId raise {
   let editor = @json_companion.new_json_editor(
     agent_id,
     parent_runtime=coordinator.runtime(),
   ) catch {
-    error => {
-      println("assemble_json_handle failed: \{error.message()}")
-      return @workspace.EditorId(-1)
-    }
+    Failure::Failure(_) as failure => raise failure
+    @text.TextError::EmptyReplicaId => return @workspace.EditorId(-1)
+    @text.TextError::InvalidPosition(..) => return @workspace.EditorId(-1)
+    @text.TextError::InvalidText(..) => return @workspace.EditorId(-1)
+    @text.TextError::InvalidRange(..) => return @workspace.EditorId(-1)
+    @text.TextError::SyncFailed(_) => return @workspace.EditorId(-1)
+    @text.TextError::VersionNotFound => return @workspace.EditorId(-1)
+    @text.TextError::Internal(..) => return @workspace.EditorId(-1)
+    error => raise error
   }
   let cells = JsonProtectedCells::JsonProtectedCells(editor)
   let editor_id = coordinator.register_editor(
@@ -59,7 +64,7 @@ fn assemble_json_handle(agent_id : String) -> @workspace.EditorId {
 ///|
 /// Create a new JSON SyncEditor instance.
 /// Returns a unique handle, or `-1` when `agent_id` is invalid.
-pub fn create_json_editor(agent_id : String) -> Int {
+pub fn create_json_editor(agent_id : String) -> Int raise {
   assemble_json_handle(agent_id).0
 }
 
@@ -87,7 +92,7 @@ pub fn json_get_text(handle : Int) -> String {
 
 ///|
 /// Set text content directly (replaces entire JSON document).
-pub fn json_set_text(handle : Int, new_text : String) -> Unit {
+pub fn json_set_text(handle : Int, new_text : String) -> Unit raise {
   match json_registry.get(handle) {
     Some(h) => h.editor.set_text(new_text)
     None => ()
@@ -163,7 +168,7 @@ pub fn json_get_source_map_json(handle : Int) -> String {
 ///|
 /// Get the ViewNode tree as JSON for a JSON editor.
 /// Returns "null" if no projection is available or any protected read fails.
-pub fn json_get_view_tree_json(handle : Int) -> String {
+pub fn json_get_view_tree_json(handle : Int) -> String raise Failure {
   match json_registry.get(handle) {
     Some(h) => {
       let _ = match
@@ -203,7 +208,7 @@ pub fn json_get_view_tree_json(handle : Int) -> String {
 /// Compute incremental view patches for a JSON editor.
 /// Returns a JSON array of ViewPatch objects, or "[]" if any protected read
 /// fails.
-pub fn json_compute_view_patches_json(handle : Int) -> String {
+pub fn json_compute_view_patches_json(handle : Int) -> String raise Failure {
   match json_registry.get(handle) {
     Some(h) => {
       let _ = match

--- a/modules/canopy/ffi/json/json_ffi.mbt
+++ b/modules/canopy/ffi/json/json_ffi.mbt
@@ -73,12 +73,17 @@ pub fn create_json_editor(agent_id : String) -> Int raise {
 /// refuses if workspace deps still reference the editor; in that case the
 /// FFI-side bookkeeping (registry handle entry, view-state entry) is
 /// intentionally left intact so reads of cached state remain valid.
-pub fn destroy_json_editor(handle : Int) -> Unit {
+pub fn try_destroy_json_editor(handle : Int) -> Bool {
   let h = match json_registry.get(handle) {
     Some(v) => v
-    None => return
+    None => return true
   }
-  let _ = json_registry.destroy(coordinator, h.editor_id, "destroy_json_editor")
+  json_registry.destroy(coordinator, h.editor_id, "destroy_json_editor")
+}
+
+///|
+pub fn destroy_json_editor(handle : Int) -> Unit {
+  ignore(try_destroy_json_editor(handle))
 }
 
 ///|

--- a/modules/canopy/ffi/json/moon.pkg
+++ b/modules/canopy/ffi/json/moon.pkg
@@ -26,6 +26,7 @@ options(
       "exports": [
         "create_json_editor",
         "destroy_json_editor",
+        "try_destroy_json_editor",
         "json_get_text",
         "json_set_text",
         "json_get_errors",

--- a/modules/canopy/ffi/json/pkg.generated.mbti
+++ b/modules/canopy/ffi/json/pkg.generated.mbti
@@ -32,6 +32,8 @@ pub fn json_set_text(Int, String) -> Unit raise
 
 pub fn parse_json_edit_op(Json) -> Result[@edits.JsonEditOp, String]
 
+pub fn try_destroy_json_editor(Int) -> Bool
+
 // Errors
 
 // Types and methods

--- a/modules/canopy/ffi/json/pkg.generated.mbti
+++ b/modules/canopy/ffi/json/pkg.generated.mbti
@@ -6,13 +6,13 @@ import {
 }
 
 // Values
-pub fn create_json_editor(String) -> Int
+pub fn create_json_editor(String) -> Int raise
 
 pub fn destroy_json_editor(Int) -> Unit
 
-pub fn json_apply_edit(Int, String, Int) -> String
+pub fn json_apply_edit(Int, String, Int) -> String raise
 
-pub fn json_compute_view_patches_json(Int) -> String
+pub fn json_compute_view_patches_json(Int) -> String raise Failure
 
 pub fn json_get_edit_log(Int) -> String
 
@@ -26,9 +26,9 @@ pub fn json_get_source_map_json(Int) -> String
 
 pub fn json_get_text(Int) -> String
 
-pub fn json_get_view_tree_json(Int) -> String
+pub fn json_get_view_tree_json(Int) -> String raise Failure
 
-pub fn json_set_text(Int, String) -> Unit
+pub fn json_set_text(Int, String) -> Unit raise
 
 pub fn parse_json_edit_op(Json) -> Result[@edits.JsonEditOp, String]
 

--- a/modules/canopy/ffi/json/protected_cells.mbt
+++ b/modules/canopy/ffi/json/protected_cells.mbt
@@ -27,7 +27,7 @@ priv struct JsonProtectedCells {
 ///|
 fn JsonProtectedCells::JsonProtectedCells(
   editor : @editor.SyncEditor[@djson.JsonValue],
-) -> JsonProtectedCells {
+) -> JsonProtectedCells raise Failure {
   {
     parser_syntax_tree: @workspace.ProtectedCell::from_derived(
       "parser_syntax_view",

--- a/modules/canopy/ffi/jsx/apply_patches.mbt
+++ b/modules/canopy/ffi/jsx/apply_patches.mbt
@@ -7,13 +7,14 @@ let legacy_container_id : String = "html-preview"
 ///|
 /// JavaScript exceptions are not represented as MoonBit `raise` effects by
 /// `Any::call`. Catch them at the JavaScript boundary so a DOM failure can
-/// become the session's structured `DomApplyError` and dirty-state path.
+/// become the session's structured `DomApplyError` and dirty-state path. Raw
+/// exception text stays inside this boundary and is never returned publicly.
 extern "js" fn catch_js(callback : @js.Any) -> @js.Any =
   #|(callback) => {
   #|  try {
   #|    return { ok: true, value: callback() };
-  #|  } catch (error) {
-  #|    return { ok: false, error: String(error) };
+  #|  } catch (_error) {
+  #|    return { ok: false };
   #|  }
   #|}
 
@@ -71,7 +72,7 @@ fn apply_patches_with_registry(
     }),
   )
   if !outcome.get("ok").cast() {
-    Err(outcome.get("error").to_str())
+    Err("DOM patch application failed")
   } else {
     outcome.get("value").cast()
   }

--- a/modules/canopy/ffi/jsx/jsx_ffi.mbt
+++ b/modules/canopy/ffi/jsx/jsx_ffi.mbt
@@ -73,16 +73,18 @@ fn proj_node_to_json(node : @canopy_core.ProjNode[@jsx_ast.JsxNode]) -> Json {
 /// Parse JSX text and return the ProjNode tree as JSON.
 /// The JSON includes node_ids, kind tags, and structural info so the demo
 /// page can highlight stable-vs-new NodeIds across streaming re-parses.
-pub fn jsx_parse_to_json(text : String) -> String {
+pub fn jsx_parse_to_json(text : String) -> String raise {
   let (proj, errors) = @jsx_proj.parse_to_proj_node(
     allocate_jsx_source_id(),
     text,
   ) catch {
-    _ =>
+    Failure::Failure(_) as failure => raise failure
+    @loomcore.LexError(_) =>
       return Json::object({
         "success": Json::boolean(false),
         "error": Json::string("LexError"),
       }).stringify()
+    error => raise error
   }
   Json::object({
     "success": Json::boolean(true),
@@ -99,7 +101,7 @@ pub fn jsx_parse_to_json(text : String) -> String {
 /// Input: a single string with prefixes separated by '\0' (NUL byte).
 /// Output: a JSON array of step objects, each with `prefix_index`, `success`,
 /// `root`, and `errors`.
-pub fn jsx_streaming_to_json(prefixes_input : String) -> String {
+pub fn jsx_streaming_to_json(prefixes_input : String) -> String raise {
   let parts : Array[String] = [
     for sv in prefixes_input.split("\u0000") => sv.to_owned()
   ]
@@ -144,12 +146,14 @@ pub fn jsx_streaming_to_json(prefixes_input : String) -> String {
 fn get_or_empty_errors(
   source_id : @loomcore.SourceId,
   text : String,
-) -> Array[String] {
+) -> Array[String] raise {
   try {
     let (_, errors) = @jsx_proj.parse_to_proj_node(source_id, text)
     errors
   } catch {
-    _ => []
+    Failure::Failure(_) as failure => raise failure
+    @loomcore.LexError(_) => []
+    error => raise error
   }
 }
 
@@ -157,11 +161,16 @@ fn get_or_empty_errors(
 /// Legacy one-cycle compatibility wrapper. Identity stability belongs to
 /// `jsx_session_new`/`jsx_session_render`; this function intentionally parses
 /// independently on every call and keeps no parser or DOM ownership state.
-pub fn jsx_parse_and_render(text : String, existing_json : String) -> String {
+pub fn jsx_parse_and_render(
+  text : String,
+  existing_json : String,
+) -> String raise {
   let parsed : (@canopy_core.ProjNode[@jsx_ast.JsxNode], Array[String])? = Some(
     @jsx_proj.parse_to_proj_node(allocate_jsx_source_id(), text),
   ) catch {
-    _ => None
+    Failure::Failure(_) as failure => raise failure
+    @loomcore.LexError(_) => None
+    error => raise error
   }
   match parsed {
     Some((proj, _)) => render_proj(proj, existing_json)

--- a/modules/canopy/ffi/jsx/pkg.generated.mbti
+++ b/modules/canopy/ffi/jsx/pkg.generated.mbti
@@ -51,9 +51,9 @@ pub fn apply_patches(String) -> String
 
 pub fn clear_registry() -> Unit
 
-pub fn jsx_parse_and_render(String, String) -> String
+pub fn jsx_parse_and_render(String, String) -> String raise
 
-pub fn jsx_parse_to_json(String) -> String
+pub fn jsx_parse_to_json(String) -> String raise
 
 pub fn jsx_session_commit_candidate(Int, @cognition.GenerativeUiRevision, @cognition.GenerativeUiCandidate) -> String
 
@@ -65,7 +65,7 @@ pub fn jsx_session_render(Int, String) -> String
 
 pub fn jsx_session_replay_candidate_json(Int, Int, String, String) -> String
 
-pub fn jsx_streaming_to_json(String) -> String
+pub fn jsx_streaming_to_json(String) -> String raise
 
 pub fn reset_jsx_state() -> Unit
 

--- a/modules/canopy/ffi/jsx/session.mbt
+++ b/modules/canopy/ffi/jsx/session.mbt
@@ -109,7 +109,7 @@ fn session_envelope_json(handle : Int?, result_json : String) -> String {
 }
 
 ///|
-fn new_jsx_session(source : String, root_id : String) -> JsxSession {
+fn new_jsx_session(source : String, root_id : String) -> JsxSession raise {
   let parser = @loom.new_parser(
     allocate_jsx_source_id(),
     source,
@@ -160,7 +160,7 @@ fn has_mount_boundary_transition(
 /// Return the parser to the last DOM-committed source after a rejected source
 /// render. Mounted truth remains in `last_proj`, so projection failure preserves
 /// the baseline's existing dirty state.
-fn restore_committed_source(session : JsxSession) -> Unit {
+fn restore_committed_source(session : JsxSession) -> Unit raise {
   session.parser.set_source(session.committed_source)
 }
 
@@ -168,7 +168,7 @@ fn restore_committed_source(session : JsxSession) -> Unit {
 fn apply_session_baseline_effect(
   session : JsxSession,
   effect : SessionBaselineEffect,
-) -> Unit {
+) -> Unit raise {
   match effect {
     NoEffect => ()
     RestoreCommittedSource => restore_committed_source(session)
@@ -193,7 +193,7 @@ fn finish_projection_failure(
   diagnostics : Array[String],
   code : String,
   message : String,
-) -> String {
+) -> String raise {
   let (baseline, effect) = finish_render(plan, ProjectionFail)
   session.baseline = baseline
   apply_session_baseline_effect(session, effect)
@@ -213,7 +213,7 @@ fn commit_projection(
   proj : @canopy_core.ProjNode[@jsx_ast.JsxNode],
   diagnostics : Array[String],
   source_to_commit : String?,
-) -> String {
+) -> String raise {
   let existing = if plan.must_remount { [] } else { session.mounted_ids.copy() }
   let (patches, next_mounted_ids) = @jsx_proj.reconcile(proj, existing)
   let dry_run_base = if plan.must_remount {
@@ -307,7 +307,7 @@ fn render_jsx_session_with_projection_read(
   source : String,
   update_source : Bool,
   projection_read_override? : SourceProjectionRead,
-) -> String {
+) -> String raise {
   match begin_render(session.baseline) {
     Err(RevisionExhausted) => revision_exhausted_result(session)
     Ok(permit) => {
@@ -354,7 +354,7 @@ fn render_jsx_session(
   session : JsxSession,
   source : String,
   update_source : Bool,
-) -> String {
+) -> String raise {
   render_jsx_session_with_projection_read(session, source, update_source)
 }
 
@@ -370,8 +370,58 @@ fn allocate_session_handle() -> Int {
 /// never enters `session_registry` and its partially created DOM is cleaned
 /// through the session-owned registry.
 pub fn jsx_session_new(source : String, root_id : String) -> String {
-  let session = new_jsx_session(source, root_id)
-  let result = render_jsx_session(session, source, false)
+  let session = new_jsx_session(source, root_id) catch {
+    Failure::Failure(_) =>
+      return session_envelope_json(
+        None,
+        render_result_json(
+          false,
+          0,
+          [],
+          [],
+          Some(("ParserFailure", "parser session failed")),
+        ),
+      )
+    _ =>
+      return session_envelope_json(
+        None,
+        render_result_json(
+          false,
+          0,
+          [],
+          [],
+          Some(("InternalFailure", "session construction failed")),
+        ),
+      )
+  }
+  let result = render_jsx_session(session, source, false) catch {
+    Failure::Failure(_) => {
+      dispose_jsx_session(session)
+      return session_envelope_json(
+        None,
+        render_result_json(
+          false,
+          0,
+          [],
+          [],
+          Some(("ParserFailure", "parser session failed")),
+        ),
+      )
+    }
+    _ => {
+      dispose_jsx_session(session)
+      return session_envelope_json(
+        None,
+        render_result_json(
+          false,
+          0,
+          [],
+          [],
+          Some(("InternalFailure", "initial render failed")),
+        ),
+      )
+    }
+  }
   let result_value = @js.parse(result)
   if result_value.get("success").cast() {
     let handle = allocate_session_handle()
@@ -387,7 +437,31 @@ pub fn jsx_session_new(source : String, root_id : String) -> String {
 /// Render a new source through one live session.
 pub fn jsx_session_render(handle : Int, source : String) -> String {
   match session_registry.get(handle) {
-    Some(session) => render_jsx_session(session, source, true)
+    Some(session) =>
+      render_jsx_session(session, source, true) catch {
+        Failure::Failure(_) => {
+          let revision = session.baseline.revision
+          jsx_session_dispose(handle)
+          render_result_json(
+            false,
+            revision,
+            [],
+            [],
+            Some(("ParserFailure", "parser session failed")),
+          )
+        }
+        _ => {
+          let revision = session.baseline.revision
+          jsx_session_dispose(handle)
+          render_result_json(
+            false,
+            revision,
+            [],
+            [],
+            Some(("InternalFailure", "session render failed")),
+          )
+        }
+      }
     None => {
       let error = if disposed_session_handles.contains(handle) {
         ("DisposedSession", "session handle has been disposed")
@@ -428,7 +502,30 @@ pub fn jsx_session_commit_candidate(
         Ok(permit) => {
           let projection = candidate_to_projection(candidate)
           let plan = plan_render(permit, Candidate, false)
-          commit_projection(session, plan, projection, [], None)
+          commit_projection(session, plan, projection, [], None) catch {
+            Failure::Failure(_) => {
+              let revision = session.baseline.revision
+              jsx_session_dispose(handle)
+              render_result_json(
+                false,
+                revision,
+                [],
+                [],
+                Some(("ParserFailure", "parser session failed")),
+              )
+            }
+            _ => {
+              let revision = session.baseline.revision
+              jsx_session_dispose(handle)
+              render_result_json(
+                false,
+                revision,
+                [],
+                [],
+                Some(("InternalFailure", "candidate commit failed")),
+              )
+            }
+          }
         }
       }
     }

--- a/modules/canopy/ffi/lambda/diagnostics.mbt
+++ b/modules/canopy/ffi/lambda/diagnostics.mbt
@@ -2,7 +2,7 @@
 
 ///|
 /// Get AST as DOT format with name resolution coloring
-pub fn get_ast_dot_resolved(handle : Int) -> String {
+pub fn get_ast_dot_resolved(handle : Int) -> String raise Failure {
   match lambda_registry.get(handle) {
     Some(h) => @lang_lambda.get_lambda_dot_resolved(h.editor)
     None => "digraph { }"
@@ -11,7 +11,7 @@ pub fn get_ast_dot_resolved(handle : Int) -> String {
 
 ///|
 /// Get AST as pretty-printed string (expression + debug tree)
-pub fn get_ast_pretty(handle : Int) -> String {
+pub fn get_ast_pretty(handle : Int) -> String raise Failure {
   match lambda_registry.get(handle) {
     Some(h) => @lang_lambda.get_lambda_ast_pretty(h.editor)
     None => ""
@@ -20,7 +20,7 @@ pub fn get_ast_pretty(handle : Int) -> String {
 
 ///|
 /// Get parse errors as JSON array
-pub fn get_errors_json(handle : Int) -> String {
+pub fn get_errors_json(handle : Int) -> String raise Failure {
   match lambda_registry.get(handle) {
     Some(h) => h.editor.get_errors().to_json().stringify()
     None => "[]"

--- a/modules/canopy/ffi/lambda/file_io.mbt
+++ b/modules/canopy/ffi/lambda/file_io.mbt
@@ -27,7 +27,7 @@ pub fn on_file_opened(
   handle : Int,
   content : String,
   timestamp_ms : Int,
-) -> Unit {
+) -> Unit raise {
   set_text_and_record(handle, content, timestamp_ms)
 }
 

--- a/modules/canopy/ffi/lambda/intent.mbt
+++ b/modules/canopy/ffi/lambda/intent.mbt
@@ -8,7 +8,7 @@ pub fn insert_at(
   position : Int,
   text : String,
   timestamp_ms : Int,
-) -> Unit {
+) -> Unit raise {
   match lambda_registry.get(handle) {
     Some(h) => h.editor.insert_at(position, text, timestamp_ms)
     None => ()
@@ -19,7 +19,11 @@ pub fn insert_at(
 /// Delete the character at a specific position without moving the cursor.
 /// Records the operation for undo. Returns false if position is out of bounds.
 /// Used by ProseMirror bridge.
-pub fn delete_at(handle : Int, position : Int, timestamp_ms : Int) -> Bool {
+pub fn delete_at(
+  handle : Int,
+  position : Int,
+  timestamp_ms : Int,
+) -> Bool raise {
   match lambda_registry.get(handle) {
     Some(h) => h.editor.delete_at(position, timestamp_ms)
     None => false
@@ -33,7 +37,7 @@ pub fn apply_tree_edit_json(
   handle : Int,
   op_json : String,
   timestamp_ms : Int,
-) -> String {
+) -> String raise {
   match lambda_registry.get(handle) {
     Some(h) => {
       let json = @json.parse(op_json) catch {
@@ -52,7 +56,32 @@ pub fn apply_tree_edit_json(
           Err(err) => "error: " + map_edit_error(err).message()
         }
       } catch {
-        err => "error: " + err.message()
+        Failure::Failure(_) as failure => raise failure
+        @editor.TreeEditError::ExpectedJsonObject as error =>
+          "error: " + error.message()
+        @editor.TreeEditError::MissingField(..) as error =>
+          "error: " + error.message()
+        @editor.TreeEditError::FieldMustBeString(..) as error =>
+          "error: " + error.message()
+        @editor.TreeEditError::FieldMustBeNumber(..) as error =>
+          "error: " + error.message()
+        @editor.TreeEditError::UnknownBop(..) as error =>
+          "error: " + error.message()
+        @editor.TreeEditError::UnknownOpType(..) as error =>
+          "error: " + error.message()
+        @editor.TreeEditError::ProjectionUnavailable as error =>
+          "error: " + error.message()
+        @editor.TreeEditError::UnhandledOperation(..) as error =>
+          "error: " + error.message()
+        @editor.TreeEditError::NodeNotInSourceMap(..) as error =>
+          "error: " + error.message()
+        @editor.TreeEditError::NodeNotInRegistry(..) as error =>
+          "error: " + error.message()
+        @editor.TreeEditError::TextTransformFailed(..) as error =>
+          "error: " + error.message()
+        @editor.TreeEditError::ProjectionEdit(..) as error =>
+          "error: " + error.message()
+        error => raise error
       }
     }
     None => "error: no editor"
@@ -69,7 +98,7 @@ pub fn handle_text_intent(
   deleted_len : Int,
   insert : String,
   timestamp_ms : Int,
-) -> Unit {
+) -> Unit raise {
   match lambda_registry.get(handle) {
     Some(h) => h.editor.apply_text_edit(from, deleted_len, insert, timestamp_ms)
     None => ()
@@ -88,7 +117,7 @@ pub fn handle_text_intent_checked(
   deleted_len : Int,
   insert : String,
   timestamp_ms : Int,
-) -> Bool {
+) -> Bool raise {
   match lambda_registry.get(handle) {
     Some(h) =>
       h.editor.apply_text_edit_exact(from, deleted_len, insert, timestamp_ms)
@@ -106,7 +135,7 @@ pub fn handle_diagnostic_fix_intent(
   diagnostic_id : Int,
   fix_id : Int,
   timestamp_ms : Int,
-) -> Bool {
+) -> Bool raise {
   match lambda_registry.get(handle) {
     Some(h) =>
       lambda_registry
@@ -123,12 +152,12 @@ pub fn handle_diagnostic_fix_intent(
 }
 
 ///|
-pub fn handle_undo(handle : Int) -> Bool {
+pub fn handle_undo(handle : Int) -> Bool raise Failure {
   undo_manager_undo(handle)
 }
 
 ///|
-pub fn handle_redo(handle : Int) -> Bool {
+pub fn handle_redo(handle : Int) -> Bool raise Failure {
   undo_manager_redo(handle)
 }
 
@@ -141,7 +170,7 @@ pub fn handle_structural_intent(
   node_id_str : String,
   timestamp_ms : Int,
   params_json : String,
-) -> String {
+) -> String raise {
   let m : Map[String, Json] = Map([])
   m["type"] = op.to_json()
   let node_id_int = @string.parse_int(node_id_str) catch {

--- a/modules/canopy/ffi/lambda/lifecycle.mbt
+++ b/modules/canopy/ffi/lambda/lifecycle.mbt
@@ -39,16 +39,21 @@ let last_created_handle : Ref[Int?] = { val: None }
 fn assemble_lambda_handle(
   agent_id : String,
   capture_timeout_ms? : Int = 500,
-) -> @workspace.EditorId {
+) -> @workspace.EditorId raise {
   let (editor, companion) = @lang_lambda.new_lambda_editor(
     agent_id,
     capture_timeout_ms~,
     parent_runtime=coordinator.runtime(),
   ) catch {
-    error => {
-      println("assemble_lambda_handle failed: \{error.message()}")
-      return @workspace.EditorId(-1)
-    }
+    Failure::Failure(_) as failure => raise failure
+    @text.TextError::EmptyReplicaId => return @workspace.EditorId(-1)
+    @text.TextError::InvalidPosition(..) => return @workspace.EditorId(-1)
+    @text.TextError::InvalidText(..) => return @workspace.EditorId(-1)
+    @text.TextError::InvalidRange(..) => return @workspace.EditorId(-1)
+    @text.TextError::SyncFailed(_) => return @workspace.EditorId(-1)
+    @text.TextError::VersionNotFound => return @workspace.EditorId(-1)
+    @text.TextError::Internal(..) => return @workspace.EditorId(-1)
+    error => raise error
   }
   let cells = LambdaProtectedCells::LambdaProtectedCells(editor, companion)
   let editor_id = coordinator.register_editor(
@@ -89,7 +94,7 @@ pub fn get_lambda_companion() -> @lang_lambda.LambdaCompanion? {
 ///|
 /// Create a new SyncEditor instance.
 /// Returns a unique handle, or `-1` when `agent_id` is invalid.
-pub fn create_editor(agent_id : String) -> Int {
+pub fn create_editor(agent_id : String) -> Int raise {
   assemble_lambda_handle(agent_id).0
 }
 
@@ -133,7 +138,7 @@ pub fn get_text(handle : Int) -> String {
 
 ///|
 /// Set text content directly (replaces entire document)
-pub fn set_text(handle : Int, new_text : String) -> Unit {
+pub fn set_text(handle : Int, new_text : String) -> Unit raise {
   match lambda_registry.get(handle) {
     Some(h) => h.editor.set_text(new_text)
     None => ()

--- a/modules/canopy/ffi/lambda/lifecycle.mbt
+++ b/modules/canopy/ffi/lambda/lifecycle.mbt
@@ -103,10 +103,10 @@ pub fn create_editor(agent_id : String) -> Int raise {
 /// gateway refuses if workspace deps still reference the editor; in that
 /// case the FFI-side bookkeeping and analysis attachment are intentionally
 /// left intact so reads of cached state remain valid.
-pub fn destroy_editor(handle : Int) -> Unit {
+pub fn try_destroy_editor(handle : Int) -> Bool {
   let h = match lambda_registry.get(handle) {
     Some(v) => v
-    None => return
+    None => return true
   }
   // The host gateway logs + skips teardown on refusal so dep references
   // remain valid (Phase 2 surfaces this to JS via a dedicated FFI error
@@ -118,13 +118,19 @@ pub fn destroy_editor(handle : Int) -> Unit {
   // observable only via incr-level inspection; a leaked registry entry
   // would be observable as a phantom editor.
   guard lambda_registry.destroy(coordinator, h.editor_id, "destroy_editor") else {
-    return
+    return false
   }
   pretty_view_states.remove(handle)
   if last_created_handle.val == Some(handle) {
     last_created_handle.val = None
   }
   h.companion.dispose_analysis_attachment()
+  true
+}
+
+///|
+pub fn destroy_editor(handle : Int) -> Unit {
+  ignore(try_destroy_editor(handle))
 }
 
 ///|

--- a/modules/canopy/ffi/lambda/moon.pkg
+++ b/modules/canopy/ffi/lambda/moon.pkg
@@ -53,6 +53,7 @@ options(
       "exports": [
         "create_editor",
         "destroy_editor",
+        "try_destroy_editor",
         "get_text",
         "set_text",
         "register_file_host",

--- a/modules/canopy/ffi/lambda/pkg.generated.mbti
+++ b/modules/canopy/ffi/lambda/pkg.generated.mbti
@@ -121,6 +121,8 @@ pub fn set_text(Int, String) -> Unit raise
 
 pub fn set_text_and_record(Int, String, Int) -> Unit raise
 
+pub fn try_destroy_editor(Int) -> Bool
+
 pub fn undo_and_export_json(Int) -> String raise Failure
 
 pub fn undo_manager_can_redo(Int) -> Bool

--- a/modules/canopy/ffi/lambda/pkg.generated.mbti
+++ b/modules/canopy/ffi/lambda/pkg.generated.mbti
@@ -15,25 +15,25 @@ pub fn apply_ast_grep_results_json(Int, String) -> String
 
 pub fn apply_sync_json(Int, String) -> String
 
-pub fn apply_tree_edit_json(Int, String, Int) -> String
+pub fn apply_tree_edit_json(Int, String, Int) -> String raise
 
-pub fn backspace_and_record(Int, Int) -> Bool
+pub fn backspace_and_record(Int, Int) -> Bool raise Failure
 
 pub fn canopy_llm_edit(String, String, String) -> @js_async.Promise[String]
 
 pub fn canopy_llm_fix_typos(String, String) -> @js_async.Promise[String]
 
-pub fn compute_pretty_patches_json(Int) -> String
+pub fn compute_pretty_patches_json(Int) -> String raise Failure
 
-pub fn compute_view_patches_json(Int) -> String
+pub fn compute_view_patches_json(Int) -> String raise Failure
 
-pub fn create_editor(String) -> Int
+pub fn create_editor(String) -> Int raise
 
-pub fn create_editor_with_undo(String, Int) -> Int
+pub fn create_editor_with_undo(String, Int) -> Int raise
 
-pub fn delete_and_record(Int, Int) -> Bool
+pub fn delete_and_record(Int, Int) -> Bool raise Failure
 
-pub fn delete_at(Int, Int, Int) -> Bool
+pub fn delete_at(Int, Int, Int) -> Bool raise
 
 pub fn destroy_editor(Int) -> Unit
 
@@ -55,19 +55,19 @@ pub fn export_all_json(Int) -> String
 
 pub fn export_since_json(Int, String) -> String
 
-pub fn get_ast_dot_resolved(Int) -> String
+pub fn get_ast_dot_resolved(Int) -> String raise Failure
 
-pub fn get_ast_pretty(Int) -> String
+pub fn get_ast_pretty(Int) -> String raise Failure
 
 pub fn get_diagnostics_json(Int) -> String
 
-pub fn get_errors_json(Int) -> String
+pub fn get_errors_json(Int) -> String raise Failure
 
 pub fn get_lambda_companion() -> @companion.LambdaCompanion?
 
 pub fn get_pattern_matches_json(Int) -> String
 
-pub fn get_pretty_view_json(Int) -> String
+pub fn get_pretty_view_json(Int) -> String raise Failure
 
 pub fn get_proj_node_json(Int) -> String
 
@@ -81,29 +81,29 @@ pub fn get_text(Int) -> String
 
 pub fn get_version_json(Int) -> String
 
-pub fn get_view_tree_json(Int) -> String
+pub fn get_view_tree_json(Int) -> String raise Failure
 
-pub fn handle_diagnostic_fix_intent(Int, Int, Int, Int, Int) -> Bool
+pub fn handle_diagnostic_fix_intent(Int, Int, Int, Int, Int) -> Bool raise
 
-pub fn handle_redo(Int) -> Bool
+pub fn handle_redo(Int) -> Bool raise Failure
 
-pub fn handle_structural_intent(Int, String, String, Int, String) -> String
+pub fn handle_structural_intent(Int, String, String, Int, String) -> String raise
 
-pub fn handle_text_intent(Int, Int, Int, String, Int) -> Unit
+pub fn handle_text_intent(Int, Int, Int, String, Int) -> Unit raise
 
-pub fn handle_text_intent_checked(Int, Int, Int, String, Int) -> Bool
+pub fn handle_text_intent_checked(Int, Int, Int, String, Int) -> Bool raise
 
-pub fn handle_undo(Int) -> Bool
+pub fn handle_undo(Int) -> Bool raise Failure
 
 pub fn insert_and_record(Int, String, Int) -> Unit
 
-pub fn insert_at(Int, Int, String, Int) -> Unit
+pub fn insert_at(Int, Int, String, Int) -> Unit raise
 
 pub fn load_file(Int) -> Unit
 
-pub fn on_file_opened(Int, String, Int) -> Unit
+pub fn on_file_opened(Int, String, Int) -> Unit raise
 
-pub fn redo_and_export_json(Int) -> String
+pub fn redo_and_export_json(Int) -> String raise Failure
 
 pub fn register_file_host(@js_ffi.Any) -> Unit
 
@@ -113,27 +113,27 @@ pub fn relay_on_disconnect(String, String) -> Unit
 
 pub fn relay_on_message(String, String, Bytes) -> Unit
 
-pub fn rename_semantic_node(Int, Int, String, Int) -> String
+pub fn rename_semantic_node(Int, Int, String, Int) -> String raise
 
 pub fn save_file(Int, String) -> Unit
 
-pub fn set_text(Int, String) -> Unit
+pub fn set_text(Int, String) -> Unit raise
 
-pub fn set_text_and_record(Int, String, Int) -> Unit
+pub fn set_text_and_record(Int, String, Int) -> Unit raise
 
-pub fn undo_and_export_json(Int) -> String
+pub fn undo_and_export_json(Int) -> String raise Failure
 
 pub fn undo_manager_can_redo(Int) -> Bool
 
 pub fn undo_manager_can_undo(Int) -> Bool
 
-pub fn undo_manager_clear(Int) -> Unit
+pub fn undo_manager_clear(Int) -> Unit raise Failure
 
-pub fn undo_manager_redo(Int) -> Bool
+pub fn undo_manager_redo(Int) -> Bool raise Failure
 
-pub fn undo_manager_set_tracking(Int, Bool) -> Unit
+pub fn undo_manager_set_tracking(Int, Bool) -> Unit raise Failure
 
-pub fn undo_manager_undo(Int) -> Bool
+pub fn undo_manager_undo(Int) -> Bool raise Failure
 
 pub fn ws_broadcast_cursor(Int) -> Unit
 

--- a/modules/canopy/ffi/lambda/pretty.mbt
+++ b/modules/canopy/ffi/lambda/pretty.mbt
@@ -6,7 +6,7 @@ let pretty_view_states : Map[Int, @editor.ViewUpdateState] = Map::default()
 ///|
 /// Get the pretty-printed ViewNode tree as JSON for a lambda editor.
 /// Returns "null" if any protected read fails.
-pub fn get_pretty_view_json(handle : Int) -> String {
+pub fn get_pretty_view_json(handle : Int) -> String raise Failure {
   match lambda_registry.get(handle) {
     Some(h) => {
       let _ = match
@@ -35,7 +35,7 @@ pub fn get_pretty_view_json(handle : Int) -> String {
 /// Compute incremental pretty-view patches for a lambda editor.
 /// Returns a JSON array of ViewPatch objects, or "[]" if any protected read
 /// fails.
-pub fn compute_pretty_patches_json(handle : Int) -> String {
+pub fn compute_pretty_patches_json(handle : Int) -> String raise Failure {
   match lambda_registry.get(handle) {
     Some(h) => {
       let _ = match

--- a/modules/canopy/ffi/lambda/protected_cells.mbt
+++ b/modules/canopy/ffi/lambda/protected_cells.mbt
@@ -36,7 +36,7 @@ priv struct LambdaProtectedCells {
 fn LambdaProtectedCells::LambdaProtectedCells(
   editor : @editor.SyncEditor[@ast.Term],
   companion : @lang_lambda.LambdaCompanion,
-) -> LambdaProtectedCells {
+) -> LambdaProtectedCells raise Failure {
   {
     diagnostic_source_revision: @workspace.ProtectedCell::from_derived(
       "diagnostic_publication_source_revision",

--- a/modules/canopy/ffi/lambda/semantic.mbt
+++ b/modules/canopy/ffi/lambda/semantic.mbt
@@ -101,7 +101,7 @@ pub fn rename_semantic_node(
   node_id : Int,
   new_name : String,
   timestamp_ms : Int,
-) -> String {
+) -> String raise {
   match lambda_registry.get(handle) {
     Some(h) => {
       let id = @core.NodeId::from_int(node_id)

--- a/modules/canopy/ffi/lambda/undo.mbt
+++ b/modules/canopy/ffi/lambda/undo.mbt
@@ -7,7 +7,7 @@
 pub fn create_editor_with_undo(
   agent_id : String,
   capture_timeout_ms : Int,
-) -> Int {
+) -> Int raise {
   assemble_lambda_handle(agent_id, capture_timeout_ms~).0
 }
 
@@ -29,7 +29,10 @@ pub fn insert_and_record(
 
 ///|
 /// Delete character at cursor (forward delete) and record for undo
-pub fn delete_and_record(handle : Int, timestamp_ms : Int) -> Bool {
+pub fn delete_and_record(
+  handle : Int,
+  timestamp_ms : Int,
+) -> Bool raise Failure {
   match lambda_registry.get(handle) {
     Some(h) => h.editor.delete_and_record(timestamp_ms)
     None => false
@@ -38,7 +41,10 @@ pub fn delete_and_record(handle : Int, timestamp_ms : Int) -> Bool {
 
 ///|
 /// Delete character before cursor (backspace) and record for undo
-pub fn backspace_and_record(handle : Int, timestamp_ms : Int) -> Bool {
+pub fn backspace_and_record(
+  handle : Int,
+  timestamp_ms : Int,
+) -> Bool raise Failure {
   match lambda_registry.get(handle) {
     Some(h) => h.editor.backspace_and_record(timestamp_ms)
     None => false
@@ -51,7 +57,7 @@ pub fn set_text_and_record(
   handle : Int,
   new_text : String,
   timestamp_ms : Int,
-) -> Unit {
+) -> Unit raise {
   match lambda_registry.get(handle) {
     Some(h) => h.editor.set_text_and_record(new_text, timestamp_ms)
     None => ()
@@ -60,7 +66,7 @@ pub fn set_text_and_record(
 
 ///|
 /// Undo the last operation group.
-pub fn undo_manager_undo(handle : Int) -> Bool {
+pub fn undo_manager_undo(handle : Int) -> Bool raise Failure {
   match lambda_registry.get(handle) {
     Some(h) => h.editor.undo()
     None => false
@@ -69,7 +75,7 @@ pub fn undo_manager_undo(handle : Int) -> Bool {
 
 ///|
 /// Redo the last undone operation group.
-pub fn undo_manager_redo(handle : Int) -> Bool {
+pub fn undo_manager_redo(handle : Int) -> Bool raise Failure {
   match lambda_registry.get(handle) {
     Some(h) => h.editor.redo()
     None => false
@@ -79,7 +85,7 @@ pub fn undo_manager_redo(handle : Int) -> Bool {
 ///|
 /// Undo and return sync ops as JSON for peer broadcast.
 /// Returns empty string if undo stack is empty.
-pub fn undo_and_export_json(handle : Int) -> String {
+pub fn undo_and_export_json(handle : Int) -> String raise Failure {
   match lambda_registry.get(handle) {
     Some(h) =>
       match h.editor.undo_and_export() {
@@ -93,7 +99,7 @@ pub fn undo_and_export_json(handle : Int) -> String {
 ///|
 /// Redo and return sync ops as JSON for peer broadcast.
 /// Returns empty string if redo stack is empty.
-pub fn redo_and_export_json(handle : Int) -> String {
+pub fn redo_and_export_json(handle : Int) -> String raise Failure {
   match lambda_registry.get(handle) {
     Some(h) =>
       match h.editor.redo_and_export() {
@@ -124,7 +130,10 @@ pub fn undo_manager_can_redo(handle : Int) -> Bool {
 
 ///|
 /// Enable or disable undo tracking
-pub fn undo_manager_set_tracking(handle : Int, enabled : Bool) -> Unit {
+pub fn undo_manager_set_tracking(
+  handle : Int,
+  enabled : Bool,
+) -> Unit raise Failure {
   match lambda_registry.get(handle) {
     Some(h) => h.editor.set_tracking(enabled)
     None => ()
@@ -133,7 +142,7 @@ pub fn undo_manager_set_tracking(handle : Int, enabled : Bool) -> Unit {
 
 ///|
 /// Clear both undo and redo stacks
-pub fn undo_manager_clear(handle : Int) -> Unit {
+pub fn undo_manager_clear(handle : Int) -> Unit raise Failure {
   match lambda_registry.get(handle) {
     Some(h) => h.editor.clear_undo()
     None => ()

--- a/modules/canopy/ffi/lambda/view.mbt
+++ b/modules/canopy/ffi/lambda/view.mbt
@@ -3,7 +3,7 @@
 ///|
 /// Get the ViewNode tree as JSON for a lambda editor.
 /// Returns "null" if no projection is available or any protected read fails.
-pub fn get_view_tree_json(handle : Int) -> String {
+pub fn get_view_tree_json(handle : Int) -> String raise Failure {
   match lambda_registry.get(handle) {
     Some(h) => {
       let _ = match
@@ -51,7 +51,7 @@ pub fn get_view_tree_json(handle : Int) -> String {
 /// Compute incremental view patches for a lambda editor.
 /// Returns a JSON array of ViewPatch objects, or "[]" if any protected read
 /// fails.
-pub fn compute_view_patches_json(handle : Int) -> String {
+pub fn compute_view_patches_json(handle : Int) -> String raise Failure {
   match lambda_registry.get(handle) {
     Some(h) => {
       let _ = match

--- a/modules/canopy/ffi/markdown/markdown_ffi.mbt
+++ b/modules/canopy/ffi/markdown/markdown_ffi.mbt
@@ -31,15 +31,20 @@ let markdown_registry : @host.HostRegistry[MarkdownHandle] = @host.HostRegistry:
 /// `EditorId`, or `EditorId(-1)` when construction fails. A failed
 /// construction leaves `markdown_registry` untouched
 /// (atomic-boundary observation, spec §3.6).
-fn assemble_markdown_handle(agent_id : String) -> @workspace.EditorId {
+fn assemble_markdown_handle(agent_id : String) -> @workspace.EditorId raise {
   let editor = @md_companion.new_markdown_editor(
     agent_id,
     parent_runtime=coordinator.runtime(),
   ) catch {
-    error => {
-      println("assemble_markdown_handle failed: \{error.message()}")
-      return @workspace.EditorId(-1)
-    }
+    Failure::Failure(_) as failure => raise failure
+    @text.TextError::EmptyReplicaId => return @workspace.EditorId(-1)
+    @text.TextError::InvalidPosition(..) => return @workspace.EditorId(-1)
+    @text.TextError::InvalidText(..) => return @workspace.EditorId(-1)
+    @text.TextError::InvalidRange(..) => return @workspace.EditorId(-1)
+    @text.TextError::SyncFailed(_) => return @workspace.EditorId(-1)
+    @text.TextError::VersionNotFound => return @workspace.EditorId(-1)
+    @text.TextError::Internal(..) => return @workspace.EditorId(-1)
+    error => raise error
   }
   let cells = MarkdownProtectedCells::MarkdownProtectedCells(editor)
   let editor_id = coordinator.register_editor(
@@ -53,7 +58,7 @@ fn assemble_markdown_handle(agent_id : String) -> @workspace.EditorId {
 ///|
 /// Create a new Markdown SyncEditor instance.
 /// Returns a unique handle, or `-1` when `agent_id` is invalid.
-pub fn create_markdown_editor(agent_id : String) -> Int {
+pub fn create_markdown_editor(agent_id : String) -> Int raise {
   assemble_markdown_handle(agent_id).0
 }
 
@@ -115,7 +120,7 @@ pub fn markdown_export_text(handle : Int) -> String {
 }
 
 ///|
-pub fn markdown_set_text(handle : Int, text : String) -> Unit {
+pub fn markdown_set_text(handle : Int, text : String) -> Unit raise {
   match markdown_registry.get(handle) {
     Some(h) => h.editor.set_text(text)
     None => ()
@@ -142,7 +147,7 @@ pub fn markdown_apply_edit(
   param1 : String,
   param2 : Int,
   timestamp_ms : Int,
-) -> String {
+) -> String raise {
   match markdown_registry.get(handle) {
     Some(h) => {
       let nid = @core.NodeId::from_int(node_id)

--- a/modules/canopy/ffi/markdown/markdown_ffi.mbt
+++ b/modules/canopy/ffi/markdown/markdown_ffi.mbt
@@ -68,16 +68,17 @@ pub fn create_markdown_editor(agent_id : String) -> Int raise {
 /// FFI-side bookkeeping (registry handle entry, view-state entry) is
 /// intentionally left intact so reads of cached state remain valid. Phase 1
 /// behavior matches Lambda's `destroy_editor` (spec §5.3).
-pub fn destroy_markdown_editor(handle : Int) -> Unit {
+pub fn try_destroy_markdown_editor(handle : Int) -> Bool {
   let h = match markdown_registry.get(handle) {
     Some(v) => v
-    None => return
+    None => return true
   }
-  let _ = markdown_registry.destroy(
-    coordinator,
-    h.editor_id,
-    "destroy_markdown_editor",
-  )
+  markdown_registry.destroy(coordinator, h.editor_id, "destroy_markdown_editor")
+}
+
+///|
+pub fn destroy_markdown_editor(handle : Int) -> Unit {
+  ignore(try_destroy_markdown_editor(handle))
 }
 
 ///|

--- a/modules/canopy/ffi/markdown/moon.pkg
+++ b/modules/canopy/ffi/markdown/moon.pkg
@@ -31,6 +31,7 @@ options(
       "exports": [
         "create_markdown_editor",
         "destroy_markdown_editor",
+        "try_destroy_markdown_editor",
         "markdown_get_text",
         "markdown_export_text",
         "markdown_set_text",

--- a/modules/canopy/ffi/markdown/pkg.generated.mbti
+++ b/modules/canopy/ffi/markdown/pkg.generated.mbti
@@ -18,6 +18,8 @@ pub fn markdown_get_text(Int) -> String
 
 pub fn markdown_set_text(Int, String) -> Unit raise
 
+pub fn try_destroy_markdown_editor(Int) -> Bool
+
 // Errors
 
 // Types and methods

--- a/modules/canopy/ffi/markdown/pkg.generated.mbti
+++ b/modules/canopy/ffi/markdown/pkg.generated.mbti
@@ -2,11 +2,11 @@
 package "dowdiness/canopy/ffi/markdown"
 
 // Values
-pub fn create_markdown_editor(String) -> Int
+pub fn create_markdown_editor(String) -> Int raise
 
 pub fn destroy_markdown_editor(Int) -> Unit
 
-pub fn markdown_apply_edit(Int, String, Int, String, Int, Int) -> String
+pub fn markdown_apply_edit(Int, String, Int, String, Int, Int) -> String raise
 
 pub fn markdown_compute_view_patches_json(Int) -> String
 
@@ -16,7 +16,7 @@ pub fn markdown_export_text(Int) -> String
 
 pub fn markdown_get_text(Int) -> String
 
-pub fn markdown_set_text(Int, String) -> Unit
+pub fn markdown_set_text(Int, String) -> Unit raise
 
 // Errors
 

--- a/modules/canopy/ffi/markdown/protected_cells.mbt
+++ b/modules/canopy/ffi/markdown/protected_cells.mbt
@@ -26,7 +26,7 @@ priv struct MarkdownProtectedCells {
 ///|
 fn MarkdownProtectedCells::MarkdownProtectedCells(
   editor : @editor.SyncEditor[@md.Block],
-) -> MarkdownProtectedCells {
+) -> MarkdownProtectedCells raise Failure {
   {
     parser_syntax_tree: @workspace.ProtectedCell::from_derived(
       "parser_syntax_view",

--- a/modules/canopy/lang/json/companion/dispatch_benchmark.mbt
+++ b/modules/canopy/lang/json/companion/dispatch_benchmark.mbt
@@ -22,10 +22,10 @@ fn make_text_ops_caps(
 ) -> TextOpsCaps {
   {
     apply_text_edit: fn(from, del, ins, ts) {
-      editor.apply_text_edit(from, del, ins, ts)
+      try! editor.apply_text_edit(from, del, ins, ts)
     },
     apply_text_edit_opt: Some(fn(from, del, ins, ts) {
-      editor.apply_text_edit(from, del, ins, ts)
+      try! editor.apply_text_edit(from, del, ins, ts)
     }),
   }
 }
@@ -48,12 +48,10 @@ fn run_text_intent_dispatch_bench(
   mode : DispatchMode,
 ) -> Unit {
   let source = json_bench_object(member_count)
-  let editor = new_json_editor("bench") catch {
-    error => abort("benchmark editor construction failed: \{error.message()}")
-  }
-  editor.set_text(source)
-  ignore(editor.get_proj_node())
-  ignore(editor.get_source_map())
+  let editor = try! new_json_editor("bench")
+  try! editor.set_text(source)
+  ignore(try! editor.get_proj_node())
+  ignore(try! editor.get_source_map())
   let caps = make_text_ops_caps(editor)
   // Edit positions: just after the value digit of 4 members spread across
   // the doc. Member i line: `  "k<i>": <i>` — find positions by scanning.
@@ -79,7 +77,7 @@ fn run_text_intent_dispatch_bench(
     let pos = positions[i / 2 % positions.length()]
     let (del, ins) = if inserted { (1, "") } else { (0, "1") }
     match mode {
-      Direct => editor.apply_text_edit(pos, del, ins, i)
+      Direct => try! editor.apply_text_edit(pos, del, ins, i)
       CapsField => (caps.apply_text_edit)(pos, del, ins, i)
       CapsOptField =>
         match caps.apply_text_edit_opt {

--- a/modules/canopy/lang/json/companion/json_benchmark.mbt
+++ b/modules/canopy/lang/json/companion/json_benchmark.mbt
@@ -47,26 +47,24 @@ fn json_bench_array(element_count : Int) -> String {
 /// ProjNode + SourceMap.
 fn run_json_object_bench(b : @bench.T, member_count : Int) -> Unit {
   let source = json_bench_object(member_count)
-  let editor = new_json_editor("bench") catch {
-    error => abort("benchmark editor construction failed: \{error.message()}")
-  }
-  editor.set_text(source)
-  ignore(editor.get_proj_node())
-  ignore(editor.get_source_map())
+  let editor = try! new_json_editor("bench")
+  try! editor.set_text(source)
+  ignore(try! editor.get_proj_node())
+  ignore(try! editor.get_source_map())
   // Edit position: just before the closing }
   let edit_pos = source.length() - 2
   editor.move_cursor(edit_pos)
   let mut inserted = false
-  b.bench(fn() {
+  b.bench(() => {
     if inserted {
-      ignore(editor.backspace())
+      ignore(try! editor.backspace())
     } else {
       editor.insert("1") catch {
         _ => ()
       }
     }
-    b.keep(editor.get_proj_node())
-    b.keep(editor.get_source_map())
+    b.keep(try! editor.get_proj_node())
+    b.keep(try! editor.get_source_map())
     inserted = !inserted
   })
 }
@@ -75,25 +73,23 @@ fn run_json_object_bench(b : @bench.T, member_count : Int) -> Unit {
 /// Benchmark: incremental edit on JSON array.
 fn run_json_array_bench(b : @bench.T, element_count : Int) -> Unit {
   let source = json_bench_array(element_count)
-  let editor = new_json_editor("bench") catch {
-    error => abort("benchmark editor construction failed: \{error.message()}")
-  }
-  editor.set_text(source)
-  ignore(editor.get_proj_node())
-  ignore(editor.get_source_map())
+  let editor = try! new_json_editor("bench")
+  try! editor.set_text(source)
+  ignore(try! editor.get_proj_node())
+  ignore(try! editor.get_source_map())
   let edit_pos = source.length() - 2
   editor.move_cursor(edit_pos)
   let mut inserted = false
-  b.bench(fn() {
+  b.bench(() => {
     if inserted {
-      ignore(editor.backspace())
+      ignore(try! editor.backspace())
     } else {
       editor.insert("1") catch {
         _ => ()
       }
     }
-    b.keep(editor.get_proj_node())
-    b.keep(editor.get_source_map())
+    b.keep(try! editor.get_proj_node())
+    b.keep(try! editor.get_source_map())
     inserted = !inserted
   })
 }

--- a/modules/canopy/lang/json/companion/json_companion.mbt
+++ b/modules/canopy/lang/json/companion/json_companion.mbt
@@ -49,7 +49,7 @@ pub fn new_json_editor(
   agent_id : String,
   capture_timeout_ms? : Int = 500,
   parent_runtime? : @incr.Runtime,
-) -> @editor.SyncEditor[@json.JsonValue] raise @text.TextError {
+) -> @editor.SyncEditor[@json.JsonValue] raise {
   let (editor, _) = json_lang.build(
     agent_id,
     capture_timeout_ms~,
@@ -66,7 +66,7 @@ pub fn apply_json_edit(
   editor : @editor.SyncEditor[@json.JsonValue],
   op : @json_edits.JsonEditOp,
   timestamp_ms : Int,
-) -> Result[Unit, String] {
+) -> Result[Unit, String] raise {
   match json_lang.apply_edit(editor, op, timestamp_ms) {
     Ok(_) => Ok(())
     Err(e) => Err(e.message())

--- a/modules/canopy/lang/json/companion/moon.pkg
+++ b/modules/canopy/lang/json/companion/moon.pkg
@@ -4,7 +4,6 @@ import {
   "dowdiness/canopy/lang/json/edits" @json_edits,
   "dowdiness/canopy/lang/json/proj" @json_proj,
   "dowdiness/canopy/lang/runtime" @lang_runtime,
-  "dowdiness/event-graph-walker/text",
   "dowdiness/incr",
   "dowdiness/json",
   "dowdiness/loom",

--- a/modules/canopy/lang/json/companion/pkg.generated.mbti
+++ b/modules/canopy/lang/json/companion/pkg.generated.mbti
@@ -4,15 +4,14 @@ package "dowdiness/canopy/lang/json/companion"
 import {
   "dowdiness/canopy/editor",
   "dowdiness/canopy/lang/json/edits",
-  "dowdiness/event-graph-walker/text",
   "dowdiness/incr/cells",
   "dowdiness/json",
 }
 
 // Values
-pub fn apply_json_edit(@editor.SyncEditor[@json.JsonValue], @edits.JsonEditOp, Int) -> Result[Unit, String]
+pub fn apply_json_edit(@editor.SyncEditor[@json.JsonValue], @edits.JsonEditOp, Int) -> Result[Unit, String] raise
 
-pub fn new_json_editor(String, capture_timeout_ms? : Int, parent_runtime? : @cells.Runtime) -> @editor.SyncEditor[@json.JsonValue] raise @text.TextError
+pub fn new_json_editor(String, capture_timeout_ms? : Int, parent_runtime? : @cells.Runtime) -> @editor.SyncEditor[@json.JsonValue] raise
 
 // Errors
 

--- a/modules/canopy/lang/json/proj/pkg.generated.mbti
+++ b/modules/canopy/lang/json/proj/pkg.generated.mbti
@@ -2,6 +2,7 @@
 package "dowdiness/canopy/lang/json/proj"
 
 import {
+  "dowdiness/canopy/core",
   "dowdiness/diagnostic",
   "dowdiness/incr/cells",
   "dowdiness/json",
@@ -11,17 +12,17 @@ import {
 }
 
 // Values
-pub fn build_json_projection_memos(@pipeline.Parser[@json.JsonValue]) -> (@cells.Derived[@dowdiness/canopy/core.ProjNode[@json.JsonValue]?], @cells.Derived[Map[@dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.ProjNode[@json.JsonValue]]], @cells.Derived[@dowdiness/canopy/core.SourceMap])
+pub fn build_json_projection_memos(@pipeline.Parser[@json.JsonValue]) -> (@cells.Derived[@core.ProjNode[@json.JsonValue]?], @cells.Derived[Map[@core.NodeId, @core.ProjNode[@json.JsonValue]]], @cells.Derived[@core.SourceMap])
 
 pub fn key_role(Int) -> String
 
 pub fn member_role(Int) -> String
 
-pub fn parse_to_proj_node(@diagnostic.SourceId, String) -> (@dowdiness/canopy/core.ProjNode[@json.JsonValue], Array[String]) raise @dowdiness/loom/core.LexError
+pub fn parse_to_proj_node(@diagnostic.SourceId, String) -> (@core.ProjNode[@json.JsonValue], Array[String]) raise
 
-pub fn populate_token_spans(@dowdiness/canopy/core.SourceMap, @seam.SyntaxNode, @dowdiness/canopy/core.ProjNode[@json.JsonValue]) -> Unit
+pub fn populate_token_spans(@core.SourceMap, @seam.SyntaxNode, @core.ProjNode[@json.JsonValue]) -> Unit
 
-pub fn syntax_to_proj_node(@seam.SyntaxNode, @ref.Ref[Int]) -> @dowdiness/canopy/core.ProjNode[@json.JsonValue]
+pub fn syntax_to_proj_node(@seam.SyntaxNode, @ref.Ref[Int]) -> @core.ProjNode[@json.JsonValue]
 
 // Errors
 

--- a/modules/canopy/lang/json/proj/proj_node.mbt
+++ b/modules/canopy/lang/json/proj/proj_node.mbt
@@ -153,7 +153,7 @@ fn extract_member(
 pub fn parse_to_proj_node(
   source_id : @loomcore.SourceId,
   text : String,
-) -> (ProjNode[@json.JsonValue], Array[String]) raise @loomcore.LexError {
+) -> (ProjNode[@json.JsonValue], Array[String]) raise {
   let (cst, diagnostics) = @json.parse_cst(source_id, text)
   let syntax_node = @seam.SyntaxNode::from_cst(cst)
   let errors = diagnostics.map(diagnostic => diagnostic.message())

--- a/modules/canopy/lang/jsx/proj/pkg.generated.mbti
+++ b/modules/canopy/lang/jsx/proj/pkg.generated.mbti
@@ -2,6 +2,7 @@
 package "dowdiness/canopy/lang/jsx/proj"
 
 import {
+  "dowdiness/canopy/core",
   "dowdiness/diagnostic",
   "dowdiness/incr/cells",
   "dowdiness/jsx",
@@ -12,19 +13,19 @@ import {
 }
 
 // Values
-pub fn build_jsx_projection_memos(@pipeline.Parser[@jsx.JsxNode]) -> (@cells.Derived[@dowdiness/canopy/core.ProjNode[@jsx.JsxNode]?], @cells.Derived[Map[@dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.ProjNode[@jsx.JsxNode]]], @cells.Derived[@dowdiness/canopy/core.SourceMap])
+pub fn build_jsx_projection_memos(@pipeline.Parser[@jsx.JsxNode]) -> (@cells.Derived[@core.ProjNode[@jsx.JsxNode]?], @cells.Derived[Map[@core.NodeId, @core.ProjNode[@jsx.JsxNode]]], @cells.Derived[@core.SourceMap])
 
 pub fn dom_patches_to_json(Array[DomPatch]) -> String
 
 pub fn normalize_dom_attribute_value(String, String) -> String
 
-pub fn parse_to_proj_node(@diagnostic.SourceId, String) -> (@dowdiness/canopy/core.ProjNode[@jsx.JsxNode], Array[String]) raise @dowdiness/loom/core.LexError
+pub fn parse_to_proj_node(@diagnostic.SourceId, String) -> (@core.ProjNode[@jsx.JsxNode], Array[String]) raise
 
-pub fn populate_token_spans(@dowdiness/canopy/core.SourceMap, @seam.SyntaxNode, @dowdiness/canopy/core.ProjNode[@jsx.JsxNode]) -> Unit
+pub fn populate_token_spans(@core.SourceMap, @seam.SyntaxNode, @core.ProjNode[@jsx.JsxNode]) -> Unit
 
-pub fn reconcile(@dowdiness/canopy/core.ProjNode[@jsx.JsxNode], Array[Int]) -> (Array[DomPatch], Array[Int])
+pub fn reconcile(@core.ProjNode[@jsx.JsxNode], Array[Int]) -> (Array[DomPatch], Array[Int])
 
-pub fn syntax_to_proj_node(@seam.SyntaxNode, @ref.Ref[Int]) -> @dowdiness/canopy/core.ProjNode[@jsx.JsxNode]
+pub fn syntax_to_proj_node(@seam.SyntaxNode, @ref.Ref[Int]) -> @core.ProjNode[@jsx.JsxNode]
 
 // Errors
 

--- a/modules/canopy/lang/jsx/proj/populate_token_spans_wbtest.mbt
+++ b/modules/canopy/lang/jsx/proj/populate_token_spans_wbtest.mbt
@@ -10,7 +10,7 @@ let jsx_token_span_test_source : @loomcore.SourceId = @loomcore.SourceId(
 ///|
 fn source_map_for(
   text : String,
-) -> (@core.ProjNode[@jsx.JsxNode], @core.SourceMap) {
+) -> (@core.ProjNode[@jsx.JsxNode], @core.SourceMap) raise {
   let parser = @loom.new_parser(
     jsx_token_span_test_source, text, @jsx.jsx_grammar,
   )

--- a/modules/canopy/lang/jsx/proj/proj_node.mbt
+++ b/modules/canopy/lang/jsx/proj/proj_node.mbt
@@ -11,7 +11,7 @@
 pub fn parse_to_proj_node(
   source_id : @loomcore.SourceId,
   text : String,
-) -> (@core.ProjNode[@jsx.JsxNode], Array[String]) raise @loomcore.LexError {
+) -> (@core.ProjNode[@jsx.JsxNode], Array[String]) raise {
   let (cst, diagnostics) = @jsx.parse_cst(source_id, text)
   let syntax_node = @seam.SyntaxNode::from_cst(cst)
   let errors = diagnostics.map(diagnostic => diagnostic.message())

--- a/modules/canopy/lang/lambda/companion/action_detection.mbt
+++ b/modules/canopy/lang/lambda/companion/action_detection.mbt
@@ -5,7 +5,7 @@
 pub fn detect_action_context(
   editor : @editor.SyncEditor[@ast.Term],
   node_id : @core.NodeId,
-) -> @lambda_edits.ActionContext? {
+) -> @lambda_edits.ActionContext? raise Failure {
   let node = match editor.get_node(node_id) {
     Some(n) => n
     None => return None

--- a/modules/canopy/lang/lambda/companion/lambda_ast_helpers.mbt
+++ b/modules/canopy/lang/lambda/companion/lambda_ast_helpers.mbt
@@ -3,7 +3,9 @@
 
 ///|
 /// Returns the parsed lambda Term.
-pub fn get_lambda_ast(editor : @editor.SyncEditor[@ast.Term]) -> @ast.Term {
+pub fn get_lambda_ast(
+  editor : @editor.SyncEditor[@ast.Term],
+) -> @ast.Term raise Failure {
   match editor.get_tree() {
     Some(t) => t
     None => @ast.Term::Unit
@@ -12,7 +14,9 @@ pub fn get_lambda_ast(editor : @editor.SyncEditor[@ast.Term]) -> @ast.Term {
 
 ///|
 /// Returns pretty-printed AST with debug tree.
-pub fn get_lambda_ast_pretty(editor : @editor.SyncEditor[@ast.Term]) -> String {
+pub fn get_lambda_ast_pretty(
+  editor : @editor.SyncEditor[@ast.Term],
+) -> String raise Failure {
   let ast = get_lambda_ast(editor)
   let formatted = @pretty.pretty_print(ast, width=60)
   "Expression: " + formatted + "\n\nAST:\n" + @debug.to_string(ast)
@@ -22,7 +26,7 @@ pub fn get_lambda_ast_pretty(editor : @editor.SyncEditor[@ast.Term]) -> String {
 /// Returns name resolution info.
 pub fn get_lambda_resolution(
   editor : @editor.SyncEditor[@ast.Term],
-) -> @parser.Resolution {
+) -> @parser.Resolution raise Failure {
   let (_, res) = @parser.resolve(get_lambda_ast(editor))
   res
 }
@@ -31,7 +35,7 @@ pub fn get_lambda_resolution(
 /// Returns Graphviz DOT with resolution.
 pub fn get_lambda_dot_resolved(
   editor : @editor.SyncEditor[@ast.Term],
-) -> String {
+) -> String raise Failure {
   let ast = get_lambda_ast(editor)
   let (resolved_ast, res) = @parser.resolve(ast)
   @parser.term_to_dot_resolved(resolved_ast, res)

--- a/modules/canopy/lang/lambda/companion/lambda_editor.mbt
+++ b/modules/canopy/lang/lambda/companion/lambda_editor.mbt
@@ -235,7 +235,7 @@ pub fn new_lambda_editor(
   agent_id : String,
   capture_timeout_ms? : Int = 500,
   parent_runtime? : @incr.Runtime,
-) -> (@editor.SyncEditor[@ast.Term], LambdaCompanion) raise @text.TextError {
+) -> (@editor.SyncEditor[@ast.Term], LambdaCompanion) raise {
   lambda_language.build(agent_id, capture_timeout_ms~, parent_runtime?)
 }
 
@@ -314,7 +314,7 @@ pub fn apply_lambda_tree_edit(
   companion : LambdaCompanion,
   op : @lambda_edits.TreeEditOp,
   timestamp_ms : Int,
-) -> Result[Array[@core.SpanEdit], @core.EditError] {
+) -> Result[Array[@core.SpanEdit], @core.EditError] raise {
   let _ = companion
   lambda_language.apply_edit(editor, op, timestamp_ms)
 }
@@ -329,7 +329,7 @@ pub fn apply_lambda_tree_edit_with_reachable_failure_review(
   op : @lambda_edits.TreeEditOp,
   timestamp_ms : Int,
   attribution : ReachableFailureAttribution,
-) -> Result[ReachableFailureReview, @core.EditError] {
+) -> Result[ReachableFailureReview, @core.EditError] raise {
   let before = snapshot_reachable_failures(editor)
   match apply_lambda_tree_edit(editor, companion, op, timestamp_ms) {
     Err(error) => Err(error)
@@ -346,7 +346,7 @@ pub fn apply_lambda_tree_edit_with_reachable_failure_review(
 /// construction and failure collection themselves remain deterministic.
 fn snapshot_reachable_failures(
   editor : @editor.SyncEditor[@ast.Term],
-) -> Array[@lambda_scope.ReachableFailure] {
+) -> Array[@lambda_scope.ReachableFailure] raise Failure {
   let source_map = editor.get_source_map()
   @lambda_scope.failures(
     @lambda_scope.build(editor.get_registry(), source_map),

--- a/modules/canopy/lang/lambda/companion/pkg.generated.mbti
+++ b/modules/canopy/lang/lambda/companion/pkg.generated.mbti
@@ -10,7 +10,6 @@ import {
   "dowdiness/canopy/lang/lambda/eval",
   "dowdiness/canopy/lang/lambda/scope",
   "dowdiness/canopy/protocol",
-  "dowdiness/event-graph-walker/text",
   "dowdiness/incr/cells",
   "dowdiness/lambda",
   "dowdiness/lambda/ast",
@@ -19,21 +18,21 @@ import {
 }
 
 // Values
-pub fn apply_lambda_tree_edit(@editor.SyncEditor[@ast.Term], LambdaCompanion, @edits.TreeEditOp, Int) -> Result[Array[@core.SpanEdit], @core.EditError]
+pub fn apply_lambda_tree_edit(@editor.SyncEditor[@ast.Term], LambdaCompanion, @edits.TreeEditOp, Int) -> Result[Array[@core.SpanEdit], @core.EditError] raise
 
-pub fn apply_lambda_tree_edit_with_reachable_failure_review(@editor.SyncEditor[@ast.Term], LambdaCompanion, @edits.TreeEditOp, Int, ReachableFailureAttribution) -> Result[ReachableFailureReview, @core.EditError]
+pub fn apply_lambda_tree_edit_with_reachable_failure_review(@editor.SyncEditor[@ast.Term], LambdaCompanion, @edits.TreeEditOp, Int, ReachableFailureAttribution) -> Result[ReachableFailureReview, @core.EditError] raise
 
-pub fn detect_action_context(@editor.SyncEditor[@ast.Term], @core.NodeId) -> @edits.ActionContext?
+pub fn detect_action_context(@editor.SyncEditor[@ast.Term], @core.NodeId) -> @edits.ActionContext? raise Failure
 
-pub fn get_lambda_ast(@editor.SyncEditor[@ast.Term]) -> @ast.Term
+pub fn get_lambda_ast(@editor.SyncEditor[@ast.Term]) -> @ast.Term raise Failure
 
-pub fn get_lambda_ast_pretty(@editor.SyncEditor[@ast.Term]) -> String
+pub fn get_lambda_ast_pretty(@editor.SyncEditor[@ast.Term]) -> String raise Failure
 
-pub fn get_lambda_dot_resolved(@editor.SyncEditor[@ast.Term]) -> String
+pub fn get_lambda_dot_resolved(@editor.SyncEditor[@ast.Term]) -> String raise Failure
 
-pub fn get_lambda_resolution(@editor.SyncEditor[@ast.Term]) -> @lambda.Resolution
+pub fn get_lambda_resolution(@editor.SyncEditor[@ast.Term]) -> @lambda.Resolution raise Failure
 
-pub fn new_lambda_editor(String, capture_timeout_ms? : Int, parent_runtime? : @cells.Runtime) -> (@editor.SyncEditor[@ast.Term], LambdaCompanion) raise @text.TextError
+pub fn new_lambda_editor(String, capture_timeout_ms? : Int, parent_runtime? : @cells.Runtime) -> (@editor.SyncEditor[@ast.Term], LambdaCompanion) raise
 
 pub fn parse_tree_edit_op(Json) -> @edits.TreeEditOp raise @editor.TreeEditError
 

--- a/modules/canopy/lang/lambda/companion/tree_edit_bridge_test.mbt
+++ b/modules/canopy/lang/lambda/companion/tree_edit_bridge_test.mbt
@@ -4,7 +4,7 @@
 ///|
 fn setup_bridge(
   text : String,
-) -> (@editor.SyncEditor[@ast.Term], LambdaCompanion) {
+) -> (@editor.SyncEditor[@ast.Term], LambdaCompanion) raise {
   let (editor, companion) = try! new_lambda_editor("test")
   editor.set_text(text)
   (editor, companion)

--- a/modules/canopy/lang/lambda/edits/scope_memo_stack_differential_wbtest.mbt
+++ b/modules/canopy/lang/lambda/edits/scope_memo_stack_differential_wbtest.mbt
@@ -37,7 +37,7 @@ struct LevelBStack {
 fn LevelBStack::LevelBStack(
   source_id : @loomcore.SourceId,
   source : String,
-) -> LevelBStack {
+) -> LevelBStack raise {
   let parser = @loom.new_parser(source_id, source, @parser.lambda_grammar)
   let (cached_proj_node, registry_memo, source_map_memo) = @lambda_proj.build_lambda_projection_memos(
     parser,
@@ -63,7 +63,11 @@ fn LevelBStack::dispose(self : LevelBStack) -> Unit {
 
 ///|
 /// Advance the parser by the minimal single-region edit turning `old` into `new`.
-fn LevelBStack::apply(self : LevelBStack, old : String, new : String) -> Unit {
+fn LevelBStack::apply(
+  self : LevelBStack,
+  old : String,
+  new : String,
+) -> Unit raise {
   self.parser.apply_edit(lb_minimal_edit(old, new), new)
 }
 

--- a/modules/canopy/lang/lambda/pkg.generated.mbti
+++ b/modules/canopy/lang/lambda/pkg.generated.mbti
@@ -7,25 +7,24 @@ import {
   "dowdiness/canopy/lang/lambda/companion",
   "dowdiness/canopy/lang/lambda/edits",
   "dowdiness/canopy/lang/lambda/eval",
-  "dowdiness/event-graph-walker/text",
   "dowdiness/incr/cells",
   "dowdiness/lambda/ast",
 }
 
 // Values
-pub fn apply_lambda_tree_edit(@editor.SyncEditor[@ast.Term], @companion.LambdaCompanion, @edits.TreeEditOp, Int) -> Result[Array[@core.SpanEdit], @core.EditError]
+pub fn apply_lambda_tree_edit(@editor.SyncEditor[@ast.Term], @companion.LambdaCompanion, @edits.TreeEditOp, Int) -> Result[Array[@core.SpanEdit], @core.EditError] raise
 
-pub fn detect_action_context(@editor.SyncEditor[@ast.Term], @core.NodeId) -> @edits.ActionContext?
+pub fn detect_action_context(@editor.SyncEditor[@ast.Term], @core.NodeId) -> @edits.ActionContext? raise Failure
 
-pub fn get_lambda_ast(@editor.SyncEditor[@ast.Term]) -> @ast.Term
+pub fn get_lambda_ast(@editor.SyncEditor[@ast.Term]) -> @ast.Term raise Failure
 
-pub fn get_lambda_ast_pretty(@editor.SyncEditor[@ast.Term]) -> String
+pub fn get_lambda_ast_pretty(@editor.SyncEditor[@ast.Term]) -> String raise Failure
 
-pub fn get_lambda_dot_resolved(@editor.SyncEditor[@ast.Term]) -> String
+pub fn get_lambda_dot_resolved(@editor.SyncEditor[@ast.Term]) -> String raise Failure
 
-pub fn get_lambda_resolution(@editor.SyncEditor[@ast.Term]) -> @dowdiness/lambda.Resolution
+pub fn get_lambda_resolution(@editor.SyncEditor[@ast.Term]) -> @dowdiness/lambda.Resolution raise Failure
 
-pub fn new_lambda_editor(String, capture_timeout_ms? : Int, parent_runtime? : @cells.Runtime) -> (@editor.SyncEditor[@ast.Term], @companion.LambdaCompanion) raise @text.TextError
+pub fn new_lambda_editor(String, capture_timeout_ms? : Int, parent_runtime? : @cells.Runtime) -> (@editor.SyncEditor[@ast.Term], @companion.LambdaCompanion) raise
 
 pub fn parse_tree_edit_op(Json) -> @edits.TreeEditOp raise @editor.TreeEditError
 

--- a/modules/canopy/lang/lambda/proj/pkg.generated.mbti
+++ b/modules/canopy/lang/lambda/proj/pkg.generated.mbti
@@ -2,6 +2,7 @@
 package "dowdiness/canopy/lang/lambda/proj"
 
 import {
+  "dowdiness/canopy/core",
   "dowdiness/diagnostic",
   "dowdiness/incr/cells",
   "dowdiness/lambda/ast",
@@ -25,23 +26,23 @@ pub const PARAM_ROLE : String = "param"
 
 pub const REFERENCE_NAME_ROLE : String = "reference:name"
 
-pub fn build_lambda_projection_memos(@pipeline.Parser[@ast.Term], identity_hints? : @dowdiness/canopy/core.IdentityHintConsumer, trace_ref? : @ref.Ref[Array[@dowdiness/canopy/core.ReconcileTraceEvent]]?) -> (@cells.Derived[@dowdiness/canopy/core.ProjNode[@ast.Term]?], @cells.Derived[Map[@dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.ProjNode[@ast.Term]]], @cells.Derived[@dowdiness/canopy/core.SourceMap])
+pub fn build_lambda_projection_memos(@pipeline.Parser[@ast.Term], identity_hints? : @core.IdentityHintConsumer, trace_ref? : @ref.Ref[Array[@core.ReconcileTraceEvent]]?) -> (@cells.Derived[@core.ProjNode[@ast.Term]?], @cells.Derived[Map[@core.NodeId, @core.ProjNode[@ast.Term]]], @cells.Derived[@core.SourceMap])
 
 pub fn module_name_role(Int) -> String
 
-pub fn parse_to_proj_node(@diagnostic.SourceId, String) -> (@dowdiness/canopy/core.ProjNode[@ast.Term], Array[String]) raise @dowdiness/loom/core.LexError
+pub fn parse_to_proj_node(@diagnostic.SourceId, String) -> (@core.ProjNode[@ast.Term], Array[String]) raise
 
-pub fn populate_token_spans(@dowdiness/canopy/core.SourceMap, @seam.SyntaxNode, @dowdiness/canopy/core.ProjNode[@ast.Term]) -> Unit
+pub fn populate_token_spans(@core.SourceMap, @seam.SyntaxNode, @core.ProjNode[@ast.Term]) -> Unit
 
-pub fn rebuild_kind(@ast.Term, Array[@dowdiness/canopy/core.ProjNode[@ast.Term]]) -> @ast.Term
+pub fn rebuild_kind(@ast.Term, Array[@core.ProjNode[@ast.Term]]) -> @ast.Term
 
-pub fn syntax_to_proj_node(@seam.SyntaxNode, @ref.Ref[Int]) -> @dowdiness/canopy/core.ProjNode[@ast.Term]
+pub fn syntax_to_proj_node(@seam.SyntaxNode, @ref.Ref[Int]) -> @core.ProjNode[@ast.Term]
 
 pub fn term_css_class(@ast.Term) -> String
 
 pub fn term_kind_tag(@ast.Term) -> String
 
-pub fn to_proj_node(@seam.SyntaxNode, @ref.Ref[Int]) -> @dowdiness/canopy/core.ProjNode[@ast.Term]
+pub fn to_proj_node(@seam.SyntaxNode, @ref.Ref[Int]) -> @core.ProjNode[@ast.Term]
 
 // Errors
 
@@ -49,9 +50,9 @@ pub fn to_proj_node(@seam.SyntaxNode, @ref.Ref[Int]) -> @dowdiness/canopy/core.P
 pub struct DefinitionIndex {
   // private fields
 }
-pub fn DefinitionIndex::binding_for_node(Self, @dowdiness/canopy/core.NodeId) -> (@dowdiness/canopy/core.NodeId, Int)?
-pub fn DefinitionIndex::cutoff_at_node(Self, @dowdiness/canopy/core.SourceMap, @dowdiness/canopy/core.NodeId) -> Int
-pub fn DefinitionIndex::from_proj_node(@dowdiness/canopy/core.ProjNode[@ast.Term]) -> Self
+pub fn DefinitionIndex::binding_for_node(Self, @core.NodeId) -> (@core.NodeId, Int)?
+pub fn DefinitionIndex::cutoff_at_node(Self, @core.SourceMap, @core.NodeId) -> Int
+pub fn DefinitionIndex::from_proj_node(@core.ProjNode[@ast.Term]) -> Self
 pub fn DefinitionIndex::length(Self) -> Int
 
 // Type aliases

--- a/modules/canopy/lang/lambda/proj/proj_node.mbt
+++ b/modules/canopy/lang/lambda/proj/proj_node.mbt
@@ -486,7 +486,7 @@ pub fn rebuild_kind(
 pub fn parse_to_proj_node(
   source_id : @loomcore.SourceId,
   text : String,
-) -> (ProjNode[@ast.Term], Array[String]) raise @loomcore.LexError {
+) -> (ProjNode[@ast.Term], Array[String]) raise {
   let (cst, diagnostics) = @parser.parse_cst(source_id, text)
   let syntax_node = @seam.SyntaxNode::from_cst(cst)
   let errors = diagnostics.map(diagnostic => diagnostic.message())

--- a/modules/canopy/lang/markdown/companion/markdown_companion.mbt
+++ b/modules/canopy/lang/markdown/companion/markdown_companion.mbt
@@ -10,7 +10,7 @@ pub fn new_markdown_editor(
   agent_id : String,
   capture_timeout_ms? : Int = 500,
   parent_runtime? : @incr.Runtime,
-) -> @editor.SyncEditor[@markdown.Block] raise @text.TextError {
+) -> @editor.SyncEditor[@markdown.Block] raise {
   let (editor, _) = md_lang_plain.build(
     agent_id,
     capture_timeout_ms~,
@@ -27,7 +27,7 @@ pub fn new_markdown_editor_with_semantic_attachment(
   agent_id : String,
   capture_timeout_ms? : Int = 500,
   parent_runtime? : @incr.Runtime,
-) -> (@editor.SyncEditor[@markdown.Block], @markdown.MarkdownSemanticAttachment) raise @text.TextError {
+) -> (@editor.SyncEditor[@markdown.Block], @markdown.MarkdownSemanticAttachment) raise {
   let (editor, attachment) = make_md_lang(true).build(
     agent_id,
     capture_timeout_ms~,
@@ -119,8 +119,11 @@ pub fn export_markdown_text(
   editor : @editor.SyncEditor[@markdown.Block],
 ) -> String {
   let src = editor.get_text()
-  guard editor.get_proj_node() is Some(root) else { return src }
-  let source_map = editor.get_source_map()
+  let root = editor.get_proj_node() catch { Failure::Failure(_) => return src }
+  guard root is Some(root) else { return src }
+  let source_map = editor.get_source_map() catch {
+    Failure::Failure(_) => return src
+  }
   let ranges : Array[(Int, Int)] = []
   collect_zwsp_ranges(root, source_map, ranges)
   if ranges.is_empty() {
@@ -183,7 +186,7 @@ pub fn apply_markdown_edit(
   editor : @editor.SyncEditor[@markdown.Block],
   op : @md_edits.MarkdownEditOp,
   timestamp_ms : Int,
-) -> Result[Unit, String] {
+) -> Result[Unit, String] raise {
   match md_lang_plain.apply_edit(editor, op, timestamp_ms) {
     Ok(_) => Ok(())
     Err(e) => Err(e.message())

--- a/modules/canopy/lang/markdown/companion/moon.pkg
+++ b/modules/canopy/lang/markdown/companion/moon.pkg
@@ -5,7 +5,6 @@ import {
   "dowdiness/canopy/lang/markdown/proj" @md_proj,
   "dowdiness/canopy/lang/markdown/sentinel" @md_sentinel,
   "dowdiness/canopy/lang/runtime" @lang_runtime,
-  "dowdiness/event-graph-walker/text",
   "dowdiness/incr",
   "dowdiness/markdown",
   "dowdiness/loom",

--- a/modules/canopy/lang/markdown/companion/pkg.generated.mbti
+++ b/modules/canopy/lang/markdown/companion/pkg.generated.mbti
@@ -4,19 +4,18 @@ package "dowdiness/canopy/lang/markdown/companion"
 import {
   "dowdiness/canopy/editor",
   "dowdiness/canopy/lang/markdown/edits",
-  "dowdiness/event-graph-walker/text",
   "dowdiness/incr/cells",
   "dowdiness/markdown",
 }
 
 // Values
-pub fn apply_markdown_edit(@editor.SyncEditor[@markdown.Block], @edits.MarkdownEditOp, Int) -> Result[Unit, String]
+pub fn apply_markdown_edit(@editor.SyncEditor[@markdown.Block], @edits.MarkdownEditOp, Int) -> Result[Unit, String] raise
 
 pub fn export_markdown_text(@editor.SyncEditor[@markdown.Block]) -> String
 
-pub fn new_markdown_editor(String, capture_timeout_ms? : Int, parent_runtime? : @cells.Runtime) -> @editor.SyncEditor[@markdown.Block] raise @text.TextError
+pub fn new_markdown_editor(String, capture_timeout_ms? : Int, parent_runtime? : @cells.Runtime) -> @editor.SyncEditor[@markdown.Block] raise
 
-pub fn new_markdown_editor_with_semantic_attachment(String, capture_timeout_ms? : Int, parent_runtime? : @cells.Runtime) -> (@editor.SyncEditor[@markdown.Block], @markdown.MarkdownSemanticAttachment) raise @text.TextError
+pub fn new_markdown_editor_with_semantic_attachment(String, capture_timeout_ms? : Int, parent_runtime? : @cells.Runtime) -> (@editor.SyncEditor[@markdown.Block], @markdown.MarkdownSemanticAttachment) raise
 
 // Errors
 

--- a/modules/canopy/lang/markdown/companion/sdeg_edit_path_wbtest.mbt
+++ b/modules/canopy/lang/markdown/companion/sdeg_edit_path_wbtest.mbt
@@ -34,9 +34,9 @@ fn heading_edit_path_observations(
   editor : @editor.SyncEditor[@markdown.Block],
 ) -> Array[HeadingEditPathObservation] {
   let observations : Array[HeadingEditPathObservation] = []
-  let root = editor.get_proj_node().unwrap()
+  let root = (try! editor.get_proj_node()).unwrap()
   let source = editor.get_text()
-  let source_map = editor.get_source_map()
+  let source_map = try! editor.get_source_map()
   for child in root.children {
     match heading_edit_path_observation(child, source, source_map) {
       Some(obs) => observations.push(obs)

--- a/modules/canopy/lang/markdown/edits/compute_markdown_edit_wbtest.mbt
+++ b/modules/canopy/lang/markdown/edits/compute_markdown_edit_wbtest.mbt
@@ -9,14 +9,18 @@ let markdown_edit_test_source : @loomcore.SourceId = @loomcore.SourceId(
 fn compute_edit_result(
   source : String,
   op : MarkdownEditOp,
-) -> (Array[SpanEdit], FocusHint)? raise @core.EditError {
+) -> (Array[SpanEdit], FocusHint)? raise {
   let (proj, _) = @md_proj.parse_to_proj_node(markdown_edit_test_source, source) catch {
+    Failure::Failure(_) as failure => raise failure
     @loomcore.LexError(msg) => raise @core.EditError::ParseFailed(detail=msg)
+    error => raise error
   }
   let source_map = @core.SourceMap::from_ast(proj)
   // Re-parse to get the SyntaxNode for populate_token_spans
   let (cst, _) = @markdown.parse_cst(markdown_edit_test_source, source) catch {
+    Failure::Failure(_) as failure => raise failure
     @loomcore.LexError(msg) => raise @core.EditError::ParseFailed(detail=msg)
+    error => raise error
   }
   let syntax_root = @seam.SyntaxNode::from_cst(cst)
   @md_proj.populate_token_spans(source_map, syntax_root, proj)
@@ -25,10 +29,7 @@ fn compute_edit_result(
 
 ///|
 /// Helper: parse, project, populate token spans, compute edit, return new source text.
-fn apply_edit(
-  source : String,
-  op : MarkdownEditOp,
-) -> String raise @core.EditError {
+fn apply_edit(source : String, op : MarkdownEditOp) -> String raise {
   match compute_edit_result(source, op) {
     Some((edits, _)) => {
       let sorted = edits.copy()
@@ -69,7 +70,20 @@ fn inspect_edit_error_contains(
     let _ = compute_edit_result(source, op)
     "no error"
   } catch {
-    e => e.message()
+    Failure::Failure(_) => "Failure"
+    @core.EditError::ProjectionUnavailable as error => error.message()
+    @core.EditError::NodeNotFound(..) as error => error.message()
+    @core.EditError::NodeNotInSourceMap(..) as error => error.message()
+    @core.EditError::NodeNotInRegistry(..) as error => error.message()
+    @core.EditError::BindingNotFound(..) as error => error.message()
+    @core.EditError::InvalidTarget(..) as error => error.message()
+    @core.EditError::UnsupportedOperation(..) as error => error.message()
+    @core.EditError::CaptureViolation(..) as error => error.message()
+    @core.EditError::ScopeViolation(..) as error => error.message()
+    @core.EditError::ParseFailed(..) as error => error.message()
+    @core.EditError::SourceSpanMissing(..) as error => error.message()
+    @core.EditError::Invariant(..) as error => error.message()
+    _ => "unknown error"
   }
   inspect(msg.contains(fragment.view()), content="true")
 }

--- a/modules/canopy/lang/markdown/proj/pkg.generated.mbti
+++ b/modules/canopy/lang/markdown/proj/pkg.generated.mbti
@@ -2,6 +2,7 @@
 package "dowdiness/canopy/lang/markdown/proj"
 
 import {
+  "dowdiness/canopy/core",
   "dowdiness/canopy/protocol",
   "dowdiness/diagnostic",
   "dowdiness/incr/cells",
@@ -12,15 +13,15 @@ import {
 }
 
 // Values
-pub fn build_markdown_projection_memos(@pipeline.Parser[@markdown.Block], identity_hints? : @dowdiness/canopy/core.IdentityHintConsumer) -> (@cells.Derived[@dowdiness/canopy/core.ProjNode[@markdown.Block]?], @cells.Derived[Map[@dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.ProjNode[@markdown.Block]]], @cells.Derived[@dowdiness/canopy/core.SourceMap])
+pub fn build_markdown_projection_memos(@pipeline.Parser[@markdown.Block], identity_hints? : @core.IdentityHintConsumer) -> (@cells.Derived[@core.ProjNode[@markdown.Block]?], @cells.Derived[Map[@core.NodeId, @core.ProjNode[@markdown.Block]]], @cells.Derived[@core.SourceMap])
 
-pub fn parse_to_proj_node(@diagnostic.SourceId, String) -> (@dowdiness/canopy/core.ProjNode[@markdown.Block], Array[String]) raise @dowdiness/loom/core.LexError
+pub fn parse_to_proj_node(@diagnostic.SourceId, String) -> (@core.ProjNode[@markdown.Block], Array[String]) raise
 
-pub fn populate_token_spans(@dowdiness/canopy/core.SourceMap, @seam.SyntaxNode, @dowdiness/canopy/core.ProjNode[@markdown.Block]) -> Unit
+pub fn populate_token_spans(@core.SourceMap, @seam.SyntaxNode, @core.ProjNode[@markdown.Block]) -> Unit
 
-pub fn proj_to_view_node(@dowdiness/canopy/core.ProjNode[@markdown.Block], @dowdiness/canopy/core.SourceMap, annotations? : Map[@dowdiness/canopy/core.NodeId, Array[@protocol.ViewAnnotation]], source_text? : String?) -> @protocol.ViewNode
+pub fn proj_to_view_node(@core.ProjNode[@markdown.Block], @core.SourceMap, annotations? : Map[@core.NodeId, Array[@protocol.ViewAnnotation]], source_text? : String?) -> @protocol.ViewNode
 
-pub fn syntax_to_proj_node(@seam.SyntaxNode, @ref.Ref[Int]) -> @dowdiness/canopy/core.ProjNode[@markdown.Block]
+pub fn syntax_to_proj_node(@seam.SyntaxNode, @ref.Ref[Int]) -> @core.ProjNode[@markdown.Block]
 
 // Errors
 

--- a/modules/canopy/lang/markdown/proj/proj_node.mbt
+++ b/modules/canopy/lang/markdown/proj/proj_node.mbt
@@ -9,7 +9,7 @@
 pub fn parse_to_proj_node(
   source_id : @loomcore.SourceId,
   text : String,
-) -> (@core.ProjNode[@markdown.Block], Array[String]) raise @loomcore.LexError {
+) -> (@core.ProjNode[@markdown.Block], Array[String]) raise {
   let (cst, diagnostics) = @markdown.parse_cst(source_id, text)
   let syntax_node = @seam.SyntaxNode::from_cst(cst)
   let errors = diagnostics.map(d => d.message())

--- a/modules/canopy/lang/markdown/proj/sdeg_heading_spike_wbtest.mbt
+++ b/modules/canopy/lang/markdown/proj/sdeg_heading_spike_wbtest.mbt
@@ -49,7 +49,7 @@ struct HeadingSemanticMatch {
 fn source_map_for(
   source : String,
   proj : @core.ProjNode[@markdown.Block],
-) -> @core.SourceMap raise @loomcore.LexError {
+) -> @core.SourceMap raise {
   let source_map = @core.SourceMap::from_ast(proj)
   let (cst, _) = @markdown.parse_cst(markdown_heading_spike_test_source, source)
   let syntax_root = @seam.SyntaxNode::from_cst(cst)
@@ -60,7 +60,7 @@ fn source_map_for(
 ///|
 fn project_source(
   source : String,
-) -> (@core.ProjNode[@markdown.Block], @core.SourceMap) raise @loomcore.LexError {
+) -> (@core.ProjNode[@markdown.Block], @core.SourceMap) raise {
   let (proj, _) = parse_to_proj_node(markdown_heading_spike_test_source, source)
   (proj, source_map_for(source, proj))
 }
@@ -70,7 +70,7 @@ fn project_after_reconcile(
   old : @core.ProjNode[@markdown.Block],
   next_source : String,
   counter : Ref[Int],
-) -> (@core.ProjNode[@markdown.Block], @core.SourceMap) raise @loomcore.LexError {
+) -> (@core.ProjNode[@markdown.Block], @core.SourceMap) raise {
   let (cst, _) = @markdown.parse_cst(
     markdown_heading_spike_test_source, next_source,
   )

--- a/modules/canopy/lang/runtime/language.mbt
+++ b/modules/canopy/lang/runtime/language.mbt
@@ -75,7 +75,7 @@ pub(all) enum EditResult {
 /// pipeline closures from the freshly constructed `E` — this ordering (data
 /// before behavior) is what eliminates construction-time Ref side-channels.
 pub struct Language[T, Op, E] {
-  priv parse : (@loom_core.SourceId, String, @incr.Runtime?) -> @loom.Parser[T]
+  priv parse : (@loom_core.SourceId, String, @incr.Runtime?) -> @loom.Parser[T] raise Failure
   priv project : (@loom.Parser[T], @core.IdentityHintConsumer) -> (
     @incr.Derived[@core.ProjNode[T]?],
     @incr.Derived[Map[@core.NodeId, @core.ProjNode[T]]],
@@ -88,7 +88,7 @@ pub struct Language[T, Op, E] {
 
 ///|
 pub fn[T, Op, E] Language::Language(
-  parse~ : (@loom_core.SourceId, String, @incr.Runtime?) -> @loom.Parser[T],
+  parse~ : (@loom_core.SourceId, String, @incr.Runtime?) -> @loom.Parser[T] raise Failure,
   project~ : (@loom.Parser[T], @core.IdentityHintConsumer) -> (
     @incr.Derived[@core.ProjNode[T]?],
     @incr.Derived[Map[@core.NodeId, @core.ProjNode[T]]],
@@ -111,7 +111,7 @@ pub fn[T, Op, E] Language::build(
   agent_id : String,
   capture_timeout_ms? : Int = 500,
   parent_runtime? : @incr.Runtime,
-) -> (@editor.SyncEditor[T], E) raise @text.TextError {
+) -> (@editor.SyncEditor[T], E) raise {
   @editor.SyncEditor::new_with_builder(
     agent_id,
     self.parse,
@@ -148,29 +148,36 @@ pub fn[T : Eq, Op, E] Language::apply_edit(
   editor : @editor.SyncEditor[T],
   op : Op,
   timestamp_ms : Int,
-) -> Result[Array[@core.SpanEdit], @core.EditError] {
-  try {
-    guard editor.get_proj_node() is Some(proj) else {
-      raise @core.EditError::ProjectionUnavailable
-    }
-    let ctx : EditContext[T] = {
-      source_text: editor.get_text(),
-      source_map: editor.get_source_map(),
-      registry: editor.get_registry(),
-      proj_node: proj,
-    }
-    match (self.edit)(op, ctx) {
-      Edits(edits, focus_hint, hint) => {
-        editor.apply_span_edits(edits, focus_hint, timestamp_ms, hint?)
-        Ok(edits)
+) -> Result[Array[@core.SpanEdit], @core.EditError] raise Failure {
+  let projection = editor.get_proj_node()
+  let source_map = editor.get_source_map()
+  let registry = editor.get_registry()
+  let computed : Result[EditResult, @core.EditError] = Ok(
+    {
+      guard projection is Some(proj) else {
+        raise @core.EditError::ProjectionUnavailable
       }
-      NoEdit => Ok([])
-    }
-  } catch {
-    @core.EditError::InvalidTarget(detail~) => {
+      let ctx : EditContext[T] = {
+        source_text: editor.get_text(),
+        source_map,
+        registry,
+        proj_node: proj,
+      }
+      (self.edit)(op, ctx)
+    },
+  ) catch {
+    error => Err(error)
+  }
+  match computed {
+    Err(@core.EditError::InvalidTarget(detail~)) => {
       editor.invalidate_pending_identity_hints()
       Err(@core.EditError::InvalidTarget(detail~))
     }
-    e => Err(e)
+    Err(error) => Err(error)
+    Ok(Edits(edits, focus_hint, hint)) => {
+      editor.apply_span_edits(edits, focus_hint, timestamp_ms, hint?)
+      Ok(edits)
+    }
+    Ok(NoEdit) => Ok([])
   }
 }

--- a/modules/canopy/lang/runtime/moon.pkg
+++ b/modules/canopy/lang/runtime/moon.pkg
@@ -1,7 +1,6 @@
 import {
   "dowdiness/canopy/core",
   "dowdiness/canopy/editor",
-  "dowdiness/event-graph-walker/text",
   "dowdiness/incr",
   "dowdiness/loom",
   "dowdiness/loom/core" @loom_core,

--- a/modules/canopy/lang/runtime/pkg.generated.mbti
+++ b/modules/canopy/lang/runtime/pkg.generated.mbti
@@ -4,7 +4,6 @@ package "dowdiness/canopy/lang/runtime"
 import {
   "dowdiness/canopy/editor",
   "dowdiness/diagnostic",
-  "dowdiness/event-graph-walker/text",
   "dowdiness/incr/cells",
   "dowdiness/loom/pipeline",
 }
@@ -30,9 +29,9 @@ pub(all) enum EditResult {
 pub struct Language[T, Op, E] {
   // private fields
 }
-pub fn[T, Op, E] Language::Language(parse~ : (@diagnostic.SourceId, String, @cells.Runtime?) -> @pipeline.Parser[T], project~ : (@pipeline.Parser[T], @dowdiness/canopy/core.IdentityHintConsumer) -> (@cells.Derived[@dowdiness/canopy/core.ProjNode[T]?], @cells.Derived[Map[@dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.ProjNode[T]]], @cells.Derived[@dowdiness/canopy/core.SourceMap], E), edit~ : (Op, EditContext[T]) -> EditResult raise @dowdiness/canopy/core.EditError, capabilities~ : (E) -> @editor.LanguageCapabilities[T]) -> Self[T, Op, E]
-pub fn[T : Eq, Op, E] Language::apply_edit(Self[T, Op, E], @editor.SyncEditor[T], Op, Int) -> Result[Array[@dowdiness/canopy/core.SpanEdit], @dowdiness/canopy/core.EditError]
-pub fn[T, Op, E] Language::build(Self[T, Op, E], String, capture_timeout_ms? : Int, parent_runtime? : @cells.Runtime) -> (@editor.SyncEditor[T], E) raise @text.TextError
+pub fn[T, Op, E] Language::Language(parse~ : (@diagnostic.SourceId, String, @cells.Runtime?) -> @pipeline.Parser[T] raise Failure, project~ : (@pipeline.Parser[T], @dowdiness/canopy/core.IdentityHintConsumer) -> (@cells.Derived[@dowdiness/canopy/core.ProjNode[T]?], @cells.Derived[Map[@dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.ProjNode[T]]], @cells.Derived[@dowdiness/canopy/core.SourceMap], E), edit~ : (Op, EditContext[T]) -> EditResult raise @dowdiness/canopy/core.EditError, capabilities~ : (E) -> @editor.LanguageCapabilities[T]) -> Self[T, Op, E]
+pub fn[T : Eq, Op, E] Language::apply_edit(Self[T, Op, E], @editor.SyncEditor[T], Op, Int) -> Result[Array[@dowdiness/canopy/core.SpanEdit], @dowdiness/canopy/core.EditError] raise Failure
+pub fn[T, Op, E] Language::build(Self[T, Op, E], String, capture_timeout_ms? : Int, parent_runtime? : @cells.Runtime) -> (@editor.SyncEditor[T], E) raise
 
 // Type aliases
 

--- a/modules/canopy/workspace/probe/gate1_runtime_safety_wbtest.mbt
+++ b/modules/canopy/workspace/probe/gate1_runtime_safety_wbtest.mbt
@@ -62,7 +62,7 @@ let next_probe_source_identity : Ref[Int] = { val: 0 }
 fn json_parser_on(
   rt : @incr.Runtime,
   source : String,
-) -> @loom.Parser[@_json_lang.JsonValue] {
+) -> @loom.Parser[@_json_lang.JsonValue] raise {
   let identity = next_probe_source_identity.val
   next_probe_source_identity.val = identity + 1
   @loom.new_parser(

--- a/modules/canopy/workspace/probe/gate4_divergence_wbtest.mbt
+++ b/modules/canopy/workspace/probe/gate4_divergence_wbtest.mbt
@@ -39,8 +39,8 @@ fn count_kind_mismatches(
   editor_a : @editor.SyncEditor[@_json_lang.JsonValue],
   editor_b : @editor.SyncEditor[@_json_lang.JsonValue],
 ) -> Int {
-  let reg_a = editor_a.get_registry()
-  let reg_b = editor_b.get_registry()
+  let reg_a = try! editor_a.get_registry()
+  let reg_b = try! editor_b.get_registry()
   let ids_a : Array[@core.NodeId] = reg_a.keys().to_array()
   ids_a
   .iter()
@@ -58,8 +58,8 @@ fn count_keys_only_in_a(
   editor_a : @editor.SyncEditor[@_json_lang.JsonValue],
   editor_b : @editor.SyncEditor[@_json_lang.JsonValue],
 ) -> Int {
-  let reg_a = editor_a.get_registry()
-  let reg_b = editor_b.get_registry()
+  let reg_a = try! editor_a.get_registry()
+  let reg_b = try! editor_b.get_registry()
   reg_a.keys().iter().filter(fn(id) { reg_b.get(id) is None }).count()
 }
 

--- a/modules/canopy/workspace/probe/moon.pkg
+++ b/modules/canopy/workspace/probe/moon.pkg
@@ -2,10 +2,11 @@ import {
   "dowdiness/canopy/editor",
   "dowdiness/canopy/core",
   "dowdiness/diagnostic",
-  "dowdiness/event-graph-walker/text",
   "dowdiness/incr",
   "dowdiness/loom",
   "dowdiness/loom/core" @loomcore,
+  "dowdiness/loom/incremental" @loom_incremental,
+  "dowdiness/loom/pipeline" @loom_pipeline,
   "dowdiness/seam",
   "moonbitlang/core/debug",
 }

--- a/modules/canopy/workspace/probe/new_with_builder_wbtest.mbt
+++ b/modules/canopy/workspace/probe/new_with_builder_wbtest.mbt
@@ -28,3 +28,30 @@ test "new_with_builder returns the language-owned extras E" {
   let _ = editor.get_proj_node()
   inspect(editor.get_text(), content="f(x) y")
 }
+
+///|
+/// Parser construction defects are part of the Loom contract. The generic
+/// editor constructor must preserve the exact Failure instead of translating
+/// it into TextError.
+test "new_with_builder preserves parser construction Failure" {
+  let result : Result[Unit, Error] = Ok(
+    {
+      let _ : (@editor.SyncEditor[TestExpr], Unit) = @editor.SyncEditor::new_with_builder(
+        "test",
+        (_source_id, _source, _runtime) => {
+          fail("injected parser construction failure")
+        },
+        fn(_parser, _channel) { abort("projection builder must not run") },
+      )
+      ()
+    },
+  ) catch {
+    error => Err(error)
+  }
+  match result {
+    Err(Failure::Failure(detail)) =>
+      assert_true(detail.contains("injected parser construction failure"))
+    Err(_) => fail("expected parser construction Failure")
+    Ok(_) => fail("expected parser construction Failure")
+  }
+}

--- a/modules/canopy/workspace/probe/pkg.generated.mbti
+++ b/modules/canopy/workspace/probe/pkg.generated.mbti
@@ -3,18 +3,19 @@ package "dowdiness/canopy/workspace/probe"
 
 import {
   "dowdiness/canopy/editor",
-  "dowdiness/event-graph-walker/text",
   "dowdiness/incr/cells",
   "dowdiness/loom/core",
   "moonbitlang/core/debug",
 }
 
 // Values
-pub fn get_test_ast(@editor.SyncEditor[TestExpr]) -> TestExpr
+pub fn get_test_ast(@editor.SyncEditor[TestExpr]) -> TestExpr raise Failure
 
-pub fn new_empty_diagnostic_test_editor(String) -> @editor.SyncEditor[TestExpr] raise @text.TextError
+pub fn new_empty_diagnostic_test_editor(String) -> @editor.SyncEditor[TestExpr] raise
 
-pub fn new_test_editor(String, capture_timeout_ms? : Int, parent_runtime? : @cells.Runtime) -> @editor.SyncEditor[TestExpr] raise @text.TextError
+pub fn new_parser_failure_test_editor(String) -> @editor.SyncEditor[TestExpr] raise
+
+pub fn new_test_editor(String, capture_timeout_ms? : Int, parent_runtime? : @cells.Runtime) -> @editor.SyncEditor[TestExpr] raise
 
 // Errors
 

--- a/modules/canopy/workspace/probe/test_grammar.mbt
+++ b/modules/canopy/workspace/probe/test_grammar.mbt
@@ -145,6 +145,7 @@ fn lex_test_expr(
       _ => i = i + 1
     }
   }
+  located.push(@loomcore.LocatedToken::LocatedToken(Eof, start=n, end=n))
   @loomcore.LexResult::from_located_tokens(
     source_id,
     source,
@@ -350,7 +351,7 @@ pub fn new_test_editor(
   agent_id : String,
   capture_timeout_ms? : Int = 500,
   parent_runtime? : @incr.Runtime,
-) -> @editor.SyncEditor[TestExpr] raise @text.TextError {
+) -> @editor.SyncEditor[TestExpr] raise {
   let (editor, _) = @editor.SyncEditor::new_with_builder(
     agent_id,
     (source_id, source, runtime) => {
@@ -369,7 +370,7 @@ pub fn new_test_editor(
 /// consumers to verify that they do not suppress diagnostics by source length.
 pub fn new_empty_diagnostic_test_editor(
   agent_id : String,
-) -> @editor.SyncEditor[TestExpr] raise @text.TextError {
+) -> @editor.SyncEditor[TestExpr] raise {
   let (editor, _) = @editor.SyncEditor::new_with_builder(
     agent_id,
     (source_id, source, runtime) => {
@@ -386,9 +387,46 @@ pub fn new_empty_diagnostic_test_editor(
 }
 
 ///|
+/// Construct a parser whose initial parse succeeds and whose first incremental
+/// publication raises Failure after Loom has accepted the engine source. This
+/// is test infrastructure for Canopy's terminal-parser contract; production
+/// languages never expose a failure switch.
+pub fn new_parser_failure_test_editor(
+  agent_id : String,
+) -> @editor.SyncEditor[TestExpr] raise {
+  let full_parse = fn(
+    _source_id : @loomcore.SourceId,
+    _source : String,
+  ) raise Failure {
+    let cst = @seam.CstNode::new_unclassified(
+      @seam.ToRawKind::to_raw(RootNode),
+      [],
+    )
+    (@seam.SyntaxNode::from_cst(cst), @loomcore.DiagnosticSet::empty(), 0)
+  }
+  let language = @loom_incremental.ImperativeLanguage::new(
+    full_parse~,
+    incremental_parse=fn(_source_id, _source, _old, _edit) raise Failure {
+      fail("injected parser publication failure")
+    },
+    to_ast=_syntax => Branch("", []),
+  )
+  let (editor, _) = @editor.SyncEditor::new_with_builder(
+    agent_id,
+    (source_id, source, runtime) => {
+      @loom_pipeline.Parser::new(source_id, source, language, runtime?)
+    },
+    build_test_editor_parts,
+  )
+  editor
+}
+
+///|
 /// Read the parsed TestExpr AST (the fold result); empty source yields the
 /// empty document Branch("", []).
-pub fn get_test_ast(editor : @editor.SyncEditor[TestExpr]) -> TestExpr {
+pub fn get_test_ast(
+  editor : @editor.SyncEditor[TestExpr],
+) -> TestExpr raise Failure {
   match editor.get_tree() {
     Some(ast) => ast
     None => Branch("", [])

--- a/modules/dom-boundary/dom_boundary.mbt
+++ b/modules/dom-boundary/dom_boundary.mbt
@@ -15,6 +15,9 @@ pub(all) enum DomAction {
   WriteTextSelection
   MeasureElement
   DispatchCustomEvent
+  CopyText
+  DownloadText
+  Reload
   ListenCustomEvent
   RemoveCustomEventListener
 } derive(Debug, Eq)
@@ -265,6 +268,39 @@ pub fn measure_element_selector(
   selector : String,
 ) -> ElementMeasurement raise DomBoundaryError {
   measure_element_target(LOOKUP_SELECTOR, selector, Selector(selector))
+}
+
+///|
+/// Copy exact text through the host clipboard boundary.
+pub fn copy_text(text : String) -> Unit raise DomBoundaryError {
+  let target = EventSubscription
+  guard !js_document_unavailable() else { raise DocumentUnavailable }
+  guard js_copy_text(text) else {
+    raise UnsupportedAction(action=CopyText, target~)
+  }
+}
+
+///|
+/// Download exact text as a named file through the host DOM boundary.
+pub fn download_text(
+  filename : String,
+  text : String,
+) -> Unit raise DomBoundaryError {
+  let target = EventSubscription
+  guard !js_document_unavailable() else { raise DocumentUnavailable }
+  guard js_download_text(filename, text) else {
+    raise ActionFailed(action=DownloadText, target~, detail="download failed")
+  }
+}
+
+///|
+/// Explicitly reload the host page.
+pub fn reload() -> Unit raise DomBoundaryError {
+  let target = EventSubscription
+  guard !js_document_unavailable() else { raise DocumentUnavailable }
+  guard js_reload() else {
+    raise ActionFailed(action=Reload, target~, detail="reload failed")
+  }
 }
 
 ///|

--- a/modules/dom-boundary/dom_boundary_runtime.mbt
+++ b/modules/dom-boundary/dom_boundary_runtime.mbt
@@ -505,6 +505,9 @@ fn DomAction::describe(self : DomAction) -> String {
     WriteTextSelection => "writeTextSelection"
     MeasureElement => "measureElement"
     DispatchCustomEvent => "dispatchCustomEvent"
+    CopyText => "copyText"
+    DownloadText => "downloadText"
+    Reload => "reload"
     ListenCustomEvent => "listenCustomEvent"
     RemoveCustomEventListener => "removeCustomEventListener"
   }
@@ -566,6 +569,53 @@ extern "js" fn dom_status_element(status : DomStatus) -> DomElement =
 ///|
 extern "js" fn js_document_unavailable() -> Bool =
   #| () => typeof document === "undefined"
+
+///|
+extern "js" fn js_copy_text(text : String) -> Bool =
+  #| (text) => {
+  #|   try {
+  #|     const field = document.createElement("textarea");
+  #|     field.value = text;
+  #|     field.setAttribute("readonly", "");
+  #|     field.style.position = "fixed";
+  #|     field.style.opacity = "0";
+  #|     document.body.appendChild(field);
+  #|     field.select();
+  #|     const copied = document.execCommand("copy");
+  #|     field.remove();
+  #|     return copied;
+  #|   } catch (_) {
+  #|     return false;
+  #|   }
+  #| }
+
+///|
+extern "js" fn js_download_text(filename : String, text : String) -> Bool =
+  #| (filename, text) => {
+  #|   try {
+  #|     const blob = new Blob([text], { type: "text/markdown;charset=utf-8" });
+  #|     const url = URL.createObjectURL(blob);
+  #|     const link = document.createElement("a");
+  #|     link.href = url;
+  #|     link.download = filename;
+  #|     link.click();
+  #|     URL.revokeObjectURL(url);
+  #|     return true;
+  #|   } catch (_) {
+  #|     return false;
+  #|   }
+  #| }
+
+///|
+extern "js" fn js_reload() -> Bool =
+  #| () => {
+  #|   try {
+  #|     globalThis.location.reload();
+  #|     return true;
+  #|   } catch (_) {
+  #|     return false;
+  #|   }
+  #| }
 
 ///|
 extern "js" fn js_get_element_by_id(

--- a/modules/dom-boundary/pkg.generated.mbti
+++ b/modules/dom-boundary/pkg.generated.mbti
@@ -10,9 +10,13 @@ pub fn click_id(String) -> Unit raise DomBoundaryError
 
 pub fn click_selector(String) -> Unit raise DomBoundaryError
 
+pub fn copy_text(String) -> Unit raise DomBoundaryError
+
 pub fn dispatch_custom_event_id(String, String, detail? : String, bubbles? : Bool, composed? : Bool) -> Unit raise DomBoundaryError
 
 pub fn dispatch_custom_event_selector(String, String, detail? : String, bubbles? : Bool, composed? : Bool) -> Unit raise DomBoundaryError
+
+pub fn download_text(String, String) -> Unit raise DomBoundaryError
 
 pub fn focus_id(String) -> Unit raise DomBoundaryError
 
@@ -33,6 +37,8 @@ pub fn measure_element_selector(String) -> ElementMeasurement raise DomBoundaryE
 pub fn read_text_selection_id(String) -> TextSelection raise DomBoundaryError
 
 pub fn read_text_selection_selector(String) -> TextSelection raise DomBoundaryError
+
+pub fn reload() -> Unit raise DomBoundaryError
 
 pub fn scroll_id(String, behavior? : ScrollBehavior, block? : ScrollBlock) -> Unit raise DomBoundaryError
 
@@ -74,6 +80,9 @@ pub(all) enum DomAction {
   WriteTextSelection
   MeasureElement
   DispatchCustomEvent
+  CopyText
+  DownloadText
+  Reload
   ListenCustomEvent
   RemoveCustomEventListener
 } derive(Eq, @debug.Debug)

--- a/scripts/check-ffi-consumers.sh
+++ b/scripts/check-ffi-consumers.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+# CI gate for the TypeScript consumers of the Canopy FFI artifacts.
+# When the FFI, shared adapter, or any direct TypeScript consumer changes,
+# run the same install + check/build fan-out as the web-build CI jobs so drift
+# in the generated JS/TS surfaces is caught before merge.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+base_ref="${1:-origin/main}"
+
+cd "$PROJECT_ROOT"
+
+if git diff --quiet "$base_ref...HEAD" -- \
+  modules/canopy/ffi \
+  apps/canvas/main \
+  adapters/editor \
+  apps/web \
+  apps/ideal/web \
+  apps/canvas/web \
+  apps/block-editor/web \
+  apps/relay-server \
+  examples/demo-react \
+  examples/prosemirror
+then
+  echo "check-ffi-consumers: no changes under $base_ref...HEAD in FFI consumers; skipping"
+  exit 0
+fi
+
+run_consumer() {
+  local label="$1"
+  local prefix="$2"
+  local script="$3"
+
+  echo "==> [$label] npm --prefix $prefix ci"
+  npm --prefix "$prefix" ci
+  echo "==> [$label] npm --prefix $prefix run $script"
+  npm --prefix "$prefix" run "$script"
+}
+
+run_consumer "adapter" "adapters/editor" "test:unit"
+echo "==> [adapter] npm --prefix adapters/editor run typecheck:cm6"
+npm --prefix adapters/editor run typecheck:cm6
+run_consumer "web" "apps/web" "typecheck"
+echo "==> [web] npm --prefix apps/web run build"
+npm --prefix apps/web run build
+run_consumer "demo-react" "examples/demo-react" "build"
+# `tsc -b` rewrites this tracked cache across local TypeScript versions; it is
+# not review evidence and must not dirty the exact candidate HEAD.
+git checkout -- examples/demo-react/tsconfig.tsbuildinfo
+run_consumer "prosemirror" "examples/prosemirror" "build"
+run_consumer "ideal-web" "apps/ideal/web" "build"
+run_consumer "canvas-web" "apps/canvas/web" "build"
+run_consumer "block-editor-web" "apps/block-editor/web" "build"
+run_consumer "relay-server" "apps/relay-server" "typecheck"
+
+echo "check-ffi-consumers: all FFI consumers passed."

--- a/scripts/check-ffi-consumers.sh
+++ b/scripts/check-ffi-consumers.sh
@@ -46,6 +46,10 @@ npm --prefix adapters/editor run typecheck:cm6
 run_consumer "web" "apps/web" "typecheck"
 echo "==> [web] npm --prefix apps/web run build"
 npm --prefix apps/web run build
+echo "==> [web] npm --prefix apps/web run test:foundation"
+npm --prefix apps/web run test:foundation
+echo "==> [web] npm --prefix apps/web run check:waku-bundles"
+npm --prefix apps/web run check:waku-bundles
 run_consumer "demo-react" "examples/demo-react" "build"
 # `tsc -b` rewrites this tracked cache across local TypeScript versions; it is
 # not review evidence and must not dirty the exact candidate HEAD.

--- a/scripts/test-pr-ready-validation.sh
+++ b/scripts/test-pr-ready-validation.sh
@@ -58,8 +58,9 @@ cat >"$expected_list" <<'EXPECTED_LIST'
 21 suite.test
 22 suite.build
 23 build.js
-24 diff.whitespace origin/main...HEAD
-25 evidence.record
+24 typescript.ffi-consumers origin/main
+25 diff.whitespace origin/main...HEAD
+26 evidence.record
 EXPECTED_LIST
 assert_files_equal "$expected_list" "$list_output" "--list order changed"
 
@@ -130,7 +131,8 @@ for script_name in \
   check-strict.sh \
   check-moonbit-pkg-compat.sh \
   check-test-baseline.sh \
-  build-js.sh; do
+  build-js.sh \
+  check-ffi-consumers.sh; do
   cat >"$fixture/scripts/$script_name" <<'FAKE_SCRIPT'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -149,10 +151,33 @@ FAKE_SCRIPT
   chmod +x "$fixture/scripts/$script_name"
 done
 
+cat >"$fixture/scripts/vendored-check-common.sh" <<'FAKE_VENDORED_FILTER'
+#!/usr/bin/env bash
+
+VENDORED_DIRS="deps/vendor"
+
+run_moon_check_with_vendored_filter() {
+  printf 'vendored-filter' >>"$PR_READY_TEST_LOG"
+  if [ "$#" -gt 0 ]; then
+    printf ' %s' "$@" >>"$PR_READY_TEST_LOG"
+  fi
+  printf '\n' >>"$PR_READY_TEST_LOG"
+  [ "${1:-}" != "--keep=pkg" ] || shift
+  moon check "$@"
+}
+FAKE_VENDORED_FILTER
+
+mkdir -p "$fixture/member/pkg"
+printf 'pub fn member_answer() -> Int { 7 }\n' >"$fixture/member/pkg/main.mbt"
+printf 'package "fixture/member/pkg"\n' >"$fixture/member/pkg/moon.pkg"
+printf 'pub fn member_answer() -> Int\n' >"$fixture/member/pkg/pkg.generated.mbti"
+printf 'name = "fixture-member"\n' >"$fixture/member/moon.mod"
+printf 'members = ["./member"]\n' >"$fixture/moon.work"
+
 printf 'pub fn answer() -> Int { 42 }\n' >"$fixture/pkg/main.mbt"
 printf 'package "fixture/pkg"\n' >"$fixture/pkg/moon.pkg"
 printf 'pub fn answer() -> Int\n' >"$fixture/pkg/pkg.generated.mbti"
-printf '{"name":"fixture"}\n' >"$fixture/moon.pkg.json"
+printf 'name = "fixture"\n' >"$fixture/pkg/moon.mod"
 printf '_build/\n' >"$fixture/.gitignore"
 
 git -C "$fixture" init --quiet --initial-branch=main
@@ -264,6 +289,7 @@ PATH="$fake_bin:$PATH" \
   PR_READY_TEST_LOG="$execution_log" \
   "$fixture/scripts/validate-pr-ready.sh" \
     --base fixture-base \
+    --target member/pkg \
     --target pkg >"$tmp_dir/success-output"
 
 fixture_plan="$tmp_dir/fixture-plan"
@@ -271,6 +297,7 @@ execution_plan="$tmp_dir/execution-plan"
 "$fixture/scripts/validate-pr-ready.sh" \
   --list \
   --base fixture-base \
+  --target member/pkg \
   --target pkg >"$fixture_plan"
 sed -n 's/^==> //p' "$tmp_dir/success-output" >"$execution_plan"
 assert_files_equal "$fixture_plan" "$execution_plan" "listed and executed phases diverged"
@@ -286,23 +313,29 @@ check-documentation-lifecycle.sh
 node ./scripts/check-export-manifest.mjs
 test-moon-update-wrapper.sh
 update-moon-deps.sh
-moon fmt --check pkg/main.mbt
-moon info --frozen . pkg
-check-strict.sh pkg
-moon test --release pkg
+moon fmt --check member/pkg/main.mbt pkg/main.mbt
+moon info --frozen member/pkg pkg
+check-strict.sh member/pkg
+moon test --release member/pkg
+vendored-filter --keep=pkg --deny-warn --warn-list=-20 .
+moon check --deny-warn --warn-list=-20 .
+moon test --release .
 check-strict.sh
 check-moonbit-pkg-compat.sh
 check-test-baseline.sh 7 moon test --release
 moon build --release
 build-js.sh
+check-ffi-consumers.sh fixture-base
 EXPECTED_EXECUTION
 assert_files_equal "$expected_execution" "$execution_log" "validation command order changed"
 
 validated_head="$(git -C "$fixture" rev-parse HEAD)"
 grep -q "validated-head=$validated_head" "$tmp_dir/success-output" ||
   fail "success output did not identify the validated HEAD"
+grep -q "validated-target=member/pkg" "$tmp_dir/success-output" ||
+  fail "success output did not identify the workspace-member target"
 grep -q "validated-target=pkg" "$tmp_dir/success-output" ||
-  fail "success output did not identify the validated target"
+  fail "success output did not identify the nested-module target"
 
 PATH="$fake_bin:$PATH" \
   PR_READY_TEST_LOG="$execution_log" \
@@ -310,8 +343,10 @@ PATH="$fake_bin:$PATH" \
     --verify-evidence >"$tmp_dir/verified-output"
 grep -q "validated-head=$validated_head" "$tmp_dir/verified-output" ||
   fail "evidence verification did not report the validated HEAD"
+grep -q "validated-target=member/pkg" "$tmp_dir/verified-output" ||
+  fail "evidence verification did not report the workspace-member target"
 grep -q "validated-target=pkg" "$tmp_dir/verified-output" ||
-  fail "evidence verification did not report the validated target"
+  fail "evidence verification did not report the nested-module target"
 
 submodule_origin_url="$(
   git -C "$fixture/vendor/test-submodule" remote get-url origin

--- a/scripts/test-pr-ready-validation.sh
+++ b/scripts/test-pr-ready-validation.sh
@@ -253,11 +253,13 @@ if PATH="$fake_bin:$PATH" \
   PR_READY_TEST_LOG="$execution_log" \
   "$fixture/scripts/validate-pr-ready.sh" \
     --base fixture-base \
-    --target pkg >"$unpushed_output" 2>&1; then
+    --no-target "submodule reachability probe" >"$unpushed_output" 2>&1; then
   fail "unpushed submodule commit unexpectedly passed"
 fi
-grep -q "submodule commit is not fetchable from origin" "$unpushed_output" ||
+if ! grep -q "submodule commit is not fetchable from origin" "$unpushed_output"; then
+  cat "$unpushed_output" >&2
   fail "unpushed submodule diagnostic was not actionable"
+fi
 if [ -s "$execution_log" ]; then
   fail "unpushed submodule failure ran dependency commands"
 fi
@@ -276,7 +278,7 @@ if ! PATH="$fake_bin:$PATH" \
   PR_READY_TEST_LOG="$execution_log" \
   "$fixture/scripts/validate-pr-ready.sh" \
     --base fixture-base \
-    --target pkg >"$pull_ref_output" 2>&1; then
+    --no-target "exact-SHA submodule probe" >"$pull_ref_output" 2>&1; then
   fail "submodule commit fetchable only by exact SHA was rejected"
 fi
 grep -q "PR-ready validation passed" "$pull_ref_output" ||

--- a/scripts/test-pr-ready-validation.sh
+++ b/scripts/test-pr-ready-validation.sh
@@ -180,6 +180,14 @@ printf 'pub fn answer() -> Int\n' >"$fixture/pkg/pkg.generated.mbti"
 printf 'name = "fixture"\n' >"$fixture/pkg/moon.mod"
 printf '_build/\n' >"$fixture/.gitignore"
 
+fixture_alias="$tmp_dir/fixture-alias"
+ln -s "$fixture" "$fixture_alias"
+"$fixture_alias/scripts/validate-pr-ready.sh" \
+  --list \
+  --target member/pkg >"$tmp_dir/symlinked-root-plan"
+grep -q "target.check member/pkg" "$tmp_dir/symlinked-root-plan" ||
+  fail "symlinked project root did not resolve its workspace target"
+
 git -C "$fixture" init --quiet --initial-branch=main
 git -C "$fixture" config user.email "pr-ready-test@example.invalid"
 git -C "$fixture" config user.name "PR Ready Test"

--- a/scripts/validate-pr-ready.sh
+++ b/scripts/validate-pr-ready.sh
@@ -103,6 +103,88 @@ assert_target_policy() {
   fi
 }
 
+target_module_root() {
+  local target="$1"
+  local current
+  current="$(cd "$target" && pwd -P)"
+
+  while [ "$current" = "$project_root" ] || [[ "$current" == "$project_root/"* ]]; do
+    if [ -f "$current/moon.mod" ] || [ -f "$current/moon.mod.json" ]; then
+      printf '%s\n' "$current"
+      return 0
+    fi
+    [ "$current" != "$project_root" ] || break
+    current="$(dirname "$current")"
+  done
+
+  die "target is not inside a MoonBit module: $target"
+}
+
+module_is_root_workspace_member() {
+  local module_root="$1"
+  local relative_module="${module_root#"$project_root"/}"
+  [ "$module_root" != "$project_root" ] || return 0
+  [ -f "$project_root/moon.work" ] || return 1
+  grep -Fq "\"./$relative_module\"" "$project_root/moon.work"
+}
+
+run_target_check() {
+  local target="$1"
+  local module_root
+  local absolute_target
+  local package_path
+  module_root="$(target_module_root "$target")"
+
+  if module_is_root_workspace_member "$module_root"; then
+    NEW_MOON_MOD=0 "$project_root/scripts/check-strict.sh" "$target"
+    return
+  fi
+
+  absolute_target="$(cd "$target" && pwd -P)"
+  package_path="${absolute_target#"$module_root"/}"
+  [ "$absolute_target" != "$module_root" ] || package_path="."
+  (
+    cd "$module_root"
+    # Match the standalone-module CI policy: diagnostics from the module under
+    # test remain gating while known transitive vendored diagnostics are
+    # filtered by their repository paths.
+    # shellcheck source=vendored-check-common.sh
+    source "$project_root/scripts/vendored-check-common.sh"
+    local module_path="${module_root#"$project_root"/}"
+    case "$module_path" in
+      deps/*)
+        NEW_MOON_MOD=0 run_moon_check_with_vendored_filter \
+          "--keep=$module_path" --deny-warn --warn-list=-20-82-83 "$package_path"
+        ;;
+      *)
+        NEW_MOON_MOD=0 run_moon_check_with_vendored_filter \
+          "--keep=$module_path" --deny-warn --warn-list=-20 "$package_path"
+        ;;
+    esac
+  )
+}
+
+run_target_test() {
+  local target="$1"
+  local module_root
+  local absolute_target
+  local package_path
+  module_root="$(target_module_root "$target")"
+
+  if module_is_root_workspace_member "$module_root"; then
+    NEW_MOON_MOD=0 moon test --release "$target"
+    return
+  fi
+
+  absolute_target="$(cd "$target" && pwd -P)"
+  package_path="${absolute_target#"$module_root"/}"
+  [ "$absolute_target" != "$module_root" ] || package_path="."
+  (
+    cd "$module_root"
+    NEW_MOON_MOD=0 moon test --release "$package_path"
+  )
+}
+
 assert_targets_are_packages() {
   local target
   local previous
@@ -118,6 +200,7 @@ assert_targets_are_packages() {
         die "duplicate target: $target"
       fi
     done
+    target_module_root "$target" >/dev/null
     seen_targets+=("$target")
   done
 }
@@ -249,6 +332,7 @@ build_plan() {
   add_phase "suite.test"
   add_phase "suite.build"
   add_phase "build.js"
+  add_phase "typescript.ffi-consumers" "$base_ref"
   add_phase "diff.whitespace" "$base_ref...HEAD"
   add_phase "evidence.record"
 }
@@ -397,10 +481,10 @@ run_phase() {
       assert_clean_worktree
       ;;
     target.check)
-      ./scripts/check-strict.sh "$argument"
+      run_target_check "$argument"
       ;;
     target.test)
-      NEW_MOON_MOD=0 moon test --release "$argument"
+      run_target_test "$argument"
       ;;
     target.skipped)
       :
@@ -419,6 +503,9 @@ run_phase() {
       ;;
     build.js)
       ./scripts/build-js.sh
+      ;;
+    typescript.ffi-consumers)
+      ./scripts/check-ffi-consumers.sh "$argument"
       ;;
     diff.whitespace)
       git diff --check "$base_ref...HEAD"

--- a/scripts/validate-pr-ready.sh
+++ b/scripts/validate-pr-ready.sh
@@ -5,7 +5,7 @@
 # pipeline error propagation.
 set -eo pipefail
 
-script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 project_root="$(dirname "$script_dir")"
 base_ref="origin/main"
 base_was_set=0


### PR DESCRIPTION
## Summary

- Update `deps/loom` from `9f630d67` to `ae3f222f` and propagate Loom's typed `Failure` through Canopy parser construction, publication, projection reads, mutations, and FFI boundaries without converting it into syntax diagnostics.
- Make a failed `SyncEditor` parser terminal while retaining accepted CRDT text, version, and history; preserve parser-independent Markdown export and invalidate parser-backed derived state.
- Add Loomark recovery: capture the exact accepted Markdown/history, attempt one fresh editor reconstruction, resume in Raw mode on success, or enter read-only Raw Recovery with Copy, `.md` Download, and Reload on failure. Private Dev Host injection covers both branches.
- Keep Ideal and Canvas integrations fail-stop when the widened Loom contract reaches them; Canvas retains canonical source and blocks later attachment mutations after the original `Failure`.
- Preserve the established JavaScript primitive API through one shared host adapter: unwrap generated MoonBit `Result` values, throw stable redacted `CanopyHostError` values, invalidate terminal handles, and retry coordinator-refused cleanup without reopening failed handles. JSON, Lambda, Markdown, GenUI, Ideal, Canvas, Demo React, ProseMirror, Block Editor, and Relay Server are covered by the compatibility gate.

Closes #1191

## UI and review evidence

- [x] Visible-label removal preserves accessible names, visible focus, and the keyboard path (no labels removed; recovery controls have visible labels and accessible names)
- [x] Interactive bounds, pointer feedback, and viewport reflow were checked in the rendered UI
- [x] Any claimed Canopy rule cites its repository source; external guidance, recommendations, and preferences are labeled as such

Recovery UI was exercised in Playwright: exact source display, read-only textarea, Copy, Download filename, Reload control, and absence of stale Preview/Block output. Standalone production tests remain green.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `SyncEditor::ensure_parser_healthy` / Loom `Failure` | `modules/canopy/editor`, `deps/loom` | Yes | Central terminal-health guard and original typed failure are reused across reads and mutations. |
| `MarkdownEditor::history`, `version`, `portable_markdown`, and `open_with_semantic_attachment` | `modules/canopy/editor/markdown` | Yes | Recovery captures parser-independent canonical state and reconstructs a fresh editor from opaque history. |
| `GraphAttachment::apply_edit` / `set_source` | `deps/loom/examples/graph-dsl` | Yes | Canvas keeps the upstream attachment API and wraps only its terminal publication boundary. |
| MoonBit `Option`, `Result`, `Map`, `String`, `Array`, and `Iter` | MoonBit core | Yes | Used for explicit health/recovery state, fallible boundaries, retained history/state, source handling, and existing collection traversal. No replacement low-level collection loop was added. |
| `HostRegistry::destroy` and generated MoonBit `Result` values | FFI host packages / generated JS | Yes | Confirmed `try_destroy_*` exports preserve legacy Unit destroy APIs while the shared TypeScript adapter restores primitive success values and owns terminal invalidation. |
| Same-parser retry after `Failure` | prior `sync_editor_parser.mbt` compatibility path | No | Loom defines `Failure` as terminal; retrying `set_source` on the failed parser could publish stale derived state. |

New helpers added (if any):

- `capture_recovery_document` / `reopen_recovery_document`: isolate parser-independent recovery capture and fresh reconstruction.
- `reduce_editor_runtime`: pure `Healthy -> Restarting -> Healthy | RawRecovery` transition logic.
- `recover_after_parser_failure` / `terminal_raw_recovery`: imperative recovery shell; exactly one reconstruction attempt and attachment disposal.
- `recovery_effect_command`: runs gesture-bound Copy/Download/Reload immediately and reports boundary failures.
- `SourceBackedGraph::apply_attachment_mutation`: one private terminal-health boundary that stores and rethrows the original Loom `Failure` while canonical source remains available.
- `adaptMoonBitModule`: one JavaScript host boundary for generated `Result` unwrapping, redacted errors, handle ownership, terminal invalidation, and retryable cleanup.
- `try_destroy_{editor,json_editor,markdown_editor,source_graph}`: confirmed cleanup operations used by the adapter while existing Unit destroy exports remain source-compatible.

## Validation scope

Boundary matrix / first failing regression:

- Pre-acceptance parser failure: source, selection, history, and event state are unchanged.
- Post-acceptance publication failure: accepted source/version/history remain canonical and exportable.
- Terminal parser: parser/projection reads and every parser-coupled mutation rethrow the stored `Failure`; no same-parser retry occurs.
- Fresh reconstruction succeeds: one attempt, old attachment disposed, Raw editing resumes on a fresh editor.
- Fresh reconstruction fails: one attempt, all stale derived views disappear, exact Markdown is exposed read-only with Copy/Download/Reload.
- JSX session failure: handle is disposed/invalidated and public errors are stable/redacted.
- Canvas GraphAttachment failure: authoritative editor source is saved before publication and all later attachment mutations fail-stop.
- JavaScript host failure: generated `Err` details and source text are redacted, owned handles fail-stop immediately, coordinator-refused cleanup remains retryable, and ordinary syntax diagnostics remain data rather than exceptions.

Target packages:

- `apps/ideal/main`
- `apps/ideal/main/internal/history_render`
- `apps/loomark/archive`
- `apps/loomark/internal/dev_host`
- `apps/loomark/internal/rabbita`
- `apps/loomark/repository`
- `modules/canopy/core`
- `modules/canopy/editor`
- `modules/canopy/editor/markdown`
- `modules/canopy/ffi/{json,jsx,lambda,markdown}`
- `modules/canopy/lang/json/{companion,proj}`
- `modules/canopy/lang/jsx/proj`
- `modules/canopy/lang/lambda/{companion,edits,proj}`
- `modules/canopy/lang/markdown/{companion,edits,proj}`
- `modules/canopy/lang/runtime`
- `modules/canopy/workspace/probe`
- `modules/dom-boundary`
- `apps/canvas/main` (standalone module; validated with its module-local check/test plus the root JS build gate)

Additional conditional gates:

- `./scripts/test-loomark-dev-host-e2e.sh` — 82/82
- `./scripts/test-loomark-standalone-e2e.sh` — 9/9
- `./scripts/check-ffi-consumers.sh origin/main` — shared adapter tests/typecheck plus Web foundation/bundle checks, Demo React, ProseMirror, Ideal, Canvas, Block Editor builds and Relay Server typecheck passed.
- `(cd apps/canvas && NEW_MOON_MOD=0 moon test main --target js --release)` — 47/47
- Independent MoonBit and browser reviews completed; all findings resolved.
- `deps/loom` is clean at `ae3f222f3c3135c55fc574ac418e8a54144af1a2`; nested `incr` is the recorded `afc715b2` pin.

## PR-ready evidence

Validated HEAD: `870553ed600257802e6cbac709a8636b326799ff`

Validated base: `origin/main@c7d9cd75b3e0843128afce8239b95910fa8c5738`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh \
  --target apps/canvas/main \
  --target apps/ideal/main \
  --target apps/ideal/main/internal/history_render \
  --target apps/loomark/archive \
  --target apps/loomark/internal/dev_host \
  --target apps/loomark/internal/rabbita \
  --target apps/loomark/repository \
  --target modules/canopy/core \
  --target modules/canopy/editor \
  --target modules/canopy/editor/markdown \
  --target modules/canopy/ffi/json \
  --target modules/canopy/ffi/jsx \
  --target modules/canopy/ffi/lambda \
  --target modules/canopy/ffi/markdown \
  --target modules/canopy/lang/json/companion \
  --target modules/canopy/lang/json/proj \
  --target modules/canopy/lang/jsx/proj \
  --target modules/canopy/lang/lambda/companion \
  --target modules/canopy/lang/lambda/edits \
  --target modules/canopy/lang/lambda/proj \
  --target modules/canopy/lang/markdown/companion \
  --target modules/canopy/lang/markdown/edits \
  --target modules/canopy/lang/markdown/proj \
  --target modules/canopy/lang/runtime \
  --target modules/canopy/workspace/probe \
  --target modules/dom-boundary
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for the exact HEAD and base above, including package-aware Canvas check/test and the conditional FFI consumer compatibility gate.
- [x] The base was fetched again and `--verify-evidence` passed immediately before this PR update.
- [x] The committed `.mbti` diff against the validated base was reviewed for unintended API or trait-bound changes; only the intended confirmed destroy exports were added in this follow-up.
- [x] Any changed submodule commit is pushed and reachable from its remote.
- [x] Validation was rerun after every commit, amend, rebase, submodule-pointer, manifest, or generated-interface change.
- [x] Independent MoonBit and host-boundary reviews returned `APPROVE` after all findings were resolved.


