### PR TITLE
feat(markdown): add portable projection core

### DIFF
--- a/modules/canopy/internal/markdown_runtime/markdown_runtime.mbt
+++ b/modules/canopy/internal/markdown_runtime/markdown_runtime.mbt
@@ -115,3 +115,58 @@ pub fn apply_edit(
 ) -> Result[Array[@core.SpanEdit], @core.EditError] raise Failure {
   plain_language.apply_edit(editor, op, timestamp_ms)
 }
+
+///|
+/// Return Markdown text with only structural empty-paragraph sentinels
+/// removed. Projection and source-map failures retain the canonical source.
+pub fn export_markdown_text(
+  editor : @editor.SyncEditor[@markdown.Block],
+) -> String {
+  let source = editor.get_text()
+  let root = editor.get_proj_node() catch {
+    Failure::Failure(_) => return source
+  }
+  guard root is Some(root) else { return source }
+  let source_map = editor.get_source_map() catch {
+    Failure::Failure(_) => return source
+  }
+  let ranges : Array[@loom.Range] = []
+  collect_hidden_sentinel_ranges(root, source_map, ranges)
+  match project_source(source, ranges) {
+    Ok(projected) => projected
+    Err(_) => source
+  }
+}
+
+///|
+/// Collect only the token span owned by an exact sentinel paragraph.
+fn collect_hidden_sentinel_ranges(
+  node : @core.ProjNode[@markdown.Block],
+  source_map : @core.SourceMap,
+  out : Array[@loom.Range],
+) -> Unit {
+  if is_hidden_sentinel(node.kind) {
+    match source_map.get_token_span(node.id(), "text") {
+      Some(range) => out.push(range)
+      None => ()
+    }
+    return
+  }
+  for child in node.children {
+    collect_hidden_sentinel_ranges(child, source_map, out)
+  }
+}
+
+///|
+/// Recognize the private paragraph shape without hiding legitimate content.
+fn is_hidden_sentinel(block : @markdown.Block) -> Bool {
+  match block {
+    Paragraph(inlines) =>
+      inlines.length() == 1 &&
+      (match inlines[0] {
+        Text(text) => @md_sentinel.is_empty_paragraph_text(text)
+        _ => false
+      })
+    _ => false
+  }
+}

