### PR TITLE
feat(loomark): preserve directed Raw selections

### DIFF
--- a/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
+++ b/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
@@ -1820,6 +1820,40 @@ test("rejected Raw repair maps canonical CRLF to textarea offsets", async ({ bro
   }
 })
 
+test("rejected Raw repair maps canonical lone CR to textarea offsets", async ({ browser }) => {
+  const host = await mountHost(browser, "a\rb")
+  try {
+    const input = host.page.locator("#loomark-input")
+    await expect(input).toHaveValue("a\nb")
+    await input.focus()
+    await forceEditorFailure(host.page)
+    await expect.poll(async () => (await snapshot(host.page)).editor_failure_armed).toBe(true)
+
+    await input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.value = "a\nbx"
+      textarea.setSelectionRange(4, 4, "none")
+      textarea.dispatchEvent(new Event("input", { bubbles: true }))
+    })
+
+    await expect.poll(async () => (await snapshot(host.page)).error_code)
+      .toBe("editor-commit-failed")
+    await expect(input).toHaveValue("a\nb")
+    await expect.poll(() => input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      return `${textarea.selectionStart}:${textarea.selectionEnd}`
+    })).toBe("3:3")
+    await host.page.waitForTimeout(100)
+    expect(await snapshot(host.page)).toMatchObject({
+      source: "a\rb",
+      error_code: "editor-commit-failed",
+      error_count: 1,
+    })
+  } finally {
+    await host.context.close()
+  }
+})
+
 test("Raw DOM selection conversion and post-render installation preserve direction", async ({ browser }) => {
   const host = await mountHost(browser, "a\r\nb\rc\n")
   try {

--- a/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
+++ b/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
@@ -82,6 +82,15 @@ async function rawSelectionProbe(page: Page, detail: "capture" | "install"): Pro
   }, detail)
 }
 
+async function commitCapturedRawSelection(page: Page, inserted: string): Promise<void> {
+  await page.evaluate(inserted => {
+    const target = document.getElementById("loomark-driver-target")
+    target?.dispatchEvent(new CustomEvent("loomark-driver", {
+      detail: `raw-selection-edit|${inserted}`,
+    }))
+  }, inserted)
+}
+
 async function selectPreview(page: Page): Promise<void> {
   await page.evaluate(moduleUrl =>
     import(moduleUrl).then(module => module.dev_host_select_preview()), moduleUrl)
@@ -1778,21 +1787,22 @@ test("rejected Raw repair round-trips a backward DOM selection", async ({ browse
 })
 
 test("Raw DOM selection conversion and post-render installation preserve direction", async ({ browser }) => {
-  const host = await mountHost(browser, "alpha\n\nbeta")
+  const host = await mountHost(browser, "a\r\nb\rc\n")
   try {
     const input = host.page.locator("#loomark-input")
+    await expect(input).toHaveValue("a\nb\nc\n")
     await input.focus()
     await input.evaluate(element => {
       const textarea = element as HTMLTextAreaElement
-      textarea.setSelectionRange(0, 11, "backward")
+      textarea.setSelectionRange(2, 4, "backward")
     })
 
     await rawSelectionProbe(host.page, "capture")
-    await expect.poll(async () => (await snapshot(host.page)).selection).toBe("11:0")
+    await expect.poll(async () => (await snapshot(host.page)).selection).toBe("5:3")
 
     await input.evaluate(element => {
       const textarea = element as HTMLTextAreaElement
-      textarea.setSelectionRange(5, 5, "none")
+      textarea.setSelectionRange(0, 0, "none")
     })
     await rawSelectionProbe(host.page, "install")
     await expect.poll(() => input.evaluate(element => {
@@ -1802,7 +1812,39 @@ test("Raw DOM selection conversion and post-render installation preserve directi
         end: textarea.selectionEnd,
         direction: textarea.selectionDirection,
       }
-    })).toEqual({ start: 0, end: 11, direction: "backward" })
+    })).toEqual({ start: 2, end: 4, direction: "backward" })
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("accepted Raw selection edit supersedes pending full-source input", async ({ browser }) => {
+  const host = await mountHost(browser, "abcdef")
+  try {
+    const input = host.page.locator("#loomark-input")
+    await input.focus()
+    await input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.setSelectionRange(0, 6, "backward")
+    })
+    await rawSelectionProbe(host.page, "capture")
+    await expect.poll(async () => (await snapshot(host.page)).selection).toBe("6:0")
+
+    await input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.value = "pending"
+      textarea.setSelectionRange(7, 7, "none")
+      textarea.dispatchEvent(new Event("input", { bubbles: true }))
+    })
+    await commitCapturedRawSelection(host.page, "x")
+
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("x")
+    await host.page.waitForTimeout(100)
+    expect(await snapshot(host.page)).toMatchObject({
+      source: "x",
+      committed_change_count: 1,
+    })
+    await expect(input).toHaveValue("x")
   } finally {
     await host.context.close()
   }

--- a/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
+++ b/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
@@ -73,6 +73,15 @@ async function rawInput(page: Page, source: string): Promise<void> {
   }, source)
 }
 
+async function rawSelectionProbe(page: Page, detail: "capture" | "install"): Promise<void> {
+  await page.evaluate(detail => {
+    const target = document.getElementById("loomark-driver-target")
+    target?.dispatchEvent(new CustomEvent("loomark-driver", {
+      detail: `${detail}-raw-selection`,
+    }))
+  }, detail)
+}
+
 async function selectPreview(page: Page): Promise<void> {
   await page.evaluate(moduleUrl =>
     import(moduleUrl).then(module => module.dev_host_select_preview()), moduleUrl)
@@ -1763,6 +1772,37 @@ test("rejected Raw repair round-trips a backward DOM selection", async ({ browse
         direction: textarea.selectionDirection,
       }
     })).toEqual({ start: 0, end: 5, direction: "backward" })
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("Raw DOM selection conversion and post-render installation preserve direction", async ({ browser }) => {
+  const host = await mountHost(browser, "alpha\n\nbeta")
+  try {
+    const input = host.page.locator("#loomark-input")
+    await input.focus()
+    await input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.setSelectionRange(0, 11, "backward")
+    })
+
+    await rawSelectionProbe(host.page, "capture")
+    await expect.poll(async () => (await snapshot(host.page)).selection).toBe("11:0")
+
+    await input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.setSelectionRange(5, 5, "none")
+    })
+    await rawSelectionProbe(host.page, "install")
+    await expect.poll(() => input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      return {
+        start: textarea.selectionStart,
+        end: textarea.selectionEnd,
+        direction: textarea.selectionDirection,
+      }
+    })).toEqual({ start: 0, end: 11, direction: "backward" })
   } finally {
     await host.context.close()
   }

--- a/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
+++ b/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
@@ -1786,6 +1786,40 @@ test("rejected Raw repair round-trips a backward DOM selection", async ({ browse
   }
 })
 
