### PR TITLE
fix(loomark): reject stale Block input

### DIFF
--- a/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
+++ b/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
@@ -1097,7 +1097,8 @@ test("clearing the only Block keeps an empty control editable", async ({ browser
     await input.fill("")
     await expect(input).toHaveValue("")
     await expect(host.page.locator("[data-loomark-block-id]")).toHaveCount(1)
-    await host.page.keyboard.type("Again")
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("\u200B\n")
+    await input.fill("Again")
     await expect.poll(async () => (await snapshot(host.page)).source).toBe("Again\n")
   } finally {
     await host.context.close()
@@ -1322,7 +1323,7 @@ test("rejected Block insertion restores a UTF-16 text cursor to its accepted pos
   }
 })
 
-test("rejected Block repair yields to a newer same-frame input", async ({ browser }) => {
+test("rejected coalesced Block input is not retried", async ({ browser }) => {
   const host = await mountHost(browser, "start\n")
   try {
     await selectBlock(host.page)
@@ -1342,13 +1343,16 @@ test("rejected Block repair yields to a newer same-frame input", async ({ browse
       requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
     }))
 
-    await expect.poll(async () => (await snapshot(host.page)).source).toBe("startXY\n")
-    await expect(input).toHaveValue("startXY")
+    await expect.poll(async () => (await snapshot(host.page)).error_code).toBe(
+      "editor-commit-failed",
+    )
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("start\n")
+    await expect(input).toHaveValue("start")
     await expect(input).toBeFocused()
     await expect.poll(() => input.evaluate(element => {
       const textarea = element as HTMLTextAreaElement
       return `${textarea.selectionStart}:${textarea.selectionEnd}`
-    })).toBe("7:7")
+    })).toBe("5:5")
   } finally {
     await host.context.close()
   }
@@ -1588,7 +1592,7 @@ test("Block split at the start creates and focuses an empty previous block", asy
       const textarea = document.activeElement as HTMLTextAreaElement | null
       return textarea === null ? "missing" : `${textarea.selectionStart}:${textarea.selectionEnd}`
     })).toBe("0:0")
-    await host.page.keyboard.type("Before")
+    await input.fill("Before")
     await expect.poll(async () => (await snapshot(host.page)).source).toBe("Before\n\nHello\n")
   } finally {
     await host.context.close()

--- a/apps/loomark/examples/vanilla/tests/standalone.spec.ts
+++ b/apps/loomark/examples/vanilla/tests/standalone.spec.ts
@@ -184,6 +184,78 @@ test("Raw, Block, and Preview editing stays inside the original production root"
   await expect(root).toHaveCount(1)
 })
 
