### PR TITLE
fix(loomark): clear Block input on fatal state

### DIFF
--- a/apps/loomark/internal/rabbita/application.mbt
+++ b/apps/loomark/internal/rabbita/application.mbt
@@ -1975,6 +1975,7 @@ fn update_lifecycle(
       (next, @rabbita_runtime.none)
     }
     Fatal(message) => {
+      block_input_coordinator.cancel_pending()
       let next = { ..model, fatal: true, error: Some(message), rejection: None }
       (next, @rabbita_runtime.none)
     }
@@ -2022,6 +2023,7 @@ fn update_model(
       match event {
         Editing(RawInput(_, _, Some(token))) =>
           raw_input_coordinator.cancel(token)
+        Editing(BlockInput(..)) => block_input_coordinator.cancel_pending()
         _ => ()
       }
       let next = {

--- a/apps/loomark/internal/rabbita/block_input_coordinator_wbtest.mbt
+++ b/apps/loomark/internal/rabbita/block_input_coordinator_wbtest.mbt
@@ -287,6 +287,109 @@ test "Block input cancellation cannot collide with an emitted delivery" {
 }
 
 ///|
+test "Fatal-state rejection cancels active Block input" {
+  let context = BlockInputTestContext::BlockInputTestContext(
+    "fatal-rejection-block-input-test", "x",
+  )
+  let model = {
+    ..context.block_model_with_editor_failure(context.document_id),
+    fatal: true,
+  }
+  let coordinator = BlockInputCoordinator::BlockInputCoordinator()
+  let (state, schedule) = coordinator.state.val.enqueue(
+    context.caret_input("xy", 2),
+  )
+  let (state, delivery) = state.flush(schedule)
+  coordinator.state.val = state
+  guard delivery is Some(delivery) else {
+    fail("the Block input must be active before fatal rejection")
+  }
+  let emit : @cmd.Emit[DriverEvent] = @cmd.Emit(_ => @rabbita_runtime.none)
+  let latest_model : @ref.Ref[DriverModel?] = @ref.Ref(Some(model))
+
+  let (next, _) = try! update_model(
+    context.editor,
+    context.attachment,
+    RawInputCoordinator::RawInputCoordinator(None),
+    coordinator,
+    model,
+    latest_model,
+    Editing(BlockInput(token=delivery.token, input=delivery.input)),
+    emit,
+  )
+
+  assert_true(next.fatal)
+  assert_eq(next.document.source(), "x")
+  assert_eq(next.document_version, model.document_version)
+  assert_eq(next.source_revision, model.source_revision)
+  assert_eq(next.committed_change_count, model.committed_change_count)
+  assert_true(next.fail_next_editor_commit)
+  assert_eq(next.rejection, Some("operation=block-input;reason=fatal-state"))
+  assert_false(coordinator.state.val.is_active(delivery.token))
+  assert_true(coordinator.state.val.pending is None)
+  assert_true(coordinator.state.val.in_flight is None)
+  assert_eq(
+    coordinator.display_text(
+      document_id=context.document_id,
+      version=context.editor.version(),
+      node_id=context.node_id,
+      input_id="loomark-block-input",
+      committed_text="x",
+    ),
+    "x",
+  )
+}
+
+///|
+test "Entering fatal state cancels pending and active Block input" {
+  let context = BlockInputTestContext::BlockInputTestContext(
+    "fatal-transition-block-input-test", "x",
+  )
+  let model = {
+    ..test_model(try! context.editor.snapshot(), context.editor.version()),
+    state: @core.ApplicationState::ApplicationState(@core.Block),
+    document_id: context.document_id,
+  }
+  let coordinator = BlockInputCoordinator::BlockInputCoordinator()
+  let (state, active_schedule) = coordinator.state.val.enqueue(
+    context.caret_input("xy", 2),
+  )
+  let (state, active_delivery) = state.flush(active_schedule)
+  guard active_delivery is Some(active_delivery) else {
+    fail("the first Block input must be active before fatal transition")
+  }
+  let (state, pending_schedule) = state.enqueue(context.caret_input("xyz", 3))
+  coordinator.state.val = state
+  let emit : @cmd.Emit[DriverEvent] = @cmd.Emit(_ => @rabbita_runtime.none)
+  let latest_model : @ref.Ref[DriverModel?] = @ref.Ref(Some(model))
+
+  let (next, _) = try! update_model(
+    context.editor,
+    context.attachment,
+    RawInputCoordinator::RawInputCoordinator(None),
+    coordinator,
+    model,
+    latest_model,
+    Lifecycle(Fatal("boom")),
+    emit,
+  )
+
+  assert_true(next.fatal)
+  assert_eq(next.error, Some("boom"))
+  assert_eq(next.document.source(), "x")
+  assert_eq(next.document_version, model.document_version)
+  assert_eq(next.source_revision, model.source_revision)
+  assert_eq(next.committed_change_count, model.committed_change_count)
+  assert_false(coordinator.state.val.is_active(active_delivery.token))
+  assert_true(coordinator.state.val.pending is None)
+  assert_true(coordinator.state.val.in_flight is None)
+  let (_, delayed_delivery) = coordinator.state.val.flush(pending_schedule)
+  guard delayed_delivery is None else {
+    fail("a pre-fatal Block schedule must remain cancelled")
+  }
+}
+
+///|
 test "Block input check rejects a changed document or version before commit" {
   let context = BlockInputTestContext::BlockInputTestContext(
     "block-input-check-test", "x",


### PR DESCRIPTION
Closes #1163.

## Summary

- clear pending and active Block input when Loomark enters a fatal state
- clear a delayed Block input before rejecting it from the fatal-state branch
- add regressions proving fatal handling cannot leave Block input active or retain its pending display value

This is a narrow follow-up to #1199. It does not change DOM selection failure handling, block lookup, or the input coordination model.

## UI and review evidence

N/A — this changes fatal-state cleanup and white-box regression coverage without changing rendered UI or interaction design.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `BlockInputCoordinator::cancel_pending` | `apps/loomark/internal/rabbita/block_input_coordinator.mbt` | Yes | Existing shell operation clears pending and active input and invalidates delayed schedules through `BlockInputState::cancel`. |
| `BlockInputState::cancel` | `apps/loomark/internal/rabbita/block_input_coordinator.mbt` | Yes, indirectly | The coordinator owns the mutable state and already delegates cancellation to this deterministic transition. |
| `BlockInputCoordinator::finish` | `apps/loomark/internal/rabbita/block_input_coordinator.mbt` | No | Fatal handling must discard both pending and active input rather than resume the newest pending delivery. |
| `Option::map`, `Option::unwrap_or`, and pattern matching | `moonbitlang/core/option` | Pattern matching only | No new optional-data transformation is introduced; the existing event match is the correct ownership boundary. |

New helpers added (if any):

None.

## Validation scope

Boundary matrix / first failing regression:

- entering `Lifecycle(Fatal)` with active and pending Block input clears both immediately and invalidates the old schedule
- receiving a delayed `Editing(BlockInput)` while already fatal clears the active token before recording the fatal-state rejection
- both paths preserve canonical source, document version, source revision, committed-change count, and no-editor-call behavior
- the already-fatal path no longer exposes the obsolete active value through `display_text`

The two focused regressions failed on `origin/main` before the product fix and passed afterward.

Target packages:

- `apps/loomark/internal/rabbita`

Additional conditional gates:

- `moon check` passed
- `moon test` passed: 4,536 wasm-gc, 2,575 JS, and 70 native tests
- Loomark internal Rabbita release tests passed: 44/44
- standalone browser tests passed: 12/12
- development-host browser tests passed: 83/83
- `moon info`, `moon fmt`, and `git diff --check` passed
- no `.mbti` or submodule-pointer diff
- independent MoonBit review: PASS, no findings

## PR-ready evidence

Validated HEAD: `7671028f3dfa6d8a28a49eea7e4029b0dc68ef21`

Validated base: `origin/main@a97fb80722cd34ef23ca8fb9e6cd1560b9e51ca1`

```bash
git fetch origin main
NEW_MOON_MOD=0 ./scripts/validate-pr-ready.sh \
  --target apps/loomark/internal/rabbita
git fetch origin main
NEW_MOON_MOD=0 ./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for the exact HEAD and base above.
- [x] The base was fetched again and `--verify-evidence` passed immediately before this PR was opened, updated, or merged.
- [x] The committed `.mbti` diff against the validated base was reviewed for unintended API or trait-bound changes.
- [x] Any changed submodule commit is pushed and reachable from its remote.
- [x] Validation was rerun after every commit, amend, rebase, cherry-pick, submodule-pointer, manifest, or generated-interface change.
- [x] Independent review findings were resolved before the final validation.
