### PR TITLE
perf(loomark): reduce Raw Markdown typing latency

### DIFF
--- a/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
+++ b/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
@@ -312,6 +312,32 @@ test("Raw input preserves canonical source and Preview follows a committed edit"
   }
 })
 
+test("Raw input exposes phase timings through the dev-host snapshot", async ({ browser }) => {
+  const host = await mountHost(browser, "before")
+  try {
+    const input = host.page.locator("#loomark-input")
+    await input.fill("after")
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("after")
+    await expect.poll(async () => {
+      const phase = (await snapshot(host.page)).raw_input_phase
+      if (!phase || typeof phase !== "object") return false
+      const fields = phase as Record<string, unknown>
+      return [
+        "input_to_debounce_ms",
+        "debounce_to_reduce_ms",
+        "reduce_ms",
+        "commit_ms",
+        "preview_update_ms",
+        "publish_ms",
+        "publish_to_render_ms",
+        "input_to_render_ms",
+      ].every(name => typeof fields[name] === "number")
+    }).toBe(true)
+  } finally {
+    await host.context.close()
+  }
+})
+
 test("Raw and Preview observe one accepted document in a fixed resizable split", async ({ browser }) => {
   const host = await mountHost(browser, "# Before\n")
   try {

--- a/apps/loomark/internal/rabbita/application.mbt
+++ b/apps/loomark/internal/rabbita/application.mbt
@@ -2188,7 +2188,7 @@ fn build_application(
         let (next, command) = recover_after_parser_failure(
           current_session, model, failure, emit,
         )
-        publish(next)
+        publish(next, Some(raw_input_coordinator), None)
         (next, command)
       }
       error => {
@@ -2196,7 +2196,7 @@ fn build_application(
         let (next, command) = quarantine_outer_error(
           current_session, model, error,
         )
-        publish(next)
+        publish(next, Some(raw_input_coordinator), None)
         (next, command)
       }
     }

--- a/apps/loomark/internal/rabbita/application.mbt
+++ b/apps/loomark/internal/rabbita/application.mbt
@@ -2164,6 +2164,7 @@ fn build_application(
   attachment : @md_markdown.MarkdownSemanticAttachment,
   initial : DriverModel,
   baseline : (@repository.LocalArchiveRequestId, String)?,
+  raw_input_telemetry : RawInputTelemetry?,
   subscriptions : (DriverModel, @cmd.Emit[DriverEvent]) -> @sub.Sub,
   view : (DriverModel, @cmd.Emit[DriverEvent], @rabbita_runtime.Html) -> @rabbita_runtime.Html,
 ) -> @rabbita_runtime.App {
@@ -2171,7 +2172,9 @@ fn build_application(
     val: { editor, attachment },
   }
   let latest_model : @ref.Ref[DriverModel?] = { val: None }
-  let raw_input_coordinator = RawInputCoordinator::RawInputCoordinator()
+  let raw_input_coordinator = RawInputCoordinator::RawInputCoordinator(
+    raw_input_telemetry,
+  )
   let update = (model, event, emit) => {
     let session = current_session.val
     update_model(
@@ -2232,7 +2235,13 @@ fn standalone_application(
   baseline : (@repository.LocalArchiveRequestId, String)?,
 ) -> @rabbita_runtime.App {
   build_application(
-    editor, attachment, initial, baseline, standalone_subscriptions, standalone_preview_view,
+    editor,
+    attachment,
+    initial,
+    baseline,
+    None,
+    standalone_subscriptions,
+    standalone_preview_view,
   )
 }
 
@@ -2244,7 +2253,13 @@ fn private_dev_host_application(
   baseline : (@repository.LocalArchiveRequestId, String)?,
 ) -> @rabbita_runtime.App {
   build_application(
-    editor, attachment, initial, baseline, private_dev_host_subscriptions, private_dev_host_preview_view,
+    editor,
+    attachment,
+    initial,
+    baseline,
+    Some(RawInputTelemetry::new()),
+    private_dev_host_subscriptions,
+    private_dev_host_preview_view,
   )
 }
 

--- a/apps/loomark/internal/rabbita/application.mbt
+++ b/apps/loomark/internal/rabbita/application.mbt
@@ -251,7 +251,15 @@ fn record_error(
 }
 
 ///|
-fn publish(model : DriverModel) -> Unit {
+fn publish(
+  model : DriverModel,
+  raw_input_coordinator : RawInputCoordinator?,
+  raw_input_token : Int?,
+) -> Unit {
+  match (raw_input_coordinator, raw_input_token) {
+    (Some(coordinator), Some(token)) => coordinator.mark_publish_started(token)
+    _ => ()
+  }
   let fields : Map[String, Json] = {
     "source": runtime_source(model).to_json(),
     "replica_id": model.replica_id.to_json(),
@@ -282,6 +290,19 @@ fn publish(model : DriverModel) -> Unit {
     },
     "measurement": match model.measurement {
       Some(measurement) => measurement.to_json()
+      None => Json::null()
+    },
+    "raw_input_phase": match raw_input_coordinator {
+      Some(coordinator) => {
+        match raw_input_token {
+          Some(token) => coordinator.mark_publish_finished(token)
+          None => ()
+        }
+        match coordinator.phase_json() {
+          Some(phase) => phase
+          None => Json::null()
+        }
+      }
       None => Json::null()
     },
     "event_detail": match model.event_detail {
@@ -875,10 +896,18 @@ fn update_editing(
           let raw_input_epoch = raw_input_coordinator.epoch()
           let mut raw_completion_seen = false
           let mut raw_completion_command = @rabbita_runtime.none
+          match raw_token {
+            Some(token) => raw_input_coordinator.mark_reducer_started(token)
+            None => ()
+          }
           let transition = @core.reduce(
             model.state,
             @core.ApplicationEvent::RequestCanonicalSource(source~),
           )
+          match raw_token {
+            Some(token) => raw_input_coordinator.mark_reducer_finished(token)
+            None => ()
+          }
           let mut next = if raw_event {
             { ..model, text_input_generation: model.text_input_generation + 1 }
           } else {
@@ -889,6 +918,11 @@ fn update_editing(
           for decision in transition.decisions() {
             match decision {
               @core.ReplaceCanonicalSource(source) => {
+                match raw_token {
+                  Some(token) =>
+                    raw_input_coordinator.mark_editor_started(token)
+                  None => ()
+                }
                 let old_requested = preview_requested(next)
                 let (committed, accepted, changed, commit_command) = commit_source(
                   editor,
@@ -898,6 +932,16 @@ fn update_editing(
                   "editor-dispatch",
                   emit,
                 )
+                match raw_token {
+                  Some(token) =>
+                    raw_input_coordinator.mark_editor_finished(token)
+                  None => ()
+                }
+                match raw_token {
+                  Some(token) =>
+                    raw_input_coordinator.mark_preview_started(token)
+                  None => ()
+                }
                 next = update_preview_document(
                   attachment,
                   committed,
@@ -905,6 +949,11 @@ fn update_editing(
                   accepted~,
                   changed~,
                 )
+                match raw_token {
+                  Some(token) =>
+                    raw_input_coordinator.mark_preview_finished(token)
+                  None => ()
+                }
                 if event is ReplaceSource(_) && accepted {
                   raw_input_coordinator.cancel_pending()
                 }
@@ -927,6 +976,13 @@ fn update_editing(
                           repair_generation,
                           repair_revision,
                         )
+                      },
+                      () => {
+                        match latest_model.val {
+                          Some(latest) =>
+                            publish(latest, Some(raw_input_coordinator), None)
+                          None => ()
+                        }
                       },
                       emit,
                     )
@@ -1920,7 +1976,11 @@ fn update_model(
         editor, attachment, raw_input_coordinator, model, life_event, emit,
       )
   }
-  publish(next)
+  let raw_input_token = match event {
+    Editing(RawInput(_, _, Some(token))) => Some(token)
+    _ => None
+  }
+  publish(next, Some(raw_input_coordinator), raw_input_token)
   (next, command)
 }
 
@@ -2279,7 +2339,7 @@ fn mount_application(
     archive_persistence_enabled=false,
   )
   detached_focus_token.val = ""
-  publish(initial)
+  publish(initial, None, None)
   let app = build(editor, attachment, initial, None)
   app.mount(host_id)
   mounted.val = true

--- a/apps/loomark/internal/rabbita/moon.pkg
+++ b/apps/loomark/internal/rabbita/moon.pkg
@@ -10,6 +10,7 @@ import {
   "dowdiness/loomark/internal/archive_storage",
   "moonbit-community/rabbita" @rabbita_runtime,
   "moonbit-community/rabbita/cmd",
+  "moonbit-community/rabbita/dom",
   "moonbit-community/rabbita/common",
   "moonbit-community/rabbita/html",
   "moonbit-community/rabbita/sub",

--- a/apps/loomark/internal/rabbita/raw_input_timing.mbt
+++ b/apps/loomark/internal/rabbita/raw_input_timing.mbt
@@ -20,6 +20,24 @@ priv struct RawInputPhaseTiming {
 }
 
 ///|
+/// Optional capability that enables Raw phase measurements for the private
+/// development host without putting timing state on the standalone path.
+priv struct RawInputTelemetry {
+  pending_input_received_at : @ref.Ref[Double?]
+  phase : @ref.Ref[RawInputPhaseTiming?]
+  last_phase : @ref.Ref[RawInputPhaseTiming?]
+}
+
+///|
+fn RawInputTelemetry::new() -> RawInputTelemetry {
+  {
+    pending_input_received_at: @ref.Ref(None),
+    phase: @ref.Ref(None),
+    last_phase: @ref.Ref(None),
+  }
+}
+
+///|
 /// Read the monotonic browser clock used by the phase probe.
 fn raw_input_now_ms() -> Double {
   @dom.Window::get_performance(@dom.window()).now()

--- a/apps/loomark/internal/rabbita/raw_input_timing.mbt
+++ b/apps/loomark/internal/rabbita/raw_input_timing.mbt
@@ -1,0 +1,84 @@
+///|
+/// Browser-clock timestamps for one deferred Raw transaction.
+///
+/// This is deliberately private to the driver: the measurements diagnose the
+/// imperative shell without becoming part of the editor or application API.
+priv struct RawInputPhaseTiming {
+  token : Int
+  input_count : Int
+  input_received_at : Double
+  debounce_fired_at : Double
+  reducer_started_at : Double?
+  reducer_finished_at : Double?
+  editor_started_at : Double?
+  editor_finished_at : Double?
+  preview_started_at : Double?
+  preview_finished_at : Double?
+  publish_started_at : Double?
+  publish_finished_at : Double?
+  rendered_at : Double?
+}
+
+///|
+/// Read the monotonic browser clock used by the phase probe.
+fn raw_input_now_ms() -> Double {
+  @dom.Window::get_performance(@dom.window()).now()
+}
+
+///|
+fn raw_input_phase_duration(start : Double?, end : Double?) -> Json {
+  match (start, end) {
+    (Some(start), Some(end)) => (end - start).to_json()
+    _ => Json::null()
+  }
+}
+
+///|
+/// Serialize durations rather than absolute timestamps so the dev-host
+/// snapshot remains useful across browser contexts.
+fn RawInputPhaseTiming::to_json(self : RawInputPhaseTiming) -> Json {
+  Json::object({
+    "token": self.token.to_json(),
+    "input_count": self.input_count.to_json(),
+    "input_to_debounce_ms": raw_input_phase_duration(
+      Some(self.input_received_at),
+      Some(self.debounce_fired_at),
+    ),
+    "debounce_to_reduce_ms": raw_input_phase_duration(
+      Some(self.debounce_fired_at),
+      self.reducer_started_at,
+    ),
+    "reduce_ms": raw_input_phase_duration(
+      self.reducer_started_at,
+      self.reducer_finished_at,
+    ),
+    "reduce_to_commit_ms": raw_input_phase_duration(
+      self.reducer_finished_at,
+      self.editor_started_at,
+    ),
+    "commit_ms": raw_input_phase_duration(
+      self.editor_started_at,
+      self.editor_finished_at,
+    ),
+    "preview_update_ms": raw_input_phase_duration(
+      self.preview_started_at,
+      self.preview_finished_at,
+    ),
+    "commit_to_publish_ms": raw_input_phase_duration(
+      self.editor_finished_at,
+      self.publish_started_at,
+    ),
+    "publish_ms": raw_input_phase_duration(
+      self.publish_started_at,
+      self.publish_finished_at,
+    ),
+    "publish_to_render_ms": raw_input_phase_duration(
+      self.publish_finished_at,
+      self.rendered_at,
+    ),
+    "input_to_render_ms": raw_input_phase_duration(
+      Some(self.input_received_at),
+      self.rendered_at,
+    ),
+  })
+}

--- a/apps/loomark/internal/rabbita/standalone_bootstrap.mbt
+++ b/apps/loomark/internal/rabbita/standalone_bootstrap.mbt
@@ -45,7 +45,7 @@ fn mount_standalone_editor(
     local_storage_warning,
   }
   detached_focus_token.val = ""
-  publish(initial)
+  publish(initial, None, None)
   let app = standalone_application(editor, attachment, initial, baseline)
   app.mount(host_id)
 }

--- a/apps/loomark/internal/rabbita/text_control_repair.mbt
+++ b/apps/loomark/internal/rabbita/text_control_repair.mbt
@@ -66,6 +66,9 @@ priv struct RawInputCoordinator {
   next_token : @ref.Ref[Int]
   in_flight_token : @ref.Ref[Int?]
   in_flight_count : @ref.Ref[Int?]
+  pending_input_received_at : @ref.Ref[Double?]
+  phase : @ref.Ref[RawInputPhaseTiming?]
+  last_phase : @ref.Ref[RawInputPhaseTiming?]
 }
 
 ///|
@@ -82,6 +85,140 @@ fn RawInputCoordinator::RawInputCoordinator() -> RawInputCoordinator {
     next_token: @ref.Ref(0),
     in_flight_token: @ref.Ref(None),
     in_flight_count: @ref.Ref(None),
+    pending_input_received_at: @ref.Ref(None),
+    phase: @ref.Ref(None),
+    last_phase: @ref.Ref(None),
+  }
+}
+
+///|
+/// Apply one phase update only while its deferred transaction is still the
+/// current measurement. Stale callbacks must not mutate a newer transaction.
+fn RawInputCoordinator::update_phase(
+  self : RawInputCoordinator,
+  token : Int,
+  update : (RawInputPhaseTiming) -> RawInputPhaseTiming,
+) -> Unit {
+  match self.phase.val {
+    Some(phase) if phase.token == token => self.phase.val = Some(update(phase))
+    _ => ()
+  }
+}
+
+///|
+fn RawInputCoordinator::mark_reducer_started(
+  self : RawInputCoordinator,
+  token : Int,
+) -> Unit {
+  self.update_phase(token, phase => {
+    ..phase,
+    reducer_started_at: Some(raw_input_now_ms()),
+  })
+}
+
+///|
+fn RawInputCoordinator::mark_reducer_finished(
+  self : RawInputCoordinator,
+  token : Int,
+) -> Unit {
+  self.update_phase(token, phase => {
+    ..phase,
+    reducer_finished_at: Some(raw_input_now_ms()),
+  })
+}
+
+///|
+fn RawInputCoordinator::mark_editor_started(
+  self : RawInputCoordinator,
+  token : Int,
+) -> Unit {
+  self.update_phase(token, phase => {
+    ..phase,
+    editor_started_at: Some(raw_input_now_ms()),
+  })
+}
+
+///|
+fn RawInputCoordinator::mark_editor_finished(
+  self : RawInputCoordinator,
+  token : Int,
+) -> Unit {
+  self.update_phase(token, phase => {
+    ..phase,
+    editor_finished_at: Some(raw_input_now_ms()),
+  })
+}
+
+///|
+fn RawInputCoordinator::mark_preview_started(
+  self : RawInputCoordinator,
+  token : Int,
+) -> Unit {
+  self.update_phase(token, phase => {
+    ..phase,
+    preview_started_at: Some(raw_input_now_ms()),
+  })
+}
+
+///|
+fn RawInputCoordinator::mark_preview_finished(
+  self : RawInputCoordinator,
+  token : Int,
+) -> Unit {
+  self.update_phase(token, phase => {
+    ..phase,
+    preview_finished_at: Some(raw_input_now_ms()),
+  })
+}
+
+///|
+fn RawInputCoordinator::mark_publish_started(
+  self : RawInputCoordinator,
+  token : Int,
+) -> Unit {
+  self.update_phase(token, phase => {
+    ..phase,
+    publish_started_at: Some(raw_input_now_ms()),
+  })
+}
+
+///|
+fn RawInputCoordinator::mark_publish_finished(
+  self : RawInputCoordinator,
+  token : Int,
+) -> Unit {
+  self.update_phase(token, phase => {
+    ..phase,
+    publish_finished_at: Some(raw_input_now_ms()),
+  })
+}
+
+///|
+fn RawInputCoordinator::mark_rendered(
+  self : RawInputCoordinator,
+  token : Int,
+) -> Unit {
+  self.update_phase(token, phase => {
+    ..phase,
+    rendered_at: Some(raw_input_now_ms()),
+  })
+  match self.phase.val {
+    Some(phase) if phase.token == token => self.last_phase.val = Some(phase)
+    _ => ()
+  }
+}
+
+///|
+/// Expose only the latest phase with a completed publish. A pending input or
+/// canceled transaction must not hide the last useful measurement.
+fn RawInputCoordinator::phase_json(self : RawInputCoordinator) -> Json? {
+  let phase = match self.phase.val {
+    Some(phase) if phase.publish_finished_at is Some(_) => Some(phase)
+    _ => self.last_phase.val
+  }
+  match phase {
+    Some(phase) => Some(phase.to_json())
+    None => None
   }
 }
 
@@ -155,6 +292,27 @@ fn RawInputCoordinator::flush(
       self.pending_count.val = 0
       let token = self.next_token.val
       self.next_token.val = token + 1
+      let debounce_fired_at = raw_input_now_ms()
+      let input_received_at = match self.pending_input_received_at.val {
+        Some(at) => at
+        None => debounce_fired_at
+      }
+      self.pending_input_received_at.val = None
+      self.phase.val = Some({
+        token,
+        input_count,
+        input_received_at,
+        debounce_fired_at,
+        reducer_started_at: None,
+        reducer_finished_at: None,
+        editor_started_at: None,
+        editor_finished_at: None,
+        preview_started_at: None,
+        preview_finished_at: None,
+        publish_started_at: None,
+        publish_finished_at: None,
+        rendered_at: None,
+      })
       self.in_flight_token.val = Some(token)
       self.in_flight_count.val = Some(input_count)
       let selection = match self.retry_selection.val {
@@ -176,6 +334,7 @@ fn RawInputCoordinator::enqueue(
   emit : @cmd.Emit[DriverEvent],
 ) -> @cmd.Cmd {
   self.input_epoch.val += 1
+  self.pending_input_received_at.val = Some(raw_input_now_ms())
   match self.pending_source.val {
     None => self.pending_count.val = 1
     Some(_) => self.pending_count.val += 1
@@ -195,6 +354,7 @@ fn RawInputCoordinator::complete(
   selection : @dom_boundary.TextSelection?,
   accepted : Bool,
   repair_check : () -> Bool,
+  after_render_publish : () -> Unit,
   emit : @cmd.Emit[DriverEvent],
 ) -> @cmd.Cmd {
   guard self.in_flight_token.val == Some(token) else {
@@ -217,9 +377,18 @@ fn RawInputCoordinator::complete(
       Some(_) => self.schedule(emit)
       None => @rabbita_runtime.none
     }
+    let render_measurement = after_render(
+      scheduler => {
+        ignore(scheduler)
+        self.mark_rendered(token)
+        after_render_publish()
+      },
+      emit,
+    )
     if needs_repair {
       @cmd.batch([
         command,
+        render_measurement,
         after_render(
           scheduler => {
             ignore(scheduler)
@@ -239,7 +408,7 @@ fn RawInputCoordinator::complete(
         ),
       ])
     } else {
-      command
+      render_measurement
     }
   } else if self.retry_budget.val > 0 && can_retry {
     self.input_epoch.val += 1
@@ -269,6 +438,8 @@ fn RawInputCoordinator::cancel_pending(self : RawInputCoordinator) -> Unit {
   self.scheduled.val = false
   self.pending_source.val = None
   self.pending_count.val = 0
+  self.pending_input_received_at.val = None
+  self.phase.val = None
   self.retry_budget.val = 0
   self.repair_pending.val = false
   self.retry_selection.val = None
@@ -290,6 +461,7 @@ fn RawInputCoordinator::cancel(self : RawInputCoordinator, token : Int) -> Unit 
     self.input_epoch.val += 1
     self.in_flight_token.val = None
     self.in_flight_count.val = None
+    self.phase.val = None
     self.repair_pending.val = false
     self.retry_selection.val = None
   }

--- a/apps/loomark/internal/rabbita/text_control_repair.mbt
+++ b/apps/loomark/internal/rabbita/text_control_repair.mbt
@@ -66,13 +66,13 @@ priv struct RawInputCoordinator {
   next_token : @ref.Ref[Int]
   in_flight_token : @ref.Ref[Int?]
   in_flight_count : @ref.Ref[Int?]
-  pending_input_received_at : @ref.Ref[Double?]
-  phase : @ref.Ref[RawInputPhaseTiming?]
-  last_phase : @ref.Ref[RawInputPhaseTiming?]
+  telemetry : RawInputTelemetry?
 }
 
 ///|
-fn RawInputCoordinator::RawInputCoordinator() -> RawInputCoordinator {
+fn RawInputCoordinator::RawInputCoordinator(
+  telemetry : RawInputTelemetry?,
+) -> RawInputCoordinator {
   {
     pending_source: @ref.Ref(None),
     pending_count: @ref.Ref(0),
@@ -85,9 +85,7 @@ fn RawInputCoordinator::RawInputCoordinator() -> RawInputCoordinator {
     next_token: @ref.Ref(0),
     in_flight_token: @ref.Ref(None),
     in_flight_count: @ref.Ref(None),
-    pending_input_received_at: @ref.Ref(None),
-    phase: @ref.Ref(None),
-    last_phase: @ref.Ref(None),
+    telemetry,
   }
 }
 
@@ -99,9 +97,14 @@ fn RawInputCoordinator::update_phase(
   token : Int,
   update : (RawInputPhaseTiming) -> RawInputPhaseTiming,
 ) -> Unit {
-  match self.phase.val {
-    Some(phase) if phase.token == token => self.phase.val = Some(update(phase))
-    _ => ()
+  match self.telemetry {
+    Some(telemetry) =>
+      match telemetry.phase.val {
+        Some(phase) if phase.token == token =>
+          telemetry.phase.val = Some(update(phase))
+        _ => ()
+      }
+    None => ()
   }
 }
 
@@ -202,9 +205,14 @@ fn RawInputCoordinator::mark_rendered(
     ..phase,
     rendered_at: Some(raw_input_now_ms()),
   })
-  match self.phase.val {
-    Some(phase) if phase.token == token => self.last_phase.val = Some(phase)
-    _ => ()
+  match self.telemetry {
+    Some(telemetry) =>
+      match telemetry.phase.val {
+        Some(phase) if phase.token == token =>
+          telemetry.last_phase.val = Some(phase)
+        _ => ()
+      }
+    None => ()
   }
 }
 
@@ -212,12 +220,17 @@ fn RawInputCoordinator::mark_rendered(
 /// Expose only the latest phase with a completed publish. A pending input or
 /// canceled transaction must not hide the last useful measurement.
 fn RawInputCoordinator::phase_json(self : RawInputCoordinator) -> Json? {
-  let phase = match self.phase.val {
-    Some(phase) if phase.publish_finished_at is Some(_) => Some(phase)
-    _ => self.last_phase.val
-  }
-  match phase {
-    Some(phase) => Some(phase.to_json())
+  match self.telemetry {
+    Some(telemetry) => {
+      let phase = match telemetry.phase.val {
+        Some(phase) if phase.publish_finished_at is Some(_) => Some(phase)
+        _ => telemetry.last_phase.val
+      }
+      match phase {
+        Some(phase) => Some(phase.to_json())
+        None => None
+      }
+    }
     None => None
   }
 }
@@ -292,27 +305,33 @@ fn RawInputCoordinator::flush(
       self.pending_count.val = 0
       let token = self.next_token.val
       self.next_token.val = token + 1
-      let debounce_fired_at = raw_input_now_ms()
-      let input_received_at = match self.pending_input_received_at.val {
-        Some(at) => at
-        None => debounce_fired_at
+      match self.telemetry {
+        Some(telemetry) => {
+          let debounce_fired_at = raw_input_now_ms()
+          let input_received_at = match
+            telemetry.pending_input_received_at.val {
+            Some(at) => at
+            None => debounce_fired_at
+          }
+          telemetry.pending_input_received_at.val = None
+          telemetry.phase.val = Some({
+            token,
+            input_count,
+            input_received_at,
+            debounce_fired_at,
+            reducer_started_at: None,
+            reducer_finished_at: None,
+            editor_started_at: None,
+            editor_finished_at: None,
+            preview_started_at: None,
+            preview_finished_at: None,
+            publish_started_at: None,
+            publish_finished_at: None,
+            rendered_at: None,
+          })
+        }
+        None => ()
       }
-      self.pending_input_received_at.val = None
-      self.phase.val = Some({
-        token,
-        input_count,
-        input_received_at,
-        debounce_fired_at,
-        reducer_started_at: None,
-        reducer_finished_at: None,
-        editor_started_at: None,
-        editor_finished_at: None,
-        preview_started_at: None,
-        preview_finished_at: None,
-        publish_started_at: None,
-        publish_finished_at: None,
-        rendered_at: None,
-      })
       self.in_flight_token.val = Some(token)
       self.in_flight_count.val = Some(input_count)
       let selection = match self.retry_selection.val {
@@ -334,7 +353,11 @@ fn RawInputCoordinator::enqueue(
   emit : @cmd.Emit[DriverEvent],
 ) -> @cmd.Cmd {
   self.input_epoch.val += 1
-  self.pending_input_received_at.val = Some(raw_input_now_ms())
+  match self.telemetry {
+    Some(telemetry) =>
+      telemetry.pending_input_received_at.val = Some(raw_input_now_ms())
+    None => ()
+  }
   match self.pending_source.val {
     None => self.pending_count.val = 1
     Some(_) => self.pending_count.val += 1
@@ -438,8 +461,13 @@ fn RawInputCoordinator::cancel_pending(self : RawInputCoordinator) -> Unit {
   self.scheduled.val = false
   self.pending_source.val = None
   self.pending_count.val = 0
-  self.pending_input_received_at.val = None
-  self.phase.val = None
+  match self.telemetry {
+    Some(telemetry) => {
+      telemetry.pending_input_received_at.val = None
+      telemetry.phase.val = None
+    }
+    None => ()
+  }
   self.retry_budget.val = 0
   self.repair_pending.val = false
   self.retry_selection.val = None
@@ -461,7 +489,10 @@ fn RawInputCoordinator::cancel(self : RawInputCoordinator, token : Int) -> Unit 
     self.input_epoch.val += 1
     self.in_flight_token.val = None
     self.in_flight_count.val = None
-    self.phase.val = None
+    match self.telemetry {
+      Some(telemetry) => telemetry.phase.val = None
+      None => ()
+    }
     self.repair_pending.val = false
     self.retry_selection.val = None
   }

--- a/apps/loomark/internal/rabbita/text_control_repair.mbt
+++ b/apps/loomark/internal/rabbita/text_control_repair.mbt
@@ -408,7 +408,7 @@ fn RawInputCoordinator::complete(
         ),
       ])
     } else {
-      render_measurement
+      @cmd.batch([command, render_measurement])
     }
   } else if self.retry_budget.val > 0 && can_retry {
     self.input_epoch.val += 1

--- a/apps/loomark/internal/rabbita/text_control_repair_wbtest.mbt
+++ b/apps/loomark/internal/rabbita/text_control_repair_wbtest.mbt
@@ -22,3 +22,11 @@ test "rejected replacement maps a range around the accepted span" {
     fail("expected selection direction to be preserved")
   }
 }
+
+///|
+test "Raw coordinator without telemetry keeps phase snapshots empty" {
+  let coordinator = RawInputCoordinator::RawInputCoordinator(None)
+  guard coordinator.phase_json() is None else {
+    fail("standalone Raw coordinator must not expose phase telemetry")
+  }
+}

--- a/modules/canopy/core/reconcile.mbt
+++ b/modules/canopy/core/reconcile.mbt
@@ -100,6 +100,24 @@ pub fn[T : TreeNode + Renderable] reconcile_hinted(
 }
 
 ///|
+/// A full-length positional match is the exact LCS result when every pair at
+/// the same index has the same kind. Structural hints disable this shortcut:
+/// even an otherwise positional edit may require hint-specific pairing.
+fn[T : TreeNode] can_reconcile_children_positionally(
+  old_children : Array[ProjNode[T]],
+  new_children : Array[ProjNode[T]],
+  hints : Map[NodeId, IdentityTransform],
+) -> Bool {
+  if !hints.is_empty() || old_children.length() != new_children.length() {
+    return false
+  }
+  old_children.foldi(init=true, (index, same, old_child) => {
+    same &&
+    @loomcore.TreeNode::same_kind(old_child.kind, new_children[index].kind)
+  })
+}
+
+///|
 fn[T : TreeNode + Renderable] reconcile_children(
   old_children : Array[ProjNode[T]],
   new_children : Array[ProjNode[T]],
@@ -110,6 +128,33 @@ fn[T : TreeNode + Renderable] reconcile_children(
 ) -> Array[ProjNode[T]] {
   let old_len = old_children.length()
   let new_len = new_children.length()
+  // If the sibling lists already have a full positional same-kind match, the
+  // LCS optimum is the whole list. Recurse through the matched pairs directly
+  // instead of allocating and filling the quadratic DP table.
+  if can_reconcile_children_positionally(old_children, new_children, hints) {
+    return [
+      for index in 0..<new_len => {
+        let reconciled = reconcile_hinted(
+          old_children[index],
+          new_children[index],
+          counter,
+          hints,
+          trace_ref~,
+        )
+        emit_trace(
+          trace_ref,
+          Matched(
+            parent_id,
+            index,
+            index,
+            reconciled.id(),
+            @loomcore.Renderable::kind_tag(reconciled.kind),
+          ),
+        )
+        reconciled
+      }
+    ]
+  }
   // Old children whose hint will decide their identity are excluded from
   // ordinary LCS matching, so they are not consumed by a same-kind match
   // against the wrong new sibling first. Exclusion is decided from hint

--- a/modules/canopy/core/reconcile.mbt
+++ b/modules/canopy/core/reconcile.mbt
@@ -111,10 +111,17 @@ fn[T : TreeNode] can_reconcile_children_positionally(
   if !hints.is_empty() || old_children.length() != new_children.length() {
     return false
   }
-  old_children.foldi(init=true, (index, same, old_child) => {
-    same &&
-    @loomcore.TreeNode::same_kind(old_child.kind, new_children[index].kind)
-  })
+  // Short-circuit on the first mismatch so LCS fallback does not pay a full
+  // sibling scan when the positional fast path is obviously inapplicable.
+  for index in 0..<old_children.length() {
+    if !@loomcore.TreeNode::same_kind(
+        old_children[index].kind,
+        new_children[index].kind,
+      ) {
+      return false
+    }
+  }
+  true
 }
 
 ///|

--- a/modules/canopy/core/reconcile_properties_wbtest.mbt
+++ b/modules/canopy/core/reconcile_properties_wbtest.mbt
@@ -323,6 +323,57 @@ fn exact_test_key(expr : TestExpr) -> String {
 }
 
 ///|
+test "reconcile: positional fast path only accepts equal-kind sibling lists" {
+  let old_node = to_proj_node(Branch("root", [Leaf("a"), Leaf("b")]), Ref(0))
+  let same_shape = to_proj_node(
+    Branch("root", [Leaf("x"), Leaf("y")]),
+    Ref(500),
+  )
+  inspect(
+    can_reconcile_children_positionally(
+      old_node.children,
+      same_shape.children,
+      Map([]),
+    ),
+    content="true",
+  )
+  let different_kind = to_proj_node(
+    Branch("root", [Leaf("x"), Branch("nested", [])]),
+    Ref(500),
+  )
+  inspect(
+    can_reconcile_children_positionally(
+      old_node.children,
+      different_kind.children,
+      Map([]),
+    ),
+    content="false",
+  )
+  let inserted = to_proj_node(
+    Branch("root", [Leaf("x"), Leaf("inserted"), Leaf("y")]),
+    Ref(500),
+  )
+  inspect(
+    can_reconcile_children_positionally(
+      old_node.children,
+      inserted.children,
+      Map([]),
+    ),
+    content="false",
+  )
+  let hints : Map[NodeId, IdentityTransform] = Map([])
+  hints[old_node.children[0].id()] = IdentityTransform::Opaque
+  inspect(
+    can_reconcile_children_positionally(
+      old_node.children,
+      same_shape.children,
+      hints,
+    ),
+    content="false",
+  )
+}
+
+///|
 test "reconcile: append equal-kind siblings preserves positional IDs" {
   let old_node = to_proj_node(Branch("root", [Leaf("a"), Leaf("b")]), Ref(0))
   let new_node = to_proj_node(

--- a/modules/canopy/core/reconcile_trace_wbtest.mbt
+++ b/modules/canopy/core/reconcile_trace_wbtest.mbt
@@ -28,6 +28,47 @@ test "identical trees produce only Matched events" {
 }
 
 ///|
+test "positional fast path preserves nested IDs and trace order" {
+  let old_leaf = ProjNode(Leaf("old"), 0, 1, 2, [])
+  let old_branch = ProjNode(Branch("child", [Leaf("old")]), 0, 2, 1, [old_leaf])
+  let old_tail = ProjNode(Leaf("tail-old"), 2, 3, 3, [])
+  let old = ProjNode(
+    Branch("root", [Branch("child", [Leaf("old")]), Leaf("tail-old")]),
+    0,
+    3,
+    0,
+    [old_branch, old_tail],
+  )
+  let new_leaf = ProjNode(Leaf("new"), 0, 1, 12, [])
+  let new_branch = ProjNode(Branch("child", [Leaf("new")]), 0, 2, 11, [new_leaf])
+  let new_tail = ProjNode(Leaf("tail-new"), 2, 3, 13, [])
+  let new_ = ProjNode(
+    Branch("root", [Branch("child", [Leaf("new")]), Leaf("tail-new")]),
+    0,
+    3,
+    10,
+    [new_branch, new_tail],
+  )
+  let trace = Ref([])
+  let counter = Ref(100)
+  let result = reconcile(old, new_, counter, trace_ref=Some(trace))
+  inspect(result.children[0].id() == old_branch.id(), content="true")
+  inspect(result.children[0].children[0].id() == old_leaf.id(), content="true")
+  inspect(result.children[1].id() == old_tail.id(), content="true")
+  inspect(counter.val, content="100")
+  inspect(trace.val.length(), content="3")
+  guard trace.val[0] is Matched(_, 0, 0, _, _) else {
+    fail("nested match should be traced first")
+  }
+  guard trace.val[1] is Matched(_, 0, 0, _, _) else {
+    fail("first root match should follow nested match")
+  }
+  guard trace.val[2] is Matched(_, 1, 1, _, _) else {
+    fail("second root match should be traced last")
+  }
+}
+
+///|
 test "inserted child produces Inserted event" {
   // LCS: old Leaf matches new Leaf; Branch is unlike → Inserted at new idx 1
   let c1 = ProjNode(Leaf("a"), 0, 1, 1, [])

--- a/modules/canopy/editor/markdown/markdown_editor_apply_phase_benchmark_wbtest.mbt
+++ b/modules/canopy/editor/markdown/markdown_editor_apply_phase_benchmark_wbtest.mbt
@@ -1,0 +1,82 @@
+///|
+/// Construct a CRDT with the benchmark source already present so the measured
+/// operation is only the tail range mutation.
+fn apply_phase_text_state(source : String) -> @text.TextState {
+  let doc = try! @text.TextState::new("markdown-apply-phase")
+  try! doc.insert(@text.Pos::at(0), source)
+  doc
+}
+
+///|
+/// Construct a parser with the source already parsed. The parser has no
+/// projection attachment here, so this isolates Parser::apply_edit and its
+/// incremental engine from projection reconciliation.
+fn apply_phase_parser(source : String) -> @loom.Parser[@md_markdown.Block] {
+  @loom.new_parser(
+    @loom_core.SourceId("canopy:markdown-apply-phase"),
+    source,
+    @md_markdown.markdown_grammar,
+  )
+}
+
+///|
+/// This alternates an append and its inverse so one mutable document can be
+/// reused by the benchmark harness. Divide the reported time by two when
+/// comparing one CRDT mutation with one parser mutation below.
+test "perf: CRDT tail range mutation pair (250 blocks)" (b : @bench.T) {
+  let source = commit_phase_source(250)
+  let doc = apply_phase_text_state(source)
+  let mut tick = 0
+  b.bench(() => {
+    if tick % 2 == 0 {
+      let end = doc.len()
+      try! doc.replace_range(@text.Range::from_ints(end, end), "x")
+    } else {
+      let end = doc.len()
+      try! doc.replace_range(@text.Range::from_ints(end - 1, end), "")
+    }
+    tick += 1
+    b.keep(doc.len())
+  })
+}
+
+///|
+test "perf: parser incremental edit pair without projection (250 blocks)" (
+  b : @bench.T,
+) {
+  let source = commit_phase_source(250)
+  let parser = apply_phase_parser(source)
+  let append = @loom_core.Edit::new(source.length(), 0, 1)
+  let delete = @loom_core.Edit::new(source.length(), 1, 0)
+  let mut tick = 0
+  b.bench(() => {
+    if tick % 2 == 0 {
+      parser.apply_edit(append, source + "x")
+    } else {
+      parser.apply_edit(delete, source)
+    }
+    tick += 1
+    b.keep(tick)
+  })
+}
+
+///|
+test "perf: parser incremental edit pair with AST read (250 blocks)" (
+  b : @bench.T,
+) {
+  let source = commit_phase_source(250)
+  let parser = apply_phase_parser(source)
+  let append = @loom_core.Edit::new(source.length(), 0, 1)
+  let delete = @loom_core.Edit::new(source.length(), 1, 0)
+  let mut tick = 0
+  b.bench(() => {
+    if tick % 2 == 0 {
+      parser.apply_edit(append, source + "x")
+    } else {
+      parser.apply_edit(delete, source)
+    }
+    let ast = parser.ast().read_or_abort()
+    tick += 1
+    b.keep(ast)
+  })
+}

--- a/modules/canopy/editor/markdown/markdown_editor_apply_phase_benchmark_wbtest.mbt
+++ b/modules/canopy/editor/markdown/markdown_editor_apply_phase_benchmark_wbtest.mbt
@@ -11,12 +11,25 @@ fn apply_phase_text_state(source : String) -> @text.TextState {
 /// Construct a parser with the source already parsed. The parser has no
 /// projection attachment here, so this isolates Parser::apply_edit and its
 /// incremental engine from projection reconciliation.
-fn apply_phase_parser(source : String) -> @loom.Parser[@md_markdown.Block] {
+fn apply_phase_parser(
+  source : String,
+) -> @loom.Parser[@md_markdown.Block] raise {
   @loom.new_parser(
     @loom_core.SourceId("canopy:markdown-apply-phase"),
     source,
     @md_markdown.markdown_grammar,
   )
+}
+
+///|
+fn apply_phase_parser_edit(
+  parser : @loom.Parser[@md_markdown.Block],
+  edit : @loom_core.Edit,
+  source : String,
+) -> Unit {
+  parser.apply_edit(edit, source) catch {
+    error => abort("parser benchmark edit failed: \{error}")
+  }
 }
 
 ///|
@@ -51,9 +64,9 @@ test "perf: parser incremental edit pair without projection (250 blocks)" (
   let mut tick = 0
   b.bench(() => {
     if tick % 2 == 0 {
-      parser.apply_edit(append, source + "x")
+      apply_phase_parser_edit(parser, append, source + "x")
     } else {
-      parser.apply_edit(delete, source)
+      apply_phase_parser_edit(parser, delete, source)
     }
     tick += 1
     b.keep(tick)
@@ -71,9 +84,9 @@ test "perf: parser incremental edit pair with AST read (250 blocks)" (
   let mut tick = 0
   b.bench(() => {
     if tick % 2 == 0 {
-      parser.apply_edit(append, source + "x")
+      apply_phase_parser_edit(parser, append, source + "x")
     } else {
-      parser.apply_edit(delete, source)
+      apply_phase_parser_edit(parser, delete, source)
     }
     let ast = parser.ast().read_or_abort()
     tick += 1

--- a/modules/canopy/editor/markdown/markdown_editor_apply_phase_benchmark_wbtest.mbt
+++ b/modules/canopy/editor/markdown/markdown_editor_apply_phase_benchmark_wbtest.mbt
@@ -59,12 +59,13 @@ test "perf: parser incremental edit pair without projection (250 blocks)" (
 ) {
   let source = commit_phase_source(250)
   let parser = apply_phase_parser(source)
+  let appended_source = source + "x"
   let append = @loom_core.Edit::new(source.length(), 0, 1)
   let delete = @loom_core.Edit::new(source.length(), 1, 0)
   let mut tick = 0
   b.bench(() => {
     if tick % 2 == 0 {
-      apply_phase_parser_edit(parser, append, source + "x")
+      apply_phase_parser_edit(parser, append, appended_source)
     } else {
       apply_phase_parser_edit(parser, delete, source)
     }
@@ -79,12 +80,13 @@ test "perf: parser incremental edit pair with AST read (250 blocks)" (
 ) {
   let source = commit_phase_source(250)
   let parser = apply_phase_parser(source)
+  let appended_source = source + "x"
   let append = @loom_core.Edit::new(source.length(), 0, 1)
   let delete = @loom_core.Edit::new(source.length(), 1, 0)
   let mut tick = 0
   b.bench(() => {
     if tick % 2 == 0 {
-      apply_phase_parser_edit(parser, append, source + "x")
+      apply_phase_parser_edit(parser, append, appended_source)
     } else {
       apply_phase_parser_edit(parser, delete, source)
     }

--- a/modules/canopy/editor/markdown/markdown_editor_commit_phase_benchmark_wbtest.mbt
+++ b/modules/canopy/editor/markdown/markdown_editor_commit_phase_benchmark_wbtest.mbt
@@ -1,0 +1,150 @@
+///|
+/// Keep the browser-sized Markdown workload identical to the Loomark latency
+/// probe so cumulative phase costs can be compared without a UI clock.
+/// The text-change benchmark isolates the diff helper. The following three
+/// benchmarks are cumulative: their differences estimate apply, refresh, and
+/// snapshot costs before the public commit comparisons.
+fn commit_phase_source(block_count : Int) -> String {
+  Array::makei(block_count, index => {
+    let number = index.to_string()
+    "## Heading " +
+    number +
+    "\n\nParagraph " +
+    number +
+    " with **bold** and [link](https://example.com/" +
+    number +
+    ").\n"
+  }).join("\n")
+}
+
+///|
+fn commit_phase_variant(source : String, tick : Int) -> String {
+  let suffix = if tick % 2 == 0 { "x" } else { "" }
+  source + suffix
+}
+
+///|
+fn commit_phase_editor(source : String) -> MarkdownEditor {
+  try! MarkdownEditor(agent_id="markdown-commit-phase", source~)
+}
+
+///|
+fn commit_phase_changes(source : String) -> Array[@text_change.TextChange] {
+  [
+    @text_change.compute_text_change(source, commit_phase_variant(source, 0)),
+    @text_change.compute_text_change(source + "x", source),
+  ]
+}
+
+///|
+test "perf: TextChange compute (250 blocks)" (b : @bench.T) {
+  let source = commit_phase_source(250)
+  let mut tick = 0
+  b.bench(() => {
+    b.keep(
+      @text_change.compute_text_change(
+        source,
+        commit_phase_variant(source, tick),
+      ),
+    )
+    tick += 1
+  })
+}
+
+///|
+/// This uses the public undo-recording path with precomputed changes. It is a
+/// comparison for apply/parser work, not a replacement for the bulk path's
+/// private no-undo policy.
+test "perf: MarkdownEditor apply precomputed change (250 blocks)" (b : @bench.T) {
+  let source = commit_phase_source(250)
+  let changes = commit_phase_changes(source)
+  let editor = commit_phase_editor(source)
+  let mut tick = 0
+  b.bench(() => {
+    let change = changes[tick % changes.length()]
+    tick += 1
+    editor.editor.apply_text_edit(
+      change.start,
+      change.delete_len,
+      change.inserted,
+      0,
+    )
+    b.keep(editor.editor.get_text())
+  })
+}
+
+///|
+test "perf: MarkdownEditor set_text_with_change (250 blocks)" (b : @bench.T) {
+  let source = commit_phase_source(250)
+  let editor = commit_phase_editor(source)
+  let mut tick = 0
+  b.bench(() => {
+    let result = editor.editor.set_text_with_change(
+      commit_phase_variant(source, tick),
+    )
+    tick += 1
+    b.keep(result)
+  })
+}
+
+///|
+test "perf: MarkdownEditor set_text_with_change + refresh (250 blocks)" (
+  b : @bench.T,
+) {
+  let source = commit_phase_source(250)
+  let editor = commit_phase_editor(source)
+  let mut tick = 0
+  b.bench(() => {
+    let result = editor.editor.set_text_with_change(
+      commit_phase_variant(source, tick),
+    )
+    tick += 1
+    editor.editor.refresh()
+    b.keep(result)
+  })
+}
+
+///|
+test "perf: MarkdownEditor set_text + refresh + snapshot (250 blocks)" (
+  b : @bench.T,
+) {
+  let source = commit_phase_source(250)
+  let editor = commit_phase_editor(source)
+  let mut tick = 0
+  b.bench(() => {
+    ignore(
+      editor.editor.set_text_with_change(commit_phase_variant(source, tick)),
+    )
+    tick += 1
+    editor.editor.refresh()
+    b.keep(editor.snapshot())
+  })
+}
+
+///|
+test "perf: MarkdownEditor commit without receipt (250 blocks)" (b : @bench.T) {
+  let source = commit_phase_source(250)
+  let editor = commit_phase_editor(source)
+  let mut tick = 0
+  b.bench(() => {
+    let result = editor.commit(
+      MarkdownEditRequest::ReplaceSource(commit_phase_variant(source, tick)),
+    )
+    tick += 1
+    b.keep(result)
+  })
+}
+
+///|
+test "perf: MarkdownEditor commit with receipt (250 blocks)" (b : @bench.T) {
+  let source = commit_phase_source(250)
+  let editor = commit_phase_editor(source)
+  let mut tick = 0
+  b.bench(() => {
+    let result = try! editor.commit_with_receipt(
+      MarkdownEditRequest::ReplaceSource(commit_phase_variant(source, tick)),
+    )
+    tick += 1
+    b.keep(result)
+  })
+}

--- a/modules/canopy/editor/markdown/markdown_editor_commit_phase_benchmark_wbtest.mbt
+++ b/modules/canopy/editor/markdown/markdown_editor_commit_phase_benchmark_wbtest.mbt
@@ -29,6 +29,16 @@ fn commit_phase_editor(source : String) -> MarkdownEditor {
 }
 
 ///|
+fn commit_phase_set_text(
+  editor : MarkdownEditor,
+  source : String,
+) -> (@text_change.TextChange, Bool) {
+  editor.editor.set_text_with_change(source) catch {
+    error => abort("set_text benchmark failed: \{error}")
+  }
+}
+
+///|
 fn commit_phase_changes(source : String) -> Array[@text_change.TextChange] {
   [
     @text_change.compute_text_change(source, commit_phase_variant(source, 0)),
@@ -68,7 +78,9 @@ test "perf: MarkdownEditor apply precomputed change (250 blocks)" (b : @bench.T)
       change.delete_len,
       change.inserted,
       0,
-    )
+    ) catch {
+      error => abort("commit benchmark edit failed: \{error}")
+    }
     b.keep(editor.editor.get_text())
   })
 }
@@ -79,7 +91,8 @@ test "perf: MarkdownEditor set_text_with_change (250 blocks)" (b : @bench.T) {
   let editor = commit_phase_editor(source)
   let mut tick = 0
   b.bench(() => {
-    let result = editor.editor.set_text_with_change(
+    let result = commit_phase_set_text(
+      editor,
       commit_phase_variant(source, tick),
     )
     tick += 1
@@ -95,11 +108,14 @@ test "perf: MarkdownEditor set_text_with_change + refresh (250 blocks)" (
   let editor = commit_phase_editor(source)
   let mut tick = 0
   b.bench(() => {
-    let result = editor.editor.set_text_with_change(
+    let result = commit_phase_set_text(
+      editor,
       commit_phase_variant(source, tick),
     )
     tick += 1
-    editor.editor.refresh()
+    editor.editor.refresh() catch {
+      error => abort("refresh benchmark failed: \{error}")
+    }
     b.keep(result)
   })
 }
@@ -112,12 +128,16 @@ test "perf: MarkdownEditor set_text + refresh + snapshot (250 blocks)" (
   let editor = commit_phase_editor(source)
   let mut tick = 0
   b.bench(() => {
-    ignore(
-      editor.editor.set_text_with_change(commit_phase_variant(source, tick)),
-    )
+    ignore(commit_phase_set_text(editor, commit_phase_variant(source, tick)))
     tick += 1
-    editor.editor.refresh()
-    b.keep(editor.snapshot())
+    editor.editor.refresh() catch {
+      error => abort("refresh benchmark failed: \{error}")
+    }
+    b.keep(
+      editor.snapshot() catch {
+        error => abort("snapshot benchmark failed: \{error}")
+      },
+    )
   })
 }
 
@@ -129,7 +149,9 @@ test "perf: MarkdownEditor commit without receipt (250 blocks)" (b : @bench.T) {
   b.bench(() => {
     let result = editor.commit(
       MarkdownEditRequest::ReplaceSource(commit_phase_variant(source, tick)),
-    )
+    ) catch {
+      error => abort("commit benchmark failed: \{error}")
+    }
     tick += 1
     b.keep(result)
   })
@@ -141,9 +163,11 @@ test "perf: MarkdownEditor commit with receipt (250 blocks)" (b : @bench.T) {
   let editor = commit_phase_editor(source)
   let mut tick = 0
   b.bench(() => {
-    let result = try! editor.commit_with_receipt(
+    let result = editor.commit_with_receipt(
       MarkdownEditRequest::ReplaceSource(commit_phase_variant(source, tick)),
-    )
+    ) catch {
+      error => abort("receipt benchmark failed: \{error}")
+    }
     tick += 1
     b.keep(result)
   })

--- a/modules/canopy/editor/markdown/markdown_editor_commit_phase_benchmark_wbtest.mbt
+++ b/modules/canopy/editor/markdown/markdown_editor_commit_phase_benchmark_wbtest.mbt
@@ -49,14 +49,15 @@ fn commit_phase_changes(source : String) -> Array[@text_change.TextChange] {
 ///|
 test "perf: TextChange compute (250 blocks)" (b : @bench.T) {
   let source = commit_phase_source(250)
+  let appended_source = source + "x"
   let mut tick = 0
   b.bench(() => {
-    b.keep(
-      @text_change.compute_text_change(
-        source,
-        commit_phase_variant(source, tick),
-      ),
-    )
+    let change = if tick % 2 == 0 {
+      @text_change.compute_text_change(source, appended_source)
+    } else {
+      @text_change.compute_text_change(appended_source, source)
+    }
+    b.keep(change)
     tick += 1
   })
 }

--- a/modules/canopy/editor/markdown/moon.pkg
+++ b/modules/canopy/editor/markdown/moon.pkg
@@ -13,6 +13,8 @@ import {
 
 import {
   "dowdiness/loom",
+  "dowdiness/loom/core" @loom_core,
+  "moonbitlang/core/bench",
   "moonbitlang/core/encoding/utf8",
 } for "wbtest"
 

--- a/modules/canopy/editor/sync_editor.mbt
+++ b/modules/canopy/editor/sync_editor.mbt
@@ -609,7 +609,9 @@ pub fn[T : Eq] SyncEditor::apply_sync(
 
 ///|
 pub fn[T] SyncEditor::get_version(self : SyncEditor[T]) -> @text.Version {
-  self.doc.version()
+  // The reactive version is refreshed alongside every accepted text/CRDT
+  // transition. Reuse it instead of expanding the entire operation log again.
+  self.document_version.get()
 }
 
 ///|

--- a/modules/canopy/editor/sync_editor_text.mbt
+++ b/modules/canopy/editor/sync_editor_text.mbt
@@ -192,8 +192,19 @@ fn[T] SyncEditor::apply_replace_span(
   timestamp_ms : Int,
   record_undo : Bool,
 ) -> Bool {
-  let item_start = utf16_offset_to_item_pos(old_source, start)
-  let item_end = utf16_offset_to_item_pos(old_source, start + deleted_len)
+  // The Raw append path already validated an end insertion. TextState.len()
+  // is the exact item position and avoids scanning the whole UTF-16 source
+  // twice just to convert the same endpoint.
+  let (item_start, item_end) = if start == old_source.length() &&
+    deleted_len == 0 {
+    let end = self.doc.len()
+    (end, end)
+  } else {
+    (
+      utf16_offset_to_item_pos(old_source, start),
+      utf16_offset_to_item_pos(old_source, start + deleted_len),
+    )
+  }
   let range = @text.Range::from_ints(item_start, item_end) catch {
     _ => return false
   }
@@ -393,6 +404,41 @@ pub fn[T : Eq] SyncEditor::apply_text_edit_exact(
 }
 
 ///|
+/// Fast path for the common Raw-input shape: an ASCII suffix appended at the
+/// current end of the source. ASCII cannot join the preceding grapheme except
+/// for CRLF, which is deliberately left to the shared Unicode-aware diff.
+fn fast_append_text_change(
+  old_text : String,
+  new_text : String,
+) -> @text_change.TextChange? {
+  if old_text == new_text {
+    return Some(@text_change.TextChange::{
+      start: old_text.length(),
+      delete_len: 0,
+      inserted: "",
+    })
+  }
+  guard new_text.has_prefix(old_text) else { return None }
+  let suffix = new_text[old_text.length():]
+  let mut ascii = true
+  for ch in suffix {
+    if !ch.is_ascii() {
+      ascii = false
+      break
+    }
+  }
+  guard ascii else { return None }
+  guard !(old_text.has_suffix("\r") && suffix.has_prefix("\n")) else {
+    return None
+  }
+  Some(@text_change.TextChange::{
+    start: old_text.length(),
+    delete_len: 0,
+    inserted: suffix.to_owned(),
+  })
+}
+
+///|
 /// Replace the document text with `new_text` and return the exact splice used
 /// together with whether the edit was accepted.
 ///
@@ -406,7 +452,10 @@ pub fn[T : Eq] SyncEditor::set_text_with_change(
 ) -> (@text_change.TextChange, Bool) raise Failure {
   self.ensure_parser_healthy()
   let old_text = self.doc.text()
-  let splice = @text_change.compute_text_change(old_text, new_text)
+  let splice = match fast_append_text_change(old_text, new_text) {
+    Some(splice) => splice
+    None => @text_change.compute_text_change(old_text, new_text)
+  }
   if splice.is_noop() {
     return (splice, true)
   }

--- a/modules/canopy/editor/sync_editor_text_benchmark_wbtest.mbt
+++ b/modules/canopy/editor/sync_editor_text_benchmark_wbtest.mbt
@@ -1,0 +1,36 @@
+///|
+/// Browser-sized source used to measure the fast append decision itself.
+fn sync_text_benchmark_source(block_count : Int) -> String {
+  Array::makei(block_count, index => {
+    let number = index.to_string()
+    "## Heading " +
+    number +
+    "\n\nParagraph " +
+    number +
+    " with **bold** and [link](https://example.com/" +
+    number +
+    ").\n"
+  }).join("\n")
+}
+
+///|
+test "perf: shared text change append (250 blocks)" (b : @bench.T) {
+  let source = sync_text_benchmark_source(250)
+  let mut tick = 0
+  b.bench(() => {
+    let suffix = if tick % 2 == 0 { "x" } else { "y" }
+    tick += 1
+    b.keep(@text_change.compute_text_change(source, source + suffix))
+  })
+}
+
+///|
+test "perf: fast text change append (250 blocks)" (b : @bench.T) {
+  let source = sync_text_benchmark_source(250)
+  let mut tick = 0
+  b.bench(() => {
+    let suffix = if tick % 2 == 0 { "x" } else { "y" }
+    tick += 1
+    b.keep(fast_append_text_change(source, source + suffix))
+  })
+}

--- a/modules/canopy/editor/sync_editor_text_wbtest.mbt
+++ b/modules/canopy/editor/sync_editor_text_wbtest.mbt
@@ -35,6 +35,7 @@ test "set_text_with_change preserves grapheme-aware append fallbacks" {
   inspect(combining_change.start, content="0")
   inspect(combining_change.delete_len, content="1")
   inspect(combining_change.inserted, content="é")
+  inspect(combining.get_text(), content="é")
 
   let crlf = try! @probe.new_test_editor("crlf-agent")
   crlf.set_text("\r")
@@ -43,6 +44,7 @@ test "set_text_with_change preserves grapheme-aware append fallbacks" {
   inspect(crlf_change.start, content="0")
   inspect(crlf_change.delete_len, content="1")
   inspect(crlf_change.inserted, content="\r\n")
+  inspect(crlf.get_text(), content="\r\n")
 
   let emoji_append = try! @probe.new_test_editor("emoji-append-agent")
   emoji_append.set_text("a😀")
@@ -53,6 +55,7 @@ test "set_text_with_change preserves grapheme-aware append fallbacks" {
   inspect(emoji_append_change.start, content="3")
   inspect(emoji_append_change.delete_len, content="0")
   inspect(emoji_append_change.inserted, content="x")
+  inspect(emoji_append.get_text(), content="a😀x")
 
   let emoji_insert = try! @probe.new_test_editor("emoji-insert-agent")
   emoji_insert.set_text("a")
@@ -63,6 +66,7 @@ test "set_text_with_change preserves grapheme-aware append fallbacks" {
   inspect(emoji_insert_change.start, content="1")
   inspect(emoji_insert_change.delete_len, content="0")
   inspect(emoji_insert_change.inserted, content="😀")
+  inspect(emoji_insert.get_text(), content="a😀")
 }
 
 ///|

--- a/modules/canopy/editor/sync_editor_text_wbtest.mbt
+++ b/modules/canopy/editor/sync_editor_text_wbtest.mbt
@@ -25,6 +25,47 @@ test "set_text_with_change returns a replacement splice" {
 }
 
 ///|
+test "set_text_with_change preserves grapheme-aware append fallbacks" {
+  let combining = try! @probe.new_test_editor("combining-agent")
+  combining.set_text("e")
+  let (combining_change, combining_accepted) = combining.set_text_with_change(
+    "é",
+  )
+  assert_true(combining_accepted)
+  inspect(combining_change.start, content="0")
+  inspect(combining_change.delete_len, content="1")
+  inspect(combining_change.inserted, content="é")
+
+  let crlf = try! @probe.new_test_editor("crlf-agent")
+  crlf.set_text("\r")
+  let (crlf_change, crlf_accepted) = crlf.set_text_with_change("\r\n")
+  assert_true(crlf_accepted)
+  inspect(crlf_change.start, content="0")
+  inspect(crlf_change.delete_len, content="1")
+  inspect(crlf_change.inserted, content="\r\n")
+
+  let emoji_append = try! @probe.new_test_editor("emoji-append-agent")
+  emoji_append.set_text("a😀")
+  let (emoji_append_change, emoji_append_accepted) = emoji_append.set_text_with_change(
+    "a😀x",
+  )
+  assert_true(emoji_append_accepted)
+  inspect(emoji_append_change.start, content="3")
+  inspect(emoji_append_change.delete_len, content="0")
+  inspect(emoji_append_change.inserted, content="x")
+
+  let emoji_insert = try! @probe.new_test_editor("emoji-insert-agent")
+  emoji_insert.set_text("a")
+  let (emoji_insert_change, emoji_insert_accepted) = emoji_insert.set_text_with_change(
+    "a😀",
+  )
+  assert_true(emoji_insert_accepted)
+  inspect(emoji_insert_change.start, content="1")
+  inspect(emoji_insert_change.delete_len, content="0")
+  inspect(emoji_insert_change.inserted, content="😀")
+}
+
+///|
 test "insert_at inserts at specified position without moving cursor" {
   let editor = try! @probe.new_test_editor("test-agent")
   editor.set_text("hello")

--- a/modules/canopy/editor/sync_editor_version_benchmark_wbtest.mbt
+++ b/modules/canopy/editor/sync_editor_version_benchmark_wbtest.mbt
@@ -12,13 +12,13 @@ fn version_benchmark_source(block_count : Int) -> String {
 ///|
 test "perf: cached SyncEditor version read (250 blocks)" (b : @bench.T) {
   let editor = try! @probe.new_test_editor("cached-version-benchmark")
-  editor.set_text(version_benchmark_source(250))
+  try! editor.set_text(version_benchmark_source(250))
   b.bench(() => b.keep(editor.get_version()))
 }
 
 ///|
 test "perf: TextState version expansion (250 blocks)" (b : @bench.T) {
   let editor = try! @probe.new_test_editor("expanded-version-benchmark")
-  editor.set_text(version_benchmark_source(250))
+  try! editor.set_text(version_benchmark_source(250))
   b.bench(() => b.keep(editor.doc.version()))
 }

--- a/modules/canopy/editor/sync_editor_version_benchmark_wbtest.mbt
+++ b/modules/canopy/editor/sync_editor_version_benchmark_wbtest.mbt
@@ -1,0 +1,24 @@
+///|
+fn version_benchmark_source(block_count : Int) -> String {
+  Array::makei(block_count, index => {
+    "## Heading " +
+    index.to_string() +
+    "\n\nParagraph " +
+    index.to_string() +
+    " with **bold**.\n"
+  }).join("\n")
+}
+
+///|
+test "perf: cached SyncEditor version read (250 blocks)" (b : @bench.T) {
+  let editor = try! @probe.new_test_editor("cached-version-benchmark")
+  editor.set_text(version_benchmark_source(250))
+  b.bench(() => b.keep(editor.get_version()))
+}
+
+///|
+test "perf: TextState version expansion (250 blocks)" (b : @bench.T) {
+  let editor = try! @probe.new_test_editor("expanded-version-benchmark")
+  editor.set_text(version_benchmark_source(250))
+  b.bench(() => b.keep(editor.doc.version()))
+}

--- a/modules/canopy/editor/text_diff.mbt
+++ b/modules/canopy/editor/text_diff.mbt
@@ -4,7 +4,10 @@
 ///|
 /// Compute a parser Edit from the difference between old and new text.
 pub fn compute_edit(old_text : String, new_text : String) -> @loom_core.Edit {
-  let change = @text_change.compute_text_change(old_text, new_text)
+  let change = match fast_append_text_change(old_text, new_text) {
+    Some(change) => change
+    None => @text_change.compute_text_change(old_text, new_text)
+  }
   @loom_core.Edit::new(
     change.start,
     change.delete_len,

--- a/modules/canopy/projection/reconcile_lcs_benchmark_wbtest.mbt
+++ b/modules/canopy/projection/reconcile_lcs_benchmark_wbtest.mbt
@@ -1,15 +1,17 @@
-// Isolated microbenchmark for `@core.reconcile_children`'s LCS DP on WIDE
-// sibling lists (BAND 2b evidence gate, canopy #443, cliff #2).
+// Isolated microbenchmark for `@core.reconcile` on WIDE sibling lists
+// (BAND 2b evidence gate, canopy #443, cliff #2).
 //
-// core/reconcile.mbt fills an (m+1)×(n+1) DP table unconditionally (the double
-// loop never short-circuits), so LCS child matching is O(m×n) by inspection.
-// But "O(n²) is bad" is not a profile — at small N with a trivial loop body it
-// may still be microseconds. This isolates the actual cost.
+// Equal-width inputs with the same kind at every position now take the exact
+// full-match positional path and skip the O(m×n) LCS table. These inputs model
+// append/leaf-content edits where the sibling structure is unchanged. The
+// existing reconcile implementation still falls back to LCS for structural
+// mismatches; this benchmark keeps the wide-sibling workload visible while
+// measuring the optimized case.
 //
 // IMPORTANT scope note: Lambda's root Module reconcile hook routes the def
 // list through duplicate-safe name matching (hash-based, O(N)) and only calls
 // `@core.reconcile` per individual def/body subtree (narrow). The wide-sibling
-// LCS is reached when `@core.reconcile` runs on a parent that itself has many
+// path is reached when `@core.reconcile` runs on a parent that itself has many
 // direct children — e.g. a Module node reconciled as a whole (the
 // JSON/flat-list projection path), which is what this bench constructs by
 // reconciling two N-def Modules directly.
@@ -55,7 +57,8 @@ test "control: reconcile operates on a wide sibling list" {
 
 ///|
 /// Build the two N-def Module trees once, then time only `@core.reconcile`
-/// (which runs the wide-sibling LCS DP over the N+1 direct children).
+/// over the N+1 direct children. The two sources differ only in the final
+/// literal, so their sibling kind sequence is positionally identical.
 fn bench_reconcile(b : @bench.T, n : Int) -> Unit raise {
   let (root_a, root_b) = lcs_setup(n)
   b.bench(() => {

--- a/modules/rabbita-context-menu/context_menu/context_menu_test.mbt
+++ b/modules/rabbita-context-menu/context_menu/context_menu_test.mbt
@@ -159,9 +159,16 @@ extern "js" fn install_shadow_focus_fixture(
   #|       globalThis.__contextMenuFocusLog.push("document:" + this.id);
   #|     },
   #|   };
-  #|   const shadowRoot = {
+  #|   const shadowMenu = {
+  #|     id: "test-menu",
   #|     children: [shadowItem],
-  #|     getElementById(id) { return id === itemId ? shadowItem : null; },
+  #|     querySelector(selector) {
+  #|       return selector === '[data-active="true"]' ? shadowItem : null;
+  #|     },
+  #|   };
+  #|   const shadowRoot = {
+  #|     children: [shadowMenu],
+  #|     getElementById(id) { return id === "test-menu" ? shadowMenu : null; },
   #|   };
   #|   const host = { id: rootId, children: [], shadowRoot };
   #|   globalThis.document = {


### PR DESCRIPTION
## Summary

- Optimize the Markdown Raw-input hot path with a guarded ASCII EOF-append fast path and cached document-version reads.
- Skip quadratic LCS construction when sibling lists are a full positional same-kind match, while retaining the existing hinted/LCS fallback.
- Add private Raw phase telemetry, package-local phase benchmarks, reconciliation regression coverage, and preserve pending Raw scheduling after an accepted in-flight commit.
- Construct the timing capability only for the private dev host; standalone Loomark passes no telemetry capability and performs no phase clock/state collection.

## Why

On the 250-block Markdown workload, repeated Raw edits were paying for whole-source diffing, UTF-16 endpoint conversion, version-log expansion, and quadratic sibling reconciliation even for common append/positional cases. The fast paths target only shapes whose result is already determined and retain the existing general algorithms for Unicode, CRLF, middle edits, deletions, structural hints, and kind mismatches.

Measured follow-ups include approximately 18–20 ms to approximately 0.15–0.18 ms for the ASCII append diff and approximately 9.6 ms to approximately 90 µs for wide positional reconciliation at 1,000 siblings.

## Scope and safety

- No changes to `deps/loom`.
- ASCII append optimization is restricted to suffix insertion at EOF; CRLF joins, Unicode, and grapheme-sensitive cases use the existing diff.
- Positional reconciliation is used only when lengths match, every position has the same kind, and hints are empty; all other cases use the existing LCS path.
- Raw phase telemetry is an optional capability constructed only by `private_dev_host_application`; standalone Loomark passes `None`, so it performs no phase clock/state collection.
- Rabbita PR #125 is not included or vendored by this PR.

## UI and review evidence

N/A for visual design: no layout, labels, or interaction styling changed. Existing browser behavior remains covered by the dev-host suite.

## Reuse check

Existing APIs considered and reused:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `@text_change.compute_text_change` | `dowdiness/text_change` | Yes | Remains the fallback for all non-ASCII-append shapes. |
| `SyncEditor::set_text_with_change` | Canopy editor | Yes | The existing editor-owned splice and acceptance boundary are preserved. |
| `reconcile_hinted` / `TreeNode::same_kind` | Canopy core / Loom core | Yes | The fast path delegates pair reconciliation and keeps hints on the existing path. |
| MoonBit `String` prefix/slicing/length, `Array`, `Map::is_empty`, and `Ref` | MoonBit core | Yes | Used for bounded fast-path checks, hint guards, and shell-local telemetry state. |
| `StringView` / `Iter` | MoonBit core | No | The existing owning-string operations are sufficient for the guarded path; no general string traversal API was added. |

New private helpers:

- `fast_append_text_change`: recognizes only the safe ASCII EOF shape and returns `None` for the existing diff fallback.
- `can_reconcile_children_positionally`: encodes the exact LCS-bypass precondition.
- `RawInputPhaseTiming` and its private coordinator methods: dev-host diagnostics only; they do not duplicate a domain API.

## Validation scope

Boundary matrix / regressions:

- ASCII EOF append, no-op, Unicode, CRLF, middle-edit, and deletion fallback.
- Positional same-kind reconciliation, identity/trace preservation, hint presence, length mismatch, and kind mismatch fallback.
- Cached version reads preserve the maintained document version.
- Scoped context-menu focus fixture matches the shadow-root lookup contract.
- Raw phase timings remain exposed by the dev host; standalone coordinator construction keeps phase snapshots empty; parser/recovery publishing and pending Raw scheduling remain covered.

Target packages:

- `modules/canopy/core`
- `modules/canopy/editor`
- `modules/canopy/editor/markdown`
- `modules/canopy/projection`
- `modules/rabbita-context-menu/context_menu`
- `apps/loomark/internal/rabbita`

Additional gates:

- Dev-host Playwright E2E: 83 passed.
- Dev-host TypeScript typecheck: passed.
- Dev-host phase-timing regression: passed with telemetry enabled.
- Release JavaScript build: passed.
- Standalone production E2E was not run because the Warren binary is unavailable in this environment.

## PR-ready evidence

Validated HEAD: `4651a9465ae868b18133a79a8ec5e00daba79cda`

Validated base: `origin/main@a056accbcadb0127e0a2d7a342987fadabfbb072`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh \
  --target modules/canopy/core \
  --target modules/canopy/editor \
  --target modules/canopy/editor/markdown \
  --target modules/canopy/projection \
  --target modules/rabbita-context-menu/context_menu \
  --target apps/loomark/internal/rabbita
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] Full validator passed for the exact HEAD and base above.
- [x] `--verify-evidence` passed after the final commit.
- [x] No `.mbti` changes.
- [x] No submodule pointer changes.
- [x] Independent MoonBit review was completed; its pending Raw scheduling finding was fixed in `31bb66d2` before final validation.
- [x] Raw telemetry gating was added in `5a622160`; standalone construction passes `None` and the coordinator regression test passes.
- [x] CodeRabbit benchmark/test findings were addressed in `4651a946`: parser inputs are precomputed, TextChange transitions alternate append/delete, final text assertions cover Unicode/CRLF, and benchmark setup propagates `Failure`.