+test("ordinary consecutive Block input preserves both characters and the caret", async ({ page }) => {
+  await page.goto("/")
+  await page.locator("#loomark-input").fill("x")
+  await page.locator("#loomark-mode-block").click()
+
+  const input = page.locator("#loomark-block-input")
+  const block = page.locator("#loomark-block")
+  await expect(input).toHaveValue("x")
+
+  await input.selectText()
+  await input.pressSequentially("a")
+  await expect(block).toHaveAttribute("data-loomark-source", "a")
+  await expect(input).toHaveValue("a")
+  await expect
+    .poll(() => input.evaluate(element => ({
+      start: (element as HTMLTextAreaElement).selectionStart,
+      end: (element as HTMLTextAreaElement).selectionEnd,
+    })))
+    .toEqual({ start: 1, end: 1 })
+
+  await input.pressSequentially("b")
+  await expect(block).toHaveAttribute("data-loomark-source", "ab")
+  await expect(input).toHaveValue("ab")
+  await expect
+    .poll(() => input.evaluate(element => ({
+      start: (element as HTMLTextAreaElement).selectionStart,
+      end: (element as HTMLTextAreaElement).selectionEnd,
+    })))
+    .toEqual({ start: 2, end: 2 })
+  await expect(page.locator("#loomark-error")).toHaveCount(0)
+})
+
+test("Block input preserves the latest value when two events arrive before redraw", async ({ page }) => {
+  await page.goto("/")
+  await page.locator("#loomark-input").fill("x")
+  await page.locator("#loomark-mode-block").click()
+  const input = page.locator("#loomark-block-input")
+  const block = page.locator("#loomark-block")
+  await expect(input).toHaveValue("x")
+
+  await input.evaluate(element => {
+    const textarea = element as HTMLTextAreaElement
+    textarea.value = "a"
+    textarea.setSelectionRange(1, 1)
+    textarea.dispatchEvent(new InputEvent("input", {
+      bubbles: true,
+      composed: true,
+      data: "a",
+      inputType: "insertText",
+    }))
+
+    textarea.value = "ab"
+    textarea.setSelectionRange(2, 2)
+    textarea.dispatchEvent(new InputEvent("input", {
+      bubbles: true,
+      composed: true,
+      data: "b",
+      inputType: "insertText",
+    }))
+  })
+
+  await expect(block).toHaveAttribute("data-loomark-source", "ab")
+  await expect(input).toHaveValue("ab")
+  await expect
+    .poll(() => input.evaluate(element => ({
+      start: (element as HTMLTextAreaElement).selectionStart,
+      end: (element as HTMLTextAreaElement).selectionEnd,
+    })))
+    .toEqual({ start: 2, end: 2 })
+  await expect(page.locator("#loomark-error")).toHaveCount(0)
+})
+
 test("Preview wraps long unbreakable content inside the reading frame", async ({ page }) => {
   await page.goto("/")
   const longUrl = `https://example.com/${`a`.repeat(200)}`

--- a/apps/loomark/internal/rabbita/application.mbt
+++ b/apps/loomark/internal/rabbita/application.mbt
@@ -390,11 +390,12 @@ fn editor_view(
   model : DriverModel,
   emit : @cmd.Emit[DriverEvent],
   raw_input_coordinator : RawInputCoordinator,
+  block_input_coordinator : BlockInputCoordinator,
 ) -> @rabbita_runtime.Html {
   match model.state.mode() {
     @core.Raw => raw_editor_view(model, emit, raw_input_coordinator)
     @core.Preview => preview_document_view(model)
-    @core.Block => block_editor_view(model, emit)
+    @core.Block => block_editor_view(model, block_input_coordinator, emit)
   }
 }
 
@@ -873,6 +874,7 @@ fn update_editing(
   editor : @markdown.MarkdownEditor,
   attachment : @md_markdown.MarkdownSemanticAttachment,
   raw_input_coordinator : RawInputCoordinator,
+  block_input_coordinator : BlockInputCoordinator,
   model : DriverModel,
   latest_model : @ref.Ref[DriverModel?],
   event : EditingEvent,
@@ -884,6 +886,22 @@ fn update_editing(
   }
   if event is RawInput(_, _, Some(_)) && !raw_token_active {
     return (model, @rabbita_runtime.none)
+  }
+  match event {
+    BlockInput(token~, input~) => {
+      if !block_input_coordinator.is_active(token) {
+        return (model, block_input_coordinator.finish(token, emit))
+      }
+      if model.state.mode() != @core.Block {
+        return (model, block_input_coordinator.finish(token, emit))
+      }
+      match check_block_edit(model.document_id, editor.version(), input) {
+        Current => ()
+        WrongDocument | StaleVersion =>
+          return (model, block_input_coordinator.finish(token, emit))
+      }
+    }
+    _ => ()
   }
   match
     editing_mode_applicable(event, model.state.mode(), model.split_preview_open) {
@@ -1218,18 +1236,34 @@ fn update_editing(
               (next, command)
             }
           }
-        BlockInput(node_id~, input_id~, text=proposed_text, selection_offset~) => {
+        BlockInput(token~, input~) => {
+          match check_block_selection(model.document, input) {
+            ValidBlockSelection => ()
+            NonCollapsedBlockSelection
+            | InvalidBlockSelection
+            | MissingBlockSelectionTarget =>
+              return (model, block_input_coordinator.finish(token, emit))
+          }
+          if !block_input_coordinator.is_active(token) {
+            return (model, block_input_coordinator.finish(token, emit))
+          }
+          match check_block_edit(model.document_id, editor.version(), input) {
+            Current => ()
+            WrongDocument | StaleVersion =>
+              return (model, block_input_coordinator.finish(token, emit))
+          }
           let (next, committed_selection, accepted, persistence_command) = commit_block_request(
             editor,
             attachment,
             model,
             @markdown.MarkdownEditRequest::CommitTextControlEdit(
-              node_id~,
-              new_text=proposed_text,
+              node_id=input.node_id,
+              new_text=input.text,
             ),
             "editor-dispatch",
             emit,
           )
+          let finish_command = block_input_coordinator.finish(token, emit)
           if accepted && next.source_revision != model.source_revision {
             raw_input_coordinator.cancel_pending()
           }
@@ -1238,40 +1272,53 @@ fn update_editing(
               block_selection_from_commit(
                 next.document,
                 selection,
-                offset=selection_offset,
+                offset=input.selection.end(),
               )
             None => None
           }
-          let next = {
-            ..next,
-            text_input_generation: model.text_input_generation + 1,
-            active_block_key: match selection {
-              Some(selection) => Some(selection.key)
-              None => model.active_block_key
-            },
-            selection: match selection {
-              Some(selection) => Some(block_selection_label(selection))
-              None => None
-            },
+          let next = if accepted {
+            {
+              ..next,
+              text_input_generation: model.text_input_generation + 1,
+              active_block_key: match selection {
+                Some(selection) => Some(selection.key)
+                None => model.active_block_key
+              },
+              selection: match selection {
+                Some(selection) => Some(block_selection_label(selection))
+                None => None
+              },
+            }
+          } else {
+            next
           }
           match selection {
             Some(selection) =>
-              (
-                next,
-                @cmd.batch([
-                  persistence_command,
-                  block_selection_after_render(
-                    latest_model,
-                    selection,
-                    next.source_revision,
-                    report_superseded=false,
-                    emit,
-                  ),
-                ]),
-              )
+              // Clearing the final payload can install the façade's empty
+              // paragraph sentinel and replace the rendered control. Ordinary
+              // input keeps the browser's native caret and must not queue an
+              // older caret write over newer keystrokes.
+              if input.text == "" {
+                (
+                  next,
+                  @cmd.batch([
+                    persistence_command,
+                    finish_command,
+                    block_selection_after_render(
+                      latest_model,
+                      selection,
+                      next.source_revision,
+                      report_superseded=false,
+                      emit,
+                    ),
+                  ]),
+                )
+              } else {
+                (next, @cmd.batch([persistence_command, finish_command]))
+              }
             None =>
               if accepted {
-                (next, persistence_command)
+                (next, @cmd.batch([persistence_command, finish_command]))
               } else {
                 let accepted_text = next.document
                   .blocks()
@@ -1279,7 +1326,7 @@ fn update_editing(
                     match found {
                       Some(_) => found
                       None =>
-                        if block.node_id() == node_id {
+                        if block.node_id() == input.node_id {
                           Some(block.text())
                         } else {
                           None
@@ -1289,7 +1336,9 @@ fn update_editing(
                 match accepted_text {
                   Some(text) => {
                     let offset = rejected_text_offset(
-                      text, proposed_text, selection_offset,
+                      text,
+                      input.text,
+                      input.selection.end(),
                     )
                     let repair_generation = next.text_input_generation
                     let repair_source_revision = next.source_revision
@@ -1297,6 +1346,7 @@ fn update_editing(
                       next,
                       @cmd.batch([
                         persistence_command,
+                        finish_command,
                         after_render(
                           scheduler => {
                             ignore(scheduler)
@@ -1306,10 +1356,13 @@ fn update_editing(
                                 repair_generation,
                                 repair_source_revision,
                               ) {
-                              @dom_boundary.write_text_value_id(input_id, text)
-                              @dom_boundary.focus_id(input_id)
+                              @dom_boundary.write_text_value_id(
+                                input.input_id,
+                                text,
+                              )
+                              @dom_boundary.focus_id(input.input_id)
                               @dom_boundary.write_text_selection_id(
-                                input_id,
+                                input.input_id,
                                 @dom_boundary.TextSelection(
                                   offset,
                                   offset,
@@ -1323,7 +1376,8 @@ fn update_editing(
                       ]),
                     )
                   }
-                  None => (next, persistence_command)
+                  None =>
+                    (next, @cmd.batch([persistence_command, finish_command]))
                 }
               }
           }
@@ -1770,6 +1824,7 @@ fn update_lifecycle(
   editor : @markdown.MarkdownEditor,
   attachment : @md_markdown.MarkdownSemanticAttachment,
   raw_input_coordinator : RawInputCoordinator,
+  block_input_coordinator : BlockInputCoordinator,
   model : DriverModel,
   event : LifecycleEvent,
   emit : @cmd.Emit[DriverEvent],
@@ -1869,6 +1924,7 @@ fn update_lifecycle(
       }
       if accepted {
         raw_input_coordinator.cancel_pending()
+        block_input_coordinator.cancel_pending()
         next = { ..next, state: transition.state() }
       }
       next = update_preview_document(
@@ -1954,6 +2010,7 @@ fn update_model(
   editor : @markdown.MarkdownEditor,
   attachment : @md_markdown.MarkdownSemanticAttachment,
   raw_input_coordinator : RawInputCoordinator,
+  block_input_coordinator : BlockInputCoordinator,
   model : DriverModel,
   latest_model : @ref.Ref[DriverModel?],
   event : DriverEvent,
@@ -1977,15 +2034,16 @@ fn update_model(
     }
     Editing(edit_event) =>
       update_editing(
-        editor, attachment, raw_input_coordinator, model, latest_model, edit_event,
-        emit,
+        editor, attachment, raw_input_coordinator, block_input_coordinator, model,
+        latest_model, edit_event, emit,
       )
     Navigation(nav_event) =>
       update_navigation(attachment, model, latest_model, nav_event, emit)
     Probe(probe_event) => update_probe(model, probe_event, emit)
     Lifecycle(life_event) =>
       update_lifecycle(
-        editor, attachment, raw_input_coordinator, model, life_event, emit,
+        editor, attachment, raw_input_coordinator, block_input_coordinator, model,
+        life_event, emit,
       )
   }
   let raw_input_token = match event {
@@ -2187,12 +2245,14 @@ fn build_application(
   let raw_input_coordinator = RawInputCoordinator::RawInputCoordinator(
     raw_input_telemetry,
   )
+  let block_input_coordinator = BlockInputCoordinator::BlockInputCoordinator()
   let update = (model, event, emit) => {
     let session = current_session.val
     update_model(
       session.editor,
       session.attachment,
       raw_input_coordinator,
+      block_input_coordinator,
       model,
       latest_model,
       event,
@@ -2200,6 +2260,7 @@ fn build_application(
     ) catch {
       Failure::Failure(_) as failure => {
         raw_input_coordinator.cancel_pending()
+        block_input_coordinator.cancel_pending()
         let (next, command) = recover_after_parser_failure(
           current_session, model, failure, emit,
         )
@@ -2208,6 +2269,7 @@ fn build_application(
       }
       error => {
         raw_input_coordinator.cancel_pending()
+        block_input_coordinator.cancel_pending()
         let (next, command) = quarantine_outer_error(
           current_session, model, error,
         )
@@ -2231,7 +2293,9 @@ fn build_application(
       update~,
       subscriptions~,
     )
-    let active_view = application_view(model, emit, raw_input_coordinator)
+    let active_view = application_view(
+      model, emit, raw_input_coordinator, block_input_coordinator,
+    )
     model.view2(active_view, (model, active_view) => {
       latest_model.val = Some(model)
       view(model, emit, active_view)

--- a/apps/loomark/internal/rabbita/block_input_coordinator.mbt
+++ b/apps/loomark/internal/rabbita/block_input_coordinator.mbt
@@ -1,0 +1,302 @@
+///|
+/// One browser Block input captured against the document state that rendered
+/// its text control. This package-private value is replaced, not accumulated,
+/// while input from the same JavaScript turn is waiting to be delivered.
+priv struct PendingBlockInput {
+  document_id : @archive.LoomarkDocumentId
+  expected_version : @markdown.MarkdownDocumentVersion
+  node_id : @markdown.MarkdownNodeId
+  input_id : String
+  text : String
+  selection : @dom_boundary.TextSelection
+}
+
+///|
+fn PendingBlockInput::PendingBlockInput(
+  document_id~ : @archive.LoomarkDocumentId,
+  expected_version~ : @markdown.MarkdownDocumentVersion,
+  node_id~ : @markdown.MarkdownNodeId,
+  input_id~ : String,
+  text~ : String,
+  selection~ : @dom_boundary.TextSelection,
+) -> PendingBlockInput {
+  { document_id, expected_version, node_id, input_id, text, selection }
+}
+
+///|
+priv enum BlockEditCheck {
+  Current
+  WrongDocument
+  StaleVersion
+}
+
+///|
+fn check_block_edit(
+  current_document_id : @archive.LoomarkDocumentId,
+  current_version : @markdown.MarkdownDocumentVersion,
+  input : PendingBlockInput,
+) -> BlockEditCheck {
+  if input.document_id != current_document_id {
+    WrongDocument
+  } else if input.expected_version != current_version {
+    StaleVersion
+  } else {
+    Current
+  }
+}
+
+///|
+priv enum BlockSelectionCheck {
+  ValidBlockSelection
+  NonCollapsedBlockSelection
+  InvalidBlockSelection
+  MissingBlockSelectionTarget
+}
+
+///|
+fn check_block_selection(
+  document : @markdown.MarkdownDocumentSnapshot,
+  input : PendingBlockInput,
+) -> BlockSelectionCheck {
+  let target_exists = document
+    .blocks()
+    .fold(init=false, (found, block) => {
+      found || block.node_id() == input.node_id
+    })
+  if !target_exists {
+    MissingBlockSelectionTarget
+  } else if input.selection.start() != input.selection.end() {
+    NonCollapsedBlockSelection
+  } else {
+    let offset = input.selection.start()
+    if offset < 0 ||
+      offset > input.text.length() ||
+      !@moji.is_grapheme_boundary(input.text, offset) {
+      InvalidBlockSelection
+    } else {
+      ValidBlockSelection
+    }
+  }
+}
+
+///|
+/// Identifies one deferred delivery attempt. A newer enqueue makes every older
+/// schedule inapplicable without requiring timer cancellation.
+priv struct BlockInputSchedule {
+  generation : Int
+}
+
+///|
+/// One latest input released for the existing Block commit path.
+priv struct BlockInputDelivery {
+  token : Int
+  input : PendingBlockInput
+}
+
+///|
+/// Deterministic state for replacing rapid Block input with its latest value.
+/// Scheduling and message delivery remain in the Rabbita command shell.
+priv struct BlockInputState {
+  pending : PendingBlockInput?
+  generation : Int
+  next_token : Int
+  in_flight : BlockInputDelivery?
+}
+
+///|
+fn BlockInputState::BlockInputState() -> BlockInputState {
+  { pending: None, generation: 0, next_token: 0, in_flight: None }
+}
+
+///|
+fn BlockInputState::enqueue(
+  self : BlockInputState,
+  input : PendingBlockInput,
+) -> (BlockInputState, BlockInputSchedule) {
+  let generation = self.generation + 1
+  ({ ..self, pending: Some(input), generation }, { generation, })
+}
+
+///|
+fn BlockInputState::flush(
+  self : BlockInputState,
+  schedule : BlockInputSchedule,
+) -> (BlockInputState, BlockInputDelivery?) {
+  guard schedule.generation == self.generation && self.in_flight is None else {
+    return (self, None)
+  }
+  match self.pending {
+    None => (self, None)
+    Some(input) => {
+      let delivery = { token: self.next_token, input }
+      (
+        {
+          ..self,
+          pending: None,
+          next_token: self.next_token + 1,
+          in_flight: Some(delivery),
+        },
+        Some(delivery),
+      )
+    }
+  }
+}
+
+///|
+fn PendingBlockInput::matches(
+  self : PendingBlockInput,
+  document_id : @archive.LoomarkDocumentId,
+  version : @markdown.MarkdownDocumentVersion,
+  node_id : @markdown.MarkdownNodeId,
+  input_id : String,
+) -> Bool {
+  self.document_id == document_id &&
+  self.expected_version == version &&
+  self.node_id == node_id &&
+  self.input_id == input_id
+}
+
+///|
+fn BlockInputState::display_text(
+  self : BlockInputState,
+  document_id~ : @archive.LoomarkDocumentId,
+  version~ : @markdown.MarkdownDocumentVersion,
+  node_id~ : @markdown.MarkdownNodeId,
+  input_id~ : String,
+  committed_text~ : String,
+) -> String {
+  let input = match self.pending {
+    Some(input) => Some(input)
+    None => self.in_flight.map(delivery => delivery.input)
+  }
+  match input {
+    Some(input) if input.matches(document_id, version, node_id, input_id) =>
+      input.text
+    _ => committed_text
+  }
+}
+
+///|
+fn BlockInputState::is_active(self : BlockInputState, token : Int) -> Bool {
+  self.pending is None &&
+  (match self.in_flight {
+    Some(delivery) => delivery.token == token
+    None => false
+  })
+}
+
+///|
+fn BlockInputState::cancel(self : BlockInputState) -> BlockInputState {
+  {
+    pending: None,
+    generation: self.generation + 1,
+    next_token: self.next_token,
+    in_flight: None,
+  }
+}
+
+///|
+fn BlockInputState::finish(
+  self : BlockInputState,
+  token : Int,
+) -> (BlockInputState, BlockInputSchedule?) {
+  match self.in_flight {
+    Some(delivery) if delivery.token == token => {
+      let state = { ..self, in_flight: None }
+      let schedule = state.pending.map(_ => { generation: state.generation })
+      (state, schedule)
+    }
+    _ => (self, None)
+  }
+}
+
+///|
+/// Mutable Rabbita shell around the deterministic Block input state.
+priv struct BlockInputCoordinator {
+  state : @ref.Ref[BlockInputState]
+}
+
+///|
+fn BlockInputCoordinator::BlockInputCoordinator() -> BlockInputCoordinator {
+  { state: @ref.Ref(BlockInputState::BlockInputState()) }
+}
+
+///|
+fn BlockInputCoordinator::schedule(
+  self : BlockInputCoordinator,
+  schedule : BlockInputSchedule,
+  emit : @cmd.Emit[DriverEvent],
+) -> @cmd.Cmd {
+  @cmd.delay(
+    @cmd.custom_cmd(scheduler => {
+      let (state, delivery) = self.state.val.flush(schedule)
+      self.state.val = state
+      match delivery {
+        Some(delivery) =>
+          scheduler.add(
+            emit(
+              Editing(BlockInput(token=delivery.token, input=delivery.input)),
+            ),
+          )
+        None => ()
+      }
+    }),
+    0,
+  )
+}
+
+///|
+fn BlockInputCoordinator::enqueue(
+  self : BlockInputCoordinator,
+  input : PendingBlockInput,
+  emit : @cmd.Emit[DriverEvent],
+) -> @cmd.Cmd {
+  let (state, schedule) = self.state.val.enqueue(input)
+  self.state.val = state
+  self.schedule(schedule, emit)
+}
+
+///|
+fn BlockInputCoordinator::is_active(
+  self : BlockInputCoordinator,
+  token : Int,
+) -> Bool {
+  self.state.val.is_active(token)
+}
+
+///|
+fn BlockInputCoordinator::finish(
+  self : BlockInputCoordinator,
+  token : Int,
+  emit : @cmd.Emit[DriverEvent],
+) -> @cmd.Cmd {
+  let (state, schedule) = self.state.val.finish(token)
+  self.state.val = state
+  match schedule {
+    Some(schedule) => self.schedule(schedule, emit)
+    None => @rabbita_runtime.none
+  }
+}
+
+///|
+fn BlockInputCoordinator::display_text(
+  self : BlockInputCoordinator,
+  document_id~ : @archive.LoomarkDocumentId,
+  version~ : @markdown.MarkdownDocumentVersion,
+  node_id~ : @markdown.MarkdownNodeId,
+  input_id~ : String,
+  committed_text~ : String,
+) -> String {
+  self.state.val.display_text(
+    document_id~,
+    version~,
+    node_id~,
+    input_id~,
+    committed_text~,
+  )
+}
+
+///|
+fn BlockInputCoordinator::cancel_pending(self : BlockInputCoordinator) -> Unit {
+  self.state.val = self.state.val.cancel()
+}

--- a/apps/loomark/internal/rabbita/block_input_coordinator_wbtest.mbt
+++ b/apps/loomark/internal/rabbita/block_input_coordinator_wbtest.mbt
@@ -1,0 +1,462 @@
+///|
+priv struct BlockInputTestContext {
+  editor : @markdown.MarkdownEditor
+  attachment : @md_markdown.MarkdownSemanticAttachment
+  document_id : @archive.LoomarkDocumentId
+  node_id : @markdown.MarkdownNodeId
+}
+
+///|
+fn block_input_test_document_id(value : String) -> @archive.LoomarkDocumentId {
+  @archive.LoomarkDocumentId::from_string(value) catch {
+    _ => abort("test document id must construct")
+  }
+}
+
+///|
+fn BlockInputTestContext::BlockInputTestContext(
+  agent_id : String,
+  source : String,
+) -> BlockInputTestContext {
+  let (editor, attachment) = try! @markdown.MarkdownEditor::with_semantic_attachment(
+    agent_id~,
+    source~,
+  )
+  let node_id = (try! editor.snapshot()).blocks()[0].node_id()
+  {
+    editor,
+    attachment,
+    document_id: block_input_test_document_id("test-document"),
+    node_id,
+  }
+}
+
+///|
+fn BlockInputTestContext::input(
+  self : BlockInputTestContext,
+  text : String,
+  selection : @dom_boundary.TextSelection,
+) -> PendingBlockInput {
+  PendingBlockInput::PendingBlockInput(
+    document_id=self.document_id,
+    expected_version=self.editor.version(),
+    node_id=self.node_id,
+    input_id="loomark-block-input",
+    text~,
+    selection~,
+  )
+}
+
+///|
+fn BlockInputTestContext::caret_input(
+  self : BlockInputTestContext,
+  text : String,
+  offset : Int,
+) -> PendingBlockInput {
+  self.input(
+    text,
+    @dom_boundary.TextSelection(offset, offset, @dom_boundary.NoDirection),
+  )
+}
+
+///|
+/// Arm one editor failure so rejected inputs prove they never reached commit.
+fn BlockInputTestContext::block_model_with_editor_failure(
+  self : BlockInputTestContext,
+  document_id : @archive.LoomarkDocumentId,
+) -> DriverModel {
+  {
+    ..test_model(try! self.editor.snapshot(), self.editor.version()),
+    state: @core.ApplicationState::ApplicationState(@core.Block),
+    document_id,
+    fail_next_editor_commit: true,
+  }
+}
+
+///|
+fn BlockInputTestContext::reduce(
+  self : BlockInputTestContext,
+  input : PendingBlockInput,
+  model : DriverModel,
+) -> (DriverModel, BlockInputState) {
+  let coordinator = BlockInputCoordinator::BlockInputCoordinator()
+  let (state, schedule) = coordinator.state.val.enqueue(input)
+  let (state, delivery) = state.flush(schedule)
+  coordinator.state.val = state
+  guard delivery is Some(delivery) else {
+    abort("test input must be ready for delivery")
+  }
+  let emit : @cmd.Emit[DriverEvent] = @cmd.Emit(_ => @rabbita_runtime.none)
+  let latest_model : @ref.Ref[DriverModel?] = @ref.Ref(Some(model))
+  let (next, _) = try! update_editing(
+    self.editor,
+    self.attachment,
+    RawInputCoordinator::RawInputCoordinator(None),
+    coordinator,
+    model,
+    latest_model,
+    BlockInput(token=delivery.token, input=delivery.input),
+    emit,
+  )
+  (next, coordinator.state.val)
+}
+
+///|
+fn assert_block_input_rejected(
+  next : DriverModel,
+  previous : DriverModel,
+  source : String,
+) -> Unit raise {
+  assert_eq(next.document.source(), source)
+  assert_eq(next.document_id, previous.document_id)
+  assert_eq(next.document_version, previous.document_version)
+  assert_eq(next.source_revision, previous.source_revision)
+  assert_eq(next.committed_change_count, previous.committed_change_count)
+  assert_eq(next.text_input_generation, previous.text_input_generation)
+  assert_eq(next.selection, previous.selection)
+  assert_true(next.fail_next_editor_commit)
+}
+
+///|
+fn assert_block_delivery_finished(state : BlockInputState) -> Unit {
+  guard state.pending is None else {
+    fail("a finished Block delivery must not retain pending input")
+  }
+  guard state.in_flight is None else {
+    fail("a finished Block delivery must not remain active")
+  }
+}
+
+///|
+test "Block input batching keeps the latest input and ignores an old schedule" {
+  let context = BlockInputTestContext::BlockInputTestContext(
+    "block-input-batching-test", "x",
+  )
+  let version = context.editor.version()
+  let (state, first_schedule) = BlockInputState::BlockInputState().enqueue(
+    context.caret_input("a", 1),
+  )
+  let (state, latest_schedule) = state.enqueue(context.caret_input("ab", 2))
+
+  let (state, old_delivery) = state.flush(first_schedule)
+  guard old_delivery is None else {
+    fail("an old schedule must not deliver superseded input")
+  }
+  let (_, latest_delivery) = state.flush(latest_schedule)
+  guard latest_delivery is Some(delivery) else {
+    fail("the latest schedule must deliver one input")
+  }
+  assert_eq(delivery.input.document_id, context.document_id)
+  assert_eq(delivery.input.expected_version, version)
+  assert_eq(delivery.input.node_id, context.node_id)
+  assert_eq(delivery.input.input_id, "loomark-block-input")
+  assert_eq(delivery.input.text, "ab")
+  assert_eq(delivery.input.selection.start(), 2)
+  assert_eq(delivery.input.selection.end(), 2)
+}
+
+///|
+test "Block input batching keeps the pending value through redraw and never retries it" {
+  let context = BlockInputTestContext::BlockInputTestContext(
+    "block-input-display-test", "x",
+  )
+  let other_document_id = block_input_test_document_id("other-document")
+  let version = context.editor.version()
+  let (state, schedule) = BlockInputState::BlockInputState().enqueue(
+    context.caret_input("ab", 2),
+  )
+
+  assert_eq(
+    state.display_text(
+      document_id=context.document_id,
+      version~,
+      node_id=context.node_id,
+      input_id="loomark-block-input",
+      committed_text="x",
+    ),
+    "ab",
+  )
+  assert_eq(
+    state.display_text(
+      document_id=other_document_id,
+      version~,
+      node_id=context.node_id,
+      input_id="loomark-block-input",
+      committed_text="x",
+    ),
+    "x",
+  )
+
+  let (state, delivery) = state.flush(schedule)
+  guard delivery is Some(delivery) else {
+    fail("the latest schedule must deliver one input")
+  }
+  assert_eq(
+    state.display_text(
+      document_id=context.document_id,
+      version~,
+      node_id=context.node_id,
+      input_id="loomark-block-input",
+      committed_text="x",
+    ),
+    "ab",
+  )
+
+  let (state, resumed) = state.finish(delivery.token)
+  guard resumed is None else {
+    fail("finishing with no pending input must not schedule another delivery")
+  }
+  assert_eq(
+    state.display_text(
+      document_id=context.document_id,
+      version~,
+      node_id=context.node_id,
+      input_id="loomark-block-input",
+      committed_text="x",
+    ),
+    "x",
+  )
+  let (_, retried) = state.flush(schedule)
+  guard retried is None else {
+    fail("a finished Block input must not be retried")
+  }
+}
+
+///|
+test "Block input batching waits for an active delivery before releasing newer input" {
+  let context = BlockInputTestContext::BlockInputTestContext(
+    "block-input-in-flight-test", "x",
+  )
+  let (state, first_schedule) = BlockInputState::BlockInputState().enqueue(
+    context.caret_input("a", 1),
+  )
+  let (state, first_delivery) = state.flush(first_schedule)
+  guard first_delivery is Some(first_delivery) else {
+    fail("the first input must be delivered")
+  }
+  assert_true(state.is_active(first_delivery.token))
+
+  let (state, second_schedule) = state.enqueue(context.caret_input("ab", 2))
+  assert_false(state.is_active(first_delivery.token))
+  let (state, early_delivery) = state.flush(second_schedule)
+  guard early_delivery is None else {
+    fail("newer input must wait while the first delivery is active")
+  }
+
+  let (state, resumed_schedule) = state.finish(first_delivery.token)
+  guard resumed_schedule is Some(resumed_schedule) else {
+    fail("finishing the active delivery must resume pending input")
+  }
+  let (_, second_delivery) = state.flush(resumed_schedule)
+  guard second_delivery is Some(second_delivery) else {
+    fail("the resumed schedule must deliver the latest input")
+  }
+  assert_eq(second_delivery.input.text, "ab")
+  assert_eq(second_delivery.input.selection.start(), 2)
+  assert_eq(second_delivery.input.selection.end(), 2)
+}
+
+///|
+test "Block input cancellation cannot collide with an emitted delivery" {
+  let context = BlockInputTestContext::BlockInputTestContext(
+    "block-input-cancel-test", "x",
+  )
+  let (state, old_schedule) = BlockInputState::BlockInputState().enqueue(
+    context.caret_input("a", 1),
+  )
+  let (state, old_delivery) = state.flush(old_schedule)
+  guard old_delivery is Some(old_delivery) else {
+    fail("the old input must be emitted before cancellation")
+  }
+
+  let (state, new_schedule) = state
+    .cancel()
+    .enqueue(context.caret_input("b", 1))
+  let (state, new_delivery) = state.flush(new_schedule)
+  guard new_delivery is Some(new_delivery) else {
+    fail("new input must be deliverable after cancellation")
+  }
+
+  assert_false(state.is_active(old_delivery.token))
+  assert_true(state.is_active(new_delivery.token))
+  let (state, retry) = state.finish(old_delivery.token)
+  guard retry is None else {
+    fail("an old emitted delivery must not schedule anything")
+  }
+  assert_true(state.is_active(new_delivery.token))
+}
+
+///|
+test "Block input check rejects a changed document or version before commit" {
+  let context = BlockInputTestContext::BlockInputTestContext(
+    "block-input-check-test", "x",
+  )
+  let version = context.editor.version()
+  let input = context.caret_input("ab", 2)
+
+  guard check_block_edit(context.document_id, version, input) is Current else {
+    fail("matching document and version must be current")
+  }
+  guard check_block_edit(
+      block_input_test_document_id("other-document"),
+      version,
+      input,
+    )
+    is WrongDocument else {
+    fail("a different active document must be rejected")
+  }
+  ignore(
+    try! context.editor.commit(
+      @markdown.MarkdownEditRequest::ReplaceText(
+        start=0,
+        delete_len=1,
+        inserted="y",
+      ),
+    ),
+  )
+  guard check_block_edit(context.document_id, context.editor.version(), input)
+    is StaleVersion else {
+    fail("an advanced editor version must reject old input")
+  }
+}
+
+///|
+test "Stale Block input does not call the editor or change Session state" {
+  let context = BlockInputTestContext::BlockInputTestContext(
+    "stale-block-input-test", "x",
+  )
+  let input = context.caret_input("ab", 2)
+  ignore(
+    try! context.editor.commit(
+      @markdown.MarkdownEditRequest::ReplaceText(
+        start=0,
+        delete_len=1,
+        inserted="y",
+      ),
+    ),
+  )
+  let model = context.block_model_with_editor_failure(context.document_id)
+
+  let (next, state) = context.reduce(input, model)
+
+  assert_block_input_rejected(next, model, "y")
+  assert_block_delivery_finished(state)
+}
+
+///|
+test "Block input from another document does not call the editor" {
+  let context = BlockInputTestContext::BlockInputTestContext(
+    "wrong-document-block-input-test", "x",
+  )
+  let input = {
+    ..context.caret_input("ab", 2),
+    document_id: block_input_test_document_id("old-document"),
+  }
+  let active_document_id = block_input_test_document_id("active-document")
+  let model = context.block_model_with_editor_failure(active_document_id)
+
+  let (next, state) = context.reduce(input, model)
+
+  assert_block_input_rejected(next, model, "x")
+  assert_block_delivery_finished(state)
+}
+
+///|
+test "Block input selection requires one collapsed grapheme boundary" {
+  let context = BlockInputTestContext::BlockInputTestContext(
+    "block-input-selection-test", "a😀b",
+  )
+  let document = try! context.editor.snapshot()
+
+  guard check_block_selection(document, context.caret_input("a😀b", 1))
+    is ValidBlockSelection else {
+    fail("a collapsed grapheme boundary must be valid")
+  }
+  guard check_block_selection(
+      document,
+      context.input(
+        "a😀b",
+        @dom_boundary.TextSelection(1, 3, @dom_boundary.Forward),
+      ),
+    )
+    is NonCollapsedBlockSelection else {
+    fail("a range selection must be unavailable")
+  }
+  guard check_block_selection(document, context.caret_input("a😀b", 2))
+    is InvalidBlockSelection else {
+    fail("a position inside a grapheme must be invalid")
+  }
+}
+
+///|
+test "Invalid Block selection does not call the editor" {
+  let context = BlockInputTestContext::BlockInputTestContext(
+    "invalid-block-selection-test", "a😀b",
+  )
+  let model = context.block_model_with_editor_failure(context.document_id)
+
+  let (next, state) = context.reduce(context.caret_input("a😀b", 2), model)
+
+  assert_block_input_rejected(next, model, "a😀b")
+  assert_block_delivery_finished(state)
+}
+
+///|
+test "Accepted snapshot restore cancels pending Block input" {
+  let context = BlockInputTestContext::BlockInputTestContext(
+    "snapshot-cancels-block-input-test", "x",
+  )
+  let model = {
+    ..test_model(try! context.editor.snapshot(), context.editor.version()),
+    state: @core.ApplicationState::ApplicationState(@core.Block),
+    document_id: context.document_id,
+  }
+  let coordinator = BlockInputCoordinator::BlockInputCoordinator()
+  let (state, old_schedule) = coordinator.state.val.enqueue(
+    context.caret_input("xy", 2),
+  )
+  coordinator.state.val = state
+  let emit : @cmd.Emit[DriverEvent] = @cmd.Emit(_ => @rabbita_runtime.none)
+
+  let (next, _) = try! update_lifecycle(
+    context.editor,
+    context.attachment,
+    RawInputCoordinator::RawInputCoordinator(None),
+    coordinator,
+    model,
+    RestoreSnapshot(version=1, source="x", mode=@core.Block),
+    emit,
+  )
+
+  assert_eq(next.document.source(), "x")
+  assert_true(next.state.mode() == @core.Block)
+  assert_block_delivery_finished(coordinator.state.val)
+  let (_, old_delivery) = coordinator.state.val.flush(old_schedule)
+  guard old_delivery is None else {
+    fail("a pre-restore Block schedule must remain cancelled")
+  }
+}
+
+///|
+test "Failed current Block input preserves committed Session state" {
+  let context = BlockInputTestContext::BlockInputTestContext(
+    "failed-block-input-test", "x",
+  )
+  let model = {
+    ..context.block_model_with_editor_failure(context.document_id),
+    selection: Some("before"),
+  }
+
+  let (next, state) = context.reduce(context.caret_input("y", 1), model)
+
+  assert_eq((try! context.editor.snapshot()).source(), "x")
+  assert_eq(context.editor.version(), model.document_version)
+  assert_eq(next.document.source(), "x")
+  assert_eq(next.document_version, model.document_version)
+  assert_eq(next.source_revision, model.source_revision)
+  assert_eq(next.committed_change_count, model.committed_change_count)
+  assert_eq(next.text_input_generation, model.text_input_generation)
+  assert_eq(next.selection, Some("before"))
+  assert_false(next.fail_next_editor_commit)
+  assert_block_delivery_finished(state)
+}

--- a/apps/loomark/internal/rabbita/block_view.mbt
+++ b/apps/loomark/internal/rabbita/block_view.mbt
@@ -321,9 +321,19 @@ fn block_input(
   index : Int,
   count : Int,
   active : Bool,
+  document_id : @archive.LoomarkDocumentId,
+  version : @markdown.MarkdownDocumentVersion,
+  coordinator : BlockInputCoordinator,
   emit : @cmd.Emit[DriverEvent],
 ) -> @rabbita_runtime.Html {
   let input_id = block_input_id(index)
+  let input_value = coordinator.display_text(
+    document_id~,
+    version~,
+    node_id=block.node_id(),
+    input_id~,
+    committed_text=block.text(),
+  )
   let attrs = @html.Attrs::build()
     .data_set("loomark-block-id", block.key())
     .data_set("loomark-block-kind", block_kind_name(block.kind()))
@@ -396,12 +406,16 @@ fn block_input(
   }
   let input = @rui.textarea(
     id=input_id,
-    value=block.text(),
+    value=input_value,
     rows=1,
     slot="block-editor-input",
     style=block_input_style(block.kind()),
     attrs~,
-    on_input=@cmd.Emit(text => block_input_command(block, input_id, text, emit)),
+    on_input=@cmd.Emit(text => {
+      block_input_command(
+        block, input_id, text, document_id, version, coordinator, emit,
+      )
+    }),
   )
   @html.div(
     attrs=@html.Attrs::build()
@@ -415,6 +429,7 @@ fn block_input(
 ///|
 fn block_editor_view(
   model : DriverModel,
+  coordinator : BlockInputCoordinator,
   emit : @cmd.Emit[DriverEvent],
 ) -> @rabbita_runtime.Html {
   let controls : Map[String, @rabbita_runtime.Html] = Map([])
@@ -425,6 +440,9 @@ fn block_editor_view(
       index,
       blocks.length(),
       model.active_block_key == Some(block.key()),
+      model.document_id,
+      model.document_version,
+      coordinator,
       emit,
     )
   }

--- a/apps/loomark/internal/rabbita/driver_types.mbt
+++ b/apps/loomark/internal/rabbita/driver_types.mbt
@@ -9,12 +9,7 @@ priv enum EditingEvent {
   BlockHeading(Int, BlockSelection?)
   BlockToggleList(BlockSelection?)
   BlockDelete
-  BlockInput(
-    node_id~ : @markdown.MarkdownNodeId,
-    input_id~ : String,
-    text~ : String,
-    selection_offset~ : Int
-  )
+  BlockInput(token~ : Int, input~ : PendingBlockInput)
   BlockSplit(node_id~ : @markdown.MarkdownNodeId, offset~ : Int)
   BlockMerge(node_id~ : @markdown.MarkdownNodeId, selection~ : BlockSelection)
   BlockNavigate(key~ : String, direction~ : Int)

--- a/apps/loomark/internal/rabbita/editing_mode_wbtest.mbt
+++ b/apps/loomark/internal/rabbita/editing_mode_wbtest.mbt
@@ -72,7 +72,19 @@ fn block_variants() -> Array[EditingEvent] {
     BlockHeading(2, None),
     BlockToggleList(None),
     BlockDelete,
-    BlockInput(node_id~, input_id="in", text="t", selection_offset=0),
+    BlockInput(
+      token=0,
+      input=PendingBlockInput::PendingBlockInput(
+        document_id=@archive.LoomarkDocumentId::from_string("test-document") catch {
+          _ => abort("test document id must construct")
+        },
+        expected_version=editor.version(),
+        node_id~,
+        input_id="in",
+        text="t",
+        selection=@dom_boundary.TextSelection(0, 0, @dom_boundary.NoDirection),
+      ),
+    ),
     BlockSplit(node_id~, offset=0),
     BlockMerge(node_id~, selection=BlockSelection::{
       key: "k",

--- a/apps/loomark/internal/rabbita/moon.pkg
+++ b/apps/loomark/internal/rabbita/moon.pkg
@@ -3,6 +3,7 @@ import {
   "dowdiness/diagnostic",
   "dowdiness/dom_boundary",
   "dowdiness/markdown" @md_markdown,
+  "dowdiness/moji",
   "dowdiness/text_change",
   "dowdiness/loomark/core",
   "dowdiness/loomark/archive",

--- a/apps/loomark/internal/rabbita/split_view.mbt
+++ b/apps/loomark/internal/rabbita/split_view.mbt
@@ -44,6 +44,7 @@ fn mode_view(
   model : DriverModel,
   emit : @cmd.Emit[DriverEvent],
   raw_input_coordinator : RawInputCoordinator,
+  block_input_coordinator : BlockInputCoordinator,
 ) -> @rabbita_runtime.Html {
   if model.state.mode() == @core.Block {
     @html.div(
@@ -65,7 +66,9 @@ fn mode_view(
             style=[
               "width:var(--lm-page-width);margin-inline:auto;min-width:0;display:flex;flex-direction:column;gap:0.25rem",
             ],
-            editor_view(model, emit, raw_input_coordinator),
+            editor_view(
+              model, emit, raw_input_coordinator, block_input_coordinator,
+            ),
           ),
         ),
       ],
@@ -74,7 +77,7 @@ fn mode_view(
     @html.div(
       id="loomark-active-view",
       style=["width:100%;min-width:0;display:flex"],
-      editor_view(model, emit, raw_input_coordinator),
+      editor_view(model, emit, raw_input_coordinator, block_input_coordinator),
     )
   }
 }
@@ -84,8 +87,11 @@ fn single_view(
   model : @rabbita_runtime.Val[DriverModel],
   emit : @cmd.Emit[DriverEvent],
   raw_input_coordinator : RawInputCoordinator,
+  block_input_coordinator : BlockInputCoordinator,
 ) -> @rabbita_runtime.Val[@rabbita_runtime.Html] {
-  model.view(model => mode_view(model, emit, raw_input_coordinator))
+  model.view(model => {
+    mode_view(model, emit, raw_input_coordinator, block_input_coordinator)
+  })
 }
 
 ///|
@@ -93,6 +99,7 @@ fn resizable_split_view(
   model : @rabbita_runtime.Val[DriverModel],
   emit : @cmd.Emit[DriverEvent],
   raw_input_coordinator : RawInputCoordinator,
+  block_input_coordinator : BlockInputCoordinator,
   orientation : @rui.SeparatorOrientation,
 ) -> @rabbita_runtime.Val[@rabbita_runtime.Html] {
   @rui.resizable_panel_group_with_input(
@@ -112,7 +119,7 @@ fn resizable_split_view(
           raw_editor_view(model, emit, raw_input_coordinator),
         )
       } else {
-        mode_view(model, emit, raw_input_coordinator)
+        mode_view(model, emit, raw_input_coordinator, block_input_coordinator)
       }
       @html.fragment([
         @rui.resizable_panel(
@@ -144,8 +151,15 @@ fn side_by_side_view(
   model : @rabbita_runtime.Val[DriverModel],
   emit : @cmd.Emit[DriverEvent],
   raw_input_coordinator : RawInputCoordinator,
+  block_input_coordinator : BlockInputCoordinator,
 ) -> @rabbita_runtime.Val[@rabbita_runtime.Html] {
-  resizable_split_view(model, emit, raw_input_coordinator, @rui.Horizontal)
+  resizable_split_view(
+    model,
+    emit,
+    raw_input_coordinator,
+    block_input_coordinator,
+    @rui.Horizontal,
+  )
 }
 
 ///|
@@ -153,8 +167,15 @@ fn stacked_view(
   model : @rabbita_runtime.Val[DriverModel],
   emit : @cmd.Emit[DriverEvent],
   raw_input_coordinator : RawInputCoordinator,
+  block_input_coordinator : BlockInputCoordinator,
 ) -> @rabbita_runtime.Val[@rabbita_runtime.Html] {
-  resizable_split_view(model, emit, raw_input_coordinator, @rui.Vertical)
+  resizable_split_view(
+    model,
+    emit,
+    raw_input_coordinator,
+    block_input_coordinator,
+    @rui.Vertical,
+  )
 }
 
 ///|
@@ -164,13 +185,21 @@ fn application_view(
   model : @rabbita_runtime.Val[DriverModel],
   emit : @cmd.Emit[DriverEvent],
   raw_input_coordinator : RawInputCoordinator,
+  block_input_coordinator : BlockInputCoordinator,
 ) -> @rabbita_runtime.Val[@rabbita_runtime.Html] {
   let presentation = model.map(split_presentation)
   presentation.switch(presentation => {
     match presentation {
-      SingleSurface => single_view(model, emit, raw_input_coordinator)
-      SideBySide => side_by_side_view(model, emit, raw_input_coordinator)
-      Stacked => stacked_view(model, emit, raw_input_coordinator)
+      SingleSurface =>
+        single_view(model, emit, raw_input_coordinator, block_input_coordinator)
+      SideBySide =>
+        side_by_side_view(
+          model, emit, raw_input_coordinator, block_input_coordinator,
+        )
+      Stacked =>
+        stacked_view(
+          model, emit, raw_input_coordinator, block_input_coordinator,
+        )
     }
   })
 }

--- a/apps/loomark/internal/rabbita/text_control_repair.mbt
+++ b/apps/loomark/internal/rabbita/text_control_repair.mbt
@@ -514,25 +514,26 @@ fn block_input_command(
   block : @markdown.MarkdownBlockSnapshot,
   input_id : String,
   text : String,
+  document_id : @archive.LoomarkDocumentId,
+  expected_version : @markdown.MarkdownDocumentVersion,
+  coordinator : BlockInputCoordinator,
   emit : @cmd.Emit[DriverEvent],
 ) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
     let selection = @dom_boundary.read_text_selection_id(input_id) catch {
-      error => {
-        scheduler.add(emit(Navigation(EffectFailed(error.message()))))
-        return
-      }
+      _ => return
     }
     scheduler.add(
-      emit(
-        Editing(
-          BlockInput(
-            node_id=block.node_id(),
-            input_id~,
-            text~,
-            selection_offset=selection.end(),
-          ),
+      coordinator.enqueue(
+        PendingBlockInput::PendingBlockInput(
+          document_id~,
+          expected_version~,
+          node_id=block.node_id(),
+          input_id~,
+          text~,
+          selection~,
         ),
+        emit,
       ),
     )
   })

--- a/apps/loomark/moon.mod
+++ b/apps/loomark/moon.mod
@@ -7,6 +7,7 @@ import {
   "dowdiness/diagnostic@0.1.0",
   "dowdiness/loom@0.1.0",
   "dowdiness/markdown@0.1.0",
+  "dowdiness/moji@0.1.0",
   "dowdiness/text_change@0.1.0",
   "dowdiness/dom_boundary@0.1.0",
   "dowdiness/js_ffi@0.1.0",


### PR DESCRIPTION
Closes #1163.

## Summary

- coalesce rapid Block `input` events into one latest-value request carrying the rendered document ID, document version, and complete text selection
- call the existing Block commit path only when the request still matches the active document and `editor.version()` immediately before commit
- discard stale, wrong-document, superseded, mode-stale, and invalid-selection requests without retrying or moving the Session selection; preserve the pending DOM value through redraws

## UI and review evidence

N/A — no visual design or label changes. Browser tests cover ordinary typing, same-task input, caret preservation, empty controls, CR/CRLF normalization, rejection repair, and snapshot restore.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `commit_block_request` | `apps/loomark/internal/rabbita/application.mbt` | Yes | Retains the existing canonical Block commit and persistence path. |
| `@cmd.delay` / `@cmd.custom_cmd` | `moonbit-community/rabbita/cmd` | Yes | Keeps timer and scheduler effects in the coordinator shell. |
| `read_text_selection_id` / `TextSelection` | `dowdiness/dom_boundary` | Yes | Captures the browser selection in the originating input command. |
| `is_grapheme_boundary` | `dowdiness/moji` | Yes | Rejects collapsed caret positions inside a grapheme cluster. |
| `Vector::fold`, `Option::map`, pattern matching | MoonBit core | Yes | Resolves targets and optional pending/in-flight values without new loops. |
| `RawInputCoordinator` | `apps/loomark/internal/rabbita/text_control_repair.mbt` | No | Its 50 ms wait and rejection retry semantics are intentionally Raw-specific and conflict with Block's no-retry contract. |

New helpers added (if any):

- `PendingBlockInput`: one package-private browser request with document identity, expected version, block/control identity, text, and selection.
- `BlockInputState`: deterministic enqueue/flush/finish/cancel transitions, including monotonic generations and delivery tokens.
- `BlockInputCoordinator`: the thin mutable Rabbita shell that schedules and emits state decisions.
- `check_block_edit` / `check_block_selection`: pure pre-commit classifications for document/version and selection validity.
- `BlockInputTestContext`: wbtest-only fixture that centralizes editor, request, model, and delivery setup without hiding editor-failure injection.

## Validation scope

Boundary matrix / first failing regression:

- ordinary consecutive input and two events in one JavaScript turn
- pending and in-flight display values across redraw
- superseded schedules, active-delivery handoff, cancellation token collision, and accepted snapshot restore
- current, stale-version, wrong-document, wrong-mode, and deleted-target requests
- collapsed/range selections, UTF-16 grapheme boundaries, and unavailable DOM selection
- accepted, rejected, and editor-failure results with no Block retry
- heading/paragraph payloads, empty controls, EOF, CR, and CRLF behavior through existing browser coverage

Target packages:

- `apps/loomark/internal/rabbita`

Additional conditional gates:

- `./scripts/test-loomark-standalone-e2e.sh`: 12 passed
- `./scripts/test-loomark-dev-host-e2e.sh`: 83 passed
- independent MoonBit review completed after rebasing; snapshot-restore and cancellation findings were fixed and re-reviewed

## PR-ready evidence

Validated HEAD: `ea494a03c657c1114eae2eaf9f2385b7b8f20fb6`

Validated base: `origin/main@31405dabc62a2385d402de4051b7ba61364689b1`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh \
  --target apps/loomark/internal/rabbita
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for the exact HEAD and base above.
- [x] The base was fetched again and `--verify-evidence` passed immediately before this PR was opened, updated, or merged.
- [x] The committed `.mbti` diff against the validated base was reviewed for unintended API or trait-bound changes; there is no `.mbti` diff.
- [x] Any changed submodule commit is pushed and reachable from its remote; this PR changes no submodule pointer.
- [x] Validation was rerun after every commit, amend, rebase, cherry-pick, submodule-pointer, manifest, or generated-interface change.
- [x] Independent review findings were resolved before the final validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Block editor input synchronization during rapid typing and consecutive edits.
  - Preserved the latest text and caret position when multiple changes occur before a screen refresh.
  - Prevented stale or rejected edits from overwriting committed content or changing the caret unexpectedly.
  - Improved handling of empty-block edits, edits at the start of a block, and input across split or stacked views.
  - Added safeguards to keep editor state consistent when documents change or edits cannot be committed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->