### PR TITLE
fix(lambda): move LetDef rows instead of duplicating bindings

### DIFF
--- a/docs/decisions/2026-08-07-generic-language-spi-deepening.md
+++ b/docs/decisions/2026-08-07-generic-language-spi-deepening.md
@@ -30,8 +30,9 @@ outside it:
    into a pure `core::compute_move` (legality checks + whitespace-preserving
    span arithmetic, parameterized by language text policies: placeholder and
    separator) and a thin `SyncEditor::move_node` application shell. Languages
-   express moves through their edit port — Lambda's `Drop` via `compute_move`,
-   Markdown's `MoveBlock` via its existing `compute_move_block`.
+   express moves through their edit port — Lambda's `Drop` selects binding-row
+   or expression-level policy, while Markdown's `MoveBlock` uses its existing
+   `compute_move_block`.
 4. **Lambda joins the common path.** `apply_lambda_tree_edit` ceases to be a
    contract-exceptional bridge; it becomes a thin wrapper over the shared apply
    path. Lambda remains a legacy stress case, not a language template.

--- a/docs/development/ADDING_A_LANGUAGE.md
+++ b/docs/development/ADDING_A_LANGUAGE.md
@@ -6,11 +6,11 @@ internals.
 
 **Primary example:** Markdown (uses CstFold, 3-memo pattern, clean structure).
 
-> **Don't follow the Lambda pattern.** Lambda predates CstFold and keeps a
-> custom editor-coupled edit bridge. It's the oldest language integration and
-> carries historical complexity even though its projection now uses the generic
-> 3-memo stack. Use Markdown as your reference; consult JSON where patterns
-> differ.
+> **Don't follow the Lambda pattern.** Lambda predates CstFold and retains
+> language-specific legacy edit policies for root binding rows and expressions.
+> It now uses the generic `Language` SPI, but its historical surface remains
+> more complex than a new language integration. Use Markdown as your reference;
+> consult JSON where patterns differ.
 
 ## How it fits together
 
