### PR TITLE
fix(markdown): remove sentinel from empty previous merge

### DIFF
--- a/modules/canopy/editor/markdown/markdown_editor_wbtest.mbt
+++ b/modules/canopy/editor/markdown/markdown_editor_wbtest.mbt
@@ -814,6 +814,143 @@ test "headless facade splits at block start into an empty previous block" {
 }
 
 ///|
+test "portable Markdown merge removes a split-created empty previous sentinel" {
+  let editor = try! MarkdownEditor(
+    agent_id="merge-empty-previous",
+    source="Hello\n",
+  )
+  let first = editor.snapshot().blocks().to_array()[0]
+  guard editor.commit(
+      MarkdownEditRequest::SplitBlock(node_id=first.node_id(), offset=0),
+    )
+    is Ok(_) else {
+    fail("expected block-start split to apply")
+  }
+  assert_eq(editor.portable_markdown(), "\n\nHello\n")
+  let current = editor.snapshot().blocks().to_array()[1]
+
+  match
+    editor.commit(
+      MarkdownEditRequest::MergeWithPrevious(node_id=current.node_id()),
+    ) {
+    Ok(MarkdownCommitResult::Applied(snapshot, Some(selection))) => {
+      assert_eq(snapshot.source(), "Hello\n")
+      assert_false(snapshot.source().contains("\u200B".view()))
+      assert_eq(editor.portable_markdown(), "Hello\n")
+      let blocks = snapshot.blocks().to_array()
+      assert_eq(blocks.length(), 1)
+      assert_eq(blocks[0].text(), "Hello")
+      assert_eq(selection.node_id(), blocks[0].node_id())
+      assert_eq(selection.offset(), 0)
+    }
+    _ => fail("expected merge into empty previous block to apply")
+  }
+}
+
+///|
+test "merge into split-created empty previous preserves source terminator" {
+  for
+    case in [
+      ("merge-empty-previous-crlf", "Hello\r\n"),
+      ("merge-empty-previous-cr", "Hello\r"),
+      ("merge-empty-previous-eof", "Hello"),
+    ] {
+    let (agent_id, source) = case
+    let editor = try! MarkdownEditor(agent_id~, source~)
+    let first = editor.snapshot().blocks().to_array()[0]
+    guard editor.commit(
+        MarkdownEditRequest::SplitBlock(node_id=first.node_id(), offset=0),
+      )
+      is Ok(_) else {
+      fail("expected block-start split to apply")
+    }
+    let current = editor.snapshot().blocks().to_array()[1]
+    guard editor.commit(
+        MarkdownEditRequest::MergeWithPrevious(node_id=current.node_id()),
+      )
+      is Ok(_) else {
+      fail("expected merge into empty previous block to apply")
+    }
+    assert_eq(editor.snapshot().source(), source)
+    assert_eq(editor.portable_markdown(), source)
+  }
+}
+
+///|
+test "merge split-created empty current selects surviving text" {
+  let editor = try! MarkdownEditor(
+    agent_id="merge-empty-current",
+    source="Hello\n",
+  )
+  let original = editor.snapshot().blocks().to_array()[0]
+  guard editor.commit(
+      MarkdownEditRequest::SplitBlock(node_id=original.node_id(), offset=5),
+    )
+    is Ok(_) else {
+    fail("expected block-end split to apply")
+  }
+  let before_merge = editor.snapshot().blocks().to_array()
+  let current = before_merge[1]
+
+  match
+    editor.commit(
+      MarkdownEditRequest::MergeWithPrevious(node_id=current.node_id()),
+    ) {
+    Ok(MarkdownCommitResult::Applied(snapshot, Some(selection))) => {
+      let blocks = snapshot.blocks().to_array()
+      assert_eq(snapshot.source(), "Hello\n")
+      assert_eq(blocks.length(), 1)
+      assert_eq(selection.node_id(), blocks[0].node_id())
+      assert_eq(selection.offset(), 5)
+    }
+    _ => fail("expected empty current block to merge into previous text")
+  }
+}
+
+///|
+test "merge two split-created empty blocks retains one projectable previous block" {
+  let editor = try! MarkdownEditor(
+    agent_id="merge-two-empty-blocks",
+    source="Hello\n",
+  )
+  let original = editor.snapshot().blocks().to_array()[0]
+  guard editor.commit(
+      MarkdownEditRequest::SplitBlock(node_id=original.node_id(), offset=0),
+    )
+    is Ok(_) else {
+    fail("expected first block-start split to apply")
+  }
+  let hello = editor.snapshot().blocks().to_array()[1]
+  guard editor.commit(
+      MarkdownEditRequest::SplitBlock(node_id=hello.node_id(), offset=0),
+    )
+    is Ok(_) else {
+    fail("expected second block-start split to apply")
+  }
+  let before_merge = editor.snapshot().blocks().to_array()
+  let current = before_merge[1]
+
+  match
+    editor.commit(
+      MarkdownEditRequest::MergeWithPrevious(node_id=current.node_id()),
+    ) {
+    Ok(MarkdownCommitResult::Applied(snapshot, Some(selection))) => {
+      let blocks = snapshot.blocks().to_array()
+      assert_eq(
+        snapshot.source(),
+        @md_sentinel.EMPTY_PARAGRAPH_SENTINEL + "\n\nHello\n",
+      )
+      assert_eq(editor.portable_markdown(), "\n\nHello\n")
+      assert_eq(blocks.length(), 2)
+      assert_eq(blocks[0].text(), "")
+      assert_eq(selection.node_id(), blocks[0].node_id())
+      assert_eq(selection.offset(), 0)
+    }
+    _ => fail("expected two empty blocks to merge into one empty block")
+  }
+}
+
+///|
 test "headless facade keeps structural no-op selection empty" {
   let editor = try! MarkdownEditor(
     agent_id="block-structure-no-op",

--- a/modules/canopy/lang/markdown/edits/compute_markdown_edit.mbt
+++ b/modules/canopy/lang/markdown/edits/compute_markdown_edit.mbt
@@ -157,6 +157,23 @@ fn block_replacement_terminator(
 }
 
 ///|
+/// Preserve an existing block terminator without adding one at EOF.
+fn block_replacement_terminator_preserving_eof(
+  source : String,
+  range_start : Int,
+  range_end : Int,
+) -> String {
+  if range_end == source.length() &&
+    range_end > range_start &&
+    source[range_end - 1] != '\n' &&
+    source[range_end - 1] != '\r' {
+    ""
+  } else {
+    block_replacement_terminator(source, range_start, range_end)
+  }
+}
+
+///|
 /// Change heading level (1-6) or convert paragraph to/from heading.
 fn compute_change_heading_level(
   source : String,
@@ -583,35 +600,52 @@ fn compute_merge_with_previous(
       )
   }
   let curr_text = source[curr_text_range.start:curr_text_range.end].to_owned()
-  // End of previous block's text content — merge point
-  let prev_text_end = match source_map.get_token_span(prev_node.id(), "text") {
-    Some(r) => r.end
+  let prev_text_range = match
+    source_map.get_token_span(prev_node.id(), "text") {
+    Some(range) => range
     None =>
       raise @core.EditError::SourceSpanMissing(
         detail="no editable text span for previous block " +
           prev_node.id().to_string(),
       )
   }
-  // Strip empty-paragraph sentinel placeholder (from InsertBlockAfter)
-  let clean_text = if @md_sentinel.is_empty_paragraph_text(curr_text) {
-    ""
+  let prev_text = source[prev_text_range.start:prev_text_range.end].to_owned()
+  let prev_is_empty = @md_sentinel.is_empty_paragraph_text(prev_text)
+  let curr_is_empty = @md_sentinel.is_empty_paragraph_text(curr_text)
+  // A sentinel in the previous block must be inside the replacement span;
+  // otherwise merging real text after it turns the private placeholder into
+  // visible content that portable Markdown can no longer strip. If both
+  // blocks are empty, keep one sentinel so the surviving paragraph remains
+  // projectable.
+  let edit_start = if prev_is_empty {
+    prev_text_range.start
   } else {
-    curr_text
+    prev_text_range.end
   }
-  // The delete span covers: previous block's trailing newline, blank-line
-  // separator, current block's prefix + text + trailing newline. Always
-  // append \n to restore the proper \n\n block separator with the next block.
-  let inserted = clean_text + "\n"
+  let clean_text = match (prev_is_empty, curr_is_empty) {
+    (true, true) => @md_sentinel.EMPTY_PARAGRAPH_SENTINEL
+    (_, true) => ""
+    (_, false) => curr_text
+  }
+  // The delete span covers: the private previous sentinel when present,
+  // separators, and the current block through its terminator. Preserve that
+  // exact terminator, including CRLF, CR, and EOF-without-terminator.
+  let terminator = block_replacement_terminator_preserving_eof(
+    source,
+    curr_range.start,
+    curr_range.end,
+  )
+  let inserted = clean_text + terminator
   Some(
     (
       [
         SpanEdit::{
-          start: prev_text_end,
-          delete_len: curr_range.end - prev_text_end,
+          start: edit_start,
+          delete_len: curr_range.end - edit_start,
           inserted,
         },
       ],
-      FocusHint::MoveCursor(position=prev_text_end),
+      FocusHint::MoveCursor(position=edit_start),
     ),
   )
 }


### PR DESCRIPTION
## Summary

- Remove the private empty-paragraph sentinel when `MergeWithPrevious` merges real text into a split-created empty previous block.
- Preserve one sentinel when both blocks are empty, so the surviving empty paragraph remains projectable.
- Preserve the current block's LF, CRLF, CR, or EOF terminator while merging.

## UI and review evidence

N/A — no visual or UI changes.

A throwaway integration prototype captured the original failure and the fix:

- Prototype primary source: https://github.com/dowdiness/canopy/commit/ecb8a38c
- Baseline matrix: 8/9; `\u200BHello\n` leaked after merging into an empty previous block.
- Candidate patch applied to the prototype: 9/9.
- Independent MoonBit re-review: PASS.

## Reuse check

| Existing API | Location | Reused? | Notes |
|---|---|---:|---|
| `is_empty_paragraph_text` / `EMPTY_PARAGRAPH_SENTINEL` | `lang/markdown/sentinel` | Yes | Identifies private empty-block placeholders and preserves exactly one for an empty+empty merge. |
| `SourceMap::get_token_span` | `core/source_map.mbt` | Yes | Reads both current and previous text spans; no parallel source lookup was added. |
| `block_replacement_terminator` | `compute_markdown_edit.mbt` | Yes | Preserves LF, CRLF, and CR through a private EOF-preserving adapter; the existing helper intentionally defaults block replacement to LF. |
| Core `String` / `StringView`, `Option`, tuple pattern matching | MoonBit core | Yes | Existing slicing and pattern matching cover the data shape. No helper, type, loop, or collection manipulation was added. |

## Behavioral boundary matrix

| Previous block | Current block | Terminator | Expected |
|---|---|---|---|
| Empty sentinel | Text | LF | Sentinel removed; text survives; caret at offset 0 |
| Empty sentinel | Text | CRLF / CR / EOF | Exact source terminator preserved |
| Text | Empty sentinel | LF | Text and its identity-facing selection survive |
| Empty sentinel | Empty sentinel | LF | Exactly one projectable empty paragraph survives |

## Validation scope

Targets:

- `modules/canopy/lang/markdown/edits`
- `modules/canopy/editor/markdown`

Results:

- Language edits: 62/62 release tests passed.
- Headless Markdown editor: 68/68 release tests passed.
- Prototype integration matrix with candidate patch: 9/9.
- Existing `.mbti` files: unchanged.
- Full PR-ready validation: passed.

## PR-ready evidence

Validated HEAD: `e8949f4ff77adc8f356db9583328ab4aa6f1f9cb`

Validated base: `origin/main@e27623476d22d9d2da52df6cd10ba668da222cf3`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh \
  --target modules/canopy/lang/markdown/edits \
  --target modules/canopy/editor/markdown
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for the exact HEAD and base above.
- [x] The base was fetched again and `--verify-evidence` passed immediately before opening this PR.
- [x] The committed `.mbti` diff was reviewed and is empty.
- [x] No submodule pointer changed.
- [x] Independent review findings were resolved before final validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved merging of adjacent empty and non-empty blocks.
  * Preserved line endings, including LF, CRLF, CR, and files without a final terminator.
  * Maintained correct cursor placement and selected text after merges.
  * Ensured empty blocks remain represented correctly when merging two empty blocks.
* **Tests**
  * Added coverage for empty-block merges, line-ending preservation, source output, Markdown output, block counts, and selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->