--- a/modules/canopy/internal/markdown_runtime/moon.pkg
+++ b/modules/canopy/internal/markdown_runtime/moon.pkg
@@ -3,6 +3,7 @@ import {
   "dowdiness/canopy/editor",
   "dowdiness/canopy/lang/markdown/edits" @md_edits,
   "dowdiness/canopy/lang/markdown/proj" @md_proj,
+  "dowdiness/canopy/lang/markdown/sentinel" @md_sentinel,
   "dowdiness/canopy/lang/runtime" @lang_runtime,
   "dowdiness/incr",
   "dowdiness/markdown",

--- a/modules/canopy/internal/markdown_runtime/pkg.generated.mbti
+++ b/modules/canopy/internal/markdown_runtime/pkg.generated.mbti
@@ -2,23 +2,34 @@
 package "dowdiness/canopy/internal/markdown_runtime"
 
 import {
-  "dowdiness/canopy/core",
   "dowdiness/canopy/editor",
   "dowdiness/canopy/lang/markdown/edits",
   "dowdiness/incr/cells",
   "dowdiness/markdown",
+  "moonbitlang/core/debug",
 }
 
 // Values
-pub fn apply_edit(@editor.SyncEditor[@markdown.Block], @edits.MarkdownEditOp, Int) -> Result[Array[@core.SpanEdit], @core.EditError] raise Failure
+pub fn apply_edit(@editor.SyncEditor[@markdown.Block], @edits.MarkdownEditOp, Int) -> Result[Array[@dowdiness/canopy/core.SpanEdit], @dowdiness/canopy/core.EditError] raise Failure
+
+pub fn export_markdown_text(@editor.SyncEditor[@markdown.Block]) -> String
 
 pub fn new_editor(String, capture_timeout_ms? : Int, parent_runtime? : @cells.Runtime) -> @editor.SyncEditor[@markdown.Block] raise
 
 pub fn new_editor_with_semantic_attachment(String, capture_timeout_ms? : Int, parent_runtime? : @cells.Runtime) -> (@editor.SyncEditor[@markdown.Block], @markdown.MarkdownSemanticAttachment) raise
 
+pub fn project_markdown_edit(String, ArrayView[@dowdiness/loom/core.Range], @dowdiness/canopy/core.SpanEdit, String, ArrayView[@dowdiness/loom/core.Range]) -> Result[@dowdiness/canopy/core.SpanEdit, PortableProjectionError]
+
 // Errors
 
 // Types and methods
+pub enum PortableProjectionError {
+  InvalidHiddenRange
+  OverlappingHiddenRanges
+  InvalidEditRange
+  CanonicalAfterSourceMismatch
+  NonRepresentable
+} derive(Eq, @debug.Debug)
 
 // Type aliases
 

--- a/modules/canopy/internal/markdown_runtime/portable_projection.mbt
+++ b/modules/canopy/internal/markdown_runtime/portable_projection.mbt
@@ -1,0 +1,169 @@
+///|
+/// Errors returned by the canonical-to-portable Markdown projection core.
+pub enum PortableProjectionError {
+  InvalidHiddenRange
+  OverlappingHiddenRanges
+  InvalidEditRange
+  CanonicalAfterSourceMismatch
+  NonRepresentable
+} derive(Debug, Eq)
+
+///|
+/// Project canonical source text by removing the supplied private ranges.
+fn project_source(
+  source : String,
+  hidden_ranges : ArrayView[@loom.Range],
+) -> Result[String, PortableProjectionError] {
+  let ranges = normalize_hidden_ranges(source, hidden_ranges)
+  match ranges {
+    Ok(ranges) => Ok(project_normalized_source(source, ranges))
+    Err(error) => Err(error)
+  }
+}
+
+///|
+/// Project one accepted canonical edit and verify it against both projected
+/// source snapshots. The hidden-range arrays are copied and never mutated.
+pub fn project_markdown_edit(
+  before : String,
+  before_hidden : ArrayView[@loom.Range],
+  edit : @core.SpanEdit,
+  after : String,
+  after_hidden : ArrayView[@loom.Range],
+) -> Result[@core.SpanEdit, PortableProjectionError] {
+  let before_ranges = match normalize_hidden_ranges(before, before_hidden) {
+    Ok(ranges) => ranges
+    Err(error) => return Err(error)
+  }
+  let after_ranges = match normalize_hidden_ranges(after, after_hidden) {
+    Ok(ranges) => ranges
+    Err(error) => return Err(error)
+  }
+  let before_length = before.length()
+  if edit.start < 0 ||
+    edit.delete_len < 0 ||
+    edit.start > before_length ||
+    edit.delete_len > before_length - edit.start {
+    return Err(PortableProjectionError::InvalidEditRange)
+  }
+  let expected_after = apply_span_edit(before, edit)
+  if expected_after != after {
+    return Err(PortableProjectionError::CanonicalAfterSourceMismatch)
+  }
+  let inserted_length = edit.inserted.length()
+  if edit.start > after.length() ||
+    inserted_length > after.length() - edit.start {
+    return Err(PortableProjectionError::CanonicalAfterSourceMismatch)
+  }
+  let before_portable = project_normalized_source(before, before_ranges)
+  let after_portable = project_normalized_source(after, after_ranges)
+  let inserted_end = edit.start + inserted_length
+  let projected_inserted = project_normalized_interval(
+    after,
+    after_ranges,
+    edit.start,
+    inserted_end,
+  )
+  let projected = @core.SpanEdit::{
+    start: edit.start - hidden_width(before_ranges, 0, edit.start),
+    delete_len: edit.delete_len -
+    hidden_width(before_ranges, edit.start, edit.start + edit.delete_len),
+    inserted: projected_inserted,
+  }
+  if apply_span_edit(before_portable, projected) != after_portable {
+    return Err(PortableProjectionError::NonRepresentable)
+  }
+  Ok(projected)
+}
+
+///|
+/// Validate, copy, and sort ranges without changing the caller's array.
+fn normalize_hidden_ranges(
+  source : String,
+  hidden_ranges : ArrayView[@loom.Range],
+) -> Result[Array[@loom.Range], PortableProjectionError] {
+  let ranges = hidden_ranges.map(range => range)
+  ranges.sort_by(fn(a, b) { a.start.compare(b.start) })
+  let mut previous_end = -1
+  for range in ranges {
+    if range.start < 0 ||
+      range.end <= range.start ||
+      range.end > source.length() {
+      return Err(PortableProjectionError::InvalidHiddenRange)
+    }
+    if previous_end >= 0 && range.start < previous_end {
+      return Err(PortableProjectionError::OverlappingHiddenRanges)
+    }
+    previous_end = range.end
+  }
+  Ok(ranges)
+}
+
+///|
+/// Assemble a projected source from already validated, sorted ranges.
+fn project_normalized_source(
+  source : String,
+  ranges : Array[@loom.Range],
+) -> String {
+  let builder = StringBuilder()
+  let mut cursor = 0
+  for range in ranges {
+    if range.start > cursor {
+      builder.write_string(source[cursor:range.start].to_owned())
+    }
+    cursor = range.end
+  }
+  if cursor < source.length() {
+    builder.write_string(source[cursor:].to_owned())
+  }
+  builder.to_string()
+}
+
+///|
+/// Assemble only the after-source insertion interval, clipping hidden ranges
+/// to that interval so newly inserted sentinels are not carried into output.
+fn project_normalized_interval(
+  source : String,
+  ranges : Array[@loom.Range],
+  start : Int,
+  end : Int,
+) -> String {
+  let builder = StringBuilder()
+  let mut cursor = start
+  for range in ranges {
+    if range.end <= start || range.start >= end {
+      continue
+    }
+    let clipped_start = if range.start < start { start } else { range.start }
+    let clipped_end = if range.end > end { end } else { range.end }
+    if clipped_start > cursor {
+      builder.write_string(source[cursor:clipped_start].to_owned())
+    }
+    cursor = clipped_end
+  }
+  if cursor < end {
+    builder.write_string(source[cursor:end].to_owned())
+  }
+  builder.to_string()
+}
+
+///|
+/// Count private characters in the half-open interval [start, end].
+fn hidden_width(ranges : Array[@loom.Range], start : Int, end : Int) -> Int {
+  ranges.fold(init=0, (total, range) => {
+    let clipped_start = if range.start < start { start } else { range.start }
+    let clipped_end = if range.end > end { end } else { range.end }
+    total +
+    (if clipped_end > clipped_start { clipped_end - clipped_start } else { 0 })
+  })
+}
+
+///|
+/// Apply one validated source-coordinate span edit.
+fn apply_span_edit(source : String, edit : @core.SpanEdit) -> String {
+  let builder = StringBuilder()
+  builder.write_string(source[:edit.start].to_owned())
+  builder.write_string(edit.inserted)
+  builder.write_string(source[edit.start + edit.delete_len:].to_owned())
+  builder.to_string()
+}

--- a/modules/canopy/internal/markdown_runtime/portable_projection_runtime_wbtest.mbt
+++ b/modules/canopy/internal/markdown_runtime/portable_projection_runtime_wbtest.mbt
@@ -1,0 +1,94 @@
+///|
+/// Real Markdown runtime trace contract for sentinel insertion.
+test "Markdown runtime projects the exact InsertBlockAfter trace" {
+  let editor = try! new_editor("internal-markdown-portable-insert")
+  editor.set_text("Hello\n")
+  editor.refresh()
+  let before = editor.get_text()
+  let before_root = editor.get_proj_node().unwrap()
+  let before_map = editor.get_source_map()
+  let before_hidden : Array[@loom.Range] = []
+  collect_hidden_sentinel_ranges(before_root, before_map, before_hidden)
+  let paragraph = before_root.children[0]
+  match
+    apply_edit(
+      editor,
+      @md_edits.MarkdownEditOp::InsertBlockAfter(node_id=paragraph.id()),
+      0,
+    ) {
+    Ok([canonical_edit]) => {
+      editor.refresh()
+      let after = editor.get_text()
+      let after_root = editor.get_proj_node().unwrap()
+      let after_map = editor.get_source_map()
+      let after_hidden : Array[@loom.Range] = []
+      collect_hidden_sentinel_ranges(after_root, after_map, after_hidden)
+      let projected = project_markdown_edit(
+        before, before_hidden, canonical_edit, after, after_hidden,
+      ).unwrap()
+      assert_eq(
+        apply_span_edit(
+          project_source(before, before_hidden).unwrap(),
+          projected,
+        ),
+        project_source(after, after_hidden).unwrap(),
+      )
+    }
+    Ok(_) => fail("InsertBlockAfter must return exactly one span")
+    Err(_) => fail("InsertBlockAfter should apply")
+  }
+}
+
+///|
+test "Markdown runtime projects the repaired empty-previous merge trace" {
+  let editor = try! new_editor("internal-markdown-portable-merge")
+  editor.set_text("Hello\n")
+  editor.refresh()
+  let initial = editor.get_proj_node().unwrap()
+  let paragraph = initial.children[0]
+  match
+    apply_edit(
+      editor,
+      @md_edits.MarkdownEditOp::SplitBlock(node_id=paragraph.id(), offset=0),
+      0,
+    ) {
+    Ok([_]) => ()
+    _ => fail("setup SplitBlock should return one span")
+  }
+  editor.refresh()
+  let with_empty_previous = editor.get_proj_node().unwrap()
+  guard with_empty_previous.children is [_, current] else {
+    fail("split at zero must create an empty previous block")
+  }
+  let before = editor.get_text()
+  let before_map = editor.get_source_map()
+  let before_hidden : Array[@loom.Range] = []
+  collect_hidden_sentinel_ranges(with_empty_previous, before_map, before_hidden)
+  match
+    apply_edit(
+      editor,
+      @md_edits.MarkdownEditOp::MergeWithPrevious(node_id=current.id()),
+      0,
+    ) {
+    Ok([canonical_edit]) => {
+      editor.refresh()
+      let after = editor.get_text()
+      let after_root = editor.get_proj_node().unwrap()
+      let after_map = editor.get_source_map()
+      let after_hidden : Array[@loom.Range] = []
+      collect_hidden_sentinel_ranges(after_root, after_map, after_hidden)
+      let projected = project_markdown_edit(
+        before, before_hidden, canonical_edit, after, after_hidden,
+      ).unwrap()
+      assert_eq(
+        apply_span_edit(
+          project_source(before, before_hidden).unwrap(),
+          projected,
+        ),
+        project_source(after, after_hidden).unwrap(),
+      )
+    }
+    Ok(_) => fail("MergeWithPrevious must return exactly one span")
+    Err(_) => fail("MergeWithPrevious should apply")
+  }
+}

--- a/modules/canopy/internal/markdown_runtime/portable_projection_wbtest.mbt
+++ b/modules/canopy/internal/markdown_runtime/portable_projection_wbtest.mbt
@@ -1,0 +1,274 @@
+///|
+test "inserted sentinel is absent from the projected edit" {
+  let before = "a\n"
+  let edit : @core.SpanEdit = {
+    start: 2,
+    delete_len: 0,
+    inserted: "\u{200B}\n",
+  }
+  let after = "a\n\u{200B}\n"
+  let after_hidden = [@loom.Range::new(2, 3)]
+  match project_markdown_edit(before, [], edit, after, after_hidden) {
+    Ok(projected) => {
+      assert_eq(projected.start, 2)
+      assert_eq(projected.delete_len, 0)
+      assert_eq(projected.inserted, "\n")
+      assert_eq(
+        apply_span_edit(project_source(before, []).unwrap(), projected),
+        "a\n\n",
+      )
+      assert_eq(project_source(after, after_hidden).unwrap(), "a\n\n")
+    }
+    Err(_) => fail("expected the inserted sentinel to project away")
+  }
+}
+
+///|
+test "source projection removes only marked hidden ranges" {
+  assert_eq(
+    project_source("a\u{200B}b", [@loom.Range::new(1, 2)]).unwrap(),
+    "ab",
+  )
+  assert_eq(project_source("a\u{200B}b", []).unwrap(), "a\u{200B}b")
+}
+
+///|
+test "source projection copies and sorts unsorted ranges" {
+  let ranges = [@loom.Range::new(6, 8), @loom.Range::new(1, 3)]
+  assert_eq(project_source("0123456789", ranges).unwrap(), "034589")
+  assert_eq(ranges[0].start, 6)
+  assert_eq(ranges[0].end, 8)
+  assert_eq(ranges[1].start, 1)
+  assert_eq(ranges[1].end, 3)
+}
+
+///|
+test "source projection permits adjacent ranges" {
+  assert_eq(
+    project_source("abcdef", [@loom.Range::new(1, 2), @loom.Range::new(2, 4)]).unwrap(),
+    "aef",
+  )
+}
+
+///|
+test "source projection uses UTF-16 offsets around non-BMP text" {
+  assert_eq(
+    project_source("😀a😀", [@loom.Range::new(2, 3)]).unwrap(),
+    "😀😀",
+  )
+}
+
+///|
+test "source projection preserves LF CRLF CR and EOF layout" {
+  assert_eq(
+    project_source("a\n\u{200B}\nb", [@loom.Range::new(2, 3)]).unwrap(),
+    "a\n\nb",
+  )
+  assert_eq(
+    project_source("a\r\n\u{200B}\r\nb", [@loom.Range::new(3, 4)]).unwrap(),
+    "a\r\n\r\nb",
+  )
+  assert_eq(
+    project_source("a\r\u{200B}\r b", [@loom.Range::new(2, 3)]).unwrap(),
+    "a\r\r b",
+  )
+  assert_eq(project_source("a\u{200B}", [@loom.Range::new(1, 2)]).unwrap(), "a")
+}
+
+///|
+test "source projection rejects malformed and overlapping ranges" {
+  expect_source_error(
+    project_source("abc", [@loom.Range::new(-1, 1)]),
+    PortableProjectionError::InvalidHiddenRange,
+  )
+  expect_source_error(
+    project_source("abc", [@loom.Range::new(1, 1)]),
+    PortableProjectionError::InvalidHiddenRange,
+  )
+  expect_source_error(
+    project_source("abc", [@loom.Range::new(2, 1)]),
+    PortableProjectionError::InvalidHiddenRange,
+  )
+  expect_source_error(
+    project_source("abc", [@loom.Range::new(1, 4)]),
+    PortableProjectionError::InvalidHiddenRange,
+  )
+  expect_source_error(
+    project_source("abc", [@loom.Range::new(0, 2), @loom.Range::new(1, 3)]),
+    PortableProjectionError::OverlappingHiddenRanges,
+  )
+}
+
+///|
+test "edit projection handles hidden deletion and unmarked user ZWSP" {
+  let hidden_delete : @core.SpanEdit = { start: 1, delete_len: 1, inserted: "" }
+  match
+    project_markdown_edit(
+      "aXb",
+      [@loom.Range::new(1, 2)],
+      hidden_delete,
+      "ab",
+      [],
+    ) {
+    Ok(projected) => {
+      assert_eq(projected.start, 1)
+      assert_eq(projected.delete_len, 0)
+      assert_eq(projected.inserted, "")
+    }
+    Err(_) => fail("hidden deletion should be representable")
+  }
+  let user_zwsp : @core.SpanEdit = {
+    start: 1,
+    delete_len: 0,
+    inserted: "\u{200B}",
+  }
+  match project_markdown_edit("ab", [], user_zwsp, "a\u{200B}b", []) {
+    Ok(projected) => assert_eq(projected.inserted, "\u{200B}")
+    Err(_) => fail("unmarked user ZWSP should remain visible")
+  }
+}
+
+///|
+test "edit projection supports sequential synthetic one-edit steps" {
+  let first : @core.SpanEdit = {
+    start: 1,
+    delete_len: 0,
+    inserted: "\n\u{200B}\n",
+  }
+  let first_after = "a\n\u{200B}\n"
+  let first_projected = project_markdown_edit("a", [], first, first_after, [
+    @loom.Range::new(2, 3),
+  ]).unwrap()
+  let portable_after_first = apply_span_edit("a", first_projected)
+  let second : @core.SpanEdit = { start: 4, delete_len: 0, inserted: "!" }
+  let second_after = "a\n\u{200B}\n!"
+  let second_projected = project_markdown_edit(
+    first_after,
+    [@loom.Range::new(2, 3)],
+    second,
+    second_after,
+    [@loom.Range::new(2, 3)],
+  ).unwrap()
+  assert_eq(
+    apply_span_edit(portable_after_first, second_projected),
+    project_source(second_after, [@loom.Range::new(2, 3)]).unwrap(),
+  )
+}
+
+///|
+test "edit projection handles non-BMP text and CRLF CR EOF" {
+  let crlf_edit : @core.SpanEdit = {
+    start: 4,
+    delete_len: 0,
+    inserted: "\u{200B}\r\n",
+  }
+  let crlf_after = "😀\r\n\u{200B}\r\n"
+  let crlf_projected = project_markdown_edit(
+    "😀\r\n",
+    [],
+    crlf_edit,
+    crlf_after,
+    [@loom.Range::new(4, 5)],
+  ).unwrap()
+  assert_eq(crlf_projected.start, 4)
+  assert_eq(crlf_projected.inserted, "\r\n")
+  assert_eq(
+    apply_span_edit(project_source("😀\r\n", []).unwrap(), crlf_projected),
+    project_source(crlf_after, [@loom.Range::new(4, 5)]).unwrap(),
+  )
+
+  let cr_edit : @core.SpanEdit = {
+    start: 3,
+    delete_len: 0,
+    inserted: "\u{200B}\r",
+  }
+  let cr_after = "😀\r\u{200B}\r"
+  let cr_projected = project_markdown_edit("😀\r", [], cr_edit, cr_after, [
+    @loom.Range::new(3, 4),
+  ]).unwrap()
+  assert_eq(cr_projected.start, 3)
+  assert_eq(cr_projected.inserted, "\r")
+  assert_eq(
+    apply_span_edit(project_source("😀\r", []).unwrap(), cr_projected),
+    project_source(cr_after, [@loom.Range::new(3, 4)]).unwrap(),
+  )
+
+  let eof_edit : @core.SpanEdit = {
+    start: 2,
+    delete_len: 0,
+    inserted: "\u{200B}",
+  }
+  let eof_after = "😀\u{200B}"
+  let eof_projected = project_markdown_edit("😀", [], eof_edit, eof_after, [
+    @loom.Range::new(2, 3),
+  ]).unwrap()
+  assert_eq(eof_projected.start, 2)
+  assert_eq(eof_projected.inserted, "")
+  assert_eq(
+    apply_span_edit(project_source("😀", []).unwrap(), eof_projected),
+    project_source(eof_after, [@loom.Range::new(2, 3)]).unwrap(),
+  )
+}
+
+///|
+test "edit projection rejects invalid edit bounds and source mismatch" {
+  let invalid : @core.SpanEdit = { start: -1, delete_len: 0, inserted: "x" }
+  expect_edit_error(
+    project_markdown_edit("abc", [], invalid, "abcx", []),
+    PortableProjectionError::InvalidEditRange,
+  )
+  let overflowing_start : @core.SpanEdit = {
+    start: 0x7FFFFFFF,
+    delete_len: 1,
+    inserted: "",
+  }
+  expect_edit_error(
+    project_markdown_edit("abc", [], overflowing_start, "abc", []),
+    PortableProjectionError::InvalidEditRange,
+  )
+  let overflowing_delete : @core.SpanEdit = {
+    start: 1,
+    delete_len: 0x7FFFFFFF,
+    inserted: "",
+  }
+  expect_edit_error(
+    project_markdown_edit("abc", [], overflowing_delete, "abc", []),
+    PortableProjectionError::InvalidEditRange,
+  )
+  let mismatch : @core.SpanEdit = { start: 1, delete_len: 1, inserted: "x" }
+  expect_edit_error(
+    project_markdown_edit("abc", [], mismatch, "abc", []),
+    PortableProjectionError::CanonicalAfterSourceMismatch,
+  )
+}
+
+///|
+test "edit projection rejects a valid but non-representable metadata transition" {
+  let edit : @core.SpanEdit = { start: 1, delete_len: 0, inserted: "x" }
+  expect_edit_error(
+    project_markdown_edit("ab", [], edit, "axb", [@loom.Range::new(0, 1)]),
+    PortableProjectionError::NonRepresentable,
+  )
+}
+
+///|
+fn expect_source_error(
+  result : Result[String, PortableProjectionError],
+  expected : PortableProjectionError,
+) -> Unit raise {
+  match result {
+    Err(error) => assert_eq(error, expected)
+    Ok(_) => fail("expected source projection error")
+  }
+}
+
+///|
+fn expect_edit_error(
+  result : Result[@core.SpanEdit, PortableProjectionError],
+  expected : PortableProjectionError,
+) -> Unit raise {
+  match result {
+    Err(error) => assert_eq(error, expected)
+    Ok(_) => fail("expected edit projection error")
+  }
+}

--- a/modules/canopy/lang/markdown/companion/integration_wbtest.mbt
+++ b/modules/canopy/lang/markdown/companion/integration_wbtest.mbt
@@ -239,3 +239,24 @@ test "merge cleans up ZWSP from empty block" {
   // After merge, ZWSP should be gone from raw text too
   inspect(ed.get_text().contains("\u200B"), content="false")
 }
+
+///|
+test "export strips sentinels with CRLF CR and EOF terminators" {
+  let crlf = try! new_markdown_editor("export-crlf")
+  crlf.set_text("A\r\n\r\n\u{200B}\r\n\r\nB")
+  let crlf_state = @editor.ViewUpdateState::ViewUpdateState()
+  let _ = @editor.compute_view_patches(crlf_state, crlf)
+  assert_eq(export_markdown_text(crlf), "A\r\n\r\n\r\n\r\nB")
+
+  let cr = try! new_markdown_editor("export-cr")
+  cr.set_text("A\r\r\u{200B}\r\rB")
+  let cr_state = @editor.ViewUpdateState::ViewUpdateState()
+  let _ = @editor.compute_view_patches(cr_state, cr)
+  assert_eq(export_markdown_text(cr), "A\r\r\r\rB")
+
+  let eof = try! new_markdown_editor("export-eof")
+  eof.set_text("A\n\n\u{200B}")
+  let eof_state = @editor.ViewUpdateState::ViewUpdateState()
+  let _ = @editor.compute_view_patches(eof_state, eof)
+  assert_eq(export_markdown_text(eof), "A\n\n")
+}

--- a/modules/canopy/lang/markdown/companion/markdown_companion.mbt
+++ b/modules/canopy/lang/markdown/companion/markdown_companion.mbt
@@ -41,65 +41,7 @@ pub fn new_markdown_editor_with_semantic_attachment(
 pub fn export_markdown_text(
   editor : @editor.SyncEditor[@markdown.Block],
 ) -> String {
-  let src = editor.get_text()
-  let root = editor.get_proj_node() catch { Failure::Failure(_) => return src }
-  guard root is Some(root) else { return src }
-  let source_map = editor.get_source_map() catch {
-    Failure::Failure(_) => return src
-  }
-  let ranges : Array[(Int, Int)] = []
-  collect_zwsp_ranges(root, source_map, ranges)
-  if ranges.is_empty() {
-    return src
-  }
-  ranges.sort_by(fn(a, b) { a.0.compare(b.0) })
-  let buf = StringBuilder::new()
-  let mut pos = 0
-  for r in ranges {
-    let (s, e) = r
-    if s > pos {
-      buf.write_string(src[pos:s].to_owned())
-    }
-    pos = e
-  }
-  if pos < src.length() {
-    buf.write_string(src[pos:].to_owned())
-  }
-  buf.to_string()
-}
-
-///|
-/// Walk the projection tree and append the source range of every ZWSP-sentinel
-/// Paragraph to `out`. The range covers exactly the ZWSP character (the "text"
-/// token span), so removing it from source converts `\n\u200B\n` into `\n\n`.
-fn collect_zwsp_ranges(
-  node : @core.ProjNode[@markdown.Block],
-  source_map : @core.SourceMap,
-  out : Array[(Int, Int)],
-) -> Unit {
-  if is_zwsp_sentinel(node.kind) {
-    match source_map.get_token_span(node.id(), "text") {
-      Some(r) => out.push((r.start, r.end))
-      None => ()
-    }
-    return
-  }
-  for child in node.children {
-    collect_zwsp_ranges(child, source_map, out)
-  }
-}
-
-///|
-fn is_zwsp_sentinel(block : @markdown.Block) -> Bool {
-  match block {
-    Paragraph(inlines) =>
-      inlines.length() == 1 &&
-      (match inlines[0] {
-        Text(s) => @md_sentinel.is_empty_paragraph_text(s)
-        _ => false
-      })
-    _ => false
-  }
+  @markdown_runtime.export_markdown_text(editor)
 }
 
 ///|

--- a/modules/canopy/lang/markdown/companion/moon.pkg
+++ b/modules/canopy/lang/markdown/companion/moon.pkg
@@ -3,7 +3,6 @@ import {
   "dowdiness/canopy/editor",
   "dowdiness/canopy/internal/markdown_runtime",
   "dowdiness/canopy/lang/markdown/edits" @md_edits,
-  "dowdiness/canopy/lang/markdown/sentinel" @md_sentinel,
   "dowdiness/incr",
   "dowdiness/markdown",
 }


### PR DESCRIPTION
## Summary

- add a pure canonical-to-portable Markdown projection core that validates hidden ranges and projects one accepted `SpanEdit`
- enforce `apply(portable_before, projected_edit) == portable_after`, including sentinel insertion/deletion, UTF-16, and exact terminator cases
- move structural sentinel export ownership into `internal/markdown_runtime` while preserving the companion API and behavior

## UI and review evidence

N/A — no UI or visual changes.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `SourceMap::get_token_span` | `modules/canopy/core/source_map.mbt` | Yes | Supplies projection-confirmed sentinel token ranges. |
| `SpanEdit` | `modules/canopy/core/types.mbt` | Yes | Preserves the exact accepted canonical edit shape. |
| `Range` | `deps/loom/loom/core/range.mbt` | Yes | Represents half-open hidden source intervals. |
| `String` / `StringView` / `StringBuilder` | MoonBit core | Yes | Uses UTF-16 lengths, non-owning slices, and local result assembly. |
| `Array` / `ArrayView` / `Result` / `Option` | MoonBit core | Yes | Uses read-only inputs, private sorting/folding, typed failures, and source-map lookup matching. |
| `Map` / `Set` | MoonBit core | No | Ordered, disjoint interval traversal needs no keyed membership structure. |
| `Bytes` / `BytesView` / `Buffer` | MoonBit core | No | The contract is UTF-16 `String` coordinates rather than byte coordinates. |
| `Iter` / `cmp` / `math` | MoonBit core | Partly | Existing array folds and `Int::compare` cover traversal and ordering; no additional iterator or math abstraction is needed. |
| `compute_text_change` | `deps/loom/text-change/text_change.mbt` | No | Re-diffing would discard provenance from the accepted `SpanEdit`. |

New helpers added:

- `project_markdown_edit`: the staged internal boundary that converts one accepted canonical edit into a verified portable edit for the follow-up façade integration.
- private range normalization, source projection, interval projection, width, and splice helpers: keep validation and coordinate arithmetic inside the functional core.
- private sentinel-range collection in `markdown_runtime`: keeps `ProjNode` and `SourceMap` access in the imperative shell.
- `markdown_runtime.export_markdown_text`: preserves the companion contract while making the runtime authoritative for structural sentinel removal.

Remaining mutation is limited to sorting a private range copy, collecting projection-owned ranges, and building returned strings.

## Validation scope

Boundary matrix / first failing regression:

- first RED test failed because the projection functions and splice oracle did not yet exist
- sentinel insertion and deletion, including the repaired empty-previous/current-text merge
- unmarked user-authored ZWSP and ZWSP-only fenced-code content
- unsorted, adjacent, overlapping, empty, inverted, negative, and out-of-bounds hidden ranges
- overflow-safe edit bounds, after-source mismatch, and non-representable metadata transitions
- sequential synthetic one-edit steps without fabricating Markdown multi-span lowering
- non-BMP UTF-16 coordinates and LF, CRLF, CR, and EOF-without-terminator
- real `InsertBlockAfter` and `MergeWithPrevious` traces from `internal/markdown_runtime`

Target packages:

- `modules/canopy/internal/markdown_runtime`
- `modules/canopy/lang/markdown/companion`

Additional conditional gates:

- independent `moonbit-reviewer` result: PASS, no findings
- no proof, browser, TypeScript, FFI, UI, or submodule changes

## PR-ready evidence

Validated HEAD: `018a7abcddfe55ced0c9edf53a8a4c9d143593fa`

Validated base: `origin/main@07c4f469be3bda56e45f1aeb9d03ff9bd42eb816`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh \
  --target modules/canopy/internal/markdown_runtime \
  --target modules/canopy/lang/markdown/companion
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for the exact HEAD and base above.
- [x] The base was fetched again and `--verify-evidence` passed immediately before this PR was opened.
- [x] The committed `.mbti` diff against the validated base was reviewed; only the intentional internal runtime additions remain.
- [x] No submodule pointer changed.
- [x] Validation was rerun after the commit and after synchronizing the moved base.
- [x] Independent review findings were resolved before the final validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Markdown exports no longer include invisible placeholder characters used for empty paragraphs.
  - Line endings, including CRLF, CR, and EOF-terminated content, are preserved during export.
  - Markdown editing operations now produce consistent results after inserting, splitting, or merging blocks.
  - Export safely preserves the original Markdown when a conversion cannot be represented reliably.

- **Tests**
  - Added coverage for empty paragraphs, hidden placeholders, line endings, sequential edits, and invalid transformations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->