@@ -421,12 +421,12 @@ pub fn new_my_editor(
 
 > **The lambda exception is gone (ADR 2026-08-07).** `lang/lambda/companion`
 > previously kept its own bridge because the SPI could not express typed
-> errors, patch traces, or editor-owned moves. The deepened SPI absorbs all
-> of these: `Language::apply_edit` returns the applied `SpanEdit` trace and
-> structured `EditError`, and moves are edit-port computation (`compute_move`
-> / `compute_move_block`). Lambda uses `Language`; it remains a legacy stress
-> case, not a template. Do not fork a separate bridge for a
-> new language.
+> errors, patch traces, or editor-owned moves. The deepened SPI absorbs all of
+> these: `Language::apply_edit` returns the applied `SpanEdit` trace and
+> structured `EditError`, and moves are edit-port computation
+> (`compute_text_edit` / `compute_move` / `compute_move_block`). Lambda uses
+> `Language`; it remains a legacy stress case, not a template. Do not fork a
+> separate bridge for a new language.
 
 **Package registration:**
 

--- a/docs/development/TREE_EDIT_MANUAL.md
+++ b/docs/development/TREE_EDIT_MANUAL.md
@@ -36,12 +36,9 @@ the text CRDT and then refreshes the projection.
 ### Drag and Drop
 - **StartDrag (`node_id`)**: Initiate a move operation.
 - **DragOver (`target_id`, `position`)**: Preview the drop location (`Before`, `After`, or `Inside`).
-- **Drop (`source_id`, `target_id`, `position`)**: Compute and apply a language-owned move.
-  - Root-module `LetDef` rows move as complete rows with newline-aware separators.
-  - Expression pairs use expression-level move semantics; `Inside` exchanges
-    their contents.
-  - Mixed `LetDef`/expression pairs and nested binding rows are rejected with
-    structured errors.
+- **Drop (`source_id`, `target_id`, `position`)**: Compute and apply a
+  language-owned move. See [`move-contract.md`](move-contract.md) for the
+  canonical position, legality, and backend semantics.
 
 ## Operational Workflow: The Edit Port
 

--- a/docs/development/TREE_EDIT_MANUAL.md
+++ b/docs/development/TREE_EDIT_MANUAL.md
@@ -21,7 +21,9 @@ These operations do not modify the document text.
 - **CancelEdit**: Exit inline editing without saving changes.
 
 ### Structural Refactoring
-These operations trigger a full round-trip: they modify the ProjNode tree, unparse to text, and update the CRDT.
+These operations are planned by the language edit port as typed `SpanEdit`
+patches. The generic `Language::apply_edit` path applies those patches through
+the text CRDT and then refreshes the projection.
 
 - **Delete (`node_id`)**: Remove a node from the tree.
   - *Example:* Deleting `x` from `f x` results in `f`.
@@ -34,13 +36,21 @@ These operations trigger a full round-trip: they modify the ProjNode tree, unpar
 ### Drag and Drop
 - **StartDrag (`node_id`)**: Initiate a move operation.
 - **DragOver (`target_id`, `position`)**: Preview the drop location (`Before`, `After`, or `Inside`).
-- **Drop (`source_id`, `target_id`, `position`)**: Perform the move. This effectively deletes the source and inserts it at the target location.
+- **Drop (`source_id`, `target_id`, `position`)**: Compute and apply a language-owned move.
+  - Root-module `LetDef` rows move as complete rows with newline-aware separators.
+  - Expression pairs use expression-level move semantics; `Inside` exchanges
+    their contents.
+  - Mixed `LetDef`/expression pairs and nested binding rows are rejected with
+    structured errors.
 
-## Operational Workflow: The Round-Trip
+## Operational Workflow: The Edit Port
 
 When a structural edit is performed:
-1.  The `TreeEditOp` is applied to the current `ProjNode` tree.
-2.  The resulting `ProjNode` is unparsed back into a Lambda Calculus string.
-3.  The `SyncEditor` performs a diff between the old and new text.
-4.  Minimal CRDT operations are generated and applied to the `TextState`.
-5.  The incremental parser reparses the text, and the `SourceMap` reconciles the new AST with existing `NodeId`s to preserve UI state.
+1. The `TreeEditOp` is sent to the language edit port with the current source
+   text, source map, registry, and projection context.
+2. The language computes typed `SpanEdit` patches and an optional focus hint.
+3. `Language::apply_edit` applies the patches through
+   `SyncEditor::apply_span_edits`, recording the change in the CRDT and undo
+   history.
+4. The incremental parser reparses the text, and the `SourceMap` reconciles the
+   new AST with existing `NodeId`s to preserve UI state.

--- a/docs/development/move-contract.md
+++ b/docs/development/move-contract.md
@@ -32,7 +32,13 @@ MoonBit types: `DropPosition` in `core/types.mbt`, `GenericTreeOp::Drop` in
 |----------|---------|:---:|:---:|
 | `Before` | Insert source as preceding sibling of target | Yes | Planned |
 | `After` | Insert source as following sibling of target | Yes | Planned |
-| `Inside` | Exchange source and target content | Yes | No (appends to parent) |
+| `Inside` | Language-specific insertion inside target | Yes | No (appends to parent) |
+
+Lambda refines `Inside` by node kind:
+
+- expression-to-expression drops exchange the two expression spans;
+- root-module `LetDef` rows move as whole binding rows after the target;
+- mixed `LetDef`/expression pairs and nested-binding pairs are rejected.
 
 ### Position Detection (browser)
 
@@ -43,8 +49,7 @@ Mouse Y within the target bounding box determines position
 - **Bottom 25%** -> After
 - **Middle 50%** -> Inside
 
-Special case: hovering over a compound node's header always maps to Inside
-(exchange).
+Special case: hovering over a compound node's header always maps to Inside.
 
 ## Legality Rules
 
@@ -73,21 +78,41 @@ Target must not be a descendant of source (would create a cycle).
 For exchange, source must also not be inside target. Swapping a node with
 its own ancestor would lose the subtree.
 
+### Lambda-specific binding rules
+
+Lambda `LetDef` row movement has additional structural constraints:
+
+- both nodes must be root-module `LetDef` rows, or both must be expressions;
+- mixed `LetDef`/expression drops are rejected with structured
+  `UnsupportedOperation`;
+- a row move checks every binding crossed by the move with the scope graph,
+  rejecting changes that would make an initializer free or retarget a
+  resolved reference.
+
 ## Backend Execution
 
-### Lambda editor: `SyncEditor::move_node`
+### Lambda editor: `Language` edit port
 
-All three positions produce `SpanEdit` arrays applied in reverse document order.
+Lambda routes `TreeEditOp` values through its language edit port. The port
+computes `SpanEdit` arrays, and the generic `Language::apply_edit` path applies
+them through `SyncEditor::apply_span_edits`.
 
-**Inside (exchange):**
-1. Strip leading whitespace from both spans to find expression boundaries
-2. Swap the expression text, preserving leading separators
-3. Two edits: replace source expression with target's, replace target's with source's
+**Root-module `LetDef` rows:**
+1. Resolve the source and target declarations in the same root scope.
+2. Check every binding crossed by the move for reference safety.
+3. Delete the complete source row, including its separator.
+4. Insert the row before the target for `Before`, or after it for `After` and
+   `Inside`.
 
-**Before / After (move):**
-1. Extract source expression text from the source map (whitespace-aware)
-2. Replace source expression with `Renderable::placeholder()` (e.g., `0` for Int, `a` for Var)
-3. Insert source text at target boundary (`tgt_range.start` for Before, `tgt_range.end` for After)
+No expression placeholder is inserted for a row move. Nested binding rows are
+rejected because their indentation and scope policy belong to the dedicated
+binding operations.
+
+**Expression pairs:**
+1. Strip leading whitespace from both spans to find expression boundaries.
+2. For `Inside`, exchange the expression text while preserving separators.
+3. For `Before`/`After`, replace the source expression with a
+   `Renderable::placeholder()` and insert the source at the target boundary.
 
 The placeholder keeps surrounding syntax valid. Without it, removing a node
 from `let id = (x) => x` would leave `let id = ` (invalid).

--- a/modules/canopy/lang/lambda/README.md
+++ b/modules/canopy/lang/lambda/README.md
@@ -26,6 +26,8 @@ Re-exported from `lang/lambda/companion`:
 - `get_lambda_ast`, `get_lambda_ast_pretty`, `get_lambda_resolution`,
   `get_lambda_dot_resolved`
 - `parse_tree_edit_op`
+- `structural_edit_op_to_tree_edit`, `snapshot_span_edits`,
+  `detect_action_context`
 
 Re-exported from `lang/lambda/eval`:
 
@@ -62,6 +64,8 @@ and was removed. Lambda's editor-facing projection memos now live in
 `lang/lambda/proj` via `build_lambda_projection_memos`, a thin wrapper around
 `@core.build_projection_memos`. Lambda now uses the shared
 `Language[Term, TreeEditOp, LambdaCompanion]` SPI; its public apply function is
-a thin wrapper over `Language::apply_edit`, and Drop plans through
-`core.compute_move`. See
+a thin wrapper over `Language::apply_edit`.
+Lambda `Drop` plans through the edit port: root-module `LetDef` rows use
+newline-aware movement, expression pairs use `core.compute_move`, and mixed
+LetDef/expression or nested-binding pairs are rejected structurally. See
 `docs/decisions/2026-08-07-generic-language-spi-deepening.md`.

--- a/modules/canopy/lang/lambda/README.md
+++ b/modules/canopy/lang/lambda/README.md
@@ -65,7 +65,5 @@ and was removed. Lambda's editor-facing projection memos now live in
 `@core.build_projection_memos`. Lambda now uses the shared
 `Language[Term, TreeEditOp, LambdaCompanion]` SPI; its public apply function is
 a thin wrapper over `Language::apply_edit`.
-Lambda `Drop` plans through the edit port: root-module `LetDef` rows use
-newline-aware movement, expression pairs use `core.compute_move`, and mixed
-LetDef/expression or nested-binding pairs are rejected structurally. See
-`docs/decisions/2026-08-07-generic-language-spi-deepening.md`.
+Lambda `Drop` semantics are defined in the canonical
+[`move-contract.md`](../../../../docs/development/move-contract.md).

--- a/modules/canopy/lang/lambda/companion/drop_convergence_test.mbt
+++ b/modules/canopy/lang/lambda/companion/drop_convergence_test.mbt
@@ -71,7 +71,10 @@ fn apply_drop(
     ),
     timestamp_ms,
   )
-  guard result is Ok(_) else { fail("apply_lambda_tree_edit Drop failed") }
+  match result {
+    Ok(_) => ()
+    Err(error) => fail("apply_lambda_tree_edit Drop failed: " + error.message())
+  }
 }
 
 ///|
@@ -84,6 +87,26 @@ fn resolve_child_id(
     fail("child index out of bounds")
   }
   proj.children[idx].id()
+}
+
+///|
+fn supported_drop_pair(
+  editor : @editor.SyncEditor[@ast.Term],
+  source_idx : Int,
+  target_idx : Int,
+) -> Bool raise {
+  guard editor.get_proj_node() is Some(proj) else { fail("expected ProjNode") }
+  guard source_idx >= 0 && source_idx < proj.children.length() else {
+    fail("source child index out of bounds")
+  }
+  guard target_idx >= 0 && target_idx < proj.children.length() else {
+    fail("target child index out of bounds")
+  }
+  let source_is_let_def = proj.children[source_idx].kind
+    is @ast.Term::LetDef(_, _)
+  let target_is_let_def = proj.children[target_idx].kind
+    is @ast.Term::LetDef(_, _)
+  source_is_let_def == target_is_let_def
 }
 
 ///|