+test("rejected Raw repair maps canonical CRLF to textarea offsets", async ({ browser }) => {
+  const host = await mountHost(browser, "a\r\nb")
+  try {
+    const input = host.page.locator("#loomark-input")
+    await expect(input).toHaveValue("a\nb")
+    await input.focus()
+    await forceEditorFailure(host.page)
+    await expect.poll(async () => (await snapshot(host.page)).editor_failure_armed).toBe(true)
+
+    await input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.value = "a\nbx"
+      textarea.setSelectionRange(4, 4, "none")
+      textarea.dispatchEvent(new Event("input", { bubbles: true }))
+    })
+
+    await expect.poll(async () => (await snapshot(host.page)).error_code)
+      .toBe("editor-commit-failed")
+    await expect(input).toHaveValue("a\nb")
+    await expect.poll(() => input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      return `${textarea.selectionStart}:${textarea.selectionEnd}`
+    })).toBe("3:3")
+    await host.page.waitForTimeout(100)
+    expect(await snapshot(host.page)).toMatchObject({
+      source: "a\r\nb",
+      error_code: "editor-commit-failed",
+      error_count: 1,
+    })
+  } finally {
+    await host.context.close()
+  }
+})
+
 test("Raw DOM selection conversion and post-render installation preserve direction", async ({ browser }) => {
   const host = await mountHost(browser, "a\r\nb\rc\n")
   try {

--- a/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
+++ b/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
@@ -1730,6 +1730,87 @@ test("Raw textarea input uses the atomic editor transaction and mode toolbar", a
   }
 })
 
+test("rejected Raw repair round-trips a backward DOM selection", async ({ browser }) => {
+  const host = await mountHost(browser, "abcdef")
+  try {
+    const input = host.page.locator("#loomark-input")
+    await input.focus()
+    await forceEditorFailure(host.page)
+    await expect.poll(async () => (await snapshot(host.page)).editor_failure_armed).toBe(true)
+
+    const eventSelection = await input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.value = "abcdef!"
+      textarea.setSelectionRange(0, 5, "backward")
+      const selection = {
+        start: textarea.selectionStart,
+        end: textarea.selectionEnd,
+        direction: textarea.selectionDirection,
+      }
+      textarea.dispatchEvent(new Event("input", { bubbles: true }))
+      return selection
+    })
+
+    expect(eventSelection).toEqual({ start: 0, end: 5, direction: "backward" })
+    await expect.poll(async () => (await snapshot(host.page)).error_code)
+      .toBe("editor-commit-failed")
+    await expect(input).toHaveValue("abcdef")
+    await expect.poll(() => input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      return {
+        start: textarea.selectionStart,
+        end: textarea.selectionEnd,
+        direction: textarea.selectionDirection,
+      }
+    })).toEqual({ start: 0, end: 5, direction: "backward" })
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("Raw input reads the selection present when its debounce fires", async ({ browser }) => {
+  const host = await mountHost(browser, "abcdef")
+  try {
+    const input = host.page.locator("#loomark-input")
+    await input.focus()
+    await forceEditorFailure(host.page)
+    await expect.poll(async () => (await snapshot(host.page)).editor_failure_armed).toBe(true)
+
+    const observed = await input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      const readSelection = () => ({
+        start: textarea.selectionStart,
+        end: textarea.selectionEnd,
+        direction: textarea.selectionDirection,
+      })
+      textarea.value = "abcdef!"
+      textarea.setSelectionRange(0, 2, "backward")
+      const atInput = readSelection()
+      textarea.dispatchEvent(new Event("input", { bubbles: true }))
+      textarea.setSelectionRange(3, 5, "forward")
+      return { atInput, beforeFlush: readSelection() }
+    })
+
+    expect(observed).toEqual({
+      atInput: { start: 0, end: 2, direction: "backward" },
+      beforeFlush: { start: 3, end: 5, direction: "forward" },
+    })
+    await expect.poll(async () => (await snapshot(host.page)).error_code)
+      .toBe("editor-commit-failed")
+    await expect(input).toHaveValue("abcdef")
+    await expect.poll(() => input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      return {
+        start: textarea.selectionStart,
+        end: textarea.selectionEnd,
+        direction: textarea.selectionDirection,
+      }
+    })).toEqual({ start: 3, end: 5, direction: "forward" })
+  } finally {
+    await host.context.close()
+  }
+})
+
 test("Raw input coalesces a same-task burst into one commit", async ({ browser }) => {
   const host = await mountHost(browser, "start")
   try {

--- a/apps/loomark/internal/rabbita/application.mbt
+++ b/apps/loomark/internal/rabbita/application.mbt
@@ -958,8 +958,10 @@ fn update_editing(
           )
           let (next, selection_command) = match outcome {
             RawSelectionEditOutcome::Applied(selection)
-            | RawSelectionEditOutcome::Unchanged(selection) =>
+            | RawSelectionEditOutcome::Unchanged(selection) => {
+              raw_input_coordinator.cancel_pending()
               (next, raw_selection_after_render(latest_model, selection, emit))
+            }
             RawSelectionEditOutcome::Rejected(rejection) =>
               (
                 {
@@ -1844,7 +1846,7 @@ fn update_probe(
             model,
             "invalid-raw-selection",
             "browser-effect",
-            markdown_document_utf16_selection_error_detail(error),
+            raw_dom_selection_conversion_error_detail(error),
           )
           return (next, @rabbita_runtime.none)
         }

--- a/apps/loomark/internal/rabbita/application.mbt
+++ b/apps/loomark/internal/rabbita/application.mbt
@@ -645,6 +645,8 @@ fn driver_event_name(event : DriverEvent) -> String {
       match edit_event {
         ReplaceSource(_) => "source"
         RawInput(_, _, _) => "raw-input"
+        RawSelectionEdit(_) => "raw-selection-edit"
+        CommitCapturedRawSelection(_) => "commit-captured-raw-selection"
         BlockFocused(_) => "block-focused"
         BlockHeading(_, _) => "block-heading"
         BlockToggleList(_) => "block-toggle-list"
@@ -673,6 +675,9 @@ fn driver_event_name(event : DriverEvent) -> String {
       match probe_event {
         WriteSelection(..) => "write-selection"
         WriteSelectionFailure => "write-selection-failure"
+        CaptureRawSelection => "capture-raw-selection"
+        RawSelectionCaptured(_) => "raw-selection-captured"
+        InstallRawSelection => "install-raw-selection"
         MeasurePreview => "measure-preview"
         MeasureFailure => "measure-failure"
         SelectionRead(..) => "selection-read"
@@ -725,6 +730,10 @@ fn parse_driver_event(detail : String) -> DriverEvent {
     Editing(ProbeBlockSelection("deleted"))
   } else if detail == "write-selection-failure" {
     Probe(WriteSelectionFailure)
+  } else if detail == "capture-raw-selection" {
+    Probe(CaptureRawSelection)
+  } else if detail == "install-raw-selection" {
+    Probe(InstallRawSelection)
   } else if detail == "measure-preview" {
     Probe(MeasurePreview)
   } else if detail == "measure-failure" {
@@ -735,6 +744,12 @@ fn parse_driver_event(detail : String) -> DriverEvent {
     Editing(ReplaceSource(detail["source|".length():].to_owned()))
   } else if detail.has_prefix("raw-input|") {
     Editing(RawInput(detail["raw-input|".length():].to_owned(), None, None))
+  } else if detail.has_prefix("raw-selection-edit|") {
+    Editing(
+      CommitCapturedRawSelection(
+        detail["raw-selection-edit|".length():].to_owned(),
+      ),
+    )
   } else if detail == "editor-failure" {
     Lifecycle(EditorFailure)
   } else if detail == "force-parser-failure" {
@@ -845,7 +860,9 @@ fn editing_mode_applicable(
   match event {
     ReplaceSource(_) | ProbeBlockSelection(_) => None
     RawInput(_, _, Some(_)) => None
-    RawInput(_, _, None) =>
+    RawInput(_, _, None)
+    | RawSelectionEdit(_)
+    | CommitCapturedRawSelection(_) =>
       if mode == @core.Raw || (mode == @core.Preview && split_preview_open) {
         None
       } else {
@@ -913,6 +930,50 @@ fn update_editing(
     }
     None =>
       match event {
+        CommitCapturedRawSelection(inserted) =>
+          match model.raw_selection {
+            None => {
+              let next = record_error(
+                model, "raw-selection-unavailable", "raw-selection-edit", "Raw selection is unavailable",
+              )
+              (next, @rabbita_runtime.none)
+            }
+            Some(selection) =>
+              update_editing(
+                editor,
+                attachment,
+                raw_input_coordinator,
+                block_input_coordinator,
+                model,
+                latest_model,
+                RawSelectionEdit(
+                  ({ selection, inserted } : RawSelectionEditRequest),
+                ),
+                emit,
+              )
+          }
+        RawSelectionEdit(request) => {
+          let (next, outcome, persistence_command) = commit_raw_selection_edit(
+            editor, attachment, model, request, emit,
+          )
+          let (next, selection_command) = match outcome {
+            RawSelectionEditOutcome::Applied(selection)
+            | RawSelectionEditOutcome::Unchanged(selection) =>
+              (next, raw_selection_after_render(latest_model, selection, emit))
+            RawSelectionEditOutcome::Rejected(rejection) =>
+              (
+                {
+                  ..next,
+                  rejection: Some(
+                    "operation=raw-selection-edit;reason=" +
+                    raw_selection_edit_rejection_reason(rejection),
+                  ),
+                },
+                @rabbita_runtime.none,
+              )
+          }
+          (next, @cmd.batch([persistence_command, selection_command]))
+        }
         ReplaceSource(source) | RawInput(source, _, _) => {
           let raw_selection = match event {
             RawInput(_, selection, _) => selection
@@ -1721,6 +1782,7 @@ fn apply_measurement(
 /// outbound results.
 fn update_probe(
   model : DriverModel,
+  latest_model : @ref.Ref[DriverModel?],
   event : ProbeEvent,
   emit : @cmd.Emit[DriverEvent],
 ) -> (DriverModel, @cmd.Cmd) {
@@ -1761,6 +1823,52 @@ fn update_probe(
           },
           emit,
         ),
+      )
+    CaptureRawSelection =>
+      (
+        model,
+        after_render(
+          scheduler => {
+            let selection = @dom_boundary.read_text_selection_id(
+              "loomark-input",
+            )
+            scheduler.add(emit(Probe(RawSelectionCaptured(selection))))
+          },
+          emit,
+        ),
+      )
+    RawSelectionCaptured(selection) => {
+      let bound = versioned_raw_selection_from_dom(model, selection) catch {
+        error => {
+          let next = record_error(
+            model,
+            "invalid-raw-selection",
+            "browser-effect",
+            markdown_document_utf16_selection_error_detail(error),
+          )
+          return (next, @rabbita_runtime.none)
+        }
+      }
+      let markdown = bound.selection
+      (
+        {
+          ..model,
+          raw_selection: Some(bound),
+          selection: Some(
+            markdown.anchor().to_string() + ":" + markdown.head().to_string(),
+          ),
+        },
+        @rabbita_runtime.none,
+      )
+    }
+    InstallRawSelection =>
+      (
+        model,
+        match model.raw_selection {
+          Some(selection) =>
+            raw_selection_after_render(latest_model, selection, emit)
+          None => @rabbita_runtime.none
+        },
       )
     MeasurePreview =>
       (
@@ -2041,7 +2149,7 @@ fn update_model(
       )
     Navigation(nav_event) =>
       update_navigation(attachment, model, latest_model, nav_event, emit)
-    Probe(probe_event) => update_probe(model, probe_event, emit)
+    Probe(probe_event) => update_probe(model, latest_model, probe_event, emit)
     Lifecycle(life_event) =>
       update_lifecycle(
         editor, attachment, raw_input_coordinator, block_input_coordinator, model,
@@ -2361,6 +2469,7 @@ fn initial_model(
     document: editor.snapshot(),
     document_version: editor.version(),
     document_id,
+    raw_selection: None,
     archive_persistence_enabled,
     semantic_document: None,
     semantic_read_count: 0,

--- a/apps/loomark/internal/rabbita/commit_classification.mbt
+++ b/apps/loomark/internal/rabbita/commit_classification.mbt
@@ -22,6 +22,7 @@ fn classify_commit(
       ..model,
       document,
       document_version: receipt.after_version(),
+      raw_selection: None,
       source_revision: if changed {
         model.source_revision + 1
       } else {
@@ -50,6 +51,7 @@ fn classify_recovered_source(
   {
     ..model,
     document_version: version,
+    raw_selection: None,
     source_revision: if changed {
       model.source_revision + 1
     } else {
@@ -77,6 +79,7 @@ fn classify_recovered_frontier(
       ..model,
       document,
       document_version: version,
+      raw_selection: None,
       source_revision: if changed {
         model.source_revision + 1
       } else {

--- a/apps/loomark/internal/rabbita/commit_classification_wbtest.mbt
+++ b/apps/loomark/internal/rabbita/commit_classification_wbtest.mbt
@@ -12,6 +12,7 @@ fn test_model(
     document_id: @archive.LoomarkDocumentId::from_string("test-doc") catch {
       _ => abort("test document id must construct")
     },
+    raw_selection: None,
     archive_persistence_enabled: false,
     semantic_document: None,
     semantic_read_count: 0,

--- a/apps/loomark/internal/rabbita/driver_types.mbt
+++ b/apps/loomark/internal/rabbita/driver_types.mbt
@@ -5,6 +5,8 @@
 priv enum EditingEvent {
   ReplaceSource(String)
   RawInput(String, @dom_boundary.TextSelection?, Int?)
+  RawSelectionEdit(RawSelectionEditRequest)
+  CommitCapturedRawSelection(String)
   BlockFocused(String)
   BlockHeading(Int, BlockSelection?)
   BlockToggleList(BlockSelection?)
@@ -39,6 +41,9 @@ priv enum NavigationEvent {
 priv enum ProbeEvent {
   WriteSelection(start~ : Int, end~ : Int)
   WriteSelectionFailure
+  CaptureRawSelection
+  RawSelectionCaptured(@dom_boundary.TextSelection)
+  InstallRawSelection
   MeasurePreview
   MeasureFailure
   SelectionRead(start~ : Int, end~ : Int)
@@ -104,6 +109,7 @@ priv struct DriverModel {
   document : @markdown.MarkdownDocumentSnapshot
   document_version : @markdown.MarkdownDocumentVersion
   document_id : @archive.LoomarkDocumentId
+  raw_selection : VersionedRawSelection?
   archive_persistence_enabled : Bool
   semantic_document : @md_markdown.MarkdownIR?
   semantic_read_count : Int

--- a/apps/loomark/internal/rabbita/editing_mode_wbtest.mbt
+++ b/apps/loomark/internal/rabbita/editing_mode_wbtest.mbt
@@ -4,10 +4,10 @@
 /// | event | mode | split_preview_open | applicable |
 /// | --- | --- | --- | --- |
 /// | ReplaceSource / ProbeBlockSelection | any | any | yes |
-/// | RawInput | Raw | any | yes |
-/// | RawInput | Preview | true | yes |
-/// | RawInput | Preview | false | no |
-/// | RawInput | Block | any | no |
+/// | RawInput / RawSelectionEdit | Raw | any | yes |
+/// | RawInput / RawSelectionEdit | Preview | true | yes |
+/// | RawInput / RawSelectionEdit | Preview | false | no |
+/// | RawInput / RawSelectionEdit | Block | any | no |
 /// | Block* | Block | any | yes |
 /// | Block* | Raw / Preview | any | no |
 ///
@@ -54,6 +54,13 @@ test "raw input requires Raw mode or a split-open Preview" {
   )
   assert_eq(
     editing_mode_applicable(raw, block_mode(), false),
+    Some("Raw input is unavailable outside Raw mode"),
+  )
+  let selection_edit = CommitCapturedRawSelection("x")
+  assert_eq(editing_mode_applicable(selection_edit, raw_mode(), false), None)
+  assert_eq(editing_mode_applicable(selection_edit, preview_mode(), true), None)
+  assert_eq(
+    editing_mode_applicable(selection_edit, block_mode(), false),
     Some("Raw input is unavailable outside Raw mode"),
   )
 }

--- a/apps/loomark/internal/rabbita/focus_runtime.mbt
+++ b/apps/loomark/internal/rabbita/focus_runtime.mbt
@@ -218,6 +218,27 @@ fn block_selection_after_render(
 }
 
 ///|
+/// Install an accepted Raw selection only while the exact document frontier
+/// and Session selection that produced it remain current.
+fn raw_selection_after_render(
+  latest_model : @ref.Ref[DriverModel?],
+  selection : VersionedRawSelection,
+  emit : @cmd.Emit[DriverEvent],
+) -> @cmd.Cmd {
+  after_render(
+    scheduler => {
+      ignore(scheduler)
+      match raw_selection_effect_value(latest_model.val, selection) {
+        Some(selection) =>
+          @dom_boundary.write_text_selection_id("loomark-input", selection)
+        None => ()
+      }
+    },
+    emit,
+  )
+}
+
+///|
 /// Revalidate the latest model after rendering, then perform the final DOM
 /// write without queuing a state update after it.
 fn focus_latest_after_render(

--- a/apps/loomark/internal/rabbita/raw_selection_transaction.mbt
+++ b/apps/loomark/internal/rabbita/raw_selection_transaction.mbt
@@ -41,14 +41,28 @@ priv enum RawSelectionEditOutcome {
 }
 
 ///|
-fn markdown_document_utf16_selection_error_detail(
-  error : @markdown.MarkdownDocumentUtf16SelectionError,
+priv suberror RawDomSelectionConversionError {
+  DomOffsetOutOfBounds(offset~ : Int, value_length~ : Int)
+  InvalidMarkdownSelection(@markdown.MarkdownDocumentUtf16SelectionError)
+}
+
+///|
+fn raw_dom_selection_conversion_error_detail(
+  error : RawDomSelectionConversionError,
 ) -> String {
   match error {
-    @markdown.MarkdownDocumentUtf16SelectionError::OutOfBounds(..) =>
-      "selection endpoint is out of bounds"
-    @markdown.MarkdownDocumentUtf16SelectionError::MidGraphemeBoundary(..) =>
-      "selection endpoint is not a grapheme boundary"
+    RawDomSelectionConversionError::DomOffsetOutOfBounds(offset~, value_length~) =>
+      "Raw DOM selection offset " +
+      offset.to_string() +
+      " is outside normalized UTF-16 length " +
+      value_length.to_string()
+    RawDomSelectionConversionError::InvalidMarkdownSelection(error) =>
+      match error {
+        @markdown.MarkdownDocumentUtf16SelectionError::OutOfBounds(..) =>
+          "selection endpoint is out of bounds"
+        @markdown.MarkdownDocumentUtf16SelectionError::MidGraphemeBoundary(..) =>
+          "selection endpoint is not a grapheme boundary"
+      }
   }
 }
 
@@ -66,26 +80,111 @@ fn raw_selection_edit_rejection_reason(
 }
 
 ///|
+/// Number of canonical UTF-16 units represented by one textarea value unit.
+/// HTML textareas normalize CRLF and lone CR line endings to one LF.
+fn raw_textarea_source_step(source : String, source_offset : Int) -> Int {
+  if source[source_offset] == '\r' &&
+    source_offset + 1 < source.length() &&
+    source[source_offset + 1] == '\n' {
+    2
+  } else {
+    1
+  }
+}
+
+///|
+/// Map a normalized textarea UTF-16 boundary back to canonical source.
+/// The two cursors are necessary because one DOM LF may own two source units.
+fn raw_source_offset_from_dom(source : String, dom_offset : Int) -> Int? {
+  guard dom_offset >= 0 else { return None }
+  let mut source_cursor = 0
+  let mut dom_cursor = 0
+  while source_cursor < source.length() {
+    if dom_cursor == dom_offset {
+      return Some(source_cursor)
+    }
+    source_cursor = source_cursor +
+      raw_textarea_source_step(source, source_cursor)
+    dom_cursor = dom_cursor + 1
+  }
+  if dom_cursor == dom_offset {
+    Some(source_cursor)
+  } else {
+    None
+  }
+}
+
+///|
+/// Map a canonical source UTF-16 boundary into the normalized textarea value.
+fn raw_dom_offset_from_source(source : String, source_offset : Int) -> Int? {
+  guard source_offset >= 0 && source_offset <= source.length() else {
+    return None
+  }
+  let mut source_cursor = 0
+  let mut dom_cursor = 0
+  while source_cursor < source_offset {
+    source_cursor = source_cursor +
+      raw_textarea_source_step(source, source_cursor)
+    dom_cursor = dom_cursor + 1
+  }
+  if source_cursor == source_offset {
+    Some(dom_cursor)
+  } else {
+    None
+  }
+}
+
+///|
 /// Convert a normalized DOM half-open range into a directed Markdown source
 /// selection while the caller still owns the detached document snapshot.
 fn markdown_document_utf16_selection_from_dom(
   snapshot : @markdown.MarkdownDocumentSnapshot,
   selection : @dom_boundary.TextSelection,
-) -> @markdown.MarkdownDocumentUtf16Selection raise @markdown.MarkdownDocumentUtf16SelectionError {
-  let (anchor, head) = match selection.direction() {
-    @dom_boundary.Backward => (selection.end(), selection.start())
-    @dom_boundary.Forward | @dom_boundary.NoDirection =>
-      (selection.start(), selection.end())
+) -> @markdown.MarkdownDocumentUtf16Selection raise RawDomSelectionConversionError {
+  let source = snapshot.source()
+  let value_length = raw_dom_offset_from_source(source, source.length()).unwrap_or(
+    0,
+  )
+  let start = match raw_source_offset_from_dom(source, selection.start()) {
+    Some(offset) => offset
+    None =>
+      raise RawDomSelectionConversionError::DomOffsetOutOfBounds(
+        offset=selection.start(),
+        value_length~,
+      )
   }
-  @markdown.MarkdownDocumentUtf16Selection(snapshot, anchor~, head~)
+  let end = match raw_source_offset_from_dom(source, selection.end()) {
+    Some(offset) => offset
+    None =>
+      raise RawDomSelectionConversionError::DomOffsetOutOfBounds(
+        offset=selection.end(),
+        value_length~,
+      )
+  }
+  let (anchor, head) = match selection.direction() {
+    @dom_boundary.Backward => (end, start)
+    @dom_boundary.Forward | @dom_boundary.NoDirection => (start, end)
+  }
+  @markdown.MarkdownDocumentUtf16Selection(snapshot, anchor~, head~) catch {
+    error =>
+      raise RawDomSelectionConversionError::InvalidMarkdownSelection(error)
+  }
 }
 
 ///|
 /// Convert a directed Markdown source selection to the normalized DOM range
 /// plus the direction needed by `setSelectionRange`.
 fn dom_selection_from_markdown_document_utf16(
+  source : String,
   selection : @markdown.MarkdownDocumentUtf16Selection,
-) -> @dom_boundary.TextSelection {
+) -> @dom_boundary.TextSelection? {
+  guard raw_dom_offset_from_source(source, selection.range_start())
+    is Some(start) else {
+    return None
+  }
+  guard raw_dom_offset_from_source(source, selection.range_end()) is Some(end) else {
+    return None
+  }
   let direction = if selection.is_collapsed() {
     @dom_boundary.NoDirection
   } else if selection.is_backward() {
@@ -93,18 +192,14 @@ fn dom_selection_from_markdown_document_utf16(
   } else {
     @dom_boundary.Forward
   }
-  @dom_boundary.TextSelection(
-    selection.range_start(),
-    selection.range_end(),
-    direction,
-  )
+  Some(@dom_boundary.TextSelection(start, end, direction))
 }
 
 ///|
 fn versioned_raw_selection_from_dom(
   model : DriverModel,
   selection : @dom_boundary.TextSelection,
-) -> VersionedRawSelection raise @markdown.MarkdownDocumentUtf16SelectionError {
+) -> VersionedRawSelection raise RawDomSelectionConversionError {
   {
     document_id: model.document_id,
     version: model.document_version,
@@ -125,7 +220,10 @@ fn raw_selection_effect_value(
   guard model.document_id == expected.document_id else { return None }
   guard model.document_version == expected.version else { return None }
   guard model.raw_selection == Some(expected) else { return None }
-  Some(dom_selection_from_markdown_document_utf16(expected.selection))
+  dom_selection_from_markdown_document_utf16(
+    model.document.source(),
+    expected.selection,
+  )
 }
 
 ///|

--- a/apps/loomark/internal/rabbita/raw_selection_transaction.mbt
+++ b/apps/loomark/internal/rabbita/raw_selection_transaction.mbt
@@ -1,0 +1,242 @@
+///|
+/// One Raw source selection together with the exact Session document frontier
+/// against which it was read.
+priv struct VersionedRawSelection {
+  document_id : @archive.LoomarkDocumentId
+  version : @markdown.MarkdownDocumentVersion
+  selection : @markdown.MarkdownDocumentUtf16Selection
+} derive(Eq)
+
+///|
+fn VersionedRawSelection::VersionedRawSelection(
+  document_id~ : @archive.LoomarkDocumentId,
+  version~ : @markdown.MarkdownDocumentVersion,
+  selection~ : @markdown.MarkdownDocumentUtf16Selection,
+) -> VersionedRawSelection {
+  { document_id, version, selection }
+}
+
+///|
+/// One normalized Raw replacement. Native browser-event pairing is owned by
+/// #1204; this value is the Session input that pairing will produce.
+priv struct RawSelectionEditRequest {
+  selection : VersionedRawSelection
+  inserted : String
+}
+
+///|
+priv enum RawSelectionEditRejection {
+  WrongDocument
+  StaleVersion
+  ModeStale
+  InvalidSelection
+  EditorCommitFailed
+}
+
+///|
+priv enum RawSelectionEditOutcome {
+  Applied(VersionedRawSelection)
+  Unchanged(VersionedRawSelection)
+  Rejected(RawSelectionEditRejection)
+}
+
+///|
+fn markdown_document_utf16_selection_error_detail(
+  error : @markdown.MarkdownDocumentUtf16SelectionError,
+) -> String {
+  match error {
+    @markdown.MarkdownDocumentUtf16SelectionError::OutOfBounds(..) =>
+      "selection endpoint is out of bounds"
+    @markdown.MarkdownDocumentUtf16SelectionError::MidGraphemeBoundary(..) =>
+      "selection endpoint is not a grapheme boundary"
+  }
+}
+
+///|
+fn raw_selection_edit_rejection_reason(
+  rejection : RawSelectionEditRejection,
+) -> String {
+  match rejection {
+    RawSelectionEditRejection::WrongDocument => "wrong-document"
+    RawSelectionEditRejection::StaleVersion => "stale-version"
+    RawSelectionEditRejection::ModeStale => "mode-stale"
+    RawSelectionEditRejection::InvalidSelection => "invalid-selection"
+    RawSelectionEditRejection::EditorCommitFailed => "editor-commit-failed"
+  }
+}
+
+///|
+/// Convert a normalized DOM half-open range into a directed Markdown source
+/// selection while the caller still owns the detached document snapshot.
+fn markdown_document_utf16_selection_from_dom(
+  snapshot : @markdown.MarkdownDocumentSnapshot,
+  selection : @dom_boundary.TextSelection,
+) -> @markdown.MarkdownDocumentUtf16Selection raise @markdown.MarkdownDocumentUtf16SelectionError {
+  let (anchor, head) = match selection.direction() {
+    @dom_boundary.Backward => (selection.end(), selection.start())
+    @dom_boundary.Forward | @dom_boundary.NoDirection =>
+      (selection.start(), selection.end())
+  }
+  @markdown.MarkdownDocumentUtf16Selection(snapshot, anchor~, head~)
+}
+
+///|
+/// Convert a directed Markdown source selection to the normalized DOM range
+/// plus the direction needed by `setSelectionRange`.
+fn dom_selection_from_markdown_document_utf16(
+  selection : @markdown.MarkdownDocumentUtf16Selection,
+) -> @dom_boundary.TextSelection {
+  let direction = if selection.is_collapsed() {
+    @dom_boundary.NoDirection
+  } else if selection.is_backward() {
+    @dom_boundary.Backward
+  } else {
+    @dom_boundary.Forward
+  }
+  @dom_boundary.TextSelection(
+    selection.range_start(),
+    selection.range_end(),
+    direction,
+  )
+}
+
+///|
+fn versioned_raw_selection_from_dom(
+  model : DriverModel,
+  selection : @dom_boundary.TextSelection,
+) -> VersionedRawSelection raise @markdown.MarkdownDocumentUtf16SelectionError {
+  {
+    document_id: model.document_id,
+    version: model.document_version,
+    selection: markdown_document_utf16_selection_from_dom(
+      model.document,
+      selection,
+    ),
+  }
+}
+
+///|
+fn raw_selection_effect_value(
+  latest_model : DriverModel?,
+  expected : VersionedRawSelection,
+) -> @dom_boundary.TextSelection? {
+  guard latest_model is Some(model) else { return None }
+  guard raw_selection_mode_applicable(model) else { return None }
+  guard model.document_id == expected.document_id else { return None }
+  guard model.document_version == expected.version else { return None }
+  guard model.raw_selection == Some(expected) else { return None }
+  Some(dom_selection_from_markdown_document_utf16(expected.selection))
+}
+
+///|
+fn raw_selection_mode_applicable(model : DriverModel) -> Bool {
+  match model.state.mode() {
+    @core.Raw => true
+    @core.Preview => model.split_preview_open
+    @core.Block => false
+  }
+}
+
+///|
+/// Commit one already-normalized Raw replacement. Validation happens before
+/// the shared editor shell so stale or malformed requests cannot consume an
+/// editor failure injection or create history.
+fn commit_raw_selection_edit(
+  editor : @markdown.MarkdownEditor,
+  attachment : @md_markdown.MarkdownSemanticAttachment,
+  model : DriverModel,
+  request : RawSelectionEditRequest,
+  emit : @cmd.Emit[DriverEvent],
+) -> (DriverModel, RawSelectionEditOutcome, @cmd.Cmd) raise {
+  let bound = request.selection
+  guard bound.document_id == model.document_id else {
+    return (
+      model,
+      RawSelectionEditOutcome::Rejected(
+        RawSelectionEditRejection::WrongDocument,
+      ),
+      @rabbita_runtime.none,
+    )
+  }
+  guard raw_selection_mode_applicable(model) else {
+    return (
+      model,
+      RawSelectionEditOutcome::Rejected(RawSelectionEditRejection::ModeStale),
+      @rabbita_runtime.none,
+    )
+  }
+  guard bound.version == model.document_version &&
+    bound.version == editor.version() else {
+    return (
+      model,
+      RawSelectionEditOutcome::Rejected(RawSelectionEditRejection::StaleVersion),
+      @rabbita_runtime.none,
+    )
+  }
+  let selection = @markdown.MarkdownDocumentUtf16Selection(
+    model.document,
+    anchor=bound.selection.anchor(),
+    head=bound.selection.head(),
+  ) catch {
+    _ =>
+      return (
+        model,
+        RawSelectionEditOutcome::Rejected(
+          RawSelectionEditRejection::InvalidSelection,
+        ),
+        @rabbita_runtime.none,
+      )
+  }
+  let range_start = selection.range_start()
+  let (committed, result, accepted, changed, persistence_command) = commit_edit_request(
+    editor,
+    model,
+    @markdown.MarkdownEditRequest::ReplaceText(
+      start=range_start,
+      delete_len=selection.range_end() - range_start,
+      inserted=request.inserted,
+    ),
+    "raw-selection-edit",
+    emit,
+  )
+  let committed = update_preview_document(
+    attachment,
+    committed,
+    preview_requested(model),
+    accepted~,
+    changed~,
+  )
+  if !accepted && !(result is Some(@markdown.Unchanged(_))) {
+    return (
+      committed,
+      RawSelectionEditOutcome::Rejected(
+        RawSelectionEditRejection::EditorCommitFailed,
+      ),
+      persistence_command,
+    )
+  }
+  let nominal_caret = range_start + request.inserted.length()
+  let caret = @moji.next_grapheme_boundary(
+    committed.document.source(),
+    nominal_caret,
+  )
+  let next_selection = @markdown.MarkdownDocumentUtf16Selection(
+    committed.document,
+    anchor=caret,
+    head=caret,
+  )
+  let versioned = VersionedRawSelection::VersionedRawSelection(
+    document_id=committed.document_id,
+    version=committed.document_version,
+    selection=next_selection,
+  )
+  (
+    { ..committed, raw_selection: Some(versioned) },
+    if accepted {
+      RawSelectionEditOutcome::Applied(versioned)
+    } else {
+      RawSelectionEditOutcome::Unchanged(versioned)
+    },
+    persistence_command,
+  )
+}

--- a/apps/loomark/internal/rabbita/raw_selection_transaction.mbt
+++ b/apps/loomark/internal/rabbita/raw_selection_transaction.mbt
@@ -80,6 +80,12 @@ fn raw_selection_edit_rejection_reason(
 }
 
 ///|
+/// Exact value exposed by an HTML textarea after assigning canonical source.
+fn raw_textarea_value(source : String) -> String {
+  source.replace_all(old="\r\n", new="\n").replace_all(old="\r", new="\n")
+}
+
+///|
 /// Number of canonical UTF-16 units represented by one textarea value unit.
 /// HTML textareas normalize CRLF and lone CR line endings to one LF.
 fn raw_textarea_source_step(source : String, source_offset : Int) -> Int {

--- a/apps/loomark/internal/rabbita/raw_selection_transaction_wbtest.mbt
+++ b/apps/loomark/internal/rabbita/raw_selection_transaction_wbtest.mbt
@@ -1,0 +1,447 @@
+///|
+priv struct RawSelectionTestContext {
+  editor : @markdown.MarkdownEditor
+  attachment : @md_markdown.MarkdownSemanticAttachment
+  model : DriverModel
+}
+
+///|
+fn RawSelectionTestContext::RawSelectionTestContext(
+  agent_id : String,
+  source : String,
+) -> RawSelectionTestContext {
+  let (editor, attachment) = try! @markdown.MarkdownEditor::with_semantic_attachment(
+    agent_id~,
+    source~,
+  )
+  {
+    editor,
+    attachment,
+    model: test_model(try! editor.snapshot(), editor.version()),
+  }
+}
+
+///|
+fn RawSelectionTestContext::selection(
+  self : RawSelectionTestContext,
+  anchor : Int,
+  head : Int,
+) -> VersionedRawSelection {
+  let selection = try! @markdown.MarkdownDocumentUtf16Selection(
+    self.model.document,
+    anchor~,
+    head~,
+  )
+  VersionedRawSelection::VersionedRawSelection(
+    document_id=self.model.document_id,
+    version=self.model.document_version,
+    selection~,
+  )
+}
+
+///|
+fn RawSelectionTestContext::commit(
+  self : RawSelectionTestContext,
+  model : DriverModel,
+  selection : VersionedRawSelection,
+  inserted : String,
+) -> (DriverModel, RawSelectionEditOutcome) {
+  let emit : @cmd.Emit[DriverEvent] = @cmd.Emit(_ => @rabbita_runtime.none)
+  let (next, outcome, _) = try! commit_raw_selection_edit(
+    self.editor,
+    self.attachment,
+    model,
+    ({ selection, inserted } : RawSelectionEditRequest),
+    emit,
+  )
+  (next, outcome)
+}
+
+///|
+fn assert_applied_raw_caret(
+  outcome : RawSelectionEditOutcome,
+  expected : Int,
+) -> VersionedRawSelection raise {
+  guard outcome is RawSelectionEditOutcome::Applied(selection) else {
+    abort("expected an applied Raw selection edit")
+  }
+  assert_eq(selection.selection.anchor(), expected)
+  assert_eq(selection.selection.head(), expected)
+  selection
+}
+
+///|
+test "directed cross-block Raw selections commit one ReplaceText transaction" {
+  for
+    case in [
+      ("raw-selection-forward", 0, 11),
+      ("raw-selection-backward", 11, 0),
+    ] {
+    let (agent_id, anchor, head) = case
+    let context = RawSelectionTestContext::RawSelectionTestContext(
+      agent_id, "alpha\n\nbeta",
+    )
+    let before = context.model
+    let selection = context.selection(anchor, head)
+    assert_eq(selection.selection.is_backward(), anchor > head)
+
+    let (next, outcome) = context.commit(before, selection, "x")
+    let accepted = assert_applied_raw_caret(outcome, 1)
+
+    assert_eq(next.document.source(), "x")
+    assert_eq(context.editor.snapshot().source(), "x")
+    assert_eq(next.source_revision, before.source_revision + 1)
+    assert_eq(next.committed_change_count, before.committed_change_count + 1)
+    assert_false(next.document_version == before.document_version)
+    assert_eq(accepted.document_id, before.document_id)
+    assert_eq(accepted.version, next.document_version)
+    assert_true(next.raw_selection == Some(accepted))
+  }
+}
+
+///|
+test "normalized Raw edit event consumes the Session selection" {
+  let context = RawSelectionTestContext::RawSelectionTestContext(
+    "raw-selection-edit-event", "alpha\n\nbeta",
+  )
+  let selection = context.selection(11, 0)
+  let selected = { ..context.model, raw_selection: Some(selection) }
+  let latest_model : @ref.Ref[DriverModel?] = @ref.Ref(Some(selected))
+  let emit : @cmd.Emit[DriverEvent] = @cmd.Emit(_ => @rabbita_runtime.none)
+
+  let (next, _) = try! update_editing(
+    context.editor,
+    context.attachment,
+    RawInputCoordinator::RawInputCoordinator(None),
+    BlockInputCoordinator::BlockInputCoordinator(),
+    selected,
+    latest_model,
+    RawSelectionEdit(({ selection, inserted: "x" } : RawSelectionEditRequest)),
+    emit,
+  )
+
+  assert_eq(next.document.source(), "x")
+  assert_eq(next.committed_change_count, selected.committed_change_count + 1)
+  guard next.raw_selection is Some(selection) else {
+    abort("accepted Raw edit must install a Session selection")
+  }
+  assert_eq(selection.selection.anchor(), 1)
+  assert_eq(selection.selection.head(), 1)
+}
+
+///|
+test "collapsed Raw selection inserts and emoji range deletes" {
+  let insertion = RawSelectionTestContext::RawSelectionTestContext(
+    "raw-selection-insert", "ab",
+  )
+  let (inserted, inserted_outcome) = insertion.commit(
+    insertion.model,
+    insertion.selection(1, 1),
+    "x",
+  )
+  assert_eq(inserted.document.source(), "axb")
+  ignore(assert_applied_raw_caret(inserted_outcome, 2))
+
+  let deletion = RawSelectionTestContext::RawSelectionTestContext(
+    "raw-selection-delete-emoji", "a😀b",
+  )
+  let (deleted, deleted_outcome) = deletion.commit(
+    deletion.model,
+    deletion.selection(1, 3),
+    "",
+  )
+  assert_eq(deleted.document.source(), "ab")
+  ignore(assert_applied_raw_caret(deleted_outcome, 1))
+}
+
+///|
+test "empty collapsed Raw edit preserves history and accepts the Session caret" {
+  let context = RawSelectionTestContext::RawSelectionTestContext(
+    "raw-selection-unchanged", "abc",
+  )
+  let history_before = try! context.editor.history_since()
+
+  let (next, outcome) = context.commit(
+    context.model,
+    context.selection(1, 1),
+    "",
+  )
+
+  guard outcome is RawSelectionEditOutcome::Unchanged(selection) else {
+    abort("empty collapsed edit must report an unchanged document")
+  }
+  assert_eq(next.document.source(), "abc")
+  assert_eq(next.document_version, context.model.document_version)
+  assert_eq(next.committed_change_count, context.model.committed_change_count)
+  assert_eq(selection.selection.anchor(), 1)
+  assert_eq(selection.selection.head(), 1)
+  assert_true(try! (context.editor.history_since() == history_before))
+}
+
+///|
+test "accepted Raw caret advances across joined grapheme clusters" {
+  let cases = [
+    ("raw-selection-combining-caret", "\u{0301}x", "e", 2),
+    ("raw-selection-zwj-caret", "👩", "👨‍", 5),
+    ("raw-selection-regional-caret", "🇯", "🇺", 4),
+  ]
+  for case in cases {
+    let (agent_id, source, inserted, expected_caret) = case
+    let context = RawSelectionTestContext::RawSelectionTestContext(
+      agent_id, source,
+    )
+    let (next, outcome) = context.commit(
+      context.model,
+      context.selection(0, 0),
+      inserted,
+    )
+    assert_eq(next.document.source(), inserted + source)
+    ignore(assert_applied_raw_caret(outcome, expected_caret))
+  }
+}
+
+///|
+test "stale Raw selection is rejected before the editor call" {
+  let context = RawSelectionTestContext::RawSelectionTestContext(
+    "raw-selection-stale", "alpha\n\nbeta",
+  )
+  let stale = context.selection(11, 0)
+  let emit : @cmd.Emit[DriverEvent] = @cmd.Emit(_ => @rabbita_runtime.none)
+  let (advanced, accepted, _, _) = try! commit_source(
+    context.editor,
+    context.model,
+    context.model.state,
+    "newer",
+    "test-advance",
+    emit,
+  )
+  assert_true(accepted)
+  let armed = { ..advanced, fail_next_editor_commit: true }
+  let history_before = try! context.editor.history_since()
+
+  let (next, outcome) = context.commit(armed, stale, "x")
+
+  assert_true(
+    outcome
+    is RawSelectionEditOutcome::Rejected(
+      RawSelectionEditRejection::StaleVersion
+    ),
+  )
+  assert_true(next == armed)
+  assert_eq(context.editor.snapshot().source(), "newer")
+  assert_true(try! (context.editor.history_since() == history_before))
+  assert_true(next.fail_next_editor_commit)
+}
+
+///|
+test "wrong-document Raw selection is rejected before the editor call" {
+  let context = RawSelectionTestContext::RawSelectionTestContext(
+    "raw-selection-wrong-document", "alpha",
+  )
+  let selection = context.selection(0, 5)
+  let other_document_id = @archive.LoomarkDocumentId::from_string(
+    "other-document",
+  ) catch {
+    _ => abort("test document id must construct")
+  }
+  let wrong = { ..selection, document_id: other_document_id }
+  let armed = { ..context.model, fail_next_editor_commit: true }
+
+  let (next, outcome) = context.commit(armed, wrong, "x")
+
+  assert_true(
+    outcome
+    is RawSelectionEditOutcome::Rejected(
+      RawSelectionEditRejection::WrongDocument
+    ),
+  )
+  assert_true(next == armed)
+  assert_eq(context.editor.snapshot().source(), "alpha")
+  assert_true(next.fail_next_editor_commit)
+}
+
+///|
+test "failed Raw selection commit preserves accepted document and selection" {
+  let context = RawSelectionTestContext::RawSelectionTestContext(
+    "raw-selection-failure", "alpha\n\nbeta",
+  )
+  let backward = context.selection(11, 0)
+  let before = {
+    ..context.model,
+    raw_selection: Some(backward),
+    fail_next_editor_commit: true,
+  }
+  let history_before = try! context.editor.history_since()
+
+  let (next, outcome) = context.commit(before, backward, "x")
+
+  assert_true(
+    outcome
+    is RawSelectionEditOutcome::Rejected(
+      RawSelectionEditRejection::EditorCommitFailed
+    ),
+  )
+  assert_eq(next.document, before.document)
+  assert_eq(next.document_version, before.document_version)
+  assert_eq(next.source_revision, before.source_revision)
+  assert_eq(next.committed_change_count, before.committed_change_count)
+  assert_true(next.raw_selection == before.raw_selection)
+  assert_true(next.raw_selection.unwrap().selection.is_backward())
+  assert_eq(context.editor.snapshot().source(), before.document.source())
+  assert_true(try! (context.editor.history_since() == history_before))
+}
+
+///|
+test "Raw selection is revalidated against the bound Session snapshot" {
+  let context = RawSelectionTestContext::RawSelectionTestContext(
+    "raw-selection-revalidation", "a😀b",
+  )
+  let other = try! @markdown.MarkdownEditor(
+    agent_id="raw-selection-other-shape",
+    source="abcd",
+  )
+  let other_selection = try! @markdown.MarkdownDocumentUtf16Selection(
+    other.snapshot(),
+    anchor=2,
+    head=3,
+  )
+  let invalid = VersionedRawSelection::VersionedRawSelection(
+    document_id=context.model.document_id,
+    version=context.model.document_version,
+    selection=other_selection,
+  )
+  let armed = { ..context.model, fail_next_editor_commit: true }
+
+  let (next, outcome) = context.commit(armed, invalid, "x")
+
+  assert_true(
+    outcome
+    is RawSelectionEditOutcome::Rejected(
+      RawSelectionEditRejection::InvalidSelection
+    ),
+  )
+  assert_true(next == armed)
+  assert_eq(context.editor.snapshot().source(), "a😀b")
+  assert_true(next.fail_next_editor_commit)
+}
+
+///|
+test "mode-stale Raw selection is rejected before the editor call" {
+  let context = RawSelectionTestContext::RawSelectionTestContext(
+    "raw-selection-mode-stale", "alpha",
+  )
+  let selection = context.selection(0, 5)
+  let blocked = {
+    ..context.model,
+    state: @core.ApplicationState::ApplicationState(@core.Block),
+    fail_next_editor_commit: true,
+  }
+
+  let (next, outcome) = context.commit(blocked, selection, "x")
+
+  assert_true(
+    outcome
+    is RawSelectionEditOutcome::Rejected(RawSelectionEditRejection::ModeStale),
+  )
+  assert_true(next == blocked)
+  assert_eq(context.editor.snapshot().source(), "alpha")
+  assert_true(next.fail_next_editor_commit)
+}
+
+///|
+test "unrelated accepted commits clear a version-bound Raw selection" {
+  let context = RawSelectionTestContext::RawSelectionTestContext(
+    "raw-selection-clear-on-commit", "alpha",
+  )
+  let selected = {
+    ..context.model,
+    raw_selection: Some(context.selection(5, 0)),
+  }
+  let emit : @cmd.Emit[DriverEvent] = @cmd.Emit(_ => @rabbita_runtime.none)
+
+  let (next, accepted, _, _) = try! commit_source(
+    context.editor,
+    selected,
+    selected.state,
+    "changed",
+    "test-replacement",
+    emit,
+  )
+
+  assert_true(accepted)
+  assert_true(next.raw_selection is None)
+}
+
+///|
+test "Raw selection DOM effect revalidates Session state and unmount" {
+  let context = RawSelectionTestContext::RawSelectionTestContext(
+    "raw-selection-effect-decision", "alpha\n\nbeta",
+  )
+  let backward = context.selection(11, 0)
+  let current = { ..context.model, raw_selection: Some(backward) }
+
+  guard raw_selection_effect_value(Some(current), backward) is Some(dom) else {
+    abort("current Raw selection must produce one DOM effect value")
+  }
+  assert_eq(dom.start(), 0)
+  assert_eq(dom.end(), 11)
+  assert_eq(dom.direction(), @dom_boundary.Backward)
+  assert_true(raw_selection_effect_value(None, backward) is None)
+  assert_true(
+    raw_selection_effect_value(
+      Some({
+        ..current,
+        state: @core.ApplicationState::ApplicationState(@core.Block),
+      }),
+      backward,
+    )
+    is None,
+  )
+  assert_true(
+    raw_selection_effect_value(
+      Some({ ..current, raw_selection: None }),
+      backward,
+    )
+    is None,
+  )
+}
+
+///|
+test "Raw DOM selection conversion preserves forward backward and collapsed direction" {
+  let context = RawSelectionTestContext::RawSelectionTestContext(
+    "raw-selection-dom-conversion", "alpha\n\nbeta",
+  )
+  let cases = [
+    (
+      @dom_boundary.TextSelection(0, 11, @dom_boundary.Forward),
+      0,
+      11,
+      @dom_boundary.Forward,
+    ),
+    (
+      @dom_boundary.TextSelection(0, 11, @dom_boundary.Backward),
+      11,
+      0,
+      @dom_boundary.Backward,
+    ),
+    (
+      @dom_boundary.TextSelection(5, 5, @dom_boundary.NoDirection),
+      5,
+      5,
+      @dom_boundary.NoDirection,
+    ),
+  ]
+  for case in cases {
+    let (dom, anchor, head, expected_direction) = case
+    let markdown = try! markdown_document_utf16_selection_from_dom(
+      context.model.document,
+      dom,
+    )
+    assert_eq(markdown.anchor(), anchor)
+    assert_eq(markdown.head(), head)
+    let round_trip = dom_selection_from_markdown_document_utf16(markdown)
+    assert_eq(round_trip.start(), dom.start())
+    assert_eq(round_trip.end(), dom.end())
+    assert_eq(round_trip.direction(), expected_direction)
+  }
+}

--- a/apps/loomark/internal/rabbita/raw_selection_transaction_wbtest.mbt
+++ b/apps/loomark/internal/rabbita/raw_selection_transaction_wbtest.mbt
@@ -108,11 +108,13 @@ test "normalized Raw edit event consumes the Session selection" {
   let selected = { ..context.model, raw_selection: Some(selection) }
   let latest_model : @ref.Ref[DriverModel?] = @ref.Ref(Some(selected))
   let emit : @cmd.Emit[DriverEvent] = @cmd.Emit(_ => @rabbita_runtime.none)
+  let raw_input_coordinator = RawInputCoordinator::RawInputCoordinator(None)
+  ignore(raw_input_coordinator.enqueue("pending", emit))
 
   let (next, _) = try! update_editing(
     context.editor,
     context.attachment,
-    RawInputCoordinator::RawInputCoordinator(None),
+    raw_input_coordinator,
     BlockInputCoordinator::BlockInputCoordinator(),
     selected,
     latest_model,
@@ -127,6 +129,7 @@ test "normalized Raw edit event consumes the Session selection" {
   }
   assert_eq(selection.selection.anchor(), 1)
   assert_eq(selection.selection.head(), 1)
+  assert_eq(raw_input_coordinator.display_source(next.document.source()), "x")
 }
 
 ///|
@@ -407,6 +410,53 @@ test "Raw selection DOM effect revalidates Session state and unmount" {
 }
 
 ///|
+test "Raw DOM selection conversion maps normalized CRLF and CR offsets" {
+  let context = RawSelectionTestContext::RawSelectionTestContext(
+    "raw-selection-dom-line-endings", "a\r\nb\rc\n",
+  )
+  let dom = @dom_boundary.TextSelection(2, 4, @dom_boundary.Backward)
+  let markdown = try! markdown_document_utf16_selection_from_dom(
+    context.model.document,
+    dom,
+  )
+
+  assert_eq(markdown.anchor(), 5)
+  assert_eq(markdown.head(), 3)
+  let round_trip = dom_selection_from_markdown_document_utf16(
+    context.model.document.source(),
+    markdown,
+  )
+  guard round_trip is Some(round_trip) else {
+    abort("valid canonical line-ending boundaries must map back to the DOM")
+  }
+  assert_eq(round_trip.start(), 2)
+  assert_eq(round_trip.end(), 4)
+  assert_eq(round_trip.direction(), @dom_boundary.Backward)
+}
+
+///|
+test "Raw DOM selection conversion rejects offsets beyond normalized value" {
+  let context = RawSelectionTestContext::RawSelectionTestContext(
+    "raw-selection-dom-invalid-offset", "a\r\nb",
+  )
+  let invalid : Result[
+    @markdown.MarkdownDocumentUtf16Selection,
+    RawDomSelectionConversionError,
+  ] = Ok(
+    markdown_document_utf16_selection_from_dom(
+      context.model.document,
+      @dom_boundary.TextSelection(4, 4, @dom_boundary.NoDirection),
+    ),
+  ) catch {
+    error => Err(error)
+  }
+
+  assert_true(
+    invalid is Err(RawDomSelectionConversionError::DomOffsetOutOfBounds(..)),
+  )
+}
+
+///|
 test "Raw DOM selection conversion preserves forward backward and collapsed direction" {
   let context = RawSelectionTestContext::RawSelectionTestContext(
     "raw-selection-dom-conversion", "alpha\n\nbeta",
@@ -439,7 +489,13 @@ test "Raw DOM selection conversion preserves forward backward and collapsed dire
     )
     assert_eq(markdown.anchor(), anchor)
     assert_eq(markdown.head(), head)
-    let round_trip = dom_selection_from_markdown_document_utf16(markdown)
+    let round_trip = dom_selection_from_markdown_document_utf16(
+      context.model.document.source(),
+      markdown,
+    )
+    guard round_trip is Some(round_trip) else {
+      abort("valid Markdown selection must map back to the Raw DOM")
+    }
     assert_eq(round_trip.start(), dom.start())
     assert_eq(round_trip.end(), dom.end())
     assert_eq(round_trip.direction(), expected_direction)

--- a/apps/loomark/internal/rabbita/text_control_repair.mbt
+++ b/apps/loomark/internal/rabbita/text_control_repair.mbt
@@ -29,16 +29,17 @@ fn rejected_text_selection(
   rejected_source : String,
   selection : @dom_boundary.TextSelection,
 ) -> @dom_boundary.TextSelection {
+  let accepted_value = raw_textarea_value(accepted_source)
   let start = rejected_text_offset(
-    accepted_source,
+    accepted_value,
     rejected_source,
     selection.start(),
   )
   let end = rejected_text_offset(
-    accepted_source,
+    accepted_value,
     rejected_source,
     selection.end(),
-  ).clamp(min=start, max=accepted_source.length())
+  ).clamp(min=start, max=accepted_value.length())
   @dom_boundary.TextSelection(start, end, selection.direction())
 }
 

--- a/apps/loomark/internal/rabbita/text_control_repair_wbtest.mbt
+++ b/apps/loomark/internal/rabbita/text_control_repair_wbtest.mbt
@@ -24,6 +24,17 @@ test "rejected replacement maps a range around the accepted span" {
 }
 
 ///|
+test "rejected Raw repair maps canonical CRLF to textarea LF offsets" {
+  let selection = rejected_text_selection(
+    "a\r\nb",
+    "a\nbx",
+    @dom_boundary.TextSelection(4, 4, @dom_boundary.NoDirection),
+  )
+  assert_eq(selection.start(), 3)
+  assert_eq(selection.end(), 3)
+}
+
+///|
 test "Raw coordinator without telemetry keeps phase snapshots empty" {
   let coordinator = RawInputCoordinator::RawInputCoordinator(None)
   guard coordinator.phase_json() is None else {

--- a/apps/loomark/internal/rabbita/text_control_repair_wbtest.mbt
+++ b/apps/loomark/internal/rabbita/text_control_repair_wbtest.mbt
@@ -35,6 +35,17 @@ test "rejected Raw repair maps canonical CRLF to textarea LF offsets" {
 }
 
 ///|
+test "rejected Raw repair maps canonical lone CR to textarea LF offsets" {
+  let selection = rejected_text_selection(
+    "a\rb",
+    "a\nbx",
+    @dom_boundary.TextSelection(4, 4, @dom_boundary.NoDirection),
+  )
+  assert_eq(selection.start(), 3)
+  assert_eq(selection.end(), 3)
+}
+
+///|
 test "Raw coordinator without telemetry keeps phase snapshots empty" {
   let coordinator = RawInputCoordinator::RawInputCoordinator(None)
   guard coordinator.phase_json() is None else {

--- a/modules/canopy/editor/markdown/editor.mbt
+++ b/modules/canopy/editor/markdown/editor.mbt
@@ -257,6 +257,55 @@ pub fn MarkdownBlockSelection::offset(self : Self) -> Int {
 }
 
 ///|
+/// Why a document-level UTF-16 selection could not be constructed.
+pub(all) suberror MarkdownDocumentUtf16SelectionError {
+  OutOfBounds(anchor~ : Int, head~ : Int, source_length~ : Int)
+  MidGraphemeBoundary(offset~ : Int)
+} derive(Eq, Debug)
+
+///|
+/// Directed source selection in one detached Markdown document snapshot.
+///
+/// `anchor` and `head` are document-level UTF-16 code-unit offsets. Their
+/// order preserves direction; range operations use their ordered bounds.
+pub struct MarkdownDocumentUtf16Selection {
+  priv anchor : Int
+  priv head : Int
+} derive(Eq, Debug)
+
+///|
+pub fn MarkdownDocumentUtf16Selection::anchor(self : Self) -> Int {
+  self.anchor
+}
+
+///|
+pub fn MarkdownDocumentUtf16Selection::head(self : Self) -> Int {
+  self.head
+}
+
+///|
+pub fn MarkdownDocumentUtf16Selection::range_start(self : Self) -> Int {
+  let (start, _) = @cmp.minmax(self.anchor, self.head)
+  start
+}
+
+///|
+pub fn MarkdownDocumentUtf16Selection::range_end(self : Self) -> Int {
+  let (_, end) = @cmp.minmax(self.anchor, self.head)
+  end
+}
+
+///|
+pub fn MarkdownDocumentUtf16Selection::is_backward(self : Self) -> Bool {
+  self.anchor > self.head
+}
+
+///|
+pub fn MarkdownDocumentUtf16Selection::is_collapsed(self : Self) -> Bool {
+  self.anchor == self.head
+}
+
+///|
 /// A caller-owned edit request lowered by the Markdown façade.
 pub(all) enum MarkdownEditRequest {
   ReplaceSource(String)
@@ -314,6 +363,37 @@ pub fn MarkdownDocumentSnapshot::blocks(
   self : Self,
 ) -> @vector.Vector[MarkdownBlockSnapshot] {
   self.blocks
+}
+
+///|
+/// Construct a directed document-level UTF-16 selection validated against an
+/// immutable Markdown snapshot.
+pub fn MarkdownDocumentUtf16Selection::MarkdownDocumentUtf16Selection(
+  snapshot : MarkdownDocumentSnapshot,
+  anchor~ : Int,
+  head~ : Int,
+) -> MarkdownDocumentUtf16Selection raise MarkdownDocumentUtf16SelectionError {
+  let source = snapshot.source()
+  let source_length = source.length()
+  guard anchor >= 0 &&
+    anchor <= source_length &&
+    head >= 0 &&
+    head <= source_length else {
+    raise MarkdownDocumentUtf16SelectionError::OutOfBounds(
+      anchor~,
+      head~,
+      source_length~,
+    )
+  }
+  guard @moji.is_grapheme_boundary(source, anchor) else {
+    raise MarkdownDocumentUtf16SelectionError::MidGraphemeBoundary(
+      offset=anchor,
+    )
+  }
+  guard @moji.is_grapheme_boundary(source, head) else {
+    raise MarkdownDocumentUtf16SelectionError::MidGraphemeBoundary(offset=head)
+  }
+  { anchor, head }
 }
 
 ///|

--- a/modules/canopy/editor/markdown/markdown_editor_wbtest.mbt
+++ b/modules/canopy/editor/markdown/markdown_editor_wbtest.mbt
@@ -31,6 +31,99 @@ fn fresh_markdown_ir(source : String) -> @md_markdown.MarkdownIR raise {
 }
 
 ///|
+test "Markdown document UTF-16 selection preserves direction and range" {
+  let editor = try! MarkdownEditor(
+    agent_id="document-selection-direction",
+    source="alpha\n\nbeta",
+  )
+  let snapshot = editor.snapshot()
+  let forward = try! MarkdownDocumentUtf16Selection(snapshot, anchor=0, head=11)
+  let backward = try! MarkdownDocumentUtf16Selection(
+    snapshot,
+    anchor=11,
+    head=0,
+  )
+  let collapsed = try! MarkdownDocumentUtf16Selection(
+    snapshot,
+    anchor=5,
+    head=5,
+  )
+
+  assert_eq(forward.anchor(), 0)
+  assert_eq(forward.head(), 11)
+  assert_eq(forward.range_start(), 0)
+  assert_eq(forward.range_end(), 11)
+  assert_false(forward.is_backward())
+  assert_eq(backward.anchor(), 11)
+  assert_eq(backward.head(), 0)
+  assert_eq(backward.range_start(), 0)
+  assert_eq(backward.range_end(), 11)
+  assert_true(backward.is_backward())
+  assert_true(collapsed.is_collapsed())
+}
+
+///|
+test "Markdown document UTF-16 selection rejects out-of-bounds endpoints" {
+  let editor = try! MarkdownEditor(
+    agent_id="document-selection-bounds",
+    source="abc",
+  )
+  let snapshot = editor.snapshot()
+  let invalid : Result[
+    MarkdownDocumentUtf16Selection,
+    MarkdownDocumentUtf16SelectionError,
+  ] = Ok(MarkdownDocumentUtf16Selection(snapshot, anchor=-1, head=0)) catch {
+    error => Err(error)
+  }
+
+  assert_true(
+    invalid
+    is Err(
+      MarkdownDocumentUtf16SelectionError::OutOfBounds(
+        anchor=-1,
+        head=0,
+        source_length=3
+      )
+    ),
+  )
+}
+
+///|
+test "Markdown document UTF-16 selection rejects mid-grapheme endpoints" {
+  let emoji_editor = try! MarkdownEditor(
+    agent_id="document-selection-emoji",
+    source="a😀b",
+  )
+  let emoji_snapshot = emoji_editor.snapshot()
+  let emoji_invalid : Result[
+    MarkdownDocumentUtf16Selection,
+    MarkdownDocumentUtf16SelectionError,
+  ] = Ok(MarkdownDocumentUtf16Selection(emoji_snapshot, anchor=2, head=3)) catch {
+    error => Err(error)
+  }
+  assert_true(
+    emoji_invalid
+    is Err(MarkdownDocumentUtf16SelectionError::MidGraphemeBoundary(offset=2)),
+  )
+
+  let combining_editor = try! MarkdownEditor(
+    agent_id="document-selection-combining",
+    source="e\u{0301}x",
+  )
+  let combining_snapshot = combining_editor.snapshot()
+  let combining_invalid : Result[
+    MarkdownDocumentUtf16Selection,
+    MarkdownDocumentUtf16SelectionError,
+  ] = Ok(MarkdownDocumentUtf16Selection(combining_snapshot, anchor=0, head=1)) catch {
+    error => Err(error)
+  }
+  assert_true(
+    combining_invalid
+    is Err(MarkdownDocumentUtf16SelectionError::MidGraphemeBoundary(offset=1)),
+  )
+}
+
+///|
 test "semantic attachment follows MarkdownEditor source commits" {
   let source = "# Heading [ref]\n\nBefore\n\n[ref]: /one \"title\"\n"
   let (editor, attachment) = try! MarkdownEditor::with_semantic_attachment(

--- a/modules/canopy/editor/markdown/moon.pkg
+++ b/modules/canopy/editor/markdown/moon.pkg
@@ -7,9 +7,11 @@ import {
   "dowdiness/canopy/editor",
   "dowdiness/markdown" @md_markdown,
   "dowdiness/text_change",
+  "dowdiness/moji",
   "dowdiness/event-graph-walker/text",
   "dowdiness/event-graph-walker/sync",
   "moonbitlang/core/immut/vector",
+  "moonbitlang/core/cmp",
 }
 
 import {

--- a/modules/canopy/editor/markdown/pkg.generated.mbti
+++ b/modules/canopy/editor/markdown/pkg.generated.mbti
@@ -22,6 +22,11 @@ pub(all) suberror MarkdownArchiveOpenLimitsError {
   InvalidLimit(dimension~ : MarkdownArchiveLimitDimension, value~ : Int)
 }
 
+pub(all) suberror MarkdownDocumentUtf16SelectionError {
+  OutOfBounds(anchor~ : Int, head~ : Int, source_length~ : Int)
+  MidGraphemeBoundary(offset~ : Int)
+} derive(Eq, @debug.Debug)
+
 pub(all) suberror MarkdownEditorError {
   InvalidAgentId
   InitializationFailed(detail~ : String)
@@ -111,6 +116,17 @@ pub struct MarkdownDocumentSnapshot {
 pub fn MarkdownDocumentSnapshot::blocks(Self) -> @vector.Vector[MarkdownBlockSnapshot]
 pub fn MarkdownDocumentSnapshot::projection(Self) -> MarkdownProjectionSnapshot
 pub fn MarkdownDocumentSnapshot::source(Self) -> String
+
+pub struct MarkdownDocumentUtf16Selection {
+  // private fields
+} derive(Eq, @debug.Debug)
+pub fn MarkdownDocumentUtf16Selection::MarkdownDocumentUtf16Selection(MarkdownDocumentSnapshot, anchor~ : Int, head~ : Int) -> Self raise MarkdownDocumentUtf16SelectionError
+pub fn MarkdownDocumentUtf16Selection::anchor(Self) -> Int
+pub fn MarkdownDocumentUtf16Selection::head(Self) -> Int
+pub fn MarkdownDocumentUtf16Selection::is_backward(Self) -> Bool
+pub fn MarkdownDocumentUtf16Selection::is_collapsed(Self) -> Bool
+pub fn MarkdownDocumentUtf16Selection::range_end(Self) -> Int
+pub fn MarkdownDocumentUtf16Selection::range_start(Self) -> Int
 
 pub struct MarkdownDocumentVersion {
   // private fields


### PR DESCRIPTION
## Summary

- add an opaque, snapshot-validated `MarkdownDocumentUtf16Selection` that preserves anchor/head direction in document UTF-16 coordinates
- bind Raw selections to document identity and the exact `MarkdownDocumentVersion`, then commit cross-block replacement/deletion through one existing `ReplaceText`
- install accepted grapheme-safe carets after render, reject stale/invalid/failed edits atomically, and map canonical LF/CRLF/CR coordinates to normalized textarea offsets
- keep native `beforeinput`/`input` pairing out of scope for #1204 while preserving characterization of the current 50 ms Raw-input boundary

Closes #1171

## UI and review evidence

N/A — no visual design or visible-label change. Browser evidence covers DOM selection conversion and installation only.

- [x] Visible-label removal preserves accessible names, visible focus, and the keyboard path (N/A)
- [x] Interactive bounds, pointer feedback, and viewport reflow were checked in the rendered UI (N/A)
- [x] Any claimed Canopy rule cites its repository source; external guidance, recommendations, and preferences are labeled as such

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `MarkdownEditRequest::ReplaceText` / `MarkdownEditor::commit_with_receipt` | `modules/canopy/editor/markdown/editor.mbt` | Yes | One existing canonical transaction and receipt path owns replacement and history |
| `MarkdownDocumentSnapshot` / `MarkdownDocumentVersion` | `modules/canopy/editor/markdown/editor.mbt` | Yes | Selection validation and exact Session frontier binding |
| `MarkdownBlockSelection` | `modules/canopy/editor/markdown/editor.mbt` | No | Block-relative, collapsed, and node-owned; cannot represent directed cross-block source ranges |
| `TextSelection` and DOM read/write functions | `modules/dom-boundary/dom_boundary.mbt` | Yes | Browser UTF-16 range and direction conversion/installation |
| `is_grapheme_boundary` / `next_grapheme_boundary` | `deps/loom/moji/grapheme.mbt` | Yes | Endpoint validation and accepted post-commit caret policy |
| `cmp::minmax` | `moonbitlang/core/cmp` | Yes | Directed anchor/head range ordering |
| `String::length` / `String::replace_all` | MoonBit core `String` | Yes | UTF-16 inserted length and textarea CRLF/CR normalization |
| `compute_text_change` | `deps/loom/text-change/text_change.mbt` | Yes | Existing rejected-input caret repair |
| #1205 internal portable commit transaction | `modules/canopy/internal/markdown_runtime` | No | Internal sentinel-stripped `SyncEditor` seam; #1171 must remain at the public Markdown façade and canonical receipt coordinates |

New helpers added (if any):

- `MarkdownDocumentUtf16Selection` and its validating constructor own only directed, snapshot-scoped Markdown source coordinates.
- `VersionedRawSelection` / `commit_raw_selection_edit` bind that value to the private Session document/version and reuse the shared commit shell.
- `raw_source_offset_from_dom` / `raw_dom_offset_from_source` bridge HTML textarea newline normalization; the two-cursor loops are necessary because one DOM LF may represent two canonical CRLF code units.
- `raw_selection_effect_value` keeps after-render DOM work behind deterministic document/version/mode/current-selection checks.

## Validation scope

Boundary matrix / first failing regression:

- forward, backward, collapsed, and cross-block selections
- out-of-bounds, surrogate-pair, combining-sequence, wrong-document, stale-version, mode-stale, failed-commit, and unavailable-model rejection
- emoji deletion plus combining-mark, ZWJ, and regional-indicator post-commit caret advancement
- DOM direction round-trip and LF/CRLF/lone-CR coordinate conversion
- pending 50 ms Raw input supersession and rejected-input CRLF/CR repair

Target packages:

- `modules/canopy/editor/markdown`
- `apps/loomark/internal/rabbita`

Additional conditional gates:

- Markdown package: 71/71
- Loomark internal/rabbita: 61/61
- full workspace validator suite: 0 failures
- Loomark dev-host Playwright: 89/89
- Loomark standalone Playwright: 12/12
- independent MoonBit and browser-shell reviews: PASS after all findings were reproduced and fixed

## PR-ready evidence

Validated HEAD: `f51681b862170829880780623d1fef1b3b84194b`

Validated base: `origin/main@09c4308d9e8dfad323aac8289c17a7455bc77f5e`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh \
  --target modules/canopy/editor/markdown \
  --target apps/loomark/internal/rabbita
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for the exact HEAD and base above.
- [x] The base was fetched again and `--verify-evidence` passed immediately before this PR was opened, updated, or merged.
- [x] The committed `.mbti` diff against the validated base was reviewed for unintended API or trait-bound changes.
- [x] Any changed submodule commit is pushed and reachable from its remote. (No Canopy submodule pointer changed.)
- [x] Validation was rerun after every commit, amend, rebase, cherry-pick, submodule-pointer, manifest, or generated-interface change.
- [x] Independent review findings were resolved before the final validation.
