### PR TITLE
test(markdown): cover post-commit parser failure

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,6 +7,7 @@ modules/canopy/probe/diagnostic_portability/pkg.generated.mbti whitespace=-blank
 # MoonBit owns these generated interfaces and emits a final blank line.
 modules/canopy/editor/markdown/pkg.generated.mbti whitespace=-blank-at-eof
 modules/canopy/internal/markdown_runtime/pkg.generated.mbti whitespace=-blank-at-eof
+modules/canopy/internal/markdown_runtime/testing/pkg.generated.mbti whitespace=-blank-at-eof
 apps/loomark/archive/pkg.generated.mbti whitespace=-blank-at-eof
 apps/loomark/core/pkg.generated.mbti whitespace=-blank-at-eof
 apps/loomark/internal/dev_host/pkg.generated.mbti whitespace=-blank-at-eof

--- a/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
+++ b/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
@@ -261,6 +261,7 @@ test("post-acceptance parser Failure reopens once and resumes Raw editing", asyn
     await expect.poll(async () => (await snapshot(host.page)).mode).toBe("raw")
     await expect.poll(async () => (await snapshot(host.page)).error_code).toBe("editor-recovered")
     await expect.poll(async () => (await snapshot(host.page)).parser_failure_armed).toBe(false)
+    await expect.poll(async () => (await snapshot(host.page)).reconstruction_attempt_count).toBe(1)
     await expect.poll(async () => (await snapshot(host.page)).committed_change_count).toBe(1)
     await expect(host.page.locator("#loomark-input")).toHaveValue("# Accepted\n")
     await expect(host.page.locator("#loomark-preview")).toHaveCount(0)

--- a/apps/loomark/internal/rabbita/commit_classification_wbtest.mbt
+++ b/apps/loomark/internal/rabbita/commit_classification_wbtest.mbt
@@ -96,6 +96,40 @@ test "source-preserving commit still advances the frontier exactly once" {
 }
 
 ///|
+test "recovery reopens the exact accepted history once without replay" {
+  let (editor, attachment) = try! @markdown.MarkdownEditor::with_semantic_attachment(
+    agent_id="recovery-original-writer",
+    source="# Before\n",
+  )
+  let model = test_model(editor.snapshot(), editor.version())
+  let receipt = match
+    (try! editor.commit_with_receipt(
+      @markdown.MarkdownEditRequest::ReplaceSource("# Accepted\n"),
+    )) {
+    Ok(receipt) => receipt
+    Err(_) => abort("expected accepted receipt")
+  }
+  let (accepted, did_commit, changed) = classify_commit(model, receipt)
+  assert_true(did_commit)
+  assert_true(changed)
+  let accepted_history = try! editor.history_since()
+  let session = @ref.Ref(EditorSession::{ editor, attachment })
+  let emit : @cmd.Emit[DriverEvent] = @cmd.Emit(_ => @rabbita_runtime.none)
+
+  let (recovered, _) = recover_after_parser_failure(
+    session,
+    accepted,
+    Failure::Failure("injected post-commit failure"),
+    emit,
+  )
+
+  assert_eq(recovered.reconstruction_attempt_count, 1)
+  assert_eq(recovered.committed_change_count, accepted.committed_change_count)
+  assert_eq(session.val.editor.portable_markdown(), "# Accepted\n")
+  assert_true(try! (session.val.editor.history_since() == accepted_history))
+}
+
+///|
 test "classification preserves unrelated model fields" {
   let editor = try! @markdown.MarkdownEditor(
     agent_id="agent-a",

--- a/modules/canopy/editor/markdown/markdown_editor_wbtest.mbt
+++ b/modules/canopy/editor/markdown/markdown_editor_wbtest.mbt
@@ -31,6 +31,14 @@ fn fresh_markdown_ir(source : String) -> @md_markdown.MarkdownIR raise {
 }
 
 ///|
+fn new_post_commit_failure_test_editor(
+  agent_id : String,
+) -> MarkdownEditor raise {
+  let editor = @markdown_runtime_testing.new_parser_failure_editor(agent_id)
+  { editor, }
+}
+
+///|
 test "Markdown document UTF-16 selection preserves direction and range" {
   let editor = try! MarkdownEditor(
     agent_id="document-selection-direction",
@@ -976,6 +984,49 @@ test "post-commit error retains portable evidence and typed issue" {
     }
     _ => fail("expected typed committed evidence")
   }
+}
+
+///|
+test "commit receipt reports an accepted parser failure without replay" {
+  let editor = try! new_post_commit_failure_test_editor(
+    "post-commit-failure-agent",
+  )
+  let before_version = editor.version()
+  let first : Result[Result[MarkdownCommitReceipt, MarkdownEditorError], Error] = Ok(
+    editor.commit_with_receipt(MarkdownEditRequest::ReplaceSource("Accepted\n")),
+  ) catch {
+    error => Err(error)
+  }
+
+  match first {
+    Ok(Err(MarkdownEditorError::Committed(evidence~, issue~))) => {
+      assert_eq(evidence.before(), "")
+      assert_eq(evidence.after(), None)
+      match issue {
+        MarkdownPostCommitIssue::RuntimeFailure(detail~) =>
+          assert_true(detail.contains("injected parser publication failure"))
+        _ => fail("expected typed runtime failure")
+      }
+    }
+    _ => fail("expected committed post-mutation failure")
+  }
+  let accepted_version = editor.version()
+  assert_false(accepted_version == before_version)
+  assert_eq(editor.portable_markdown(), "Accepted\n")
+
+  let second : Result[Result[MarkdownCommitReceipt, MarkdownEditorError], Error] = Ok(
+    editor.commit_with_receipt(
+      MarkdownEditRequest::ReplaceSource("Must not land\n"),
+    ),
+  ) catch {
+    error => Err(error)
+  }
+  match second {
+    Err(Failure::Failure(_)) => ()
+    _ => fail("expected terminal parser to reject before another mutation")
+  }
+  assert_eq(editor.version(), accepted_version)
+  assert_eq(editor.portable_markdown(), "Accepted\n")
 }
 
 ///|

--- a/modules/canopy/editor/markdown/moon.pkg
+++ b/modules/canopy/editor/markdown/moon.pkg
@@ -15,6 +15,7 @@ import {
 }
 
 import {
+  "dowdiness/canopy/internal/markdown_runtime/testing" @markdown_runtime_testing,
   "dowdiness/loom",
   "dowdiness/loom/core" @loom_core,
   "moonbitlang/core/bench",

--- a/modules/canopy/internal/markdown_runtime/testing/moon.pkg
+++ b/modules/canopy/internal/markdown_runtime/testing/moon.pkg
@@ -1,0 +1,13 @@
+import {
+  "dowdiness/canopy/editor",
+  "dowdiness/canopy/lang/markdown/proj" @md_proj,
+  "dowdiness/markdown",
+  "dowdiness/loom/core" @loom_core,
+  "dowdiness/loom/incremental" @loom_incremental,
+  "dowdiness/loom/pipeline" @loom_pipeline,
+  "dowdiness/seam",
+}
+
+options(
+  is_main: false,
+)

--- a/modules/canopy/internal/markdown_runtime/testing/parser_failure_editor.mbt
+++ b/modules/canopy/internal/markdown_runtime/testing/parser_failure_editor.mbt
@@ -1,0 +1,39 @@
+///|
+/// Build a Markdown editor whose initial empty projection is valid, then fail
+/// its first incremental parser publication after the text engine accepts it.
+/// Production Markdown construction never imports this test-support package.
+pub fn new_parser_failure_editor(
+  agent_id : String,
+) -> @editor.SyncEditor[@markdown.Block] raise {
+  let full_parse = fn(
+    _source_id : @loom_core.SourceId,
+    _source : String,
+  ) raise Failure {
+    let cst = @seam.CstNode::new_unclassified(
+      @seam.ToRawKind::to_raw(@markdown.SyntaxKind::DocumentNode),
+      [],
+    )
+    (@seam.SyntaxNode::from_cst(cst), @loom_core.DiagnosticSet::empty(), 0)
+  }
+  let language = @loom_incremental.ImperativeLanguage::new(
+    full_parse~,
+    incremental_parse=fn(_source_id, _source, _old, _edit) raise Failure {
+      fail("injected parser publication failure")
+    },
+    to_ast=_syntax => @markdown.Block::Document([]),
+  )
+  let (editor, _) = @editor.SyncEditor::new_with_builder(
+    agent_id,
+    (source_id, source, runtime) => {
+      @loom_pipeline.Parser::new(source_id, source, language, runtime?)
+    },
+    (parser, identity_hints) => {
+      let memos = @md_proj.build_markdown_projection_memos(
+        parser,
+        identity_hints~,
+      )
+      (memos.0, memos.1, memos.2, @editor.LanguageCapabilities::default(), ())
+    },
+  )
+  editor
+}

--- a/modules/canopy/internal/markdown_runtime/testing/pkg.generated.mbti
+++ b/modules/canopy/internal/markdown_runtime/testing/pkg.generated.mbti
@@ -1,0 +1,19 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "dowdiness/canopy/internal/markdown_runtime/testing"
+
+import {
+  "dowdiness/canopy/editor",
+  "dowdiness/markdown",
+}
+
+// Values
+pub fn new_parser_failure_editor(String) -> @editor.SyncEditor[@markdown.Block] raise
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+


### PR DESCRIPTION
## Summary

- drive a real `MarkdownEditor::commit_with_receipt` through a parser-publication failure after the text engine accepts the mutation
- prove the first call returns typed `Committed` evidence and a terminal retry cannot mutate source or version again
- prove Loomark recovery reconstructs once from the exact accepted history without replaying the edit
- keep failure injection out of production Markdown construction and preserve dependency Rule G through a dedicated internal test-support package

## UI and review evidence

No visual or production behavior changes. The existing Loomark development-host recovery scenario now also asserts exactly one reconstruction attempt.

## Reuse check

| API | Location | Reused? | Purpose |
|-----|----------|---------|---------|
| `SyncEditor::new_with_builder` | `modules/canopy/editor` | Yes | Builds the deterministic parser-failure fixture without changing production constructors. |
| `ImperativeLanguage::new` | `deps/loom/loom/incremental` | Yes | Publishes one healthy empty parse, then injects an incremental publication failure. |
| `Parser::new` | `deps/loom/loom/pipeline` | Yes | Wraps the custom language in Loom's actual parser lifecycle. |
| `build_markdown_projection_memos` | `modules/canopy/lang/markdown/proj` | Yes | Gives the fixture the real Markdown projection/source-map pipeline. |
| `MarkdownEditor::commit_with_receipt` | `modules/canopy/editor/markdown` | Yes | Public seam under test. |
| `recover_after_parser_failure` | `apps/loomark/internal/rabbita` | Yes | Reopens the accepted archive once without resetting or retrying the failed editor. |
| `history_since` | `modules/canopy/editor/markdown` | Yes | Compares complete accepted and reopened histories, not only equal source text. |
| `workspace/probe::new_parser_failure_test_editor` | `modules/canopy/workspace/probe` | No | It is intentionally `TestExpr`-specific and cannot provide a Markdown projection/source map. |

MoonBit core reuse: `Result` models raised-vs-returned failure channels and `String` provides exact accepted-source assertions. `Map`, `Set`, `Bytes`, and new collection loops are unnecessary for this parser lifecycle fixture.

New responsibility boundary:

- `modules/canopy/internal/markdown_runtime/testing` owns Markdown-specific parser-failure fixtures; production runtime remains free of failure flags, while `editor/markdown` imports no `lang/*` or grammar package even in wbtests

## TDD and boundary evidence

First RED: the editor integration test referenced a missing post-commit failure fixture.

The final matrix verifies:

| Phase | Contract |
|-------|----------|
| healthy before capture | empty Markdown projection and coordinate map are available |
| mutation accepted, parser publication fails | `Committed(before="", after=None, RuntimeFailure)` |
| accepted state inspection | version advances and portable source is `Accepted\n` |
| terminal retry | fails before mutation; accepted source and version remain unchanged |
| Loomark recovery | reconstruction count advances once and reopened history equals accepted history exactly |
| browser shell | one accepted change and one reconstruction attempt are published |

Post-after-capture projection failures remain covered by the existing runtime transaction tests; this PR adds the missing real public post-mutation/pre-after-capture slice.

## Validation

Affected targets:

- `modules/canopy/internal/markdown_runtime/testing`
- `modules/canopy/editor/markdown`
- `apps/loomark/internal/rabbita`

Results:

- Markdown editor release tests: 78/78
- Loomark Rabbita release tests: 62/62
- Loomark Dev Host Playwright: 89/89
- dependency rules: 270 packages, no violations
- deny-warn checks, `moon fmt`, `moon info`, JavaScript build, workspace suite/build gates: passed
- independent MoonBit and recovery review: passed after strengthening the no-replay proof with exact history equality
- no submodule pointer changes

Interface scope:

- no external Markdown façade `.mbti` change
- one generated interface for the new internal test-support package
- no production failure switch or public lifecycle/API change

## PR-ready evidence

Validated HEAD: `ad0a2830d38537453b0e602db9529328e35c9a4a`

Validated base: `origin/main@d9ecfc740c4a2ed06b94ecff0add5ca35a6ca69e`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh \
  --target modules/canopy/internal/markdown_runtime/testing
./scripts/validate-pr-ready.sh \
  --target modules/canopy/editor/markdown
./scripts/validate-pr-ready.sh \
  --target apps/loomark/internal/rabbita
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] Full validation passed for every affected MoonBit package on the exact HEAD and base above.
- [x] The base was fetched again and `--verify-evidence` passed immediately before opening.
- [x] Generated interface output was reviewed; only the internal test-support package is new.
- [x] No submodule pointer changed.
- [x] Independent review findings were resolved before final validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery handling when parser publication fails after a committed edit.
  * Ensured accepted document history and source content remain unchanged without replaying commits.
  * Editors now enter a terminal state with clear committed-error feedback after unrecoverable failures.

* **Tests**
  * Added coverage for single-attempt parser recovery and post-commit failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->