@@ -160,12 +183,12 @@ fn pick_seed(size : Int) -> (String, Int) {
 }
 
 ///|
-fn pick_distinct(child_count : Int, rs : @splitmix.RandomState) -> (Int, Int) {
-  // Uniform over all pairs (a, b) with b != a in [0..child_count).
-  // offset uniform in [0..child_count-1); wrapping by count excludes a exactly once.
-  let a = rs.split().next_uint64().to_int().abs() % child_count
-  let offset = rs.split().next_uint64().to_int().abs() % (child_count - 1)
-  let b = (a + 1 + offset) % child_count
+fn pick_distinct(binding_count : Int, rs : @splitmix.RandomState) -> (Int, Int) {
+  // Uniform over all pairs (a, b) with b != a in [0..binding_count).
+  // Only LetDef children are generated; the final module child is an expression.
+  let a = rs.split().next_uint64().to_int().abs() % binding_count
+  let offset = rs.split().next_uint64().to_int().abs() % (binding_count - 1)
+  let b = (a + 1 + offset) % binding_count
   (a, b)
 }
 
@@ -175,8 +198,8 @@ impl @quickcheck.Arbitrary for ConcurrentDropScenario with fn arbitrary(
   rs,
 ) {
   let (seed_text, child_count) = pick_seed(size)
-  let (p1_source, p1_target) = pick_distinct(child_count, rs)
-  let (p2_source, p2_target) = pick_distinct(child_count, rs)
+  let (p1_source, p1_target) = pick_distinct(child_count - 1, rs)
+  let (p2_source, p2_target) = pick_distinct(child_count - 1, rs)
   let p1_pos = match rs.split().next_uint64().to_int().abs() % 3 {
     0 => @core.DropPosition::Before
     1 => @core.DropPosition::After
@@ -249,7 +272,7 @@ fn shrink_seed(scenario : ConcurrentDropScenario) -> ConcurrentDropScenario? {
       },
       peer2_drop: {
         source_idx: 1,
-        target_idx: 2,
+        target_idx: 0,
         position: @core.DropPosition::Before,
       },
     })
@@ -280,25 +303,38 @@ fn prop_concurrent_drops_converge(
   scenario : ConcurrentDropScenario,
 ) -> Bool raise {
   let (ed1, ed2, comp1, comp2) = setup_two_peers(scenario.seed_text)
-  apply_drop(
-    ed1,
-    comp1,
-    scenario.peer1_drop.source_idx,
-    scenario.peer1_drop.target_idx,
-    scenario.peer1_drop.position,
-    1,
-  )
-  apply_drop(
-    ed2,
-    comp2,
-    scenario.peer2_drop.source_idx,
-    scenario.peer2_drop.target_idx,
-    scenario.peer2_drop.position,
-    1,
-  )
-  bidirectional_sync(ed1, ed2)
-  assert_peers_converged(ed1, ed2)
-  true
+  if !supported_drop_pair(
+      ed1,
+      scenario.peer1_drop.source_idx,
+      scenario.peer1_drop.target_idx,
+    ) ||
+    !supported_drop_pair(
+      ed2,
+      scenario.peer2_drop.source_idx,
+      scenario.peer2_drop.target_idx,
+    ) {
+    true
+  } else {
+    apply_drop(
+      ed1,
+      comp1,
+      scenario.peer1_drop.source_idx,
+      scenario.peer1_drop.target_idx,
+      scenario.peer1_drop.position,
+      1,
+    )
+    apply_drop(
+      ed2,
+      comp2,
+      scenario.peer2_drop.source_idx,
+      scenario.peer2_drop.target_idx,
+      scenario.peer2_drop.position,
+      1,
+    )
+    bidirectional_sync(ed1, ed2)
+    assert_peers_converged(ed1, ed2)
+    true
+  }
 }
 
 ///|
@@ -311,32 +347,53 @@ test "property P1: concurrent drops converge" {
 ///|
 fn prop_undo_after_drops(scenario : ConcurrentDropScenario) -> Bool raise {
   let (ed1, ed2, comp1, comp2) = setup_two_peers(scenario.seed_text)
-  apply_drop(
-    ed1,
-    comp1,
-    scenario.peer1_drop.source_idx,
-    scenario.peer1_drop.target_idx,
-    scenario.peer1_drop.position,
-    1,
-  )
-  apply_drop(
-    ed2,
-    comp2,
-    scenario.peer2_drop.source_idx,
-    scenario.peer2_drop.target_idx,
-    scenario.peer2_drop.position,
-    1,
-  )
-  bidirectional_sync(ed1, ed2)
-  guard ed1.can_undo() else { fail("ed1 cannot undo") }
-  guard ed2.can_undo() else { fail("ed2 cannot undo") }
-  guard ed1.undo() else { fail("ed1 undo failed") }
-  guard ed2.undo() else { fail("ed2 undo failed") }
-  bidirectional_sync(ed1, ed2)
-  assert_peers_converged(ed1, ed2)
-  assert_no_structural_errors(ed1)
-  assert_no_structural_errors(ed2)
-  true
+  if !supported_drop_pair(
+      ed1,
+      scenario.peer1_drop.source_idx,
+      scenario.peer1_drop.target_idx,
+    ) ||
+    !supported_drop_pair(
+      ed2,
+      scenario.peer2_drop.source_idx,
+      scenario.peer2_drop.target_idx,
+    ) {
+    true
+  } else {
+    let ed1_before = ed1.get_text()
+    apply_drop(
+      ed1,
+      comp1,
+      scenario.peer1_drop.source_idx,
+      scenario.peer1_drop.target_idx,
+      scenario.peer1_drop.position,
+      1,
+    )
+    let ed1_changed = ed1.get_text() != ed1_before
+    let ed2_before = ed2.get_text()
+    apply_drop(
+      ed2,
+      comp2,
+      scenario.peer2_drop.source_idx,
+      scenario.peer2_drop.target_idx,
+      scenario.peer2_drop.position,
+      1,
+    )
+    let ed2_changed = ed2.get_text() != ed2_before
+    bidirectional_sync(ed1, ed2)
+    if ed1_changed {
+      guard ed1.can_undo() else { fail("ed1 cannot undo") }
+      guard ed1.undo() else { fail("ed1 undo failed") }
+    }
+    if ed2_changed {
+      guard ed2.can_undo() else { fail("ed2 cannot undo") }
+      guard ed2.undo() else { fail("ed2 undo failed") }
+    }
+    bidirectional_sync(ed1, ed2)
+    assert_peers_converged(ed1, ed2)
+    assert_no_structural_errors(ed1)
+    assert_no_structural_errors(ed2)
+    true
+  }
 }
 
 ///|
@@ -362,10 +419,20 @@ fn scenario_is_structural_safe(scenario : ConcurrentDropScenario) -> Bool {
 
 ///|
 fn prop_no_structural_errors(scenario : ConcurrentDropScenario) -> Bool? raise {
-  if !scenario_is_structural_safe(scenario) {
+  let (ed1, ed2, comp1, comp2) = setup_two_peers(scenario.seed_text)
+  if !scenario_is_structural_safe(scenario) ||
+    !supported_drop_pair(
+      ed1,
+      scenario.peer1_drop.source_idx,
+      scenario.peer1_drop.target_idx,
+    ) ||
+    !supported_drop_pair(
+      ed2,
+      scenario.peer2_drop.source_idx,
+      scenario.peer2_drop.target_idx,
+    ) {
     None
   } else {
-    let (ed1, ed2, comp1, comp2) = setup_two_peers(scenario.seed_text)
     apply_drop(
       ed1,
       comp1,
@@ -398,13 +465,195 @@ test "property P3: no structural errors after each sync" {
 }
 
 ///|
+test "R0: concurrent row drops stay structurally valid" {
+  let (ed1, ed2, comp1, comp2) = setup_two_peers("let p = 1\nlet q = 2\np - q")
+  apply_drop(ed1, comp1, 1, 0, @core.DropPosition::Before, 1)
+  guard ed1.get_proj_node() is Some(proj1) else {
+    fail("ed1 local projection missing")
+  }
+  guard !has_error_term(proj1.kind) else { fail("ed1 local structural error") }
+  apply_drop(ed2, comp2, 0, 1, @core.DropPosition::After, 1)
+  guard ed2.get_proj_node() is Some(proj2) else {
+    fail("ed2 local projection missing")
+  }
+  guard !has_error_term(proj2.kind) else { fail("ed2 local structural error") }
+  ed1.apply_sync(ed2.export_all())
+  guard ed1.get_proj_node() is Some(proj1_after_sync) else {
+    fail("ed1 synced projection missing")
+  }
+  guard !has_error_term(proj1_after_sync.kind) else {
+    fail("ed1 structural error after peer2 sync")
+  }
+  ed2.apply_sync(ed1.export_all())
+  guard ed2.get_proj_node() is Some(proj2_after_sync) else {
+    fail("ed2 synced projection missing")
+  }
+  guard !has_error_term(proj2_after_sync.kind) else {
+    fail("ed2 structural error after peer1 sync")
+  }
+}
+
+///|
+fn assert_root_def_order(
+  editor : @editor.SyncEditor[@ast.Term],
+  expected_text : String,
+  first_name : String,
+  second_name : String,
+) -> Unit raise {
+  inspect(editor.get_text(), content=expected_text)
+  guard editor.get_proj_node() is Some(proj) else { fail("missing ProjNode") }
+  match proj.kind {
+    @ast.Term::Module(defs, _) => {
+      inspect(defs.length(), content="2")
+      inspect(defs[0].0, content=first_name)
+      inspect(defs[1].0, content=second_name)
+    }
+    _ => fail("expected root Module")
+  }
+}
+
+///|
+test "R0: LetDef Drop Before moves one binding row through public bridge" {
+  let (editor, companion) = new_lambda_editor("drop-letdef-before")
+  editor.set_text("let a = 1\nlet b = 2\na")
+  let source = resolve_child_id(editor, 1)
+  let target = resolve_child_id(editor, 0)
+  let result = apply_lambda_tree_edit(
+    editor,
+    companion,
+    @lambda_edits.TreeEditOp::Drop(
+      source~,
+      target~,
+      position=@core.DropPosition::Before,
+    ),
+    1,
+  )
+  guard result is Ok(_) else { fail("Drop Before failed") }
+  assert_root_def_order(editor, "let b = 2\nlet a = 1\na", "b", "a")
+}
+
+///|
+test "R0: LetDef Drop After moves one binding row through public bridge" {
+  let (editor, companion) = new_lambda_editor("drop-letdef-after")
+  editor.set_text("let a = 1\nlet b = 2\na")
+  let source = resolve_child_id(editor, 0)
+  let target = resolve_child_id(editor, 1)
+  let result = apply_lambda_tree_edit(
+    editor,
+    companion,
+    @lambda_edits.TreeEditOp::Drop(
+      source~,
+      target~,
+      position=@core.DropPosition::After,
+    ),
+    1,
+  )
+  guard result is Ok(_) else { fail("Drop After failed") }
+  assert_root_def_order(editor, "let b = 2\nlet a = 1\na", "b", "a")
+}
+
+///|
+test "R0: LetDef Drop Inside moves one binding row through public bridge" {
+  let (editor, companion) = new_lambda_editor("drop-letdef-inside")
+  editor.set_text("let a = 1\nlet b = 2\na")
+  let source = resolve_child_id(editor, 0)
+  let target = resolve_child_id(editor, 1)
+  let result = apply_lambda_tree_edit(
+    editor,
+    companion,
+    @lambda_edits.TreeEditOp::Drop(
+      source~,
+      target~,
+      position=@core.DropPosition::Inside,
+    ),
+    1,
+  )
+  guard result is Ok(_) else { fail("Drop Inside failed") }
+  assert_root_def_order(editor, "let b = 2\nlet a = 1\na", "b", "a")
+}
+
+///|
+test "R0: expression Drop keeps expression-level semantics through public bridge" {
+  let (editor, companion) = new_lambda_editor("drop-expression")
+  editor.set_text("x + 1")
+  let source = resolve_child_id(editor, 0)
+  let target = resolve_child_id(editor, 1)
+  let result = apply_lambda_tree_edit(
+    editor,
+    companion,
+    @lambda_edits.TreeEditOp::Drop(
+      source~,
+      target~,
+      position=@core.DropPosition::After,
+    ),
+    1,
+  )
+  guard result is Ok(_) else { fail("expression Drop failed") }
+  inspect(editor.get_text(), content="x + 1x ")
+}
+
+///|
+test "R0: mixed LetDef and expression Drop is rejected structurally" {
+  let (editor, companion) = new_lambda_editor("drop-mixed")
+  editor.set_text("let a = 1\na")
+  let source = resolve_child_id(editor, 0)
+  let target = resolve_child_id(editor, 1)
+  let result = apply_lambda_tree_edit(
+    editor,
+    companion,
+    @lambda_edits.TreeEditOp::Drop(
+      source~,
+      target~,
+      position=@core.DropPosition::Before,
+    ),
+    1,
+  )
+  match result {
+    Err(@core.EditError::UnsupportedOperation(detail~)) =>
+      inspect(
+        detail,
+        content="Drop requires source and target to have matching node kinds",
+      )
+    Err(error) => fail("unexpected Drop error: " + error.message())
+    Ok(_) => fail("mixed Drop should fail")
+  }
+}
+
+///|
+test "R0: expression to LetDef Drop is rejected structurally" {
+  let (editor, companion) = new_lambda_editor("drop-mixed-reverse")
+  editor.set_text("let a = 1\na")
+  let source = resolve_child_id(editor, 1)
+  let target = resolve_child_id(editor, 0)
+  let result = apply_lambda_tree_edit(
+    editor,
+    companion,
+    @lambda_edits.TreeEditOp::Drop(
+      source~,
+      target~,
+      position=@core.DropPosition::Before,
+    ),
+    1,
+  )
+  match result {
+    Err(@core.EditError::UnsupportedOperation(detail~)) =>
+      inspect(
+        detail,
+        content="Drop requires source and target to have matching node kinds",
+      )
+    Err(error) => fail("unexpected Drop error: " + error.message())
+    Ok(_) => fail("mixed Drop should fail")
+  }
+}
+
+///|
 /// ── Named Regression Tests ──────────────────────────────────────────
 
 // R1: Different sources, same target, both Before
 test "R1: different sources, same target, both Before" {
   let (ed1, ed2, comp1, comp2) = setup_two_peers("let a = 1\nlet b = 2\na")
   apply_drop(ed1, comp1, 0, 1, @core.DropPosition::Before, 1)
-  apply_drop(ed2, comp2, 2, 1, @core.DropPosition::Before, 1)
+  apply_drop(ed2, comp2, 1, 0, @core.DropPosition::Before, 1)
   bidirectional_sync(ed1, ed2)
   assert_peers_converged(ed1, ed2)
 }
@@ -449,7 +698,7 @@ test "R4: Inside vs Before on same pair" {
 ///|
 test "R5: drop + concurrent text edit" {
   let (ed1, ed2, comp1, comp2) = setup_two_peers("let a = 1\nlet b = 2\na")
-  apply_drop(ed1, comp1, 2, 0, @core.DropPosition::Before, 1)
+  apply_drop(ed1, comp1, 1, 0, @core.DropPosition::Before, 1)
   let len = ed2.get_text().length()
   ed2.move_cursor(len)
   try! ed2.insert(" + 99")
@@ -463,7 +712,7 @@ test "R5: drop + concurrent text edit" {
 test "R6: undo after concurrent drops" {
   let (ed1, ed2, comp1, comp2) = setup_two_peers("let a = 1\nlet b = 2\na")
   apply_drop(ed1, comp1, 1, 0, @core.DropPosition::Before, 1)
-  apply_drop(ed2, comp2, 2, 1, @core.DropPosition::After, 1)
+  apply_drop(ed2, comp2, 0, 1, @core.DropPosition::After, 1)
   bidirectional_sync(ed1, ed2)
   assert_peers_converged(ed1, ed2)
   guard ed1.can_undo() else { fail("ed1 can_undo") }
@@ -484,7 +733,7 @@ test "R7: three-peer convergence" {
   let (ed3, comp3) = new_lambda_editor("peer3")
   ed3.apply_sync(ed1.export_all())
   apply_drop(ed1, comp1, 1, 0, @core.DropPosition::Before, 1)
-  apply_drop(ed2, comp2, 2, 3, @core.DropPosition::After, 1)
+  apply_drop(ed2, comp2, 2, 1, @core.DropPosition::After, 1)
   apply_drop(ed3, comp3, 0, 2, @core.DropPosition::Inside, 1)
   ed1.apply_sync(ed2.export_all())
   ed1.apply_sync(ed3.export_all())

--- a/modules/canopy/lang/lambda/companion/lambda_editor.mbt
+++ b/modules/canopy/lang/lambda/companion/lambda_editor.mbt
@@ -58,39 +58,17 @@ let lambda_language : @lang_runtime.Language[
     (cached_proj_node, registry_memo, source_map_memo, companion)
   },
   edit=(op, ctx) => {
-    match op {
-      @lambda_edits.TreeEditOp::Drop(source~, target~, position~) => {
-        let (source_node, source_range) = ctx.resolve(source)
-        let (_, target_range) = ctx.resolve(target)
-        let (edits, focus_hint) = @core.compute_move(
-          ctx.source_text,
-          source,
-          source_range,
-          target,
-          target_range,
-          position,
-          @loom_core.Renderable::placeholder(source_node.kind),
-          " ",
-        )
+    match @lambda_edits.compute_text_edit(op, ctx) {
+      Some((edits, focus_hint)) =>
         @lang_runtime.EditResult::Edits(
           edits,
           focus_hint,
-          Some(@core.IdentityTransform::Opaque),
+          Some(op.to_identity_transform(id => ctx.registry.get(id))),
         )
-      }
-      _ =>
-        match @lambda_edits.compute_text_edit(op, ctx) {
-          Some((edits, focus_hint)) =>
-            @lang_runtime.EditResult::Edits(
-              edits,
-              focus_hint,
-              Some(op.to_identity_transform(id => ctx.registry.get(id))),
-            )
-          None =>
-            raise @core.EditError::UnsupportedOperation(
-              detail="Unhandled tree edit op: " + op.to_string(),
-            )
-        }
+      None =>
+        raise @core.EditError::UnsupportedOperation(
+          detail="Unhandled tree edit op: " + op.to_string(),
+        )
     }
   },
   capabilities=build_lambda_capabilities,

--- a/modules/canopy/lang/lambda/companion/moon.pkg
+++ b/modules/canopy/lang/lambda/companion/moon.pkg
@@ -16,7 +16,6 @@ import {
   "dowdiness/lambda/ast",
   "dowdiness/lambda/typecheck",
   "dowdiness/loom",
-  "dowdiness/loom/core" @loom_core,
   "dowdiness/pretty",
   "dowdiness/seam",
   "moonbitlang/core/debug",

--- a/modules/canopy/lang/lambda/edits/text_edit_drop.mbt
+++ b/modules/canopy/lang/lambda/edits/text_edit_drop.mbt
@@ -86,10 +86,8 @@ fn is_row_immediately_after(
   next_range : @loomcore.Range,
 ) -> Bool {
   guard next_range.start > previous_range.end else { return false }
-  let mut i = previous_range.end
-  while i < next_range.start {
-    guard is_space_code(source_text[i]) else { return false }
-    i = i + 1
+  for pos = previous_range.end; pos < next_range.start; pos = pos + 1 {
+    guard is_space_code(source_text[pos]) else { return false }
   }
   true
 }

--- a/modules/canopy/lang/lambda/edits/text_edit_drop.mbt
+++ b/modules/canopy/lang/lambda/edits/text_edit_drop.mbt
@@ -19,14 +19,35 @@ fn compute_drop(
     target_range.end <= source_range.end) else {
     raise InvalidTarget(detail="Cannot drop into own descendant")
   }
-  let is_let_def_drop = source_node.kind is @ast.Term::LetDef(_, _) &&
-    target_node.kind is @ast.Term::LetDef(_, _)
-  let (delete_start, delete_len, insert_pos, inserted) = if is_let_def_drop {
+  let source_is_let_def = source_node.kind is @ast.Term::LetDef(_, _)
+  let target_is_let_def = target_node.kind is @ast.Term::LetDef(_, _)
+  let is_let_def_drop = source_is_let_def && target_is_let_def
+  guard source_is_let_def == target_is_let_def else {
+    raise UnsupportedOperation(
+      detail="Drop requires source and target to have matching node kinds",
+    )
+  }
+  // Validate scope before the no-op fast path: nested and cross-scope rows
+  // remain rejected even when their requested position is already adjacent.
+  if is_let_def_drop {
+    ensure_let_def_drop_scope(ctx, source, target)
+  }
+  let is_noop_row_drop = match position {
+    Before => is_row_immediately_after(source_text, source_range, target_range)
+    After | Inside =>
+      is_row_immediately_after(source_text, target_range, source_range)
+  }
+  // LetDef rows use newline-aware movement; expression pairs use compute_move.
+  if is_let_def_drop && is_noop_row_drop {
+    Some(([], RestoreCursor))
+  } else if is_let_def_drop {
+    ensure_let_def_drop_safety(ctx, source, target, position)
     let source_row = source_text[source_range.start:source_range.end].to_owned()
     let (delete_start, delete_len) = binding_delete_range(
       source_text,
       source_range.start,
       source_range.end,
+      prefer_leading=source_range.start > target_range.end,
     )
     let (insert_pos, inserted) = match position {
       Before => (target_range.start, source_row + "\n")
@@ -34,28 +55,133 @@ fn compute_drop(
       // initializer is a child, not the row's drop target.
       After | Inside => (target_range.end, "\n" + source_row)
     }
-    (delete_start, delete_len, insert_pos, inserted)
-  } else {
-    let source_slice = source_text[source_range.start:source_range.end].to_owned()
-    let insert_pos = match position {
-      Before => target_range.start
-      After => target_range.end
-      Inside => target_range.start
-    }
-    (
-      source_range.start,
-      source_range.end - source_range.start,
-      insert_pos,
-      source_slice,
+    Some(
+      (
+        [
+          { start: delete_start, delete_len, inserted: "" },
+          { start: insert_pos, delete_len: 0, inserted },
+        ],
+        RestoreCursor,
+      ),
     )
+  } else {
+    let (edits, focus_hint) = @core.compute_move(
+      source_text,
+      source,
+      source_range,
+      target,
+      target_range,
+      position,
+      @loomcore.Renderable::placeholder(source_node.kind),
+      " ",
+    )
+    Some((edits, focus_hint))
   }
-  Some(
-    (
-      [
-        { start: delete_start, delete_len, inserted: "" },
-        { start: insert_pos, delete_len: 0, inserted },
-      ],
-      RestoreCursor,
-    ),
-  )
+}
+
+///|
+fn is_row_immediately_after(
+  source_text : String,
+  previous_range : @loomcore.Range,
+  next_range : @loomcore.Range,
+) -> Bool {
+  guard next_range.start > previous_range.end else { return false }
+  let mut i = previous_range.end
+  while i < next_range.start {
+    guard is_space_code(source_text[i]) else { return false }
+    i = i + 1
+  }
+  true
+}
+
+///|
+/// LetDef rows may move only within the root binding scope.
+fn ensure_let_def_drop_scope(
+  ctx : EditContext[@ast.Term],
+  source : NodeId,
+  target : NodeId,
+) -> Unit raise EditError {
+  let g = @scope.build(ctx.registry, ctx.source_map)
+  let source_decl = module_def_decl_for_binding(g, source)
+  let target_decl = module_def_decl_for_binding(g, target)
+  guard source_decl.scope == target_decl.scope else {
+    raise InvalidTarget(detail="Cannot drop bindings across scopes")
+  }
+  guard root_scope_id(g) is Some(root_scope) else {
+    raise InvalidTarget(detail="Cannot drop bindings outside root module")
+  }
+  guard source_decl.scope == root_scope else {
+    raise InvalidTarget(detail="Cannot drop bindings outside root module")
+  }
+}
+
+///|
+/// Check every root binding crossed by a non-no-op row move.
+fn ensure_let_def_drop_safety(
+  ctx : EditContext[@ast.Term],
+  source : NodeId,
+  target : NodeId,
+  position : DropPosition,
+) -> Unit raise EditError {
+  let g = @scope.build(ctx.registry, ctx.source_map)
+  let source_decl = module_def_decl_for_binding(g, source)
+  let target_decl = module_def_decl_for_binding(g, target)
+  let source_index = match source_decl.kind {
+    @scope.DeclKind::ModuleDef(def_index~) => def_index
+    @scope.DeclKind::LamParam(_) =>
+      raise InvalidTarget(detail="Expected module binding")
+  }
+  let target_index = match target_decl.kind {
+    @scope.DeclKind::ModuleDef(def_index~) => def_index
+    @scope.DeclKind::LamParam(_) =>
+      raise InvalidTarget(detail="Expected module binding")
+  }
+  let source_def = edit_binding_for_decl(ctx, source_decl)
+  let target_def = edit_binding_for_decl(ctx, target_decl)
+  guard source_def.name != target_def.name else {
+    raise InvalidTarget(detail="Cannot drop bindings with the same name")
+  }
+  let destination_index = match position {
+    Before =>
+      if source_index < target_index {
+        target_index - 1
+      } else {
+        target_index
+      }
+    After | Inside =>
+      if source_index < target_index {
+        target_index
+      } else {
+        target_index + 1
+      }
+  }
+  if destination_index < source_index {
+    let mut i = source_index - 1
+    while i >= destination_index {
+      guard sibling_module_def_decl(g, source_decl.scope, i)
+        is Some(crossed_decl) else {
+        raise InvalidTarget(detail="Cannot resolve binding reorder")
+      }
+      let crossed_def = edit_binding_for_decl(ctx, crossed_decl)
+      guard source_def.name != crossed_def.name else {
+        raise InvalidTarget(detail="Cannot drop bindings with the same name")
+      }
+      check_swap_scoping(g, source_def, crossed_def, "drop", ctx.registry)
+      i = i - 1
+    }
+  } else if destination_index > source_index {
+    let mut i = source_index + 1
+    while i <= destination_index {
+      guard sibling_module_def_decl(g, source_decl.scope, i)
+        is Some(crossed_decl) else {
+        raise InvalidTarget(detail="Cannot resolve binding reorder")
+      }
+      let crossed_def = edit_binding_for_decl(ctx, crossed_decl)
+      guard source_def.name != crossed_def.name else {
+        raise InvalidTarget(detail="Cannot drop bindings with the same name")
+      }
+      check_swap_scoping(g, crossed_def, source_def, "drop", ctx.registry)
+      i = i + 1
+    }
+  }
 }

--- a/modules/canopy/lang/lambda/edits/text_edit_middleware.mbt
+++ b/modules/canopy/lang/lambda/edits/text_edit_middleware.mbt
@@ -56,7 +56,9 @@ fn extract_primary_node_id(op : TreeEditOp) -> NodeId? {
     | ExtractToLet(node_id~, ..)
     | InlineDefinition(node_id~)
     | Rename(node_id~, ..) => Some(node_id)
-    Drop(source~, ..) => Some(source)
+    // Drop resolves both IDs in compute_drop so missing-node errors retain
+    // the shared Resolve action instead of validating only the source here.
+    Drop(..) => None
     InsertChild(parent~, ..) => Some(parent)
     DeleteBinding(binding_node_id~)
     | DuplicateBinding(binding_node_id~)

--- a/modules/canopy/lang/lambda/edits/text_edit_utils.mbt
+++ b/modules/canopy/lang/lambda/edits/text_edit_utils.mbt
@@ -83,13 +83,19 @@ fn ensure_replaceable_node_range(
 
 ///|
 /// Compute (start, length) for deleting a binding line, consuming
-/// the adjacent newline if present (trailing preferred, else leading).
+/// the adjacent newline if present. Trailing newline is the default; callers
+/// moving a row across an earlier target can prefer the leading newline so
+/// concurrent row edits retain a line separator at the source site.
 fn binding_delete_range(
   source_text : String,
   let_start : Int,
   binding_end : Int,
+  prefer_leading? : Bool = false,
 ) -> (Int, Int) {
-  if binding_end < source_text.length() && source_text[binding_end] == '\n' {
+  if prefer_leading && let_start > 0 && source_text[let_start - 1] == '\n' {
+    (let_start - 1, binding_end - let_start + 1)
+  } else if binding_end < source_text.length() &&
+    source_text[binding_end] == '\n' {
     (let_start, binding_end - let_start + 1)
   } else if let_start > 0 && source_text[let_start - 1] == '\n' {
     (let_start - 1, binding_end - let_start + 1)

--- a/modules/canopy/lang/lambda/edits/text_edit_wbtest.mbt
+++ b/modules/canopy/lang/lambda/edits/text_edit_wbtest.mbt
@@ -346,12 +346,7 @@ test "compute_text_edit: Drop produces two edits" {
       // Drop should produce 2 edits: delete at source + insert at target
       inspect(edits.length(), content="2")
       let new_text = apply_edits(text, edits)
-      inspect(
-        new_text,
-        content=(
-          #| + 1x
-        ),
-      )
+      inspect(new_text, content="x + 1x ")
     }
     _ => fail("expected Some edits")
   }
@@ -384,6 +379,44 @@ test "compute_text_edit: Drop LetDef Inside moves the whole binding row after ta
 }
 
 ///|
+test "compute_text_edit: Drop LetDef Inside is a no-op when already after target" {
+  let text = "let x = 1\nlet y = 2\nx"
+  let (proj, source_map, registry) = parse_with_token_spans(text)
+  let source = proj.children[1]
+  let target = proj.children[0]
+  let result = test_edit(
+    Drop(source=source.id(), target=target.id(), position=Inside),
+    make_edit_ctx(text, source_map, registry, proj),
+  )
+  match result {
+    Ok(Some((edits, _))) => {
+      inspect(edits.length(), content="0")
+      inspect(apply_edits(text, edits), content=text)
+    }
+    _ => fail("expected Some edits")
+  }
+}
+
+///|
+test "compute_text_edit: Drop adjacent duplicate-name rows is a no-op" {
+  let text = "let x = 1\nlet x = 2\nx"
+  let (proj, source_map, registry) = parse_with_token_spans(text)
+  let source = proj.children[1]
+  let target = proj.children[0]
+  let result = test_edit(
+    Drop(source=source.id(), target=target.id(), position=After),
+    make_edit_ctx(text, source_map, registry, proj),
+  )
+  match result {
+    Ok(Some((edits, _))) => {
+      inspect(edits.length(), content="0")
+      inspect(apply_edits(text, edits), content=text)
+    }
+    _ => fail("expected duplicate-name adjacent Drop to be a no-op")
+  }
+}
+
+///|
 test "compute_text_edit: Drop LetDef Before moves the whole binding row before target" {
   let text = "let x = 1\nlet y = 2\nx"
   let (proj, source_map, registry) = parse_with_token_spans(text)
@@ -407,6 +440,147 @@ test "compute_text_edit: Drop LetDef Before moves the whole binding row before t
     }
     _ => fail("expected Some edits")
   }
+}
+
+///|
+test "compute_text_edit: Drop LetDef After moves the whole binding row after target" {
+  let text = "let x = 1\nlet y = 2\nx"
+  let (proj, source_map, registry) = parse_with_token_spans(text)
+  let source = proj.children[0]
+  let target = proj.children[1]
+  let result = test_edit(
+    Drop(source=source.id(), target=target.id(), position=After),
+    make_edit_ctx(text, source_map, registry, proj),
+  )
+  match result {
+    Ok(Some((edits, _))) => {
+      let new_text = apply_edits(text, edits)
+      inspect(
+        new_text,
+        content=(
+          #|let y = 2
+          #|let x = 1
+          #|x
+        ),
+      )
+    }
+    _ => fail("expected Some edits")
+  }
+}
+
+///|
+test "compute_text_edit: Drop LetDef with multiline initializer preserves row" {
+  let text = "let x = { let inner = 1\n  inner }\nlet y = 2\nx"
+  let (proj, source_map, registry) = parse_with_token_spans(text)
+  let source = proj.children[0]
+  let target = proj.children[1]
+  let result = test_edit(
+    Drop(source=source.id(), target=target.id(), position=After),
+    make_edit_ctx(text, source_map, registry, proj),
+  )
+  match result {
+    Ok(Some((edits, _))) =>
+      inspect(
+        apply_edits(text, edits),
+        content=(
+          #|let y = 2
+          #|let x = { let inner = 1
+          #|  inner }
+          #|x
+        ),
+      )
+    _ => fail("expected Some edits")
+  }
+}
+
+///|
+test "compute_text_edit: Drop LetDef at EOF preserves missing trailing newline" {
+  let text = "let x = 1\nlet y = 2"
+  let (proj, source_map, registry) = parse_with_token_spans(text)
+  let source = proj.children[1]
+  let target = proj.children[0]
+  let result = test_edit(
+    Drop(source=source.id(), target=target.id(), position=Before),
+    make_edit_ctx(text, source_map, registry, proj),
+  )
+  match result {
+    Ok(Some((edits, _))) =>
+      inspect(apply_edits(text, edits), content="let y = 2\nlet x = 1")
+    _ => fail("expected Some edits")
+  }
+}
+
+///|
+test "compute_text_edit: Drop mixed LetDef and expression is rejected" {
+  let text = "let x = 1\nx"
+  let (proj, source_map, registry) = parse_with_token_spans(text)
+  let source = proj.children[0]
+  let target = proj.children[1]
+  let let_to_expr = test_edit(
+    Drop(source=source.id(), target=target.id(), position=Before),
+    make_edit_ctx(text, source_map, registry, proj),
+  )
+  let expr_to_let = test_edit(
+    Drop(source=target.id(), target=source.id(), position=Before),
+    make_edit_ctx(text, source_map, registry, proj),
+  )
+  @debug.debug_inspect(
+    let_to_expr,
+    content="Err(\"Drop requires source and target to have matching node kinds\")",
+  )
+  @debug.debug_inspect(
+    expr_to_let,
+    content="Err(\"Drop requires source and target to have matching node kinds\")",
+  )
+}
+
+///|
+test "compute_text_edit: Drop LetDef across scopes is rejected" {
+  let text = "let x = 0\nlet z = { let a = 1\n  let b = 2\n  a }\nz"
+  let (proj, source_map, registry) = parse_with_token_spans(text)
+  let source = proj.children[0]
+  let target = proj.children[1].children[0].children[0]
+  let result = test_edit(
+    Drop(source=source.id(), target=target.id(), position=Before),
+    make_edit_ctx(text, source_map, registry, proj),
+  )
+  @debug.debug_inspect(
+    result,
+    content="Err(\"Cannot drop bindings across scopes\")",
+  )
+}
+
+///|
+test "compute_text_edit: Drop nested LetDef rows is rejected" {
+  let text = "let x = 0\nlet z = { let a = 1\n  let b = 2\n  a }\nz"
+  let (proj, source_map, registry) = parse_with_token_spans(text)
+  let block = proj.children[1].children[0]
+  let source = block.children[0]
+  let target = block.children[1]
+  let result = test_edit(
+    Drop(source=source.id(), target=target.id(), position=Before),
+    make_edit_ctx(text, source_map, registry, proj),
+  )
+  @debug.debug_inspect(
+    result,
+    content="Err(\"Cannot drop bindings outside root module\")",
+  )
+}
+
+///|
+test "compute_text_edit: Drop LetDef checks every crossed binding" {
+  let text = "let a = 0\nlet b = a\nlet c = b\nc"
+  let (proj, source_map, registry) = parse_with_token_spans(text)
+  let source = proj.children[2]
+  let target = proj.children[0]
+  let result = test_edit(
+    Drop(source=source.id(), target=target.id(), position=Before),
+    make_edit_ctx(text, source_map, registry, proj),
+  )
+  @debug.debug_inspect(
+    result,
+    content="Err(\"Cannot move drop: c uses b in its init\")",
+  )
 }
 
 ///|
@@ -3193,7 +3367,7 @@ test "compute_text_edit: Drop with Before position inserts at target start" {
       inspect(
         new_text,
         content=(
-          #| 1x +
+          #|1 x + 0
         ),
       )
     }

--- a/modules/canopy/lang/lambda/edits/tree_lens.mbt
+++ b/modules/canopy/lang/lambda/edits/tree_lens.mbt
@@ -103,8 +103,9 @@ pub fn TreeEditOp::to_generic(self : TreeEditOp) -> @core.GenericTreeOp {
 /// standard LCS reconciliation — never produces wrong identity (T3).
 ///
 /// `Language::apply_edit` now owns every application path, including empty
-/// edit batches. Lambda `Drop` bypasses this mapper because its edit-port arm
-/// supplies `Opaque` explicitly alongside `core.compute_move`.
+/// edit batches. Lambda `Drop` uses this mapper after its edit port chooses
+/// the binding-row or expression-level span policy; both intentionally use
+/// `Opaque`.
 pub fn TreeEditOp::to_identity_transform(
   self : TreeEditOp,
   get_node : (@core.NodeId) -> @core.ProjNode[@ast.Term]?,

--- a/modules/canopy/lang/runtime/language.mbt
+++ b/modules/canopy/lang/runtime/language.mbt
@@ -9,8 +9,8 @@
 //     of the apply path,
 //   - makes per-op identity hints first-class in the edit result,
 //   - keeps the edit-port signature uniform so moves are ordinary edit
-//     computation (Lambda `Drop` via `compute_move`, Markdown `MoveBlock`
-//     via `compute_move_block`).
+//     computation (Lambda `Drop` selects its binding-row or `compute_move`
+//     policy, Markdown `MoveBlock` uses `compute_move_block`).
 //
 // Closure record rather than a trait: MoonBit traits are Self-based without
 // type parameters, and the orphan rule blocks downstream impls — closures


### PR DESCRIPTION
Closes #1188

## Summary
- Route Lambda structural edits through the language edit port.
- Move root-module LetDef bindings as complete newline-aware rows for Before, After, and Inside drops.
- Reject mixed-kind, nested, cross-scope, and scoping-unsafe drops with structured errors.
- Preserve expression-level move semantics, convergence, undo, and identity hints.
- Add exact text/order, duplicate-prevention, scope, convergence, undo, multiline-initializer, and EOF regression coverage.

## Validation
- `moon check` and `moon test` passed.
- `edits`: 266 tests passed.
- `companion`: 120 tests passed.
- `runtime`: 6 tests passed.
- `./scripts/validate-pr-ready.sh --target modules/canopy/lang/lambda/edits` passed.
- `./scripts/validate-pr-ready.sh --target modules/canopy/lang/lambda/companion` passed.
- `./scripts/validate-pr-ready.sh --target modules/canopy/lang/runtime` passed.
- Final `--verify-evidence` passed on HEAD `7cc75b762012122a60dda645a3f3ad7cf6c50440`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved Lambda drag-and-drop editing for root-level bindings and expression pairs.
  * Added safeguards against invalid moves, including mismatched elements, nested bindings, scope violations, and naming conflicts.
  * Preserved formatting and newline behavior when reordering bindings.
  * Improved handling of no-op moves and unsupported operations.

* **Documentation**
  * Updated language-development and editing guides with current drag-and-drop behavior and integration guidance.
  * Expanded the Lambda API reference and move contract documentation.

* **Tests**
  * Added extensive coverage for valid moves, rejected edits, undo behavior, concurrency, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->