### PR TITLE
refactor(markdown): unify edit application runtime

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,7 @@ modules/canopy/probe/diagnostic_portability/pkg.generated.mbti whitespace=-blank
 
 # MoonBit owns these generated interfaces and emits a final blank line.
 modules/canopy/editor/markdown/pkg.generated.mbti whitespace=-blank-at-eof
+modules/canopy/internal/markdown_runtime/pkg.generated.mbti whitespace=-blank-at-eof
 apps/loomark/archive/pkg.generated.mbti whitespace=-blank-at-eof
 apps/loomark/core/pkg.generated.mbti whitespace=-blank-at-eof
 apps/loomark/internal/dev_host/pkg.generated.mbti whitespace=-blank-at-eof

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -71,3 +71,7 @@ _Avoid_: Matching mode, strategy, policy record
 **Fresh identity**:
 A newly allocated NodeId, given to a node that reconciliation cannot match to any previous node — including fresh nodes at unmatched positions and nodes whose old identity retired or was ambiguous (Replace / Move / unresolved wrap). The counterpart of preserved identity, where a node keeps its previous NodeId across an edit.
 _Avoid_: Identity carry (as a noun), id retention
+
+**Markdown edit application**:
+The language-owned transition that turns one typed Markdown structural-edit intent into one accepted document change, preserves its identity evidence, and reports the exact source transforms. It does not decide Loomark receipt, history, or selection meaning, and it does not serialize an FFI response.
+_Avoid_: Edit train, Loomark commit

