### PR TITLE
feat(markdown): project snapshots and receipts portably

### DIFF
--- a/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
+++ b/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
@@ -1115,7 +1115,7 @@ test("clearing the only Block keeps an empty control editable", async ({ browser
     await input.fill("")
     await expect(input).toHaveValue("")
     await expect(host.page.locator("[data-loomark-block-id]")).toHaveCount(1)
-    await expect.poll(async () => (await snapshot(host.page)).source).toBe("\u200B\n")
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("\n")
     await input.fill("Again")
     await expect.poll(async () => (await snapshot(host.page)).source).toBe("Again\n")
   } finally {

--- a/apps/loomark/internal/rabbita/application.mbt
+++ b/apps/loomark/internal/rabbita/application.mbt
@@ -2379,6 +2379,15 @@ fn build_application(
         publish(next, Some(raw_input_coordinator), None)
         (next, command)
       }
+      @markdown.MarkdownEditorError::Committed(..) as committed => {
+        raw_input_coordinator.cancel_pending()
+        block_input_coordinator.cancel_pending()
+        let (next, command) = recover_after_parser_failure(
+          current_session, model, committed, emit,
+        )
+        publish(next, Some(raw_input_coordinator), None)
+        (next, command)
+      }
       error => {
         raw_input_coordinator.cancel_pending()
         block_input_coordinator.cancel_pending()

--- a/apps/loomark/internal/rabbita/document_transaction.mbt
+++ b/apps/loomark/internal/rabbita/document_transaction.mbt
@@ -7,6 +7,7 @@ fn editor_error_detail(error : @markdown.MarkdownEditorError) -> String {
     @markdown.ProjectionUnavailable => "projection-unavailable"
     @markdown.InvalidTextRange(..) => "invalid text range"
     @markdown.EditFailed(detail~) => detail
+    @markdown.Committed(..) => "edit-committed"
   }
 }
 
@@ -158,6 +159,8 @@ fn commit_edit_request(
     raise Failure::Failure("dev-host injected parser publication failure")
   }
   match receipt {
+    Err(@markdown.MarkdownEditorError::Committed(..) as committed) =>
+      raise committed
     Err(error) => {
       let failed = record_error(
         next,

--- a/apps/loomark/internal/rabbita/recovery_shell.mbt
+++ b/apps/loomark/internal/rabbita/recovery_shell.mbt
@@ -39,11 +39,12 @@ fn persist_recovered_editor(
 
 ///|
 /// Rebuild once from the accepted archive. This is the only shell that may
-/// catch parser Failure; the old session is never retried or reset.
+/// recover after parser Failure or a typed committed-receipt interruption; the
+/// old session is never retried or reset.
 fn recover_after_parser_failure(
   session_ref : @ref.Ref[EditorSession],
   model : DriverModel,
-  failure : Failure,
+  failure : Error,
   emit : @cmd.Emit[DriverEvent],
 ) -> (DriverModel, @cmd.Cmd) {
   ignore(failure)

--- a/modules/canopy/editor/README.md
+++ b/modules/canopy/editor/README.md
@@ -43,6 +43,17 @@ Do not add parallel frontend-only view models or special-case language behavior 
 
 Internal but stable — this is the central package of the monorepo. The `SyncEditor` struct shape and `LanguageCapabilities` interface are touched whenever a new editor feature lands.
 
+## Markdown façade coordinate migration
+
+Starting with the portable snapshot and receipt contract:
+
+- `MarkdownDocumentSnapshot::source`, block source/text/marker/fence ranges, block and document selections, and `MarkdownCommitReceipt::transforms` share one sentinel-free UTF-16 coordinate space.
+- Only runtime-confirmed structural empty-paragraph sentinels collapse from that source and its ranges. Caller-authored inline ZWSP remains visible, while an empty block's public text is empty and its text range is zero-width.
+- A source-equal accepted commit may report `MarkdownCommitResult::Unchanged` while its version and history advance. Its receipt still retains the accepted transform evidence.
+- `MarkdownEditorError::Committed` means mutation landed and must not be retried. It carries portable before/optional-after `MarkdownCommittedEvidence` and a typed `MarkdownPostCommitIssue`.
+
+Two compatibility paths are intentionally outside this coordinate migration. `MarkdownEditRequest::ReplaceText` still accepts legacy canonical coordinates; do not derive those offsets from a portable snapshot when hidden sentinels exist. `MarkdownEditRequest::ReplaceSource` remains a lossy source import and does not continue causal identity; use `MarkdownEditor::open` or `MarkdownEditor::admit` with history to continue an owned document.
+
 ## Notes
 
 WebSocket wiring is split into two per-target files (`websocket_js.mbt` / `websocket_native.mbt`). Ephemeral state (peer cursors) is encoded in a compact binary varint format, not JSON. The binary sync protocol uses a versioned framing defined in `sync_protocol.mbt`; `encode_message` / `decode_message` are the only crossing points.

--- a/modules/canopy/editor/markdown/editor.mbt
+++ b/modules/canopy/editor/markdown/editor.mbt
@@ -6,7 +6,39 @@ pub(all) suberror MarkdownEditorError {
   ProjectionUnavailable
   InvalidTextRange(start~ : Int, delete_len~ : Int, source_length~ : Int)
   EditFailed(detail~ : String)
+  /// The causal edit landed; this is never authorization to retry it.
+  Committed(
+    evidence~ : MarkdownCommittedEvidence,
+    issue~ : MarkdownPostCommitIssue
+  )
 }
+
+///|
+/// Sentinel-free evidence retained when receipt construction is interrupted
+/// after the document version has advanced.
+pub struct MarkdownCommittedEvidence {
+  priv before : String
+  priv after : String?
+} derive(Eq, Debug)
+
+///|
+pub fn MarkdownCommittedEvidence::before(self : Self) -> String {
+  self.before
+}
+
+///|
+pub fn MarkdownCommittedEvidence::after(self : Self) -> String? {
+  self.after
+}
+
+///|
+/// Typed post-commit reasons that require recovery rather than edit retry.
+pub(all) enum MarkdownPostCommitIssue {
+  RuntimeFailure(detail~ : String)
+  ProjectionUnavailable
+  ProjectionFailed
+  UnexpectedTransformCount(count~ : Int)
+} derive(Eq, Debug)
 
 ///|
 /// Stable editable block kinds exposed by the Markdown façade.
@@ -67,11 +99,13 @@ fn MarkdownBlockSnapshot::canonical_text(self : Self) -> String {
 }
 
 ///|
+/// Sentinel-free UTF-16 range in the owning document snapshot source.
 pub fn MarkdownBlockSnapshot::source_range(self : Self) -> (Int, Int) {
   (self.source_start, self.source_end)
 }
 
 ///|
+/// Sentinel-free UTF-16 payload range in the owning snapshot source.
 pub fn MarkdownBlockSnapshot::text_range(self : Self) -> (Int, Int) {
   (self.text_start, self.text_end)
 }
@@ -347,6 +381,7 @@ pub struct MarkdownDocumentSnapshot {
 } derive(Eq, Debug)
 
 ///|
+/// Sentinel-free UTF-16 source shared by all snapshot ranges and receipts.
 pub fn MarkdownDocumentSnapshot::source(self : Self) -> String {
   self.source
 }
@@ -394,6 +429,13 @@ pub fn MarkdownDocumentUtf16Selection::MarkdownDocumentUtf16Selection(
     raise MarkdownDocumentUtf16SelectionError::MidGraphemeBoundary(offset=head)
   }
   { anchor, head }
+}
+
+///|
+/// One coherent snapshot and the opaque map used to project its cursor.
+priv struct PortableDocumentSnapshot {
+  snapshot : MarkdownDocumentSnapshot
+  coordinates : @markdown_runtime.PortableCoordinateMap
 }
 
 ///|
@@ -884,7 +926,7 @@ pub fn MarkdownEditor::admit(
 }
 
 ///|
-/// Read the last committed canonical source without exposing editor state.
+/// Read the last committed sentinel-free UTF-16 source and ranges.
 pub fn MarkdownEditor::snapshot(
   self : Self,
 ) -> MarkdownDocumentSnapshot raise Failure {
@@ -993,19 +1035,87 @@ fn MarkdownEditor::commit_recording_transforms(
 ] raise {
   match request {
     ReplaceSource(source) => {
-      let before = self.editor.get_text()
-      if before == source {
+      let before = capture_portable_coordinates(self.editor)
+      if before.source() == source {
         Ok((MarkdownCommitResult::Unchanged(self.snapshot()), @vector.new()))
       } else {
-        // The synchronization edit returns the same splice used internally,
-        // so the receipt does not compute the text diff a second time.
-        let (change, accepted) = self.editor.set_text_with_change(source)
+        // The synchronization edit returns the same accepted splice used by
+        // the CRDT; project that splice rather than diffing portable sources.
+        let before_source = before.source()
+        let version_before = self.editor.get_version()
+        let applied : Result[
+          (@text_change.TextChange, Bool),
+          MarkdownEditorError,
+        ] = Ok(self.editor.set_text_with_change(source)) catch {
+          Failure::Failure(detail) =>
+            if self.editor.get_version() != version_before {
+              Err(
+                committed_editor_error(
+                  before_source,
+                  None,
+                  MarkdownPostCommitIssue::RuntimeFailure(detail~),
+                ),
+              )
+            } else {
+              raise Failure::Failure(detail)
+            }
+        }
+        let (change, accepted) = match applied {
+          Ok(applied) => applied
+          Err(error) => return Err(error)
+        }
         if accepted {
-          self.editor.refresh()
-          Ok(
-            (
-              MarkdownCommitResult::Applied(self.snapshot(), None),
-              @vector.Vector::singleton(MarkdownTextTransform::{ change, }),
+          self.editor.refresh() catch {
+            Failure::Failure(detail) =>
+              return Err(
+                committed_editor_error(
+                  before_source,
+                  None,
+                  MarkdownPostCommitIssue::RuntimeFailure(detail~),
+                ),
+              )
+          }
+          let after = match
+            capture_committed_portable_coordinates(self.editor, before_source) {
+            Ok(after) => after
+            Err(error) => return Err(error)
+          }
+          let state = match
+            committed_document_snapshot_from_coordinates(
+              self.editor,
+              before_source,
+              after,
+            ) {
+            Ok(state) => state
+            Err(error) => return Err(error)
+          }
+          let transform = match
+            project_portable_transform(
+              before,
+              @core.SpanEdit::{
+                start: change.start,
+                delete_len: change.delete_len,
+                inserted: change.inserted,
+              },
+              after,
+            ) {
+            Ok(transform) => transform
+            Err(error) => return Err(error)
+          }
+          let result = if state.snapshot.source() == before_source {
+            MarkdownCommitResult::Unchanged(state.snapshot)
+          } else {
+            MarkdownCommitResult::Applied(state.snapshot, None)
+          }
+          Ok((result, @vector.Vector::singleton(transform)))
+        } else if self.editor.get_version() != version_before {
+          Err(
+            committed_editor_error(
+              before_source,
+              None,
+              MarkdownPostCommitIssue::RuntimeFailure(
+                detail="source replacement interrupted after commit",
+              ),
             ),
           )
         } else {
@@ -1031,26 +1141,83 @@ fn MarkdownEditor::commit_recording_transforms(
             source_length~,
           ),
         )
-      } else if self.editor.apply_text_edit_exact(
-          start, delete_len, inserted, 0,
-        ) {
-        self.editor.refresh()
-        let snapshot = self.snapshot()
-        let result = if snapshot.source() == source {
-          MarkdownCommitResult::Unchanged(snapshot)
-        } else {
-          MarkdownCommitResult::Applied(snapshot, None)
-        }
-        Ok(
-          (
-            result,
-            @vector.Vector::singleton(MarkdownTextTransform::{
-              change: @text_change.TextChange::{ start, delete_len, inserted },
-            }),
-          ),
-        )
       } else {
-        Err(MarkdownEditorError::EditFailed(detail="text edit rejected"))
+        let before = capture_portable_coordinates(self.editor)
+        let before_source = before.source()
+        let version_before = self.editor.get_version()
+        let applied : Result[Bool, MarkdownEditorError] = Ok(
+          self.editor.apply_text_edit_exact(start, delete_len, inserted, 0),
+        ) catch {
+          Failure::Failure(detail) =>
+            if self.editor.get_version() != version_before {
+              Err(
+                committed_editor_error(
+                  before_source,
+                  None,
+                  MarkdownPostCommitIssue::RuntimeFailure(detail~),
+                ),
+              )
+            } else {
+              raise Failure::Failure(detail)
+            }
+        }
+        let accepted = match applied {
+          Ok(accepted) => accepted
+          Err(error) => return Err(error)
+        }
+        if accepted {
+          self.editor.refresh() catch {
+            Failure::Failure(detail) =>
+              return Err(
+                committed_editor_error(
+                  before_source,
+                  None,
+                  MarkdownPostCommitIssue::RuntimeFailure(detail~),
+                ),
+              )
+          }
+          let after = match
+            capture_committed_portable_coordinates(self.editor, before_source) {
+            Ok(after) => after
+            Err(error) => return Err(error)
+          }
+          let state = match
+            committed_document_snapshot_from_coordinates(
+              self.editor,
+              before_source,
+              after,
+            ) {
+            Ok(state) => state
+            Err(error) => return Err(error)
+          }
+          let transform = match
+            project_portable_transform(
+              before,
+              @core.SpanEdit::{ start, delete_len, inserted },
+              after,
+            ) {
+            Ok(transform) => transform
+            Err(error) => return Err(error)
+          }
+          let result = if state.snapshot.source() == before_source {
+            MarkdownCommitResult::Unchanged(state.snapshot)
+          } else {
+            MarkdownCommitResult::Applied(state.snapshot, None)
+          }
+          Ok((result, @vector.Vector::singleton(transform)))
+        } else if self.editor.get_version() != version_before {
+          Err(
+            committed_editor_error(
+              before_source,
+              None,
+              MarkdownPostCommitIssue::RuntimeFailure(
+                detail="text edit interrupted after commit",
+              ),
+            ),
+          )
+        } else {
+          Err(MarkdownEditorError::EditFailed(detail="text edit rejected"))
+        }
       }
     }
     CommitEdit(node_id~, new_text~) =>
@@ -1150,7 +1317,6 @@ fn MarkdownEditor::commit_structural_recording_transforms(
   (MarkdownCommitResult, @vector.Vector[MarkdownTextTransform]),
   MarkdownEditorError,
 ] raise {
-  let source = self.editor.get_text()
   let deleted_block_index = match op {
     @md_edits.Delete(node_id~) =>
       self
@@ -1160,13 +1326,38 @@ fn MarkdownEditor::commit_structural_recording_transforms(
       .search_by(block => block.node_id().value == node_id)
     _ => None
   }
-  match @markdown_runtime.apply_edit(self.editor, op, 0) {
-    Err(error) => Err(structural_edit_error(error))
-    Ok(edits) => {
-      self.editor.refresh()
-      let snapshot = self.snapshot()
-      let result = if snapshot.source() == source {
-        // A no-op never authorizes a new caret move for the caller.
+  match @markdown_runtime.commit_portable_edit(self.editor, op, 0) {
+    Err(@markdown_runtime.PortableCommitError::EditRejected(error~)) =>
+      Err(structural_edit_error(error))
+    Err(@markdown_runtime.PortableCommitError::NotCommitted(issue~)) =>
+      portable_not_committed_error(issue)
+    Ok(@markdown_runtime.PortableCommitOutcome::Committed(evidence~, issue~)) =>
+      Err(markdown_committed_error(evidence, issue))
+    Ok(@markdown_runtime.PortableCommitOutcome::Unchanged(_)) =>
+      Ok((MarkdownCommitResult::Unchanged(self.snapshot()), @vector.new()))
+    Ok(@markdown_runtime.PortableCommitOutcome::Applied(commit)) => {
+      let state = match
+        committed_document_snapshot(
+          self.editor,
+          commit.before(),
+          commit.after(),
+        ) {
+        Ok(state) => state
+        Err(error) => return Err(error)
+      }
+      let snapshot = state.snapshot
+      if snapshot.source() != commit.after() {
+        return Err(
+          committed_editor_error(
+            commit.before(),
+            Some(commit.after()),
+            MarkdownPostCommitIssue::ProjectionFailed,
+          ),
+        )
+      }
+      let result = if commit.before() == commit.after() {
+        // History advanced, but a source-oriented result never authorizes a
+        // caret move when the portable source did not change.
         MarkdownCommitResult::Unchanged(snapshot)
       } else {
         let selection = match deleted_block_index {
@@ -1181,17 +1372,126 @@ fn MarkdownEditor::commit_structural_recording_transforms(
               offset: block.text().length(),
             })
           }
-          None =>
-            selection_for_cursor(
-              snapshot,
-              self.editor.get_cursor(),
-              allow_nearest=false,
-            )
+          None => {
+            let cursor = match
+              state.coordinates.project_offset(self.editor.get_cursor()) {
+              Ok(cursor) => cursor
+              Err(_) =>
+                return Err(
+                  committed_editor_error(
+                    commit.before(),
+                    Some(commit.after()),
+                    MarkdownPostCommitIssue::ProjectionFailed,
+                  ),
+                )
+            }
+            selection_for_cursor(snapshot, cursor, allow_nearest=false)
+          }
         }
         MarkdownCommitResult::Applied(snapshot, selection)
       }
-      Ok((result, sequential_text_transforms(edits)))
+      let transform = markdown_text_transform(commit.transform())
+      Ok((result, @vector.Vector::singleton(transform)))
     }
+  }
+}
+
+///|
+fn markdown_committed_error(
+  evidence : @markdown_runtime.PortableCommitEvidence,
+  issue : @markdown_runtime.PortableCommitIssue,
+) -> MarkdownEditorError {
+  committed_editor_error(
+    evidence.before(),
+    evidence.after(),
+    markdown_post_commit_issue(issue),
+  )
+}
+
+///|
+fn committed_editor_error(
+  before : String,
+  after : String?,
+  issue : MarkdownPostCommitIssue,
+) -> MarkdownEditorError {
+  MarkdownEditorError::Committed(
+    evidence=MarkdownCommittedEvidence::{ before, after },
+    issue~,
+  )
+}
+
+///|
+fn markdown_post_commit_issue(
+  issue : @markdown_runtime.PortableCommitIssue,
+) -> MarkdownPostCommitIssue {
+  match issue {
+    @markdown_runtime.PortableCommitIssue::RuntimeFailure(detail~) =>
+      MarkdownPostCommitIssue::RuntimeFailure(detail~)
+    @markdown_runtime.PortableCommitIssue::ProjectionUnavailable =>
+      MarkdownPostCommitIssue::ProjectionUnavailable
+    @markdown_runtime.PortableCommitIssue::ProjectionFailed(..) =>
+      MarkdownPostCommitIssue::ProjectionFailed
+    @markdown_runtime.PortableCommitIssue::UnexpectedTransformCount(count~) =>
+      MarkdownPostCommitIssue::UnexpectedTransformCount(count~)
+  }
+}
+
+///|
+/// Preserve pre-commit failure categories while keeping committed failures out
+/// of the edit-rejection channel.
+fn portable_not_committed_error(
+  issue : @markdown_runtime.PortableCommitIssue,
+) -> Result[
+  (MarkdownCommitResult, @vector.Vector[MarkdownTextTransform]),
+  MarkdownEditorError,
+] raise Failure {
+  match issue {
+    @markdown_runtime.PortableCommitIssue::ProjectionUnavailable =>
+      Err(MarkdownEditorError::ProjectionUnavailable)
+    @markdown_runtime.PortableCommitIssue::RuntimeFailure(detail~) =>
+      raise Failure::Failure(detail)
+    @markdown_runtime.PortableCommitIssue::ProjectionFailed(..) =>
+      Err(
+        MarkdownEditorError::EditFailed(
+          detail="portable Markdown projection failed",
+        ),
+      )
+    @markdown_runtime.PortableCommitIssue::UnexpectedTransformCount(..) =>
+      Err(
+        MarkdownEditorError::EditFailed(
+          detail="unexpected Markdown transform count",
+        ),
+      )
+  }
+}
+
+///|
+fn markdown_text_transform(edit : @core.SpanEdit) -> MarkdownTextTransform {
+  MarkdownTextTransform::{
+    change: @text_change.TextChange::{
+      start: edit.start,
+      delete_len: edit.delete_len,
+      inserted: edit.inserted,
+    },
+  }
+}
+
+///|
+fn project_portable_transform(
+  before : @markdown_runtime.PortableCoordinateMap,
+  edit : @core.SpanEdit,
+  after : @markdown_runtime.PortableCoordinateMap,
+) -> Result[MarkdownTextTransform, MarkdownEditorError] {
+  match before.project_edit(edit, after) {
+    Ok(projected) => Ok(markdown_text_transform(projected))
+    Err(_) =>
+      Err(
+        committed_editor_error(
+          before.source(),
+          Some(after.source()),
+          MarkdownPostCommitIssue::ProjectionFailed,
+        ),
+      )
   }
 }
 
@@ -1204,25 +1504,6 @@ fn structural_edit_error(error : @core.EditError) -> MarkdownEditorError {
       MarkdownEditorError::ProjectionUnavailable
     _ => MarkdownEditorError::EditFailed(detail=error.message())
   }
-}
-
-///|
-/// Mirror SyncEditor's reverse-document-order application as a sequential,
-/// immutable façade value. Local mutation only sorts a private copy used to
-/// build the returned vector.
-fn sequential_text_transforms(
-  edits : Array[@core.SpanEdit],
-) -> @vector.Vector[MarkdownTextTransform] {
-  let ordered = edits.copy()
-  ordered.sort_by((a, b) => b.start.compare(a.start))
-  let transforms = ordered.map(edit => MarkdownTextTransform::{
-    change: @text_change.TextChange::{
-      start: edit.start,
-      delete_len: edit.delete_len,
-      inserted: edit.inserted,
-    },
-  })
-  @vector.Vector(transforms[:])
 }
 
 ///|
@@ -1371,11 +1652,91 @@ fn projection_snapshot(
 fn document_snapshot(
   editor : @editor.SyncEditor[@md_markdown.Block],
 ) -> MarkdownDocumentSnapshot raise Failure {
-  let source = editor.get_text()
-  {
-    source,
+  document_snapshot_with_coordinates(editor).snapshot
+}
+
+///|
+/// Build the detached snapshot and cursor map from the same parser epoch.
+fn document_snapshot_with_coordinates(
+  editor : @editor.SyncEditor[@md_markdown.Block],
+) -> PortableDocumentSnapshot raise Failure {
+  let coordinates = capture_portable_coordinates(editor)
+  document_snapshot_from_coordinates(editor, coordinates)
+}
+
+///|
+fn document_snapshot_from_coordinates(
+  editor : @editor.SyncEditor[@md_markdown.Block],
+  coordinates : @markdown_runtime.PortableCoordinateMap,
+) -> PortableDocumentSnapshot raise Failure {
+  let canonical = editor.get_text()
+  let snapshot = MarkdownDocumentSnapshot::{
+    source: coordinates.source(),
     projection: projection_snapshot(editor),
-    blocks: editable_block_snapshots(editor, source),
+    blocks: editable_block_snapshots(editor, canonical, coordinates),
+  }
+  { snapshot, coordinates }
+}
+
+///|
+fn committed_document_snapshot(
+  editor : @editor.SyncEditor[@md_markdown.Block],
+  before : String,
+  after : String,
+) -> Result[PortableDocumentSnapshot, MarkdownEditorError] {
+  Ok(document_snapshot_with_coordinates(editor)) catch {
+    Failure::Failure(detail) =>
+      Err(
+        committed_editor_error(
+          before,
+          Some(after),
+          MarkdownPostCommitIssue::RuntimeFailure(detail~),
+        ),
+      )
+  }
+}
+
+///|
+fn committed_document_snapshot_from_coordinates(
+  editor : @editor.SyncEditor[@md_markdown.Block],
+  before : String,
+  coordinates : @markdown_runtime.PortableCoordinateMap,
+) -> Result[PortableDocumentSnapshot, MarkdownEditorError] {
+  let after = coordinates.source()
+  Ok(document_snapshot_from_coordinates(editor, coordinates)) catch {
+    Failure::Failure(detail) =>
+      Err(
+        committed_editor_error(
+          before,
+          Some(after),
+          MarkdownPostCommitIssue::RuntimeFailure(detail~),
+        ),
+      )
+  }
+}
+
+///|
+fn capture_portable_coordinates(
+  editor : @editor.SyncEditor[@md_markdown.Block],
+) -> @markdown_runtime.PortableCoordinateMap raise Failure {
+  match @markdown_runtime.capture_portable_coordinates(editor) {
+    Ok(coordinates) => coordinates
+    Err(_) =>
+      raise Failure::Failure("Markdown portable snapshot projection failed")
+  }
+}
+
+///|
+fn capture_committed_portable_coordinates(
+  editor : @editor.SyncEditor[@md_markdown.Block],
+  before : String,
+) -> Result[@markdown_runtime.PortableCoordinateMap, MarkdownEditorError] {
+  match @markdown_runtime.capture_portable_coordinates(editor) {
+    Ok(coordinates) => Ok(coordinates)
+    Err(issue) =>
+      Err(
+        committed_editor_error(before, None, markdown_post_commit_issue(issue)),
+      )
   }
 }
 
@@ -1383,6 +1744,7 @@ fn document_snapshot(
 fn editable_block_snapshots(
   editor : @editor.SyncEditor[@md_markdown.Block],
   source : String,
+  coordinates : @markdown_runtime.PortableCoordinateMap,
 ) -> @vector.Vector[MarkdownBlockSnapshot] raise Failure {
   match editor.get_proj_node() {
     None => @vector.new()
@@ -1402,6 +1764,7 @@ fn editable_block_snapshots(
                       MarkdownBlockKind::UnorderedListItem,
                       source,
                       source_map,
+                      coordinates,
                     )
                   @md_markdown.OrderedListItem(_, marker) => {
                     guard marker is Some(_) else { continue }
@@ -1418,6 +1781,7 @@ fn editable_block_snapshots(
                       ),
                       source,
                       source_map,
+                      coordinates,
                     )
                   }
                   _ => ()
@@ -1431,6 +1795,7 @@ fn editable_block_snapshots(
               MarkdownBlockKind::Paragraph,
               source,
               source_map,
+              coordinates,
             )
           @md_markdown.Heading(level, _) =>
             append_editable_block_snapshot(
@@ -1439,6 +1804,7 @@ fn editable_block_snapshots(
               MarkdownBlockKind::Heading(level~),
               source,
               source_map,
+              coordinates,
             )
           @md_markdown.CodeBlock(info, _) =>
             append_editable_block_snapshot(
@@ -1447,6 +1813,7 @@ fn editable_block_snapshots(
               MarkdownBlockKind::CodeBlock(info~),
               source,
               source_map,
+              coordinates,
             )
           _ => ()
         }
@@ -1464,7 +1831,8 @@ fn append_editable_block_snapshot(
   kind : MarkdownBlockKind,
   source : String,
   source_map : @core.SourceMap,
-) -> Unit {
+  coordinates : @markdown_runtime.PortableCoordinateMap,
+) -> Unit raise Failure {
   guard source_map.get_range(node.id()) is Some(source_range) else { return }
   let text_span = match source_map.get_token_span(node.id(), "text") {
     Some(span) => span
@@ -1481,21 +1849,75 @@ fn append_editable_block_snapshot(
     (fence_open_range is None || fence_close_range is None) {
     return
   }
+  let (source_start, source_end) = project_snapshot_range(
+    coordinates,
+    source_range.start,
+    source_range.end,
+  )
+  let (text_start, text_end) = project_snapshot_range(
+    coordinates,
+    text_span.start,
+    text_span.end,
+  )
+  let (marker_start, marker_end) = project_optional_snapshot_range(
+    coordinates,
+    marker_range.map(range => range.start),
+    marker_range.map(range => range.end),
+  )
+  let (fence_open_start, fence_open_end) = project_optional_snapshot_range(
+    coordinates,
+    fence_open_range.map(range => range.start),
+    fence_open_range.map(range => range.end),
+  )
+  let (fence_close_start, fence_close_end) = project_optional_snapshot_range(
+    coordinates,
+    fence_close_range.map(range => range.start),
+    fence_close_range.map(range => range.end),
+  )
   blocks.push({
     node_id: { value: node.id() },
     kind,
     text: source[text_span.start:text_span.end].to_owned(),
-    source_start: source_range.start,
-    source_end: source_range.end,
-    text_start: text_span.start,
-    text_end: text_span.end,
-    marker_start: marker_range.map(r => r.start),
-    marker_end: marker_range.map(r => r.end),
-    fence_open_start: fence_open_range.map(r => r.start),
-    fence_open_end: fence_open_range.map(r => r.end),
-    fence_close_start: fence_close_range.map(r => r.start),
-    fence_close_end: fence_close_range.map(r => r.end),
+    source_start,
+    source_end,
+    text_start,
+    text_end,
+    marker_start,
+    marker_end,
+    fence_open_start,
+    fence_open_end,
+    fence_close_start,
+    fence_close_end,
   })
+}
+
+///|
+fn project_snapshot_range(
+  coordinates : @markdown_runtime.PortableCoordinateMap,
+  start : Int,
+  end : Int,
+) -> (Int, Int) raise Failure {
+  match coordinates.project_range(start, end) {
+    Ok(projected) => projected
+    Err(_) =>
+      raise Failure::Failure("Markdown snapshot range projection failed")
+  }
+}
+
+///|
+fn project_optional_snapshot_range(
+  coordinates : @markdown_runtime.PortableCoordinateMap,
+  start : Int?,
+  end : Int?,
+) -> (Int?, Int?) raise Failure {
+  match (start, end) {
+    (None, None) => (None, None)
+    (Some(start), Some(end)) => {
+      let (start, end) = project_snapshot_range(coordinates, start, end)
+      (Some(start), Some(end))
+    }
+    _ => raise Failure::Failure("Markdown snapshot range roles disagreed")
+  }
 }
 
 ///|

--- a/modules/canopy/editor/markdown/markdown_editor_commit_phase_benchmark_wbtest.mbt
+++ b/modules/canopy/editor/markdown/markdown_editor_commit_phase_benchmark_wbtest.mbt
@@ -18,6 +18,17 @@ fn commit_phase_source(block_count : Int) -> String {
 }
 
 ///|
+fn commit_phase_sentinel_dense_source(block_count : Int) -> String {
+  Array::makei(block_count, index => {
+    if index % 2 == 0 {
+      "\u{200B}\n"
+    } else {
+      "Paragraph 😀 " + index.to_string() + " keeps A\u{200B}B visible.\n"
+    }
+  }).join("\n")
+}
+
+///|
 fn commit_phase_variant(source : String, tick : Int) -> String {
   let suffix = if tick % 2 == 0 { "x" } else { "" }
   source + suffix
@@ -171,6 +182,56 @@ test "perf: MarkdownEditor commit with receipt (250 blocks)" (b : @bench.T) {
     }
     tick += 1
     b.keep(result)
+  })
+}
+
+///|
+test "perf: MarkdownEditor structural receipt (250 blocks)" (b : @bench.T) {
+  let editor = commit_phase_editor(commit_phase_source(250))
+  let heading = editor.snapshot().blocks().to_array()[0].node_id()
+  let mut changed = false
+  b.bench(() => {
+    let new_text = if changed { "Heading 0 changed" } else { "Heading 0" }
+    let receipt = editor.commit_with_receipt(
+      MarkdownEditRequest::CommitEdit(node_id=heading, new_text~),
+    ) catch {
+      error => abort("structural receipt benchmark raised: \{error}")
+    }
+    changed = !changed
+    match receipt {
+      Ok(receipt) => b.keep(receipt)
+      Err(_) => abort("structural receipt benchmark failed")
+    }
+  })
+}
+
+///|
+test "perf: sentinel-dense structural receipt (250 blocks)" (b : @bench.T) {
+  let editor = commit_phase_editor(commit_phase_sentinel_dense_source(250))
+  let blocks = editor.snapshot().blocks().to_array()
+  let paragraph = blocks[blocks.length() - 1].node_id()
+  let original = "Paragraph 😀 249 keeps A\u{200B}B visible."
+  let changed_text = "Paragraph 😀 249 changed A\u{200B}B visibly."
+  match
+    editor.commit(
+      MarkdownEditRequest::CommitEdit(node_id=paragraph, new_text=changed_text),
+    ) {
+    Ok(result) => b.keep(result)
+    Err(_) => abort("sentinel-dense structural receipt prime failed")
+  }
+  let mut changed = true
+  b.bench(() => {
+    let new_text = if changed { original } else { changed_text }
+    let receipt = editor.commit_with_receipt(
+      MarkdownEditRequest::CommitEdit(node_id=paragraph, new_text~),
+    ) catch {
+      error => abort("sentinel-dense structural receipt raised: \{error}")
+    }
+    changed = !changed
+    match receipt {
+      Ok(receipt) => b.keep(receipt)
+      Err(_) => abort("sentinel-dense structural receipt failed")
+    }
   })
 }
 

--- a/modules/canopy/editor/markdown/markdown_editor_wbtest.mbt
+++ b/modules/canopy/editor/markdown/markdown_editor_wbtest.mbt
@@ -328,6 +328,81 @@ test "source-changing receipt carries history and a UTF-16 transform" {
 }
 
 ///|
+test "source replacement receipt transforms the portable before source" {
+  let editor = try! MarkdownEditor(
+    agent_id="portable-receipt-replace-source",
+    source="Hello\n",
+  )
+  let first = editor.snapshot().blocks().to_array()[0]
+  guard editor.commit(
+      MarkdownEditRequest::SplitBlock(node_id=first.node_id(), offset=0),
+    )
+    is Ok(_) else {
+    fail("expected block-start split to apply")
+  }
+  let before = editor.snapshot().source()
+  let receipt = match
+    (try! editor.commit_with_receipt(
+      MarkdownEditRequest::ReplaceSource("\n\nChanged\n"),
+    )) {
+    Ok(receipt) => receipt
+    Err(_) => fail("expected portable replacement receipt")
+  }
+  let snapshot = match receipt.result() {
+    MarkdownCommitResult::Applied(snapshot, None) => snapshot
+    _ => fail("expected applied source replacement")
+  }
+  let transforms = receipt.transforms().to_array()
+  guard transforms is [transform] else {
+    fail("expected one portable replacement transform")
+  }
+  let after = before[:transform.start()].to_owned() +
+    transform.inserted() +
+    before[transform.start() + transform.delete_len():].to_owned()
+  assert_eq(before, "\n\nHello\n")
+  assert_eq(snapshot.source(), "\n\nChanged\n")
+  assert_eq(after, snapshot.source())
+  assert_false(transform.inserted().contains("\u200B".view()))
+}
+
+///|
+test "exact text receipt projects canonical edit after a hidden block" {
+  let editor = try! MarkdownEditor(
+    agent_id="portable-receipt-replace-text",
+    source="Hello\n",
+  )
+  let first = editor.snapshot().blocks().to_array()[0]
+  guard editor.commit(
+      MarkdownEditRequest::SplitBlock(node_id=first.node_id(), offset=0),
+    )
+    is Ok(_) else {
+    fail("expected block-start split to apply")
+  }
+  let before = editor.snapshot().source()
+  let receipt = match
+    (try! editor.commit_with_receipt(
+      MarkdownEditRequest::ReplaceText(start=3, delete_len=1, inserted="J"),
+    )) {
+    Ok(receipt) => receipt
+    Err(_) => fail("expected exact text receipt")
+  }
+  let snapshot = match receipt.result() {
+    MarkdownCommitResult::Applied(snapshot, None) => snapshot
+    _ => fail("expected applied exact text edit")
+  }
+  let transforms = receipt.transforms().to_array()
+  guard transforms is [transform] else {
+    fail("expected one portable exact-text transform")
+  }
+  let after = before[:transform.start()].to_owned() +
+    transform.inserted() +
+    before[transform.start() + transform.delete_len():].to_owned()
+  assert_eq(transform.start(), 2)
+  assert_eq(snapshot.source(), "\n\nJello\n")
+  assert_eq(after, snapshot.source())
+}
+
+///|
 test "headless facade reports unchanged source atomically" {
   let editor = try! MarkdownEditor(agent_id="unchanged", source="before")
   let before = editor.snapshot()
@@ -370,7 +445,11 @@ test "headless facade preserves caller-owned ZWSP in exact source" {
   let source = "Hello\u200Bworld\n"
   let editor = try! MarkdownEditor(agent_id="zwsp", source~)
 
-  assert_eq(editor.snapshot().source(), source)
+  let snapshot = editor.snapshot()
+  assert_eq(snapshot.source(), source)
+  let block = snapshot.blocks().to_array()[0]
+  assert_eq(block.source_range(), (0, 12))
+  assert_eq(block.text_range(), (0, 11))
   let result = editor.commit(MarkdownEditRequest::ReplaceSource(source))
   match result {
     Ok(MarkdownCommitResult::Unchanged(snapshot)) =>
@@ -554,6 +633,22 @@ test "snapshot exposes editable heading payload and source spans" {
   assert_eq(blocks[0].source_range(), (0, 8))
   assert_eq(blocks[0].text_range(), (2, 7))
   assert_eq(blocks[0].marker_range(), Some((0, 2)))
+}
+
+///|
+test "snapshot marker ranges shift past a hidden empty block" {
+  let editor = try! MarkdownEditor(
+    agent_id="portable-marker-after-empty",
+    source="\u200B\n\n# Title\n",
+  )
+  let snapshot = editor.snapshot()
+  let blocks = snapshot.blocks().to_array()
+  assert_eq(snapshot.source(), "\n\n# Title\n")
+  assert_eq(blocks.length(), 2)
+  assert_eq(blocks[0].text_range(), (0, 0))
+  assert_eq(blocks[1].source_range(), (2, 10))
+  assert_eq(blocks[1].marker_range(), Some((2, 4)))
+  assert_eq(blocks[1].text_range(), (4, 9))
 }
 
 ///|
@@ -742,6 +837,73 @@ test "typed block receipt carries the lowered transform and selection" {
 }
 
 ///|
+test "source-equal structural receipt retains causal transform evidence" {
+  let editor = try! MarkdownEditor(
+    agent_id="portable-receipt-source-equal",
+    source="Same\n",
+  )
+  let block = editor.snapshot().blocks().to_array()[0]
+  let before_version = editor.version()
+  let receipt = match
+    (try! editor.commit_with_receipt(
+      MarkdownEditRequest::CommitEdit(node_id=block.node_id(), new_text="Same"),
+    )) {
+    Ok(receipt) => receipt
+    Err(_) => fail("expected source-equal structural receipt")
+  }
+  match receipt.result() {
+    MarkdownCommitResult::Unchanged(snapshot) =>
+      assert_eq(snapshot.source(), "Same\n")
+    _ => fail("expected source-oriented unchanged result")
+  }
+  assert_false(receipt.after_version() == before_version)
+  assert_true(receipt.history() is Some(_))
+  let transforms = receipt.transforms().to_array()
+  guard transforms is [transform] else {
+    fail("expected one source-equal accepted transform")
+  }
+  let before = "Same\n"
+  let after = before[:transform.start()].to_owned() +
+    transform.inserted() +
+    before[transform.start() + transform.delete_len():].to_owned()
+  assert_eq(after, before)
+}
+
+///|
+test "structural receipt transform targets the portable snapshot source" {
+  let editor = try! MarkdownEditor(
+    agent_id="portable-receipt-empty-block",
+    source="Hello\n",
+  )
+  let first = editor.snapshot().blocks().to_array()[0]
+  let receipt = match
+    (try! editor.commit_with_receipt(
+      MarkdownEditRequest::SplitBlock(node_id=first.node_id(), offset=0),
+    )) {
+    Ok(receipt) => receipt
+    Err(_) => fail("expected portable split receipt")
+  }
+  let snapshot = match receipt.result() {
+    MarkdownCommitResult::Applied(snapshot, Some(selection)) => {
+      assert_eq(selection.offset(), 0)
+      snapshot
+    }
+    _ => fail("expected applied portable split")
+  }
+  let transforms = receipt.transforms().to_array()
+  guard transforms is [transform] else {
+    fail("expected one portable transform")
+  }
+  let before = "Hello\n"
+  let after = before[:transform.start()].to_owned() +
+    transform.inserted() +
+    before[transform.start() + transform.delete_len():].to_owned()
+  assert_eq(snapshot.source(), "\n\nHello\n")
+  assert_eq(after, snapshot.source())
+  assert_false(transform.inserted().contains("\u200B".view()))
+}
+
+///|
 test "split and merge receipts retain exact sequential lowering transforms" {
   let editor = try! MarkdownEditor(
     agent_id="receipt-block-structure",
@@ -800,27 +962,20 @@ test "split and merge receipts retain exact sequential lowering transforms" {
 }
 
 ///|
-test "receipt transforms use sequential reverse-document order" {
-  let transforms = sequential_text_transforms([
-    @core.SpanEdit::{ start: 1, delete_len: 1, inserted: "X" },
-    @core.SpanEdit::{ start: 4, delete_len: 0, inserted: "!" },
-  ]).to_array()
-
-  assert_eq(transforms.length(), 2)
-  assert_eq(transforms[0].start(), 4)
-  assert_eq(transforms[0].delete_len(), 0)
-  assert_eq(transforms[0].inserted(), "!")
-  assert_eq(transforms[1].start(), 1)
-  assert_eq(transforms[1].delete_len(), 1)
-  assert_eq(transforms[1].inserted(), "X")
-
-  // Every coordinate is read against the source left by the prior transform.
-  let source = "abcde"
-  let after_first = source[:4].to_owned() + "!" + source[4:].to_owned()
-  let after_second = after_first[:1].to_owned() +
-    "X" +
-    after_first[2:].to_owned()
-  assert_eq(after_second, "aXcd!e")
+test "post-commit error retains portable evidence and typed issue" {
+  let error = committed_editor_error(
+    "Before\n",
+    Some("After\n"),
+    MarkdownPostCommitIssue::ProjectionFailed,
+  )
+  match error {
+    MarkdownEditorError::Committed(evidence~, issue~) => {
+      assert_eq(evidence.before(), "Before\n")
+      assert_eq(evidence.after(), Some("After\n"))
+      assert_eq(issue, MarkdownPostCommitIssue::ProjectionFailed)
+    }
+    _ => fail("expected typed committed evidence")
+  }
 }
 
 ///|
@@ -874,6 +1029,32 @@ test "headless facade lowers supported split and merge requests" {
 }
 
 ///|
+test "snapshot and block ranges share sentinel-free UTF-16 source" {
+  let editor = try! MarkdownEditor(
+    agent_id="portable-snapshot-empty-block",
+    source="Hello\n",
+  )
+  let first = editor.snapshot().blocks().to_array()[0]
+  guard editor.commit(
+      MarkdownEditRequest::SplitBlock(node_id=first.node_id(), offset=0),
+    )
+    is Ok(_) else {
+    fail("expected block-start split to apply")
+  }
+
+  let snapshot = editor.snapshot()
+  let blocks = snapshot.blocks().to_array()
+  assert_eq(snapshot.source(), "\n\nHello\n")
+  assert_eq(blocks.length(), 2)
+  assert_eq(blocks[0].text(), "")
+  assert_eq(blocks[0].source_range(), (0, 1))
+  assert_eq(blocks[0].text_range(), (0, 0))
+  assert_eq(blocks[1].text(), "Hello")
+  assert_eq(blocks[1].source_range(), (2, 8))
+  assert_eq(blocks[1].text_range(), (2, 7))
+}
+
+///|
 test "headless facade splits at block start into an empty previous block" {
   let editor = try! MarkdownEditor(
     agent_id="block-start-split",
@@ -886,10 +1067,7 @@ test "headless facade splits at block start into an empty previous block" {
       MarkdownEditRequest::SplitBlock(node_id=first.node_id(), offset=0),
     ) {
     Ok(MarkdownCommitResult::Applied(snapshot, selection)) => {
-      assert_eq(
-        snapshot.source(),
-        @md_sentinel.EMPTY_PARAGRAPH_SENTINEL + "\n\nHello\n",
-      )
+      assert_eq(snapshot.source(), "\n\nHello\n")
       let blocks = snapshot.blocks().to_array()
       assert_eq(blocks.length(), 2)
       assert_eq(blocks[0].text(), "")
@@ -1029,10 +1207,7 @@ test "merge two split-created empty blocks retains one projectable previous bloc
     ) {
     Ok(MarkdownCommitResult::Applied(snapshot, Some(selection))) => {
       let blocks = snapshot.blocks().to_array()
-      assert_eq(
-        snapshot.source(),
-        @md_sentinel.EMPTY_PARAGRAPH_SENTINEL + "\n\nHello\n",
-      )
+      assert_eq(snapshot.source(), "\n\nHello\n")
       assert_eq(editor.portable_markdown(), "\n\nHello\n")
       assert_eq(blocks.length(), 2)
       assert_eq(blocks[0].text(), "")
@@ -1074,7 +1249,7 @@ test "text-control clear keeps an empty editable block" {
       ),
     ) {
     Ok(MarkdownCommitResult::Applied(snapshot, _)) => {
-      assert_eq(snapshot.source(), @md_sentinel.EMPTY_PARAGRAPH_SENTINEL + "\n")
+      assert_eq(snapshot.source(), "\n")
       let blocks = snapshot.blocks().to_array()
       assert_eq(blocks.length(), 1)
       assert_eq(blocks[0].text(), "")

--- a/modules/canopy/editor/markdown/pkg.generated.mbti
+++ b/modules/canopy/editor/markdown/pkg.generated.mbti
@@ -33,6 +33,7 @@ pub(all) suberror MarkdownEditorError {
   ProjectionUnavailable
   InvalidTextRange(start~ : Int, delete_len~ : Int, source_length~ : Int)
   EditFailed(detail~ : String)
+  Committed(evidence~ : MarkdownCommittedEvidence, issue~ : MarkdownPostCommitIssue)
 }
 
 pub(all) suberror MarkdownHistoryCodecError {
@@ -103,6 +104,12 @@ pub(all) enum MarkdownCommitResult {
   Unchanged(MarkdownDocumentSnapshot)
 } derive(Eq, @debug.Debug)
 
+pub struct MarkdownCommittedEvidence {
+  // private fields
+} derive(Eq, @debug.Debug)
+pub fn MarkdownCommittedEvidence::after(Self) -> String?
+pub fn MarkdownCommittedEvidence::before(Self) -> String
+
 pub struct MarkdownDocumentHistory {
   // private fields
 }
@@ -163,6 +170,13 @@ pub struct MarkdownNodeId {
   // private fields
 } derive(Eq, @debug.Debug)
 pub fn MarkdownNodeId::key(Self) -> String
+
+pub(all) enum MarkdownPostCommitIssue {
+  RuntimeFailure(detail~ : String)
+  ProjectionUnavailable
+  ProjectionFailed
+  UnexpectedTransformCount(count~ : Int)
+} derive(Eq, @debug.Debug)
 
 pub struct MarkdownProjectionSnapshot {
   // private fields

--- a/modules/canopy/internal/markdown_runtime/markdown_runtime.mbt
+++ b/modules/canopy/internal/markdown_runtime/markdown_runtime.mbt
@@ -67,15 +67,6 @@ pub(all) enum PortableCommitOutcome {
 }
 
 ///|
-/// Package-private canonical and projection state used only while completing
-/// one transaction. Hidden ranges and canonical coordinates never escape it.
-priv struct PortableProjectionState {
-  canonical : String
-  portable : String
-  hidden : Array[@loom.Range]
-}
-
-///|
 let plain_language : @lang_runtime.Language[
   @markdown.Block,
   @md_edits.MarkdownEditOp,
@@ -250,9 +241,6 @@ pub fn commit_portable_edit(
     }
     return Ok(PortableCommitOutcome::Committed(evidence~, issue~))
   }
-  if before.canonical == after.canonical {
-    return Ok(PortableCommitOutcome::Unchanged(source=after.portable))
-  }
   let transform = match
     project_markdown_edit(
       before.canonical,
@@ -281,11 +269,11 @@ pub fn commit_portable_edit(
 }
 
 ///|
-/// Capture canonical parser state, but expose only its portable projection to
-/// transaction results. The mutable range array is fresh and package-private.
-fn capture_portable_projection_state(
+/// Capture one immutable coordinate map while keeping canonical source and
+/// hidden sentinel ranges inside the Markdown runtime.
+pub fn capture_portable_coordinates(
   editor : @editor.SyncEditor[@markdown.Block],
-) -> Result[PortableProjectionState, PortableCommitIssue] {
+) -> Result[PortableCoordinateMap, PortableCommitIssue] {
   let canonical = editor.get_text()
   let root = editor.get_proj_node() catch {
     Failure::Failure(detail) =>
@@ -300,11 +288,18 @@ fn capture_portable_projection_state(
   }
   let hidden : Array[@loom.Range] = []
   collect_hidden_sentinel_ranges(root, source_map, hidden)
-  let portable = match project_source(canonical, hidden) {
-    Ok(portable) => portable
-    Err(error) => return Err(PortableCommitIssue::ProjectionFailed(error~))
+  match make_portable_coordinate_map(canonical, hidden) {
+    Ok(coordinates) => Ok(coordinates)
+    Err(error) => Err(PortableCommitIssue::ProjectionFailed(error~))
   }
-  Ok({ canonical, portable, hidden })
+}
+
+///|
+/// Keep the transaction and benchmark capture seam on the same implementation.
+fn capture_portable_projection_state(
+  editor : @editor.SyncEditor[@markdown.Block],
+) -> Result[PortableCoordinateMap, PortableCommitIssue] {
+  capture_portable_coordinates(editor)
 }
 
 ///|

--- a/modules/canopy/internal/markdown_runtime/pkg.generated.mbti
+++ b/modules/canopy/internal/markdown_runtime/pkg.generated.mbti
@@ -12,6 +12,8 @@ import {
 // Values
 pub fn apply_edit(@editor.SyncEditor[@markdown.Block], @edits.MarkdownEditOp, Int) -> Result[Array[@dowdiness/canopy/core.SpanEdit], @dowdiness/canopy/core.EditError] raise Failure
 
+pub fn capture_portable_coordinates(@editor.SyncEditor[@markdown.Block]) -> Result[PortableCoordinateMap, PortableCommitIssue]
+
 pub fn commit_portable_edit(@editor.SyncEditor[@markdown.Block], @edits.MarkdownEditOp, Int) -> Result[PortableCommitOutcome, PortableCommitError]
 
 pub fn export_markdown_text(@editor.SyncEditor[@markdown.Block]) -> String
@@ -59,9 +61,18 @@ pub(all) enum PortableCommitOutcome {
   Committed(evidence~ : PortableCommitEvidence, issue~ : PortableCommitIssue)
 }
 
+pub struct PortableCoordinateMap {
+  // private fields
+} derive(Eq, @debug.Debug)
+pub fn PortableCoordinateMap::project_edit(Self, @dowdiness/canopy/core.SpanEdit, Self) -> Result[@dowdiness/canopy/core.SpanEdit, PortableProjectionError]
+pub fn PortableCoordinateMap::project_offset(Self, Int) -> Result[Int, PortableProjectionError]
+pub fn PortableCoordinateMap::project_range(Self, Int, Int) -> Result[(Int, Int), PortableProjectionError]
+pub fn PortableCoordinateMap::source(Self) -> String
+
 pub enum PortableProjectionError {
   InvalidHiddenRange
   OverlappingHiddenRanges
+  InvalidCoordinateRange
   InvalidEditRange
   CanonicalAfterSourceMismatch
   NonRepresentable

--- a/modules/canopy/internal/markdown_runtime/portable_commit_transaction_benchmark_wbtest.mbt
+++ b/modules/canopy/internal/markdown_runtime/portable_commit_transaction_benchmark_wbtest.mbt
@@ -15,6 +15,17 @@ fn portable_commit_benchmark_source(block_count : Int) -> String {
 }
 
 ///|
+fn portable_commit_sentinel_dense_source(block_count : Int) -> String {
+  Array::makei(block_count, index => {
+    if index % 2 == 0 {
+      "\u{200B}\n"
+    } else {
+      "Paragraph 😀 " + index.to_string() + " keeps A\u{200B}B visible.\n"
+    }
+  }).join("\n")
+}
+
+///|
 test "perf: project source without hidden ranges (250 blocks)" (b : @bench.T) {
   let sources = [
     portable_commit_benchmark_source(250),
@@ -76,6 +87,30 @@ test "perf: capture portable projection state (250 blocks)" (b : @bench.T) {
     )
     tick += 1
     b.keep(state)
+  })
+}
+
+///|
+test "perf: capture sentinel-dense coordinate map (250 blocks)" (b : @bench.T) {
+  let sources = [
+    portable_commit_sentinel_dense_source(250),
+    portable_commit_sentinel_dense_source(250) + "x",
+  ]
+  let editors = [
+    try! new_editor("portable-capture-sentinel-dense-a"),
+    try! new_editor("portable-capture-sentinel-dense-b"),
+  ]
+  editors.eachi((index, editor) => {
+    editor.set_text(sources[index])
+    editor.refresh()
+  })
+  let mut tick = 0
+  b.bench(() => {
+    let coordinates = capture_portable_coordinates(
+      editors[tick % editors.length()],
+    )
+    tick += 1
+    b.keep(coordinates)
   })
 }
 

--- a/modules/canopy/internal/markdown_runtime/portable_commit_transaction_wbtest.mbt
+++ b/modules/canopy/internal/markdown_runtime/portable_commit_transaction_wbtest.mbt
@@ -167,11 +167,16 @@ test "portable commit transaction keeps source equality distinct from history" {
       ),
       0,
     ) {
-    Ok(PortableCommitOutcome::Unchanged(source~)) => {
-      assert_eq(source, "Same\n")
+    Ok(PortableCommitOutcome::Applied(commit)) => {
+      assert_eq(commit.before(), "Same\n")
+      assert_eq(commit.after(), "Same\n")
+      assert_eq(
+        apply_span_edit(commit.before(), commit.transform()),
+        commit.after(),
+      )
       assert_true(editor.get_version() != version_before)
     }
-    _ => fail("expected source-unchanged commit classification")
+    _ => fail("expected committed source-equal transform evidence")
   }
 }
 

--- a/modules/canopy/internal/markdown_runtime/portable_projection.mbt
+++ b/modules/canopy/internal/markdown_runtime/portable_projection.mbt
@@ -3,10 +3,85 @@
 pub enum PortableProjectionError {
   InvalidHiddenRange
   OverlappingHiddenRanges
+  InvalidCoordinateRange
   InvalidEditRange
   CanonicalAfterSourceMismatch
   NonRepresentable
 } derive(Debug, Eq)
+
+///|
+/// An immutable canonical-to-portable coordinate projection. Its canonical
+/// source and private hidden ranges remain inside the Markdown runtime.
+pub struct PortableCoordinateMap {
+  priv canonical : String
+  priv portable : String
+  priv hidden : Array[@loom.Range]
+} derive(Debug, Eq)
+
+///|
+pub fn PortableCoordinateMap::source(self : Self) -> String {
+  self.portable
+}
+
+///|
+/// Collapse one canonical UTF-16 offset onto its sentinel-free position.
+pub fn PortableCoordinateMap::project_offset(
+  self : Self,
+  offset : Int,
+) -> Result[Int, PortableProjectionError] {
+  if offset < 0 || offset > self.canonical.length() {
+    return Err(PortableProjectionError::InvalidCoordinateRange)
+  }
+  Ok(offset - hidden_width(self.hidden, 0, offset))
+}
+
+///|
+/// Project one canonical half-open UTF-16 range without exposing hidden spans.
+pub fn PortableCoordinateMap::project_range(
+  self : Self,
+  start : Int,
+  end : Int,
+) -> Result[(Int, Int), PortableProjectionError] {
+  if start < 0 || end < start || end > self.canonical.length() {
+    return Err(PortableProjectionError::InvalidCoordinateRange)
+  }
+  Ok(
+    (
+      start - hidden_width(self.hidden, 0, start),
+      end - hidden_width(self.hidden, 0, end),
+    ),
+  )
+}
+
+///|
+/// Project one accepted canonical edit between two validated coordinate maps.
+pub fn PortableCoordinateMap::project_edit(
+  self : Self,
+  edit : @core.SpanEdit,
+  after : PortableCoordinateMap,
+) -> Result[@core.SpanEdit, PortableProjectionError] {
+  project_markdown_edit(
+    self.canonical,
+    self.hidden,
+    edit,
+    after.canonical,
+    after.hidden,
+  )
+}
+
+///|
+/// Validate and own one coordinate map without retaining caller-owned arrays.
+fn make_portable_coordinate_map(
+  canonical : String,
+  hidden : ArrayView[@loom.Range],
+) -> Result[PortableCoordinateMap, PortableProjectionError] {
+  let hidden = match normalize_hidden_ranges(canonical, hidden) {
+    Ok(ranges) => ranges
+    Err(error) => return Err(error)
+  }
+  let portable = project_normalized_source(canonical, hidden)
+  Ok({ canonical, portable, hidden })
+}
 
 ///|
 /// Project canonical source text by removing the supplied private ranges.

--- a/modules/canopy/internal/markdown_runtime/portable_projection_wbtest.mbt
+++ b/modules/canopy/internal/markdown_runtime/portable_projection_wbtest.mbt
@@ -252,6 +252,41 @@ test "edit projection rejects a valid but non-representable metadata transition"
 }
 
 ///|
+test "coordinate map collapses only validated hidden UTF-16 ranges" {
+  let coordinates = make_portable_coordinate_map("😀\u{200B}A\u{200B}B", [
+    @loom.Range::new(2, 3),
+  ]).unwrap()
+  assert_eq(coordinates.source(), "😀A\u{200B}B")
+  assert_eq(coordinates.project_offset(0), Ok(0))
+  assert_eq(coordinates.project_offset(2), Ok(2))
+  assert_eq(coordinates.project_offset(3), Ok(2))
+  assert_eq(coordinates.project_offset(6), Ok(5))
+  assert_eq(coordinates.project_range(2, 3), Ok((2, 2)))
+  assert_eq(coordinates.project_range(0, 6), Ok((0, 5)))
+}
+
+///|
+test "coordinate map rejects invalid canonical offsets and ranges" {
+  let coordinates = make_portable_coordinate_map("abc", []).unwrap()
+  assert_eq(
+    coordinates.project_offset(-1),
+    Err(PortableProjectionError::InvalidCoordinateRange),
+  )
+  assert_eq(
+    coordinates.project_offset(4),
+    Err(PortableProjectionError::InvalidCoordinateRange),
+  )
+  assert_eq(
+    coordinates.project_range(2, 1),
+    Err(PortableProjectionError::InvalidCoordinateRange),
+  )
+  assert_eq(
+    coordinates.project_range(0, 4),
+    Err(PortableProjectionError::InvalidCoordinateRange),
+  )
+}
+
+///|
 fn expect_source_error(
   result : Result[String, PortableProjectionError],
   expected : PortableProjectionError,


### PR DESCRIPTION
## Summary

- make Markdown document snapshots, block ranges, selections, and receipt transforms share one sentinel-free UTF-16 coordinate space
- route structural edits through the authoritative portable commit transaction and project raw accepted edits without re-diffing
- preserve typed causal evidence when receipt construction is interrupted after mutation, and route committed interruptions through Loomark recovery rather than edit rejection
- document the coordinate migration and the legacy canonical-coordinate `ReplaceText` exception

## UI and review evidence

No visual design changes. Browser behavior was validated through the existing Loomark development-host and standalone suites.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `commit_portable_edit` | `modules/canopy/internal/markdown_runtime/markdown_runtime.mbt` | Yes | Applies one accepted Markdown structural edit exactly once and retains causal/post-commit classification. |
| `project_markdown_edit` | `modules/canopy/internal/markdown_runtime/portable_projection.mbt` | Yes | Projects the exact accepted canonical edit and verifies it against portable before/after sources. |
| sentinel range collector | `modules/canopy/internal/markdown_runtime/markdown_runtime.mbt` | Yes | Removes only projection-confirmed structural empty-paragraph sentinels. |
| `SourceMap` token/range APIs | `modules/canopy/core/source_map.mbt` | Yes | Supplies canonical block roles before opaque coordinate projection. |
| `SyncEditor::get_version` | `modules/canopy/editor/` | Yes | Distinguishes pre-mutation failure from an interruption after causal advancement. |
| `ArrayView::map` / `Array::fold` | MoonBit core | Yes | Copies caller ranges and computes hidden interval widths without exposing mutable arrays. |
| `String` UTF-16 length/slicing / `StringBuilder` | MoonBit core | Yes | Preserves JavaScript/DOM-compatible UTF-16 source coordinates. |
| `Option` / `Result` | MoonBit core | Yes | Models optional after evidence and typed projection/commit outcomes. |
| `Map` / `Set` | MoonBit core | No | Coordinate projection has no keyed lookup or membership requirement. |
| `Bytes` / `BytesView` | MoonBit core | No | The public contract is UTF-16 source coordinates, not byte coordinates. |
| `compute_text_change` for receipts | `dowdiness/text_change` | No | Re-diffing would discard provenance from the accepted CRDT/structural edit. Existing text-control reconciliation remains unchanged. |

New responsibility boundaries:

- opaque `PortableCoordinateMap`: owns canonical source and hidden ranges inside `internal/markdown_runtime`; exposes only portable source and projected offsets/ranges/accepted edits
- `MarkdownCommittedEvidence` / `MarkdownPostCommitIssue`: preserve sentinel-free evidence when mutation landed but receipt projection could not complete
- private snapshot/coordinate pairing in `editor/markdown`: builds ranges and selection from one portable coordinate epoch

Remaining mutation is limited to the editor application/refresh shell, fresh hidden-range collection, Loomark recovery-session replacement, and benchmark counters.

## Validation scope

Boundary matrix / TDD evidence:

- first RED reproduced sentinel leakage in `MarkdownDocumentSnapshot::source()` after a block-start split
- empty paragraph text ranges collapse to zero width while following block/marker ranges shift correctly
- caller-authored inline ZWSP remains visible and retains UTF-16 width
- non-BMP text and LF/CRLF/CR/EOF remain exact
- structural and raw accepted transforms apply to the portable before source and yield the receipt snapshot source
- source-equal accepted edits remain public `Unchanged` without selection, while version/history advance and one accepted transform is retained
- delete selection, move identity/order, split/merge selection, and directed Raw selection remain coherent
- post-mutation Failure, projection capture, snapshot, cursor, and transform interruption produce typed `Committed` evidence rather than rejection
- Loomark passes typed committed interruptions to the accepted-document reconstruction shell without retrying the edit
- only projection-confirmed structural sentinels collapse; user ZWSP remains

Target packages:

- `modules/canopy/internal/markdown_runtime`
- `modules/canopy/editor/markdown`
- `apps/loomark/internal/rabbita`

Additional gates:

- targeted release tests: runtime 29/29, editor 77/77, Loomark Rabbita 61/61
- full workspace: 4541 wasm-gc + 2631 JS + 70 native passed
- Loomark Dev Host Playwright: 89/89
- Loomark Standalone Playwright: 12/12
- JavaScript build and both Loomark TypeScript checks passed
- independent MoonBit and API-boundary reviews passed after resolving findings and after syncing `origin/main` / #1206
- no proof or submodule-pointer changes

250-block release benchmarks:

- regular structural receipt: 72.49 ms ± 2.05 ms
- regular structural commit without receipt: 70.42 ms ± 3.37 ms
- sentinel-dense coordinate-map capture: 22.09 µs ± 3.81 µs
- sentinel-dense structural receipt: 19.12 ms ± 1.64 ms (simpler alternating grammar workload; not compared directly with the regular workload)

Intentional interface changes:

- `modules/canopy/internal/markdown_runtime/pkg.generated.mbti`: opaque coordinate map/capture API and `InvalidCoordinateRange`
- `modules/canopy/editor/markdown/pkg.generated.mbti`: typed committed evidence and post-commit issue
- FFI JSON shapes and existing FFI error strings are unchanged

Migration note: `modules/canopy/editor/README.md` documents portable output coordinates, retry rules, lossy source import, and the legacy canonical-coordinate `ReplaceText` exception.

## PR-ready evidence

Validated HEAD: `8536ce54b24679c228c3c670a0ddf982c60c6516`

Validated base: `origin/main@d3be656573dba6081429cf17e19479e5e2b349cd`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh \
  --target modules/canopy/internal/markdown_runtime
./scripts/validate-pr-ready.sh \
  --target modules/canopy/editor/markdown
./scripts/validate-pr-ready.sh \
  --target apps/loomark/internal/rabbita
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for every affected MoonBit package on the exact HEAD and base above.
- [x] The base was fetched again and `--verify-evidence` passed immediately before this PR was opened.
- [x] The committed `.mbti` diff against the validated base was reviewed; only the two intentional interfaces changed.
- [x] No submodule pointer changed.
- [x] Validation and independent review were repeated after the base moved.
- [x] Independent review findings were resolved before final validation.