--- a/modules/canopy/editor/markdown/editor.mbt
+++ b/modules/canopy/editor/markdown/editor.mbt
@@ -1071,7 +1071,7 @@ fn MarkdownEditor::commit_structural_recording_transforms(
   MarkdownEditorError,
 ] raise {
   let source = self.editor.get_text()
-  guard self.editor.get_proj_node() is Some(proj) else {
+  guard self.editor.get_proj_node() is Some(_) else {
     return Err(MarkdownEditorError::ProjectionUnavailable)
   }
   let deleted_block_index = match op {
@@ -1083,20 +1083,9 @@ fn MarkdownEditor::commit_structural_recording_transforms(
       .search_by(block => block.node_id().value == node_id)
     _ => None
   }
-  let source_map = self.editor.get_source_map()
-  let computed = Ok(
-    @md_edits.compute_markdown_edit(op, source, proj, source_map),
-  ) catch {
-    error => Err(error.message())
-  }
-  match computed {
-    Err(detail) => Err(MarkdownEditorError::EditFailed(detail~))
-    Ok(lowered) => {
-      let (edits, focus_hint) = match lowered {
-        Some(pair) => pair
-        None => ([], @core.FocusHint::RestoreCursor)
-      }
-      self.editor.apply_span_edits(edits, focus_hint, 0)
+  match @markdown_runtime.apply_edit(self.editor, op, 0) {
+    Err(error) => Err(MarkdownEditorError::EditFailed(detail=error.message()))
+    Ok(edits) => {
       self.editor.refresh()
       let snapshot = self.snapshot()
       let result = if snapshot.source() == source {

--- a/modules/canopy/editor/markdown/editor.mbt
+++ b/modules/canopy/editor/markdown/editor.mbt
@@ -1071,9 +1071,6 @@ fn MarkdownEditor::commit_structural_recording_transforms(
   MarkdownEditorError,
 ] raise {
   let source = self.editor.get_text()
-  guard self.editor.get_proj_node() is Some(_) else {
-    return Err(MarkdownEditorError::ProjectionUnavailable)
-  }
   let deleted_block_index = match op {
     @md_edits.Delete(node_id~) =>
       self
@@ -1084,7 +1081,7 @@ fn MarkdownEditor::commit_structural_recording_transforms(
     _ => None
   }
   match @markdown_runtime.apply_edit(self.editor, op, 0) {
-    Err(error) => Err(MarkdownEditorError::EditFailed(detail=error.message()))
+    Err(error) => Err(structural_edit_error(error))
     Ok(edits) => {
       self.editor.refresh()
       let snapshot = self.snapshot()
@@ -1115,6 +1112,17 @@ fn MarkdownEditor::commit_structural_recording_transforms(
       }
       Ok((result, sequential_text_transforms(edits)))
     }
+  }
+}
+
+///|
+/// Preserve the façade's projection category while rendering all language
+/// lowering failures through its existing compatibility error.
+fn structural_edit_error(error : @core.EditError) -> MarkdownEditorError {
+  match error {
+    @core.EditError::ProjectionUnavailable =>
+      MarkdownEditorError::ProjectionUnavailable
+    _ => MarkdownEditorError::EditFailed(detail=error.message())
   }
 }
 

--- a/modules/canopy/editor/markdown/markdown_editor_commit_phase_benchmark_wbtest.mbt
+++ b/modules/canopy/editor/markdown/markdown_editor_commit_phase_benchmark_wbtest.mbt
@@ -173,3 +173,33 @@ test "perf: MarkdownEditor commit with receipt (250 blocks)" (b : @bench.T) {
     b.keep(result)
   })
 }
+
+///|
+test "perf: MarkdownEditor structural block edit (250 blocks)" (b : @bench.T) {
+  let editor = commit_phase_editor(commit_phase_source(250))
+  let heading = editor.snapshot().blocks().to_array()[0].node_id()
+  match
+    editor.commit(
+      MarkdownEditRequest::CommitEdit(
+        node_id=heading,
+        new_text="Heading 0 changed",
+      ),
+    ) {
+    Ok(result) => b.keep(result)
+    Err(_) => abort("structural block benchmark prime failed")
+  }
+  let mut changed = false
+  b.bench(() => {
+    let new_text = if changed { "Heading 0 changed" } else { "Heading 0" }
+    let result = editor.commit(
+      MarkdownEditRequest::CommitEdit(node_id=heading, new_text~),
+    ) catch {
+      error => abort("structural block benchmark raised: \{error}")
+    }
+    changed = !changed
+    match result {
+      Ok(result) => b.keep(result)
+      Err(_) => abort("structural block benchmark failed")
+    }
+  })
+}

--- a/modules/canopy/editor/markdown/markdown_editor_wbtest.mbt
+++ b/modules/canopy/editor/markdown/markdown_editor_wbtest.mbt
@@ -731,6 +731,26 @@ test "receipt transforms use sequential reverse-document order" {
 }
 
 ///|
+test "structural edit errors preserve façade categorization" {
+  match structural_edit_error(@core.EditError::ProjectionUnavailable) {
+    MarkdownEditorError::ProjectionUnavailable => ()
+    _ => fail("expected the categorized projection-unavailable error")
+  }
+
+  match
+    structural_edit_error(
+      @core.EditError::NodeNotFound(
+        action="compute_markdown_edit",
+        node_id=@core.NodeId::from_int(999999),
+      ),
+    ) {
+    MarkdownEditorError::EditFailed(detail~) =>
+      assert_eq(detail, "compute_markdown_edit: node NodeId(999999) not found")
+    _ => fail("expected compatibility rendering for lowering errors")
+  }
+}
+
+///|
 test "headless facade lowers supported split and merge requests" {
   let editor = try! MarkdownEditor(
     agent_id="block-structure",

--- a/modules/canopy/editor/markdown/moon.pkg
+++ b/modules/canopy/editor/markdown/moon.pkg
@@ -1,4 +1,5 @@
 import {
+  "dowdiness/canopy/internal/markdown_runtime",
   "dowdiness/canopy/lang/markdown/companion" @md_companion,
   "dowdiness/canopy/lang/markdown/edits" @md_edits,
   "dowdiness/canopy/lang/markdown/sentinel" @md_sentinel,

--- a/modules/canopy/internal/markdown_runtime/markdown_runtime.mbt
+++ b/modules/canopy/internal/markdown_runtime/markdown_runtime.mbt
@@ -1,0 +1,117 @@
+///| Module-private owner of Markdown Language construction and edit application.
+
+///|
+let plain_language : @lang_runtime.Language[
+  @markdown.Block,
+  @md_edits.MarkdownEditOp,
+  @markdown.MarkdownSemanticAttachment?,
+] = make_language(false)
+
+///|
+fn make_language(
+  with_attachment : Bool,
+) -> @lang_runtime.Language[
+  @markdown.Block,
+  @md_edits.MarkdownEditOp,
+  @markdown.MarkdownSemanticAttachment?,
+] {
+  @lang_runtime.Language::Language(
+    parse=(source_id, source, runtime) => {
+      @loom.new_parser(source_id, source, @markdown.markdown_grammar, runtime?)
+    },
+    project=(parser, hints) => {
+      let memos = @md_proj.build_markdown_projection_memos(
+        parser,
+        identity_hints=hints,
+      )
+      let attachment = if with_attachment {
+        Some(
+          @markdown.MarkdownSemanticAttachment::MarkdownSemanticAttachment(
+            parser,
+          ),
+        )
+      } else {
+        None
+      }
+      (memos.0, memos.1, memos.2, attachment)
+    },
+    edit=(op, ctx) => {
+      match
+        @md_edits.compute_markdown_edit(
+          op,
+          ctx.source_text,
+          ctx.proj_node,
+          ctx.source_map,
+        ) {
+        Some((edits, focus_hint)) =>
+          @lang_runtime.EditResult::Edits(
+            edits,
+            focus_hint,
+            markdown_identity_hint(op),
+          )
+        None => @lang_runtime.EditResult::NoEdit
+      }
+    },
+    capabilities=_ => {
+      @editor.LanguageCapabilities::default().with_to_view_node((
+        proj,
+        source_map,
+        annotations,
+        source_text,
+      ) => {
+        @md_proj.proj_to_view_node(proj, source_map, annotations~, source_text~)
+      })
+    },
+  )
+}
+
+///|
+fn markdown_identity_hint(
+  op : @md_edits.MarkdownEditOp,
+) -> @core.IdentityTransform? {
+  match op {
+    MoveBlock(source~, ..) =>
+      Some(@core.IdentityTransform::Move(subtree=source))
+    _ => None
+  }
+}
+
+///|
+/// Construct the ordinary Markdown editor through the shared Language.
+pub fn new_editor(
+  agent_id : String,
+  capture_timeout_ms? : Int = 500,
+  parent_runtime? : @incr.Runtime,
+) -> @editor.SyncEditor[@markdown.Block] raise {
+  let (editor, _) = plain_language.build(
+    agent_id,
+    capture_timeout_ms~,
+    parent_runtime?,
+  )
+  editor
+}
+
+///|
+/// Construct a Markdown editor and semantic attachment over one live parser.
+pub fn new_editor_with_semantic_attachment(
+  agent_id : String,
+  capture_timeout_ms? : Int = 500,
+  parent_runtime? : @incr.Runtime,
+) -> (@editor.SyncEditor[@markdown.Block], @markdown.MarkdownSemanticAttachment) raise {
+  let (editor, attachment) = make_language(true).build(
+    agent_id,
+    capture_timeout_ms~,
+    parent_runtime?,
+  )
+  (editor, attachment.unwrap())
+}
+
+///|
+/// Apply one Markdown structural edit and return its exact source transforms.
+pub fn apply_edit(
+  editor : @editor.SyncEditor[@markdown.Block],
+  op : @md_edits.MarkdownEditOp,
+  timestamp_ms : Int,
+) -> Result[Array[@core.SpanEdit], @core.EditError] raise Failure {
+  plain_language.apply_edit(editor, op, timestamp_ms)
+}

--- a/modules/canopy/internal/markdown_runtime/markdown_runtime_test.mbt
+++ b/modules/canopy/internal/markdown_runtime/markdown_runtime_test.mbt
@@ -1,0 +1,26 @@
+///| The module-private Markdown edit application seam.
+
+///|
+test "Markdown edit application applies once and returns exact source transforms" {
+  let editor = try! new_editor("internal-markdown-runtime")
+  editor.set_text("# Title\n")
+  editor.refresh()
+  guard editor.get_proj_node() is Some(proj) && proj.children is [heading] else {
+    fail("expected one projected heading")
+  }
+
+  let result = apply_edit(
+    editor,
+    @md_edits.MarkdownEditOp::ChangeHeadingLevel(node_id=heading.id(), level=3),
+    0,
+  )
+  match result {
+    Ok([edit]) => {
+      assert_eq(edit.start, 0)
+      assert_eq(edit.delete_len, 8)
+      assert_eq(edit.inserted, "### Title\n")
+    }
+    _ => fail("expected one exact applied source transform")
+  }
+  assert_eq(editor.get_text(), "### Title\n")
+}

--- a/modules/canopy/internal/markdown_runtime/markdown_runtime_test.mbt
+++ b/modules/canopy/internal/markdown_runtime/markdown_runtime_test.mbt
@@ -24,3 +24,80 @@ test "Markdown edit application applies once and returns exact source transforms
   }
   assert_eq(editor.get_text(), "### Title\n")
 }
+
+///|
+test "Markdown edit application returns an empty trace for a no-op" {
+  let editor = try! new_editor("internal-markdown-no-op")
+  editor.set_text("First\n")
+  editor.refresh()
+  guard editor.get_proj_node() is Some(proj) && proj.children is [paragraph] else {
+    fail("expected one projected paragraph")
+  }
+
+  match
+    apply_edit(
+      editor,
+      @md_edits.MarkdownEditOp::MergeWithPrevious(node_id=paragraph.id()),
+      0,
+    ) {
+    Ok([]) => ()
+    _ => fail("expected an empty source-transform trace")
+  }
+  assert_eq(editor.get_text(), "First\n")
+}
+
+///|
+test "Markdown edit application preserves typed lowering errors" {
+  let editor = try! new_editor("internal-markdown-error")
+  editor.set_text("# Present\n")
+  editor.refresh()
+  let missing = @core.NodeId::from_int(999999)
+
+  match
+    apply_edit(
+      editor,
+      @md_edits.MarkdownEditOp::ChangeHeadingLevel(node_id=missing, level=2),
+      0,
+    ) {
+    Err(@core.EditError::NodeNotFound(action~, node_id~)) => {
+      assert_eq(action, "compute_markdown_edit")
+      assert_eq(node_id, missing)
+    }
+    _ => fail("expected the typed missing-node lowering error")
+  }
+  assert_eq(editor.get_text(), "# Present\n")
+}
+
+///|
+test "Markdown edit application preserves moved identity across renumbering" {
+  let editor = try! new_editor("internal-markdown-move")
+  editor.set_text("1. A\n2. B\n3. C\n")
+  editor.refresh()
+  guard editor.get_proj_node() is Some(before) &&
+    before.children is [list] &&
+    list.children is [first, _, third] else {
+    fail("expected one three-item ordered list")
+  }
+
+  match
+    apply_edit(
+      editor,
+      @md_edits.MarkdownEditOp::MoveBlock(
+        source=third.id(),
+        target=first.id(),
+        position=@core.DropPosition::Before,
+      ),
+      0,
+    ) {
+    Ok([_]) => ()
+    _ => fail("expected one exact move transform")
+  }
+  editor.refresh()
+  guard editor.get_proj_node() is Some(after) &&
+    after.children is [moved_list] &&
+    moved_list.children is [moved, ..] else {
+    fail("expected the moved ordered list")
+  }
+  assert_eq(moved.id(), third.id())
+  assert_eq(editor.get_text(), "1. C\n2. A\n3. B\n")
+}

--- a/modules/canopy/internal/markdown_runtime/moon.pkg
+++ b/modules/canopy/internal/markdown_runtime/moon.pkg
@@ -1,13 +1,10 @@
 import {
   "dowdiness/canopy/core",
   "dowdiness/canopy/editor",
-  "dowdiness/canopy/internal/markdown_runtime",
   "dowdiness/canopy/lang/markdown/edits" @md_edits,
-  "dowdiness/canopy/lang/markdown/sentinel" @md_sentinel,
+  "dowdiness/canopy/lang/markdown/proj" @md_proj,
+  "dowdiness/canopy/lang/runtime" @lang_runtime,
   "dowdiness/incr",
   "dowdiness/markdown",
+  "dowdiness/loom",
 }
-
-import {
-  "dowdiness/canopy/protocol",
-} for "wbtest"

--- a/modules/canopy/internal/markdown_runtime/pkg.generated.mbti
+++ b/modules/canopy/internal/markdown_runtime/pkg.generated.mbti
@@ -1,0 +1,26 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "dowdiness/canopy/internal/markdown_runtime"
+
+import {
+  "dowdiness/canopy/core",
+  "dowdiness/canopy/editor",
+  "dowdiness/canopy/lang/markdown/edits",
+  "dowdiness/incr/cells",
+  "dowdiness/markdown",
+}
+
+// Values
+pub fn apply_edit(@editor.SyncEditor[@markdown.Block], @edits.MarkdownEditOp, Int) -> Result[Array[@core.SpanEdit], @core.EditError] raise Failure
+
+pub fn new_editor(String, capture_timeout_ms? : Int, parent_runtime? : @cells.Runtime) -> @editor.SyncEditor[@markdown.Block] raise
+
+pub fn new_editor_with_semantic_attachment(String, capture_timeout_ms? : Int, parent_runtime? : @cells.Runtime) -> (@editor.SyncEditor[@markdown.Block], @markdown.MarkdownSemanticAttachment) raise
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/modules/canopy/lang/markdown/companion/markdown_companion.mbt
+++ b/modules/canopy/lang/markdown/companion/markdown_companion.mbt
@@ -11,12 +11,7 @@ pub fn new_markdown_editor(
   capture_timeout_ms? : Int = 500,
   parent_runtime? : @incr.Runtime,
 ) -> @editor.SyncEditor[@markdown.Block] raise {
-  let (editor, _) = md_lang_plain.build(
-    agent_id,
-    capture_timeout_ms~,
-    parent_runtime?,
-  )
-  editor
+  @markdown_runtime.new_editor(agent_id, capture_timeout_ms~, parent_runtime?)
 }
 
 ///|
@@ -28,82 +23,10 @@ pub fn new_markdown_editor_with_semantic_attachment(
   capture_timeout_ms? : Int = 500,
   parent_runtime? : @incr.Runtime,
 ) -> (@editor.SyncEditor[@markdown.Block], @markdown.MarkdownSemanticAttachment) raise {
-  let (editor, attachment) = make_md_lang(true).build(
+  @markdown_runtime.new_editor_with_semantic_attachment(
     agent_id,
     capture_timeout_ms~,
     parent_runtime?,
-  )
-  (editor, attachment.unwrap())
-}
-
-///|
-/// Ordinary Markdown language definition (no semantic attachment). Used for
-/// the plain constructor and the apply bridge; the semantic path builds a
-/// separate definition that also constructs the attachment in `project`.
-let md_lang_plain : @lang_runtime.Language[
-  @markdown.Block,
-  @md_edits.MarkdownEditOp,
-  @markdown.MarkdownSemanticAttachment?,
-] = make_md_lang(false)
-
-///|
-/// Markdown language definition. `with_attachment` controls whether `project`
-/// also constructs a `MarkdownSemanticAttachment` over the exact parser and
-/// returns it as the extras value `E`.
-fn make_md_lang(
-  with_attachment : Bool,
-) -> @lang_runtime.Language[
-  @markdown.Block,
-  @md_edits.MarkdownEditOp,
-  @markdown.MarkdownSemanticAttachment?,
-] {
-  @lang_runtime.Language::Language(
-    parse=(source_id, source, runtime) => {
-      @loom.new_parser(source_id, source, @markdown.markdown_grammar, runtime?)
-    },
-    project=(parser, hints) => {
-      let memos = @md_proj.build_markdown_projection_memos(
-        parser,
-        identity_hints=hints,
-      )
-      let attachment = if with_attachment {
-        Some(
-          @markdown.MarkdownSemanticAttachment::MarkdownSemanticAttachment(
-            parser,
-          ),
-        )
-      } else {
-        None
-      }
-      (memos.0, memos.1, memos.2, attachment)
-    },
-    edit=(op, ctx) => {
-      match
-        @md_edits.compute_markdown_edit(
-          op,
-          ctx.source_text,
-          ctx.proj_node,
-          ctx.source_map,
-        ) {
-        Some((edits, focus_hint)) =>
-          @lang_runtime.EditResult::Edits(
-            edits,
-            focus_hint,
-            markdown_identity_hint(op),
-          )
-        None => @lang_runtime.EditResult::NoEdit
-      }
-    },
-    capabilities=_e => {
-      @editor.LanguageCapabilities::default().with_to_view_node((
-        proj,
-        source_map,
-        annotations,
-        source_text,
-      ) => {
-        @md_proj.proj_to_view_node(proj, source_map, annotations~, source_text~)
-      })
-    },
   )
 }
 
@@ -187,19 +110,8 @@ pub fn apply_markdown_edit(
   op : @md_edits.MarkdownEditOp,
   timestamp_ms : Int,
 ) -> Result[Unit, String] raise {
-  match md_lang_plain.apply_edit(editor, op, timestamp_ms) {
+  match @markdown_runtime.apply_edit(editor, op, timestamp_ms) {
     Ok(_) => Ok(())
     Err(e) => Err(e.message())
-  }
-}
-
-///|
-fn markdown_identity_hint(
-  op : @md_edits.MarkdownEditOp,
-) -> @core.IdentityTransform? {
-  match op {
-    MoveBlock(source~, ..) =>
-      Some(@core.IdentityTransform::Move(subtree=source))
-    _ => None
   }
 }


### PR DESCRIPTION
## Summary

- Add module-private `internal/markdown_runtime` as the single owner of Markdown `Language` construction and structural edit application.
- Route both the companion and headless Markdown adapters through that runtime while preserving their existing errors, receipts, selection policy, timestamps, identity hints, and public `.mbti` surfaces.
- Characterize exact transforms, no-op traces, typed lowering errors, moved identity, façade error mapping, and the 250-block structural-edit hot path.

## UI and review evidence

N/A — no UI or visual changes.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `Language::Language`, `Language::build`, `Language::apply_edit` | `modules/canopy/lang/runtime/language.mbt` | Yes | Own construction, structured error handling, identity-hint application, and exact `SpanEdit` return values. |
| `compute_markdown_edit` | `modules/canopy/lang/markdown/edits/compute_markdown_edit.mbt` | Yes | Remains the authoritative pure Markdown lowering function. |
| `EditError::message` | `modules/canopy/core/edit_error.mbt` | Yes | Preserves legacy companion/headless error text. |
| Core `Option` / `Result` | MoonBit core | Yes | Represent `NoEdit`, semantic attachment presence, and structured edit outcomes without a new plan/outcome type. |
| Core `Array` plus existing `copy` / `sort_by` / `map` receipt path | MoonBit core and `modules/canopy/editor/markdown/editor.mbt` | Yes | Keeps exact transform arrays from the runtime and preserves the existing defensive-copy receipt ordering. |
| `Result::map_err` | MoonBit core | No | The headless façade must preserve `ProjectionUnavailable` as a distinct variant while rendering every other lowering error through the legacy compatibility string. |

New helpers added (if any):

- `make_language`: module-private construction boundary for Markdown parse/project/edit/capability wiring.
- `markdown_identity_hint`: keeps Markdown `MoveBlock` identity evidence beside the language edit definition; moved from the companion rather than duplicated.
- `new_editor`, `new_editor_with_semantic_attachment`, `apply_edit`: the minimal module-private API consumed by compatibility adapters.
- `structural_edit_error`: pure private mapping from core edit errors to the existing headless façade error contract.

## Validation scope

Boundary matrix / first failing regression:

- Applied edit: applies once and returns the exact source transform in lowering order.
- No edit: returns `Ok([])` and leaves source unchanged.
- Lowering failure: preserves the typed `EditError` and leaves source unchanged.
- MoveBlock: preserves source-node identity across ordered-list renumbering.
- Projection unavailable: remains `MarkdownEditorError::ProjectionUnavailable`; other failures retain legacy detail text.
- Companion and headless adapters retain existing `Applied` / `Unchanged`, selection, receipt, timestamp, and FFI behavior.
- Current Markdown lowerers emit at most one `SpanEdit`; generic runtime tests own multi-span application, and the existing synthetic receipt test pins reverse-document transform ordering.
- First tracer test failed because the new internal `new_editor` and `apply_edit` seam did not yet exist.

Target packages:

- `modules/canopy/internal/markdown_runtime`
- `modules/canopy/lang/markdown/companion`
- `modules/canopy/editor/markdown`

Additional conditional gates:

- Release tests: internal runtime 4/4, companion 18/18, headless Markdown 64/64, Markdown FFI 12/12.
- All 11 editor benchmarks passed. Interleaved 250-block structural-edit measurements were `78.58 ms ± 11.11 ms` on `origin/main` and `77.42 ms ± 9.15 ms` on the candidate, showing no detectable regression within run-to-run noise.
- Independent MoonBit re-review: PASS.
- No proof, UI, submodule, or FFI-consumer source changed.

## PR-ready evidence

Validated HEAD: `02fb302a0f6c91d12f6bc216321ddb07ce8db143`

Validated base: `origin/main@b43f5364f3450e45c8b07268137b893dde7df1bd`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh \
  --target modules/canopy/internal/markdown_runtime \
  --target modules/canopy/lang/markdown/companion \
  --target modules/canopy/editor/markdown
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for the exact HEAD and base above.
- [x] The base was fetched again and `--verify-evidence` passed immediately before this PR was opened.
- [x] The committed `.mbti` diff against the validated base was reviewed: existing interfaces are unchanged; only the new internal package interface was added.
- [x] No submodule pointer changed; recorded submodule commits passed the validator reachability checks.
- [x] Validation was rerun after the follow-up commit and amend.
- [x] Independent review findings and the dependency-rule gate finding were resolved before final validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved Markdown structural edit application and error categorization.
  * Preserved projection-unavailable and missing-node error details.
  * Maintained block identity during moves and generated accurate source transforms.
  * Added support for semantic attachments in Markdown editing.

* **Tests & Performance**
  * Added coverage for edit transforms, no-op edits, errors, and block moves.
  * Added a benchmark for structural edits in large Markdown documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->