### PR TITLE
feat(loomark): pair pre-input Raw selections

### DIFF
--- a/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
+++ b/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Browser, type BrowserContext, type Page } from "@playwright/test"
+import { expect, test, type Browser, type BrowserContext, type Locator, type Page } from "@playwright/test"
 
 /**
  * #1075 behavioral boundary matrix (each row gets a fresh BrowserContext,
@@ -71,6 +71,61 @@ async function rawInput(page: Page, source: string): Promise<void> {
     const target = document.getElementById("loomark-driver-target")
     target?.dispatchEvent(new CustomEvent("loomark-driver", { detail: `raw-input|${source}` }))
   }, source)
+}
+
+type RawNativeEdit = {
+  value: string
+  beforeStart: number
+  beforeEnd: number
+  beforeDirection?: "forward" | "backward" | "none"
+  afterStart: number
+  afterEnd: number
+  afterDirection?: "forward" | "backward" | "none"
+  inputType?: string
+  data?: string | null
+  isComposing?: boolean
+}
+
+async function dispatchRawNativeEdits(input: Locator, edits: RawNativeEdit[]): Promise<void> {
+  await input.evaluate((element, edits) => {
+    const textarea = element as HTMLTextAreaElement
+    for (const edit of edits) {
+      const init: InputEventInit = {
+        bubbles: true,
+        cancelable: true,
+        inputType: edit.inputType ?? "insertText",
+        data: edit.data ?? null,
+        isComposing: edit.isComposing ?? false,
+      }
+      textarea.setSelectionRange(
+        edit.beforeStart,
+        edit.beforeEnd,
+        edit.beforeDirection ?? "none",
+      )
+      textarea.dispatchEvent(new InputEvent("beforeinput", init))
+      textarea.value = edit.value
+      textarea.setSelectionRange(
+        edit.afterStart,
+        edit.afterEnd,
+        edit.afterDirection ?? "none",
+      )
+      textarea.dispatchEvent(new InputEvent("input", init))
+    }
+  }, edits)
+}
+
+async function replaceRawValue(input: Locator, value: string): Promise<void> {
+  const currentLength = await input.evaluate(element =>
+    (element as HTMLTextAreaElement).value.length)
+  await dispatchRawNativeEdits(input, [{
+    value,
+    beforeStart: 0,
+    beforeEnd: currentLength,
+    beforeDirection: "forward",
+    afterStart: value.length,
+    afterEnd: value.length,
+    data: value,
+  }])
 }
 
 async function rawSelectionProbe(page: Page, detail: "capture" | "install"): Promise<void> {
@@ -267,7 +322,7 @@ test("post-acceptance parser Failure reopens once and resumes Raw editing", asyn
     await expect(host.page.locator("#loomark-preview")).toHaveCount(0)
     await expect(host.page.locator("#loomark-block")).toHaveCount(0)
 
-    await host.page.locator("#loomark-input").fill("# Continued\n")
+    await replaceRawValue(host.page.locator("#loomark-input"), "# Continued\n")
     await expect.poll(async () => (await snapshot(host.page)).source).toBe("# Continued\n")
   } finally {
     await host.context.close()
@@ -335,7 +390,7 @@ test("Raw input exposes phase timings through the dev-host snapshot", async ({ b
   const host = await mountHost(browser, "before")
   try {
     const input = host.page.locator("#loomark-input")
-    await input.fill("after")
+    await replaceRawValue(input, "after")
     await expect.poll(async () => (await snapshot(host.page)).source).toBe("after")
     await expect.poll(async () => {
       const phase = (await snapshot(host.page)).raw_input_phase
@@ -384,18 +439,14 @@ test("Raw and Preview observe one accepted document in a fixed resizable split",
     await expect(host.page.locator("#loomark-split")).toHaveCount(1)
     await expect.poll(async () => (await snapshot(host.page)).semantic_read_count).toBe(1)
 
-    await host.page.locator("#loomark-input").fill("# After\n")
+    await replaceRawValue(host.page.locator("#loomark-input"), "# After\n")
     await expect.poll(async () => (await snapshot(host.page)).source).toBe("# After\n")
     await expectPreviewSource(host.page, "# After\n")
     await expect.poll(async () => (await snapshot(host.page)).semantic_read_count).toBe(2)
 
     await forceEditorFailure(host.page)
     await expect.poll(async () => (await snapshot(host.page)).editor_failure_armed).toBe(true)
-    await host.page.locator("#loomark-input").evaluate(element => {
-      const textarea = element as HTMLTextAreaElement
-      textarea.value = "# Rejected\n"
-      textarea.dispatchEvent(new Event("input", { bubbles: true }))
-    })
+    await replaceRawValue(host.page.locator("#loomark-input"), "# Rejected\n")
     await expect.poll(async () => (await snapshot(host.page)).error_code).toBe("editor-commit-failed")
     await expect.poll(async () => (await snapshot(host.page)).source).toBe("# After\n")
     await expectPreviewSource(host.page, "# After\n")
@@ -1728,7 +1779,7 @@ test("Raw textarea input uses the atomic editor transaction and mode toolbar", a
       "aria-label",
       "Raw Markdown source",
     )
-    await host.page.locator("#loomark-input").fill("edited\nsource")
+    await replaceRawValue(host.page.locator("#loomark-input"), "edited\nsource")
     await expect.poll(async () => (await snapshot(host.page)).source).toBe("edited\nsource")
     await expect.poll(async () => (await snapshot(host.page)).committed_change_count).toBe(1)
     await selectPreview(host.page)
@@ -1749,7 +1800,7 @@ test("Raw textarea input uses the atomic editor transaction and mode toolbar", a
   }
 })
 
-test("rejected Raw repair round-trips a backward DOM selection", async ({ browser }) => {
+test("failed normalized Raw replacement preserves committed state", async ({ browser }) => {
   const host = await mountHost(browser, "abcdef")
   try {
     const input = host.page.locator("#loomark-input")
@@ -1757,20 +1808,15 @@ test("rejected Raw repair round-trips a backward DOM selection", async ({ browse
     await forceEditorFailure(host.page)
     await expect.poll(async () => (await snapshot(host.page)).editor_failure_armed).toBe(true)
 
-    const eventSelection = await input.evaluate(element => {
-      const textarea = element as HTMLTextAreaElement
-      textarea.value = "abcdef!"
-      textarea.setSelectionRange(0, 5, "backward")
-      const selection = {
-        start: textarea.selectionStart,
-        end: textarea.selectionEnd,
-        direction: textarea.selectionDirection,
-      }
-      textarea.dispatchEvent(new Event("input", { bubbles: true }))
-      return selection
-    })
-
-    expect(eventSelection).toEqual({ start: 0, end: 5, direction: "backward" })
+    await dispatchRawNativeEdits(input, [{
+      value: "!f",
+      beforeStart: 0,
+      beforeEnd: 5,
+      beforeDirection: "backward",
+      afterStart: 1,
+      afterEnd: 1,
+      data: "!",
+    }])
     await expect.poll(async () => (await snapshot(host.page)).error_code)
       .toBe("editor-commit-failed")
     await expect(input).toHaveValue("abcdef")
@@ -1787,7 +1833,7 @@ test("rejected Raw repair round-trips a backward DOM selection", async ({ browse
   }
 })
 
-test("rejected Raw repair maps canonical CRLF to textarea offsets", async ({ browser }) => {
+test("failed normalized Raw input maps canonical CRLF to textarea offsets", async ({ browser }) => {
   const host = await mountHost(browser, "a\r\nb")
   try {
     const input = host.page.locator("#loomark-input")
@@ -1796,12 +1842,14 @@ test("rejected Raw repair maps canonical CRLF to textarea offsets", async ({ bro
     await forceEditorFailure(host.page)
     await expect.poll(async () => (await snapshot(host.page)).editor_failure_armed).toBe(true)
 
-    await input.evaluate(element => {
-      const textarea = element as HTMLTextAreaElement
-      textarea.value = "a\nbx"
-      textarea.setSelectionRange(4, 4, "none")
-      textarea.dispatchEvent(new Event("input", { bubbles: true }))
-    })
+    await dispatchRawNativeEdits(input, [{
+      value: "a\nbx",
+      beforeStart: 3,
+      beforeEnd: 3,
+      afterStart: 4,
+      afterEnd: 4,
+      data: "x",
+    }])
 
     await expect.poll(async () => (await snapshot(host.page)).error_code)
       .toBe("editor-commit-failed")
@@ -1821,7 +1869,7 @@ test("rejected Raw repair maps canonical CRLF to textarea offsets", async ({ bro
   }
 })
 
-test("rejected Raw repair maps canonical lone CR to textarea offsets", async ({ browser }) => {
+test("failed normalized Raw input maps canonical lone CR to textarea offsets", async ({ browser }) => {
   const host = await mountHost(browser, "a\rb")
   try {
     const input = host.page.locator("#loomark-input")
@@ -1830,12 +1878,14 @@ test("rejected Raw repair maps canonical lone CR to textarea offsets", async ({ 
     await forceEditorFailure(host.page)
     await expect.poll(async () => (await snapshot(host.page)).editor_failure_armed).toBe(true)
 
-    await input.evaluate(element => {
-      const textarea = element as HTMLTextAreaElement
-      textarea.value = "a\nbx"
-      textarea.setSelectionRange(4, 4, "none")
-      textarea.dispatchEvent(new Event("input", { bubbles: true }))
-    })
+    await dispatchRawNativeEdits(input, [{
+      value: "a\nbx",
+      beforeStart: 3,
+      beforeEnd: 3,
+      afterStart: 4,
+      afterEnd: 4,
+      data: "x",
+    }])
 
     await expect.poll(async () => (await snapshot(host.page)).error_code)
       .toBe("editor-commit-failed")
@@ -1899,12 +1949,15 @@ test("accepted Raw selection edit supersedes pending full-source input", async (
     await rawSelectionProbe(host.page, "capture")
     await expect.poll(async () => (await snapshot(host.page)).selection).toBe("6:0")
 
-    await input.evaluate(element => {
-      const textarea = element as HTMLTextAreaElement
-      textarea.value = "pending"
-      textarea.setSelectionRange(7, 7, "none")
-      textarea.dispatchEvent(new Event("input", { bubbles: true }))
-    })
+    await dispatchRawNativeEdits(input, [{
+      value: "pending",
+      beforeStart: 0,
+      beforeEnd: 6,
+      beforeDirection: "backward",
+      afterStart: 7,
+      afterEnd: 7,
+      data: "pending",
+    }])
     await commitCapturedRawSelection(host.page, "x")
 
     await expect.poll(async () => (await snapshot(host.page)).source).toBe("x")
@@ -1919,44 +1972,41 @@ test("accepted Raw selection edit supersedes pending full-source input", async (
   }
 })
 
-test("Raw input reads the selection present when its debounce fires", async ({ browser }) => {
+test("Raw input retains the first backward selection and latest native caret", async ({ browser }) => {
   const host = await mountHost(browser, "abcdef")
   try {
     const input = host.page.locator("#loomark-input")
     await input.focus()
-    await forceEditorFailure(host.page)
-    await expect.poll(async () => (await snapshot(host.page)).editor_failure_armed).toBe(true)
+    await dispatchRawNativeEdits(input, [
+      {
+        value: "abxef",
+        beforeStart: 2,
+        beforeEnd: 4,
+        beforeDirection: "backward",
+        afterStart: 3,
+        afterEnd: 3,
+        data: "x",
+      },
+      {
+        value: "abxyef",
+        beforeStart: 3,
+        beforeEnd: 3,
+        afterStart: 4,
+        afterEnd: 4,
+        data: "y",
+      },
+    ])
 
-    const observed = await input.evaluate(element => {
-      const textarea = element as HTMLTextAreaElement
-      const readSelection = () => ({
-        start: textarea.selectionStart,
-        end: textarea.selectionEnd,
-        direction: textarea.selectionDirection,
-      })
-      textarea.value = "abcdef!"
-      textarea.setSelectionRange(0, 2, "backward")
-      const atInput = readSelection()
-      textarea.dispatchEvent(new Event("input", { bubbles: true }))
-      textarea.setSelectionRange(3, 5, "forward")
-      return { atInput, beforeFlush: readSelection() }
-    })
-
-    expect(observed).toEqual({
-      atInput: { start: 0, end: 2, direction: "backward" },
-      beforeFlush: { start: 3, end: 5, direction: "forward" },
-    })
-    await expect.poll(async () => (await snapshot(host.page)).error_code)
-      .toBe("editor-commit-failed")
-    await expect(input).toHaveValue("abcdef")
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("abxyef")
+    expect(await snapshot(host.page)).toMatchObject({ committed_change_count: 1 })
+    await expect(input).toHaveValue("abxyef")
     await expect.poll(() => input.evaluate(element => {
       const textarea = element as HTMLTextAreaElement
       return {
         start: textarea.selectionStart,
         end: textarea.selectionEnd,
-        direction: textarea.selectionDirection,
       }
-    })).toEqual({ start: 3, end: 5, direction: "forward" })
+    })).toEqual({ start: 4, end: 4 })
   } finally {
     await host.context.close()
   }
@@ -1967,15 +2017,21 @@ test("Raw input coalesces a same-task burst into one commit", async ({ browser }
   try {
     const input = host.page.locator("#loomark-input")
     await input.focus()
-    await input.evaluate(element => {
-      const textarea = element as HTMLTextAreaElement
-      textarea.setSelectionRange(textarea.value.length, textarea.value.length)
-      for (const character of "abcdefghij") {
-        textarea.value += character
-        textarea.setSelectionRange(textarea.value.length, textarea.value.length)
-        textarea.dispatchEvent(new Event("input", { bubbles: true }))
-      }
-    })
+    const edits: RawNativeEdit[] = []
+    let value = "start"
+    for (const character of "abcdefghij") {
+      const before = value.length
+      value += character
+      edits.push({
+        value,
+        beforeStart: before,
+        beforeEnd: before,
+        afterStart: value.length,
+        afterEnd: value.length,
+        data: character,
+      })
+    }
+    await dispatchRawNativeEdits(input, edits)
     await expect.poll(async () => (await snapshot(host.page)).source).toBe("startabcdefghij")
     expect(await snapshot(host.page)).toMatchObject({
       source: "startabcdefghij",
@@ -1987,20 +2043,228 @@ test("Raw input coalesces a same-task burst into one commit", async ({ browser }
   }
 })
 
-test("pending Raw input survives leaving the Raw view", async ({ browser }) => {
+test("Raw input coalesces delete then insert into one replacement", async ({ browser }) => {
+  const host = await mountHost(browser, "start")
+  try {
+    const input = host.page.locator("#loomark-input")
+    await dispatchRawNativeEdits(input, [
+      {
+        value: "star",
+        beforeStart: 5,
+        beforeEnd: 5,
+        afterStart: 4,
+        afterEnd: 4,
+        inputType: "deleteContentBackward",
+      },
+      {
+        value: "starX",
+        beforeStart: 4,
+        beforeEnd: 4,
+        afterStart: 5,
+        afterEnd: 5,
+        data: "X",
+      },
+    ])
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("starX")
+    expect(await snapshot(host.page)).toMatchObject({
+      source: "starX",
+      committed_change_count: 1,
+    })
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("Raw input coalesces insert then deletes from the net change", async ({ browser }) => {
+  const host = await mountHost(browser, "start")
+  try {
+    const input = host.page.locator("#loomark-input")
+    await dispatchRawNativeEdits(input, [
+      {
+        value: "startX",
+        beforeStart: 5,
+        beforeEnd: 5,
+        afterStart: 6,
+        afterEnd: 6,
+        data: "X",
+      },
+      {
+        value: "start",
+        beforeStart: 6,
+        beforeEnd: 6,
+        afterStart: 5,
+        afterEnd: 5,
+        inputType: "deleteContentBackward",
+      },
+      {
+        value: "star",
+        beforeStart: 5,
+        beforeEnd: 5,
+        afterStart: 4,
+        afterEnd: 4,
+        inputType: "deleteContentBackward",
+      },
+    ])
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("star")
+    expect(await snapshot(host.page)).toMatchObject({
+      source: "star",
+      committed_change_count: 1,
+    })
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("Raw input without beforeinput does not guess a canonical edit", async ({ browser }) => {
   const host = await mountHost(browser, "start")
   try {
     const input = host.page.locator("#loomark-input")
     await input.evaluate(element => {
       const textarea = element as HTMLTextAreaElement
-      textarea.focus()
-      textarea.value += "X"
-      textarea.setSelectionRange(textarea.value.length, textarea.value.length)
-      textarea.dispatchEvent(new Event("input", { bubbles: true }))
+      textarea.value = "startX"
+      textarea.setSelectionRange(6, 6)
+      textarea.dispatchEvent(new InputEvent("input", {
+        bubbles: true,
+        data: "X",
+        inputType: "insertText",
+      }))
     })
+    await host.page.waitForTimeout(100)
+    expect(await snapshot(host.page)).toMatchObject({
+      source: "start",
+      committed_change_count: 0,
+      error_code: null,
+    })
+    await expect(input).toHaveValue("start")
+    await dispatchRawNativeEdits(input, [{
+      value: "startY",
+      beforeStart: 5,
+      beforeEnd: 5,
+      afterStart: 6,
+      afterEnd: 6,
+      data: "Y",
+    }])
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("startY")
+    expect(await snapshot(host.page)).toMatchObject({ committed_change_count: 1 })
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("beforeinput without same-task input expires unmatched", async ({ browser }) => {
+  const host = await mountHost(browser, "start")
+  try {
+    const input = host.page.locator("#loomark-input")
+    await input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.setSelectionRange(5, 5)
+      textarea.dispatchEvent(new InputEvent("beforeinput", {
+        bubbles: true,
+        cancelable: true,
+        data: "X",
+        inputType: "insertText",
+      }))
+    })
+    await host.page.waitForTimeout(20)
+    await input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.value = "startX"
+      textarea.setSelectionRange(6, 6)
+      textarea.dispatchEvent(new InputEvent("input", {
+        bubbles: true,
+        data: "X",
+        inputType: "insertText",
+      }))
+    })
+    await host.page.waitForTimeout(100)
+    expect(await snapshot(host.page)).toMatchObject({
+      source: "start",
+      committed_change_count: 0,
+      error_code: null,
+    })
+    await expect(input).toHaveValue("start")
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("malformed matched Raw input repairs without a canonical edit", async ({ browser }) => {
+  const host = await mountHost(browser, "abc")
+  try {
+    const input = host.page.locator("#loomark-input")
+    await dispatchRawNativeEdits(input, [{
+      value: "XYZ",
+      beforeStart: 1,
+      beforeEnd: 2,
+      afterStart: 3,
+      afterEnd: 3,
+      data: "XYZ",
+    }])
+    await host.page.waitForTimeout(100)
+    expect(await snapshot(host.page)).toMatchObject({
+      source: "abc",
+      committed_change_count: 0,
+      error_code: null,
+    })
+    await expect(input).toHaveValue("abc")
+    await expect.poll(() => input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      return {
+        start: textarea.selectionStart,
+        end: textarea.selectionEnd,
+        direction: textarea.selectionDirection,
+      }
+    })).toEqual({ start: 1, end: 2, direction: "forward" })
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("composition-intermediate Raw input does not commit", async ({ browser }) => {
+  const host = await mountHost(browser, "start")
+  try {
+    const input = host.page.locator("#loomark-input")
+    await dispatchRawNativeEdits(input, [{
+      value: "startあ",
+      beforeStart: 5,
+      beforeEnd: 5,
+      afterStart: 6,
+      afterEnd: 6,
+      inputType: "insertCompositionText",
+      data: "あ",
+      isComposing: true,
+    }])
+    await host.page.waitForTimeout(100)
+    expect(await snapshot(host.page)).toMatchObject({
+      source: "start",
+      committed_change_count: 0,
+      error_code: null,
+    })
+    await expect(input).toHaveValue("startあ")
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("mode change discards pending normalized Raw input", async ({ browser }) => {
+  const host = await mountHost(browser, "start")
+  try {
+    const input = host.page.locator("#loomark-input")
+    await dispatchRawNativeEdits(input, [{
+      value: "startX",
+      beforeStart: 5,
+      beforeEnd: 5,
+      afterStart: 6,
+      afterEnd: 6,
+      data: "X",
+    }])
     await selectBlock(host.page)
-    await expect.poll(async () => (await snapshot(host.page)).source).toBe("startX")
-    expect(await snapshot(host.page)).toMatchObject({ mode: "block", source: "startX" })
+    await host.page.waitForTimeout(100)
+    expect(await snapshot(host.page)).toMatchObject({
+      mode: "block",
+      source: "start",
+      committed_change_count: 0,
+    })
   } finally {
     await host.context.close()
   }
@@ -2011,9 +2275,20 @@ test("a newer Block edit supersedes pending Raw input", async ({ browser }) => {
   try {
     await host.page.evaluate(async moduleUrl => {
       const rawInput = document.getElementById("loomark-input") as HTMLTextAreaElement
+      rawInput.setSelectionRange(rawInput.value.length, rawInput.value.length)
+      rawInput.dispatchEvent(new InputEvent("beforeinput", {
+        bubbles: true,
+        cancelable: true,
+        data: "X",
+        inputType: "insertText",
+      }))
       rawInput.value += "X"
       rawInput.setSelectionRange(rawInput.value.length, rawInput.value.length)
-      rawInput.dispatchEvent(new Event("input", { bubbles: true }))
+      rawInput.dispatchEvent(new InputEvent("input", {
+        bubbles: true,
+        data: "X",
+        inputType: "insertText",
+      }))
       const module = await import(moduleUrl)
       module.dev_host_select_block()
       await new Promise<void>(resolve => requestAnimationFrame(() => resolve()))
@@ -2037,53 +2312,53 @@ test("a newer Block edit supersedes pending Raw input", async ({ browser }) => {
   }
 })
 
-test("rejected pending Raw input does not repair a removed Raw control", async ({ browser }) => {
+test("mode change discards pending Raw input before an armed failure", async ({ browser }) => {
   const host = await mountHost(browser, "start")
   try {
     await forceEditorFailure(host.page)
     await expect.poll(async () => (await snapshot(host.page)).editor_failure_armed).toBe(true)
-    const input = host.page.locator("#loomark-input")
-    await input.evaluate(element => {
-      const textarea = element as HTMLTextAreaElement
-      textarea.value += "X"
-      textarea.setSelectionRange(textarea.value.length, textarea.value.length)
-      textarea.dispatchEvent(new Event("input", { bubbles: true }))
-    })
+    await dispatchRawNativeEdits(host.page.locator("#loomark-input"), [{
+      value: "startX",
+      beforeStart: 5,
+      beforeEnd: 5,
+      afterStart: 6,
+      afterEnd: 6,
+      data: "X",
+    }])
     await selectBlock(host.page)
-    await expect.poll(async () => (await snapshot(host.page)).error_code).toBe("editor-commit-failed")
+    await host.page.waitForTimeout(100)
     expect(await snapshot(host.page)).toMatchObject({
       source: "start",
       mode: "block",
-      error_operation: "editor-dispatch",
+      error_code: null,
+      editor_failure_armed: true,
+      committed_change_count: 0,
     })
-    await host.page.waitForTimeout(100)
-    expect(await snapshot(host.page)).not.toMatchObject({ error_code: "browser-effect-failed" })
   } finally {
     await host.context.close()
   }
 })
 
-test("rejected pending Raw input does not repair a closed Raw surface in Preview", async ({ browser }) => {
+test("closing the Raw surface discards pending input without DOM repair", async ({ browser }) => {
   const host = await mountHost(browser, "start")
   try {
-    await forceEditorFailure(host.page)
-    await expect.poll(async () => (await snapshot(host.page)).editor_failure_armed).toBe(true)
-    const input = host.page.locator("#loomark-input")
-    await input.evaluate(element => {
-      const textarea = element as HTMLTextAreaElement
-      textarea.value += "X"
-      textarea.setSelectionRange(textarea.value.length, textarea.value.length)
-      textarea.dispatchEvent(new Event("input", { bubbles: true }))
-    })
+    await dispatchRawNativeEdits(host.page.locator("#loomark-input"), [{
+      value: "startX",
+      beforeStart: 5,
+      beforeEnd: 5,
+      afterStart: 6,
+      afterEnd: 6,
+      data: "X",
+    }])
     await selectPreview(host.page)
-    await expect.poll(async () => (await snapshot(host.page)).error_code).toBe("editor-commit-failed")
+    await host.page.waitForTimeout(100)
     expect(await snapshot(host.page)).toMatchObject({
       source: "start",
       mode: "preview",
-      error_operation: "editor-dispatch",
+      error_code: null,
+      committed_change_count: 0,
     })
-    await host.page.waitForTimeout(100)
-    expect(await snapshot(host.page)).not.toMatchObject({ error_code: "browser-effect-failed" })
+    await expect(host.page.locator("#loomark-input")).toHaveCount(0)
   } finally {
     await host.context.close()
   }
@@ -2092,11 +2367,14 @@ test("rejected pending Raw input does not repair a closed Raw surface in Preview
 test("external source replacement supersedes pending Raw input", async ({ browser }) => {
   const host = await mountHost(browser, "start")
   try {
-    await host.page.locator("#loomark-input").evaluate(element => {
-      const textarea = element as HTMLTextAreaElement
-      textarea.value += "X"
-      textarea.dispatchEvent(new Event("input", { bubbles: true }))
-    })
+    await dispatchRawNativeEdits(host.page.locator("#loomark-input"), [{
+      value: "startX",
+      beforeStart: 5,
+      beforeEnd: 5,
+      afterStart: 6,
+      afterEnd: 6,
+      data: "X",
+    }])
     await requestSource(host.page, "external")
     await expect.poll(async () => (await snapshot(host.page)).source).toBe("external")
     await host.page.waitForTimeout(100)
@@ -2111,11 +2389,14 @@ test("failed external source replacement preserves pending Raw input", async ({ 
   try {
     await forceEditorFailure(host.page)
     await expect.poll(async () => (await snapshot(host.page)).editor_failure_armed).toBe(true)
-    await host.page.locator("#loomark-input").evaluate(element => {
-      const textarea = element as HTMLTextAreaElement
-      textarea.value += "X"
-      textarea.dispatchEvent(new Event("input", { bubbles: true }))
-    })
+    await dispatchRawNativeEdits(host.page.locator("#loomark-input"), [{
+      value: "startX",
+      beforeStart: 5,
+      beforeEnd: 5,
+      afterStart: 6,
+      afterEnd: 6,
+      data: "X",
+    }])
     await requestSource(host.page, "external")
     await expect.poll(async () => (await snapshot(host.page)).error_code)
       .toBe("editor-commit-failed")
@@ -2133,11 +2414,14 @@ test("failed external source replacement preserves pending Raw input", async ({ 
 test("snapshot restore supersedes pending Raw input", async ({ browser }) => {
   const host = await mountHost(browser, "start")
   try {
-    await host.page.locator("#loomark-input").evaluate(element => {
-      const textarea = element as HTMLTextAreaElement
-      textarea.value += "X"
-      textarea.dispatchEvent(new Event("input", { bubbles: true }))
-    })
+    await dispatchRawNativeEdits(host.page.locator("#loomark-input"), [{
+      value: "startX",
+      beforeStart: 5,
+      beforeEnd: 5,
+      afterStart: 6,
+      afterEnd: 6,
+      data: "X",
+    }])
     await restoreSnapshot(host.page, 1, "restored", "raw")
     await expect.poll(async () => (await snapshot(host.page)).source).toBe("restored")
     await host.page.waitForTimeout(100)
@@ -2150,11 +2434,14 @@ test("snapshot restore supersedes pending Raw input", async ({ browser }) => {
 test("rejected snapshot preserves pending Raw input", async ({ browser }) => {
   const host = await mountHost(browser, "start")
   try {
-    await host.page.locator("#loomark-input").evaluate(element => {
-      const textarea = element as HTMLTextAreaElement
-      textarea.value += "X"
-      textarea.dispatchEvent(new Event("input", { bubbles: true }))
-    })
+    await dispatchRawNativeEdits(host.page.locator("#loomark-input"), [{
+      value: "startX",
+      beforeStart: 5,
+      beforeEnd: 5,
+      afterStart: 6,
+      afterEnd: 6,
+      data: "X",
+    }])
     await restoreSnapshot(host.page, 999, "ignored", "raw")
     await expect.poll(async () => (await snapshot(host.page)).error_code)
       .toBe("unsupported-snapshot-version")
@@ -2178,12 +2465,7 @@ test("Raw textarea editor failure preserves committed state and consumes the arm
     await expect.poll(async () => (await snapshot(host.page)).editor_failure_armed).toBe(true)
     const before = await snapshot(host.page)
 
-    await input.evaluate(element => {
-      const textarea = element as HTMLTextAreaElement
-      textarea.value = "failed edit\n"
-      textarea.setSelectionRange(3, 6, "backward")
-      textarea.dispatchEvent(new Event("input", { bubbles: true }))
-    })
+    await replaceRawValue(input, "failed edit\n")
     await expect.poll(async () => (await snapshot(host.page)).error_code).toBe("editor-commit-failed")
     expect(await snapshot(host.page)).toMatchObject({
       source: before.source,
@@ -2191,7 +2473,7 @@ test("Raw textarea editor failure preserves committed state and consumes the arm
       source_revision: before.source_revision,
       committed_change_count: before.committed_change_count,
       error_count: (before.error_count as number) + 1,
-      error_operation: "editor-dispatch",
+      error_operation: "raw-selection-edit",
       editor_failure_armed: false,
     })
     await expect(input).toHaveValue("before\n")
@@ -2199,7 +2481,7 @@ test("Raw textarea editor failure preserves committed state and consumes the arm
     await expect.poll(() => input.evaluate(element => {
       const textarea = element as HTMLTextAreaElement
       return `${textarea.selectionStart}:${textarea.selectionEnd}`
-    })).toBe("0:0")
+    })).toBe("0:7")
     await expect.poll(() => input.evaluate(
       element => (element as HTMLTextAreaElement & { __loomarkIdentity?: string }).__loomarkIdentity,
     )).toBe("preserved")
@@ -2214,15 +2496,11 @@ test("Raw textarea editor failure can be retried and reflected in Preview", asyn
     await selectRaw(host.page)
     await forceEditorFailure(host.page)
     await expect.poll(async () => (await snapshot(host.page)).editor_failure_armed).toBe(true)
-    await host.page.locator("#loomark-input").evaluate(element => {
-      const textarea = element as HTMLTextAreaElement
-      textarea.value = "failed edit\n"
-      textarea.dispatchEvent(new Event("input", { bubbles: true }))
-    })
+    await replaceRawValue(host.page.locator("#loomark-input"), "failed edit\n")
     await expect.poll(async () => (await snapshot(host.page)).error_code).toBe("editor-commit-failed")
     await expect(host.page.locator("#loomark-input")).toHaveValue("before\n")
 
-    await host.page.locator("#loomark-input").fill("retried edit\n")
+    await replaceRawValue(host.page.locator("#loomark-input"), "retried edit\n")
     await expect.poll(async () => (await snapshot(host.page)).source).toBe("retried edit\n")
     await selectPreview(host.page)
     await expectPreviewSource(host.page, "retried edit\n")
@@ -2231,7 +2509,7 @@ test("Raw textarea editor failure can be retried and reflected in Preview", asyn
   }
 })
 
-test("rejected Raw insertion restores a UTF-16 text cursor to its accepted position", async ({ browser }) => {
+test("failed Raw insertion restores the pre-input UTF-16 cursor", async ({ browser }) => {
   const host = await mountHost(browser, "A😀B")
   try {
     const input = host.page.locator("#loomark-input")
@@ -2260,32 +2538,41 @@ test("rejected Raw insertion restores a UTF-16 text cursor to its accepted posit
   }
 })
 
-test("rejected Raw repair yields to a newer same-frame input", async ({ browser }) => {
+test("failed coalesced Raw input is not retried", async ({ browser }) => {
   const host = await mountHost(browser, "start")
   try {
     const input = host.page.locator("#loomark-input")
     await input.focus()
     await forceEditorFailure(host.page)
     await expect.poll(async () => (await snapshot(host.page)).editor_failure_armed).toBe(true)
-    await input.evaluate(element => {
-      const textarea = element as HTMLTextAreaElement
-      for (const value of ["startX", "startXY"]) {
-        textarea.value = value
-        textarea.setSelectionRange(value.length, value.length)
-        textarea.dispatchEvent(new Event("input", { bubbles: true }))
-      }
-    })
-    await host.page.evaluate(() => new Promise<void>(resolve => {
-      requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
-    }))
+    await dispatchRawNativeEdits(input, [
+      {
+        value: "startX",
+        beforeStart: 5,
+        beforeEnd: 5,
+        afterStart: 6,
+        afterEnd: 6,
+        data: "X",
+      },
+      {
+        value: "startXY",
+        beforeStart: 6,
+        beforeEnd: 6,
+        afterStart: 7,
+        afterEnd: 7,
+        data: "Y",
+      },
+    ])
 
-    await expect.poll(async () => (await snapshot(host.page)).source).toBe("startXY")
-    await expect(input).toHaveValue("startXY")
-    await expect(input).toBeFocused()
-    await expect.poll(() => input.evaluate(element => {
-      const textarea = element as HTMLTextAreaElement
-      return `${textarea.selectionStart}:${textarea.selectionEnd}`
-    })).toBe("7:7")
+    await expect.poll(async () => (await snapshot(host.page)).error_code)
+      .toBe("editor-commit-failed")
+    await host.page.waitForTimeout(100)
+    expect(await snapshot(host.page)).toMatchObject({
+      source: "start",
+      committed_change_count: 0,
+      error_count: 1,
+    })
+    await expect(input).toHaveValue("start")
   } finally {
     await host.context.close()
   }

--- a/apps/loomark/examples/vanilla/tests/standalone.spec.ts
+++ b/apps/loomark/examples/vanilla/tests/standalone.spec.ts
@@ -1,4 +1,28 @@
-import { expect, test } from "@playwright/test"
+import { expect, test, type Locator } from "@playwright/test"
+
+async function replaceRawValue(input: Locator, value: string): Promise<void> {
+  await input.evaluate((element, nextValue) => {
+    const textarea = element as HTMLTextAreaElement
+    const currentLength = textarea.value.length
+    textarea.setSelectionRange(0, currentLength, "forward")
+    textarea.dispatchEvent(new InputEvent("beforeinput", {
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+      data: nextValue,
+      inputType: "insertText",
+    }))
+    textarea.value = nextValue
+    textarea.setSelectionRange(nextValue.length, nextValue.length)
+    textarea.dispatchEvent(new InputEvent("input", {
+      bubbles: true,
+      composed: true,
+      data: nextValue,
+      inputType: "insertText",
+    }))
+  }, value)
+  await input.page().waitForTimeout(100)
+}
 
 /**
  * #1176 standalone production boundary matrix:
@@ -38,7 +62,7 @@ test("standalone edit replaces the archive and reload restores the durable sourc
   const documentId = await page.evaluate(() => (
     JSON.parse(localStorage.getItem("loomark.active-document-archive") ?? "{}").document_id as string
   ))
-  await page.locator("#loomark-input").fill("# Durable\n\nSaved locally\n")
+  await replaceRawValue(page.locator("#loomark-input"), "# Durable\n\nSaved locally\n")
   await expect.poll(() => page.evaluate(() => {
     const raw = localStorage.getItem("loomark.active-document-archive")
     return raw === null ? null : (JSON.parse(raw) as { portable_markdown?: string }).portable_markdown
@@ -109,7 +133,7 @@ test("storage read failures mount a separate recovery view", async ({ page }) =>
 
 test("a failed replacement keeps the applied source but reload restores the previous archive", async ({ page }) => {
   await page.goto("/")
-  await page.locator("#loomark-input").fill("# Previous\n")
+  await replaceRawValue(page.locator("#loomark-input"), "# Previous\n")
   await expect.poll(() => page.evaluate(() => (
     JSON.parse(localStorage.getItem("loomark.active-document-archive") ?? "{}").portable_markdown as string
   ))).toBe("# Previous\n")
@@ -123,7 +147,7 @@ test("a failed replacement keeps the applied source but reload restores the prev
       original.call(this, key, value)
     }
   })
-  await page.locator("#loomark-input").fill("# Applied\n")
+  await replaceRawValue(page.locator("#loomark-input"), "# Applied\n")
   await expect(page.locator("#loomark-input")).toHaveValue("# Applied\n")
   await expect(page.locator("#loomark-error")).toContainText(
     "Changes are applied but not saved locally.",
@@ -166,7 +190,7 @@ test("Raw, Block, and Preview editing stays inside the original production root"
   await expect(root).toBeVisible()
   await root.evaluate(element => element.setAttribute("data-mount-probe", "original"))
 
-  await page.locator("#loomark-input").fill("# Before\n\nBody\n")
+  await replaceRawValue(page.locator("#loomark-input"), "# Before\n\nBody\n")
   await page.locator("#loomark-mode-block").click()
   await expect(page.locator("#loomark-block-input")).toHaveValue("Before")
   await page.locator("#loomark-block-input").fill("After")
@@ -186,7 +210,7 @@ test("Raw, Block, and Preview editing stays inside the original production root"
 
 test("ordinary consecutive Block input preserves both characters and the caret", async ({ page }) => {
   await page.goto("/")
-  await page.locator("#loomark-input").fill("x")
+  await replaceRawValue(page.locator("#loomark-input"), "x")
   await page.locator("#loomark-mode-block").click()
 
   const input = page.locator("#loomark-block-input")
@@ -218,7 +242,7 @@ test("ordinary consecutive Block input preserves both characters and the caret",
 
 test("Block input preserves the latest value when two events arrive before redraw", async ({ page }) => {
   await page.goto("/")
-  await page.locator("#loomark-input").fill("x")
+  await replaceRawValue(page.locator("#loomark-input"), "x")
   await page.locator("#loomark-mode-block").click()
   const input = page.locator("#loomark-block-input")
   const block = page.locator("#loomark-block")
@@ -261,7 +285,7 @@ test("Preview wraps long unbreakable content inside the reading frame", async ({
   const longUrl = `https://example.com/${`a`.repeat(200)}`
   const source =
     `# Long content\n\nVisit ${longUrl} and read this paragraph.\n\nInline code: \`${`x`.repeat(150)}\`\n`
-  await page.locator("#loomark-input").fill(source)
+  await replaceRawValue(page.locator("#loomark-input"), source)
   await page.locator("#loomark-mode-preview").click()
   const preview = page.locator("#loomark-preview")
   await expect(preview).toHaveAttribute("data-loomark-source", source)
@@ -289,7 +313,7 @@ test("frames stay borderless and only the split divider separates panes", async 
   await expect(raw).toHaveCSS("padding-left", "16px")
 
   await page.setViewportSize({ width: 640, height: 844 })
-  await raw.fill("# Narrow\n")
+  await replaceRawValue(raw, "# Narrow\n")
   await page.locator("#loomark-split-toggle").click()
 
   const split = page.locator("#loomark-split")

--- a/apps/loomark/internal/rabbita/application.mbt
+++ b/apps/loomark/internal/rabbita/application.mbt
@@ -374,12 +374,63 @@ fn raw_editor_view(
       id="loomark-input",
       value=source,
       rows=4,
-      attrs=@html.Attrs::build().aria_label("Raw Markdown source"),
+      attrs=@html.Attrs::build()
+        .aria_label("Raw Markdown source")
+        .on_beforeinput(event => {
+          raw_input_coordinator.capture_native_before_input(model, event)
+        })
+        .on_input(event => {
+          if raw_input_event_is_composing(event) {
+            raw_input_coordinator.suppress_composing_input_repair()
+          }
+          @rabbita_runtime.none
+        }),
       style=[
         "display:block;min-width:0;min-height:clamp(24rem,70vh,36rem);width:var(--lm-page-width);margin-inline:auto;field-sizing:content;resize:none;overflow:hidden;--rui-control-base-border:transparent;--rui-control-base-shadow:none;background:transparent;padding:1rem var(--lm-page-x-padding);font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,\"Liberation Mono\",\"Courier New\",monospace;font-size:1.125rem;line-height:1.65",
       ],
       on_input=@cmd.Emit(source => {
-        raw_input_command(source, raw_input_coordinator, emit)
+        match read_raw_selection() {
+          Some(selection) => {
+            let matched = raw_input_coordinator.has_captured_before_input()
+            let repair_unmatched = raw_input_coordinator.take_unmatched_input_repair()
+            let input_command = raw_input_coordinator.enqueue(
+              source, selection, emit,
+            )
+            if matched || !repair_unmatched {
+              input_command
+            } else {
+              let repair_epoch = raw_input_coordinator.epoch()
+              let repair_selection = rejected_text_selection(
+                model.document.source(),
+                source,
+                selection,
+              )
+              @cmd.batch([
+                input_command,
+                after_render(
+                  scheduler => {
+                    ignore(scheduler)
+                    guard raw_input_coordinator.epoch() == repair_epoch else {
+                      return
+                    }
+                    @dom_boundary.write_text_value_id(
+                      "loomark-input",
+                      raw_textarea_value(model.document.source()),
+                    )
+                    @dom_boundary.write_text_selection_id(
+                      "loomark-input", repair_selection,
+                    )
+                  },
+                  emit,
+                ),
+              ])
+            }
+          }
+          None => {
+            raw_input_coordinator.cancel_pending()
+            @rabbita_runtime.none
+          }
+        }
       }),
     ),
   )
@@ -644,7 +695,8 @@ fn driver_event_name(event : DriverEvent) -> String {
     Editing(edit_event) =>
       match edit_event {
         ReplaceSource(_) => "source"
-        RawInput(_, _, _) => "raw-input"
+        RawInput(_, _) => "raw-input"
+        RawNativeInput(..) => "raw-native-input"
         RawSelectionEdit(_) => "raw-selection-edit"
         CommitCapturedRawSelection(_) => "commit-captured-raw-selection"
         BlockFocused(_) => "block-focused"
@@ -743,7 +795,7 @@ fn parse_driver_event(detail : String) -> DriverEvent {
   } else if detail.has_prefix("source|") {
     Editing(ReplaceSource(detail["source|".length():].to_owned()))
   } else if detail.has_prefix("raw-input|") {
-    Editing(RawInput(detail["raw-input|".length():].to_owned(), None, None))
+    Editing(RawInput(detail["raw-input|".length():].to_owned(), None))
   } else if detail.has_prefix("raw-selection-edit|") {
     Editing(
       CommitCapturedRawSelection(
@@ -858,11 +910,8 @@ fn editing_mode_applicable(
   split_preview_open : Bool,
 ) -> String? {
   match event {
-    ReplaceSource(_) | ProbeBlockSelection(_) => None
-    RawInput(_, _, Some(_)) => None
-    RawInput(_, _, None)
-    | RawSelectionEdit(_)
-    | CommitCapturedRawSelection(_) =>
+    ReplaceSource(_) | ProbeBlockSelection(_) | RawNativeInput(..) => None
+    RawInput(_, _) | RawSelectionEdit(_) | CommitCapturedRawSelection(_) =>
       if mode == @core.Raw || (mode == @core.Preview && split_preview_open) {
         None
       } else {
@@ -897,11 +946,11 @@ fn update_editing(
   event : EditingEvent,
   emit : @cmd.Emit[DriverEvent],
 ) -> (DriverModel, @cmd.Cmd) raise {
-  let raw_token_active = match event {
-    RawInput(_, _, Some(token)) => raw_input_coordinator.is_active(token)
+  let native_token_active = match event {
+    RawNativeInput(token~, ..) => raw_input_coordinator.is_active(token)
     _ => true
   }
-  if event is RawInput(_, _, Some(_)) && !raw_token_active {
+  if event is RawNativeInput(..) && !native_token_active {
     return (model, @rabbita_runtime.none)
   }
   match event {
@@ -930,6 +979,79 @@ fn update_editing(
     }
     None =>
       match event {
+        RawNativeInput(token~, candidate~) => {
+          raw_input_coordinator.mark_reducer_started(token)
+          let request = normalize_raw_input_candidate(model, candidate)
+          raw_input_coordinator.mark_reducer_finished(token)
+          match request {
+            None => {
+              let repair_epoch = raw_input_coordinator.epoch()
+              let expected = candidate.before_input.selection
+              raw_input_coordinator.discard(token)
+              (
+                model,
+                rejected_raw_input_after_render(
+                  latest_model, raw_input_coordinator, repair_epoch, expected, emit,
+                ),
+              )
+            }
+            Some(request) => {
+              let (next, outcome, persistence_command) = commit_raw_selection_edit(
+                editor,
+                attachment,
+                model,
+                request,
+                emit,
+                editor_started=() => {
+                  raw_input_coordinator.mark_editor_started(token)
+                },
+                editor_finished=() => {
+                  raw_input_coordinator.mark_editor_finished(token)
+                },
+                preview_started=() => {
+                  raw_input_coordinator.mark_preview_started(token)
+                },
+                preview_finished=() => {
+                  raw_input_coordinator.mark_preview_finished(token)
+                },
+              )
+              let (next, selection_command, repair_command) = match outcome {
+                RawSelectionEditOutcome::Applied(selection)
+                | RawSelectionEditOutcome::Unchanged(selection) =>
+                  (
+                    next,
+                    raw_selection_after_render(latest_model, selection, emit),
+                    @rabbita_runtime.none,
+                  )
+                RawSelectionEditOutcome::Rejected(
+                  RawSelectionEditRejection::EditorCommitFailed
+                ) => {
+                  let repair_epoch = raw_input_coordinator.epoch()
+                  let expected = candidate.before_input.selection
+                  (
+                    next,
+                    @rabbita_runtime.none,
+                    rejected_raw_input_after_render(
+                      latest_model, raw_input_coordinator, repair_epoch, expected,
+                      emit,
+                    ),
+                  )
+                }
+                RawSelectionEditOutcome::Rejected(_) =>
+                  (next, @rabbita_runtime.none, @rabbita_runtime.none)
+              }
+              let finish_command = raw_input_coordinator.finish(
+                token, latest_model, emit,
+              )
+              (
+                next,
+                @cmd.batch([
+                  persistence_command, selection_command, repair_command, finish_command,
+                ]),
+              )
+            }
+          }
+        }
         CommitCapturedRawSelection(inserted) =>
           match model.raw_selection {
             None => {
@@ -976,31 +1098,17 @@ fn update_editing(
           }
           (next, @cmd.batch([persistence_command, selection_command]))
         }
-        ReplaceSource(source) | RawInput(source, _, _) => {
-          let raw_selection = match event {
-            RawInput(_, selection, _) => selection
-            _ => None
-          }
-          let raw_event = event is RawInput(_, _, _)
-          let raw_token = match event {
-            RawInput(_, _, token) => token
-            _ => None
-          }
+        ReplaceSource(source) | RawInput(source, _) => {
           let raw_input_epoch = raw_input_coordinator.epoch()
-          let mut raw_completion_seen = false
-          let mut raw_completion_command = @rabbita_runtime.none
-          match raw_token {
-            Some(token) => raw_input_coordinator.mark_reducer_started(token)
-            None => ()
+          let raw_selection = match event {
+            RawInput(_, selection) => selection
+            _ => None
           }
+          let raw_event = event is RawInput(_, _)
           let transition = @core.reduce(
             model.state,
             @core.ApplicationEvent::RequestCanonicalSource(source~),
           )
-          match raw_token {
-            Some(token) => raw_input_coordinator.mark_reducer_finished(token)
-            None => ()
-          }
           let mut next = if raw_event {
             { ..model, text_input_generation: model.text_input_generation + 1 }
           } else {
@@ -1011,11 +1119,6 @@ fn update_editing(
           for decision in transition.decisions() {
             match decision {
               @core.ReplaceCanonicalSource(source) => {
-                match raw_token {
-                  Some(token) =>
-                    raw_input_coordinator.mark_editor_started(token)
-                  None => ()
-                }
                 let old_requested = preview_requested(next)
                 let (committed, accepted, changed, commit_command) = commit_source(
                   editor,
@@ -1025,16 +1128,6 @@ fn update_editing(
                   "editor-dispatch",
                   emit,
                 )
-                match raw_token {
-                  Some(token) =>
-                    raw_input_coordinator.mark_editor_finished(token)
-                  None => ()
-                }
-                match raw_token {
-                  Some(token) =>
-                    raw_input_coordinator.mark_preview_started(token)
-                  None => ()
-                }
                 next = update_preview_document(
                   attachment,
                   committed,
@@ -1042,46 +1135,12 @@ fn update_editing(
                   accepted~,
                   changed~,
                 )
-                match raw_token {
-                  Some(token) =>
-                    raw_input_coordinator.mark_preview_finished(token)
-                  None => ()
-                }
-                if event is ReplaceSource(_) && accepted {
+                if accepted {
                   raw_input_coordinator.cancel_pending()
                 }
                 persistence_command = @cmd.batch([
                   persistence_command, commit_command,
                 ])
-                match (raw_token, raw_completion_seen) {
-                  (Some(token), false) => {
-                    raw_completion_seen = true
-                    let repair_generation = next.text_input_generation
-                    let repair_revision = next.source_revision
-                    raw_completion_command = raw_input_coordinator.complete(
-                      token,
-                      source,
-                      raw_selection,
-                      accepted,
-                      () => {
-                        raw_input_repair_eligible(
-                          latest_model.val,
-                          repair_generation,
-                          repair_revision,
-                        )
-                      },
-                      () => {
-                        match latest_model.val {
-                          Some(latest) =>
-                            publish(latest, Some(raw_input_coordinator), None)
-                          None => ()
-                        }
-                      },
-                      emit,
-                    )
-                  }
-                  _ => ()
-                }
                 restore_raw_value = restore_raw_value ||
                   (raw_event && !accepted)
               }
@@ -1091,15 +1150,6 @@ fn update_editing(
                 )
             }
           }
-          if !raw_completion_seen {
-            match raw_token {
-              Some(token) => raw_input_coordinator.cancel(token)
-              None => ()
-            }
-          }
-          persistence_command = @cmd.batch([
-            persistence_command, raw_completion_command,
-          ])
           let command = if restore_raw_value {
             let repair_generation = next.text_input_generation
             let repair_source_revision = next.source_revision
@@ -1635,6 +1685,7 @@ fn update_editing(
 /// effect reports that accompany them. Not mode-gated.
 fn update_navigation(
   attachment : @md_markdown.MarkdownSemanticAttachment,
+  raw_input_coordinator : RawInputCoordinator,
   model : DriverModel,
   latest_model : @ref.Ref[DriverModel?],
   event : NavigationEvent,
@@ -1651,6 +1702,9 @@ fn update_navigation(
         SelectPreview => @core.Preview
         _ => @core.Raw
       }
+      if mode != model.state.mode() {
+        raw_input_coordinator.cancel_pending()
+      }
       let transition = @core.reduce(
         model.state,
         @core.ApplicationEvent::SelectMode(mode~),
@@ -1665,6 +1719,9 @@ fn update_navigation(
       (next, @rabbita_runtime.none)
     }
     ToggleSplitPreview => {
+      if model.state.mode() == @core.Preview && model.split_preview_open {
+        raw_input_coordinator.cancel_pending()
+      }
       let old_requested = preview_requested(model)
       let next = update_preview_document(
         attachment,
@@ -2085,6 +2142,7 @@ fn update_lifecycle(
       (next, @rabbita_runtime.none)
     }
     Fatal(message) => {
+      raw_input_coordinator.cancel_pending()
       block_input_coordinator.cancel_pending()
       let next = { ..model, fatal: true, error: Some(message), rejection: None }
       (next, @rabbita_runtime.none)
@@ -2131,7 +2189,7 @@ fn update_model(
     Archive(completion) => update_archive_tracker(model, completion)
     _ if model.fatal && !recovery_control_event(event) => {
       match event {
-        Editing(RawInput(_, _, Some(token))) =>
+        Editing(RawNativeInput(token~, ..)) =>
           raw_input_coordinator.cancel(token)
         Editing(BlockInput(..)) => block_input_coordinator.cancel_pending()
         _ => ()
@@ -2150,7 +2208,9 @@ fn update_model(
         latest_model, edit_event, emit,
       )
     Navigation(nav_event) =>
-      update_navigation(attachment, model, latest_model, nav_event, emit)
+      update_navigation(
+        attachment, raw_input_coordinator, model, latest_model, nav_event, emit,
+      )
     Probe(probe_event) => update_probe(model, latest_model, probe_event, emit)
     Lifecycle(life_event) =>
       update_lifecycle(
@@ -2159,7 +2219,7 @@ fn update_model(
       )
   }
   let raw_input_token = match event {
-    Editing(RawInput(_, _, Some(token))) => Some(token)
+    Editing(RawNativeInput(token~, ..)) => Some(token)
     _ => None
   }
   publish(next, Some(raw_input_coordinator), raw_input_token)

--- a/apps/loomark/internal/rabbita/driver_types.mbt
+++ b/apps/loomark/internal/rabbita/driver_types.mbt
@@ -4,7 +4,8 @@
 /// from the mode gate (driver source replacement works in any mode).
 priv enum EditingEvent {
   ReplaceSource(String)
-  RawInput(String, @dom_boundary.TextSelection?, Int?)
+  RawInput(String, @dom_boundary.TextSelection?)
+  RawNativeInput(token~ : Int, candidate~ : RawNativeInputCandidate)
   RawSelectionEdit(RawSelectionEditRequest)
   CommitCapturedRawSelection(String)
   BlockFocused(String)

--- a/apps/loomark/internal/rabbita/editing_mode_wbtest.mbt
+++ b/apps/loomark/internal/rabbita/editing_mode_wbtest.mbt
@@ -45,7 +45,7 @@ test "source replacement and the block selection probe are exempt from the mode 
 
 ///|
 test "raw input requires Raw mode or a split-open Preview" {
-  let raw = RawInput("source", None, None)
+  let raw = RawInput("source", None)
   assert_eq(editing_mode_applicable(raw, raw_mode(), false), None)
   assert_eq(editing_mode_applicable(raw, preview_mode(), true), None)
   assert_eq(

--- a/apps/loomark/internal/rabbita/focus_runtime.mbt
+++ b/apps/loomark/internal/rabbita/focus_runtime.mbt
@@ -239,6 +239,45 @@ fn raw_selection_after_render(
 }
 
 ///|
+/// Restore canonical Raw text and the trusted pre-input selection after a
+/// matched native batch is rejected. A newer capture or document frontier
+/// supersedes this repair before it can write to the DOM.
+fn rejected_raw_input_after_render(
+  latest_model : @ref.Ref[DriverModel?],
+  raw_input_coordinator : RawInputCoordinator,
+  repair_epoch : Int,
+  expected : VersionedRawSelection,
+  emit : @cmd.Emit[DriverEvent],
+) -> @cmd.Cmd {
+  after_render(
+    scheduler => {
+      ignore(scheduler)
+      guard raw_input_coordinator.epoch() == repair_epoch else { return }
+      guard latest_model.val is Some(latest) else { return }
+      guard latest.document_id == expected.document_id &&
+        latest.document_version == expected.version &&
+        raw_selection_mode_applicable(latest) else {
+        return
+      }
+      @dom_boundary.write_text_value_id(
+        "loomark-input",
+        raw_textarea_value(latest.document.source()),
+      )
+      match
+        dom_selection_from_markdown_document_utf16(
+          latest.document.source(),
+          expected.selection,
+        ) {
+        Some(selection) =>
+          @dom_boundary.write_text_selection_id("loomark-input", selection)
+        None => ()
+      }
+    },
+    emit,
+  )
+}
+
+///|
 /// Revalidate the latest model after rendering, then perform the final DOM
 /// write without queuing a state update after it.
 fn focus_latest_after_render(

--- a/apps/loomark/internal/rabbita/raw_selection_transaction.mbt
+++ b/apps/loomark/internal/rabbita/raw_selection_transaction.mbt
@@ -25,6 +25,40 @@ priv struct RawSelectionEditRequest {
 }
 
 ///|
+/// The immutable beforeinput snapshot paired with a later native input.
+priv struct RawBeforeInputCandidate {
+  selection : VersionedRawSelection
+  input_type : String
+  is_composing : Bool
+}
+
+///|
+fn RawBeforeInputCandidate::RawBeforeInputCandidate(
+  selection~ : VersionedRawSelection,
+  input_type~ : String,
+  is_composing~ : Bool,
+) -> RawBeforeInputCandidate {
+  { selection, input_type, is_composing }
+}
+
+///|
+/// The latest native textarea value and caret for one captured input batch.
+priv struct RawNativeInputCandidate {
+  before_input : RawBeforeInputCandidate
+  source : String
+  post_input_selection : @dom_boundary.TextSelection
+}
+
+///|
+fn RawNativeInputCandidate::RawNativeInputCandidate(
+  before_input~ : RawBeforeInputCandidate,
+  source~ : String,
+  post_input_selection~ : @dom_boundary.TextSelection,
+) -> RawNativeInputCandidate {
+  { before_input, source, post_input_selection }
+}
+
+///|
 priv enum RawSelectionEditRejection {
   WrongDocument
   StaleVersion
@@ -202,6 +236,92 @@ fn dom_selection_from_markdown_document_utf16(
 }
 
 ///|
+fn normalize_raw_input_candidate(
+  model : DriverModel,
+  candidate : RawNativeInputCandidate,
+) -> RawSelectionEditRequest? {
+  let before = candidate.before_input
+  guard !before.is_composing && !before.input_type.is_empty() else {
+    return None
+  }
+  guard before.selection.document_id == model.document_id else { return None }
+  guard before.selection.version == model.document_version else { return None }
+  guard raw_selection_mode_applicable(model) else { return None }
+
+  let selection = @markdown.MarkdownDocumentUtf16Selection(
+    model.document,
+    anchor=before.selection.selection.anchor(),
+    head=before.selection.selection.head(),
+  ) catch {
+    _ => return None
+  }
+  let old_source = model.document.source()
+  let old_value = raw_textarea_value(old_source)
+  let latest_value = raw_textarea_value(candidate.source)
+  guard candidate.post_input_selection.start() ==
+    candidate.post_input_selection.end() else {
+    return None
+  }
+  let post_offset = candidate.post_input_selection.start()
+  guard post_offset >= 0 &&
+    post_offset <= latest_value.length() &&
+    @moji.is_grapheme_boundary(latest_value, post_offset) else {
+    return None
+  }
+  guard dom_selection_from_markdown_document_utf16(old_source, selection)
+    is Some(dom_selection) else {
+    return None
+  }
+  let (change_start, old_end, inserted) = if !selection.is_collapsed() {
+    let prefix = old_value.sub(end=dom_selection.start())
+    let suffix = old_value.sub(start=dom_selection.end())
+    guard latest_value.has_prefix(prefix) && latest_value.has_suffix(suffix) else {
+      return None
+    }
+    let inserted_end = latest_value.length() - suffix.length()
+    guard inserted_end >= dom_selection.start() else { return None }
+    let inserted = latest_value
+      .sub(start=dom_selection.start(), end=inserted_end)
+      .to_owned()
+    (dom_selection.start(), dom_selection.end(), inserted)
+  } else {
+    let change = @text_change.compute_text_change(old_value, latest_value)
+    let old_end = change.start + change.delete_len
+    let caret = dom_selection.start()
+    guard change.start <= caret && caret <= old_end else { return None }
+    (change.start, old_end, change.inserted)
+  }
+  guard post_offset == change_start + inserted.length() else { return None }
+  let request_selection = if !selection.is_collapsed() {
+    selection
+  } else {
+    let start = match raw_source_offset_from_dom(old_source, change_start) {
+      Some(offset) => offset
+      None => return None
+    }
+    let end = match raw_source_offset_from_dom(old_source, old_end) {
+      Some(offset) => offset
+      None => return None
+    }
+    @markdown.MarkdownDocumentUtf16Selection(
+      model.document,
+      anchor=start,
+      head=end,
+    ) catch {
+      _ => return None
+    }
+  }
+  Some({
+    selection: VersionedRawSelection::VersionedRawSelection(
+      document_id=model.document_id,
+      version=model.document_version,
+      selection=request_selection,
+    ),
+    inserted,
+  })
+}
+
+///|
 fn versioned_raw_selection_from_dom(
   model : DriverModel,
   selection : @dom_boundary.TextSelection,
@@ -251,6 +371,10 @@ fn commit_raw_selection_edit(
   model : DriverModel,
   request : RawSelectionEditRequest,
   emit : @cmd.Emit[DriverEvent],
+  editor_started? : () -> Unit = () => (),
+  editor_finished? : () -> Unit = () => (),
+  preview_started? : () -> Unit = () => (),
+  preview_finished? : () -> Unit = () => (),
 ) -> (DriverModel, RawSelectionEditOutcome, @cmd.Cmd) raise {
   let bound = request.selection
   guard bound.document_id == model.document_id else {
@@ -292,6 +416,7 @@ fn commit_raw_selection_edit(
       )
   }
   let range_start = selection.range_start()
+  editor_started()
   let (committed, result, accepted, changed, persistence_command) = commit_edit_request(
     editor,
     model,
@@ -303,6 +428,8 @@ fn commit_raw_selection_edit(
     "raw-selection-edit",
     emit,
   )
+  editor_finished()
+  preview_started()
   let committed = update_preview_document(
     attachment,
     committed,
@@ -310,6 +437,7 @@ fn commit_raw_selection_edit(
     accepted~,
     changed~,
   )
+  preview_finished()
   if !accepted && !(result is Some(@markdown.Unchanged(_))) {
     return (
       committed,

--- a/apps/loomark/internal/rabbita/raw_selection_transaction_wbtest.mbt
+++ b/apps/loomark/internal/rabbita/raw_selection_transaction_wbtest.mbt
@@ -71,6 +71,348 @@ fn assert_applied_raw_caret(
 }
 
 ///|
+test "native Raw pairing retains the first backward replacement" {
+  let context = RawSelectionTestContext::RawSelectionTestContext(
+    "raw-native-backward-pairing", "abcdef",
+  )
+  let captured = RawBeforeInputCandidate::RawBeforeInputCandidate(
+    selection=context.selection(4, 2),
+    input_type="insertText",
+    is_composing=false,
+  )
+  let candidate = RawNativeInputCandidate::RawNativeInputCandidate(
+    before_input=captured,
+    source="abxyef",
+    post_input_selection=@dom_boundary.TextSelection(
+      4,
+      4,
+      @dom_boundary.NoDirection,
+    ),
+  )
+
+  guard normalize_raw_input_candidate(context.model, candidate) is Some(request) else {
+    abort("compatible native replacement must normalize")
+  }
+  assert_eq(request.selection.selection.anchor(), 4)
+  assert_eq(request.selection.selection.head(), 2)
+  assert_true(request.selection.selection.is_backward())
+  assert_eq(request.inserted, "xy")
+}
+
+///|
+test "native Raw pairing accepts two collapsed insertions as one change" {
+  let context = RawSelectionTestContext::RawSelectionTestContext(
+    "raw-native-collapsed-insertion", "abcd",
+  )
+  let candidate = RawNativeInputCandidate::RawNativeInputCandidate(
+    before_input=RawBeforeInputCandidate::RawBeforeInputCandidate(
+      selection=context.selection(2, 2),
+      input_type="insertText",
+      is_composing=false,
+    ),
+    source="abxycd",
+    post_input_selection=@dom_boundary.TextSelection(
+      4,
+      4,
+      @dom_boundary.NoDirection,
+    ),
+  )
+  guard normalize_raw_input_candidate(context.model, candidate) is Some(request) else {
+    abort("collapsed native insertions must normalize")
+  }
+  assert_eq(request.selection.selection.anchor(), 2)
+  assert_eq(request.selection.selection.head(), 2)
+  assert_eq(request.inserted, "xy")
+}
+
+///|
+test "native Raw pairing normalizes a ten-character collapsed burst" {
+  let context = RawSelectionTestContext::RawSelectionTestContext(
+    "raw-native-collapsed-burst", "start",
+  )
+  let candidate = RawNativeInputCandidate::RawNativeInputCandidate(
+    before_input=RawBeforeInputCandidate::RawBeforeInputCandidate(
+      selection=context.selection(5, 5),
+      input_type="insertText",
+      is_composing=false,
+    ),
+    source="startabcdefghij",
+    post_input_selection=@dom_boundary.TextSelection(
+      15,
+      15,
+      @dom_boundary.NoDirection,
+    ),
+  )
+  guard normalize_raw_input_candidate(context.model, candidate) is Some(request) else {
+    abort("collapsed native burst must normalize")
+  }
+  assert_eq(request.selection.selection.anchor(), 5)
+  assert_eq(request.selection.selection.head(), 5)
+  assert_eq(request.inserted, "abcdefghij")
+}
+
+///|
+test "native Raw pairing lowers a delete then insert burst from its net change" {
+  let context = RawSelectionTestContext::RawSelectionTestContext(
+    "raw-native-delete-insert", "start",
+  )
+  let candidate = RawNativeInputCandidate::RawNativeInputCandidate(
+    before_input=RawBeforeInputCandidate::RawBeforeInputCandidate(
+      selection=context.selection(5, 5),
+      input_type="deleteContentBackward",
+      is_composing=false,
+    ),
+    source="starX",
+    post_input_selection=@dom_boundary.TextSelection(
+      5,
+      5,
+      @dom_boundary.NoDirection,
+    ),
+  )
+  guard normalize_raw_input_candidate(context.model, candidate) is Some(request) else {
+    abort("mixed delete-insert burst must normalize")
+  }
+  assert_eq(request.selection.selection.anchor(), 4)
+  assert_eq(request.selection.selection.head(), 5)
+  assert_eq(request.inserted, "X")
+}
+
+///|
+test "native Raw pairing lowers an insert then delete burst from its net change" {
+  let context = RawSelectionTestContext::RawSelectionTestContext(
+    "raw-native-insert-delete", "start",
+  )
+  let candidate = RawNativeInputCandidate::RawNativeInputCandidate(
+    before_input=RawBeforeInputCandidate::RawBeforeInputCandidate(
+      selection=context.selection(5, 5),
+      input_type="insertText",
+      is_composing=false,
+    ),
+    source="star",
+    post_input_selection=@dom_boundary.TextSelection(
+      4,
+      4,
+      @dom_boundary.NoDirection,
+    ),
+  )
+  guard normalize_raw_input_candidate(context.model, candidate) is Some(request) else {
+    abort("mixed insert-delete burst must normalize")
+  }
+  assert_eq(request.selection.selection.anchor(), 4)
+  assert_eq(request.selection.selection.head(), 5)
+  assert_eq(request.inserted, "")
+}
+
+///|
+test "native Raw pairing keeps a net no-op burst unchanged" {
+  let context = RawSelectionTestContext::RawSelectionTestContext(
+    "raw-native-net-noop", "start",
+  )
+  let candidate = RawNativeInputCandidate::RawNativeInputCandidate(
+    before_input=RawBeforeInputCandidate::RawBeforeInputCandidate(
+      selection=context.selection(5, 5),
+      input_type="insertText",
+      is_composing=false,
+    ),
+    source="start",
+    post_input_selection=@dom_boundary.TextSelection(
+      5,
+      5,
+      @dom_boundary.NoDirection,
+    ),
+  )
+  guard normalize_raw_input_candidate(context.model, candidate) is Some(request) else {
+    abort("net no-op burst must normalize")
+  }
+  assert_eq(request.selection.selection.anchor(), 5)
+  assert_eq(request.selection.selection.head(), 5)
+  assert_eq(request.inserted, "")
+}
+
+///|
+test "native Raw pairing accepts a collapsed native deletion" {
+  let context = RawSelectionTestContext::RawSelectionTestContext(
+    "raw-native-collapsed-deletion", "abcd",
+  )
+  let candidate = RawNativeInputCandidate::RawNativeInputCandidate(
+    before_input=RawBeforeInputCandidate::RawBeforeInputCandidate(
+      selection=context.selection(2, 2),
+      input_type="deleteContentBackward",
+      is_composing=false,
+    ),
+    source="acd",
+    post_input_selection=@dom_boundary.TextSelection(
+      1,
+      1,
+      @dom_boundary.NoDirection,
+    ),
+  )
+  guard normalize_raw_input_candidate(context.model, candidate) is Some(request) else {
+    abort("collapsed native deletion must normalize")
+  }
+  assert_eq(request.selection.selection.anchor(), 1)
+  assert_eq(request.selection.selection.head(), 2)
+  assert_eq(request.inserted, "")
+}
+
+///|
+test "native Raw pairing rejects composition-intermediate input" {
+  let context = RawSelectionTestContext::RawSelectionTestContext(
+    "raw-native-composition", "abc",
+  )
+  let candidate = RawNativeInputCandidate::RawNativeInputCandidate(
+    before_input=RawBeforeInputCandidate::RawBeforeInputCandidate(
+      selection=context.selection(1, 1),
+      input_type="insertCompositionText",
+      is_composing=true,
+    ),
+    source="aXbc",
+    post_input_selection=@dom_boundary.TextSelection(
+      2,
+      2,
+      @dom_boundary.NoDirection,
+    ),
+  )
+  assert_true(normalize_raw_input_candidate(context.model, candidate) is None)
+}
+
+///|
+test "native Raw pairing rejects an incompatible changed range" {
+  let context = RawSelectionTestContext::RawSelectionTestContext(
+    "raw-native-incompatible-range", "abcdef",
+  )
+  let candidate = RawNativeInputCandidate::RawNativeInputCandidate(
+    before_input=RawBeforeInputCandidate::RawBeforeInputCandidate(
+      selection=context.selection(1, 3),
+      input_type="insertText",
+      is_composing=false,
+    ),
+    source="abXYef",
+    post_input_selection=@dom_boundary.TextSelection(
+      4,
+      4,
+      @dom_boundary.NoDirection,
+    ),
+  )
+  assert_true(normalize_raw_input_candidate(context.model, candidate) is None)
+}
+
+///|
+test "native Raw pairing maps canonical CRLF insertion boundaries" {
+  let context = RawSelectionTestContext::RawSelectionTestContext(
+    "raw-native-crlf", "a\r\nb",
+  )
+  let candidate = RawNativeInputCandidate::RawNativeInputCandidate(
+    before_input=RawBeforeInputCandidate::RawBeforeInputCandidate(
+      selection=context.selection(3, 3),
+      input_type="insertText",
+      is_composing=false,
+    ),
+    source="a\nXb",
+    post_input_selection=@dom_boundary.TextSelection(
+      3,
+      3,
+      @dom_boundary.NoDirection,
+    ),
+  )
+  guard normalize_raw_input_candidate(context.model, candidate) is Some(request) else {
+    abort("CRLF native insertion must normalize")
+  }
+  assert_eq(request.selection.selection.anchor(), 3)
+  assert_eq(request.inserted, "X")
+}
+
+///|
+test "native Raw pairing rejects a capture from another document" {
+  let context = RawSelectionTestContext::RawSelectionTestContext(
+    "raw-native-wrong-document", "abc",
+  )
+  let other = RawSelectionTestContext::RawSelectionTestContext(
+    "raw-native-other-document", "abc",
+  )
+  let candidate = RawNativeInputCandidate::RawNativeInputCandidate(
+    before_input=RawBeforeInputCandidate::RawBeforeInputCandidate(
+      selection=other.selection(1, 1),
+      input_type="insertText",
+      is_composing=false,
+    ),
+    source="aXbc",
+    post_input_selection=@dom_boundary.TextSelection(
+      2,
+      2,
+      @dom_boundary.NoDirection,
+    ),
+  )
+  assert_true(normalize_raw_input_candidate(context.model, candidate) is None)
+}
+
+///|
+test "native Raw pairing maps a lone CR insertion boundary" {
+  let context = RawSelectionTestContext::RawSelectionTestContext(
+    "raw-native-lone-cr", "a\rb",
+  )
+  let candidate = RawNativeInputCandidate::RawNativeInputCandidate(
+    before_input=RawBeforeInputCandidate::RawBeforeInputCandidate(
+      selection=context.selection(2, 2),
+      input_type="insertText",
+      is_composing=false,
+    ),
+    source="a\nXb",
+    post_input_selection=@dom_boundary.TextSelection(
+      3,
+      3,
+      @dom_boundary.NoDirection,
+    ),
+  )
+  guard normalize_raw_input_candidate(context.model, candidate) is Some(request) else {
+    abort("lone CR native insertion must normalize")
+  }
+  assert_eq(request.selection.selection.anchor(), 2)
+  assert_eq(request.inserted, "X")
+}
+
+///|
+test "native Raw pairing silently rejects stale and mode-stale captures" {
+  let context = RawSelectionTestContext::RawSelectionTestContext(
+    "raw-native-stale", "abc",
+  )
+  let candidate = RawNativeInputCandidate::RawNativeInputCandidate(
+    before_input=RawBeforeInputCandidate::RawBeforeInputCandidate(
+      selection=context.selection(1, 1),
+      input_type="insertText",
+      is_composing=false,
+    ),
+    source="aXbc",
+    post_input_selection=@dom_boundary.TextSelection(
+      2,
+      2,
+      @dom_boundary.NoDirection,
+    ),
+  )
+  let emit : @cmd.Emit[DriverEvent] = @cmd.Emit(_ => @rabbita_runtime.none)
+  let (advanced, accepted, _, _) = try! commit_source(
+    context.editor,
+    context.model,
+    context.model.state,
+    "newer",
+    "native-stale-test",
+    emit,
+  )
+  assert_true(accepted)
+  assert_true(normalize_raw_input_candidate(advanced, candidate) is None)
+  assert_true(
+    normalize_raw_input_candidate(
+      {
+        ..context.model,
+        state: @core.ApplicationState::ApplicationState(@core.Block),
+      },
+      candidate,
+    )
+    is None,
+  )
+}
+
+///|
 test "directed cross-block Raw selections commit one ReplaceText transaction" {
   for
     case in [
@@ -109,8 +451,6 @@ test "normalized Raw edit event consumes the Session selection" {
   let latest_model : @ref.Ref[DriverModel?] = @ref.Ref(Some(selected))
   let emit : @cmd.Emit[DriverEvent] = @cmd.Emit(_ => @rabbita_runtime.none)
   let raw_input_coordinator = RawInputCoordinator::RawInputCoordinator(None)
-  ignore(raw_input_coordinator.enqueue("pending", emit))
-
   let (next, _) = try! update_editing(
     context.editor,
     context.attachment,

--- a/apps/loomark/internal/rabbita/text_control_repair.mbt
+++ b/apps/loomark/internal/rabbita/text_control_repair.mbt
@@ -48,14 +48,21 @@ fn rejected_text_selection(
 const RAW_INPUT_DEBOUNCE_MS : Int = 50
 
 ///|
+/// One complete pending batch. Keeping its base, latest browser state, and
+/// count together prevents partially populated coordinator states.
+priv struct PendingRawInput {
+  before_input : RawBeforeInputCandidate
+  source : String
+  post_input_selection : @dom_boundary.TextSelection
+  input_count : Int
+}
+
+///|
 /// Coalesce native textarea events into one delayed, tokenized Raw transaction.
 /// Custom-driver RawInput events bypass this coordinator and remain token-less.
 priv struct RawInputCoordinator {
   unmatched_before_input : @ref.Ref[RawBeforeInputCandidate?]
-  pending_before_input : @ref.Ref[RawBeforeInputCandidate?]
-  pending_source : @ref.Ref[String?]
-  pending_selection : @ref.Ref[@dom_boundary.TextSelection?]
-  pending_count : @ref.Ref[Int]
+  pending : @ref.Ref[PendingRawInput?]
   scheduled : @ref.Ref[Bool]
   schedule_generation : @ref.Ref[Int]
   capture_generation : @ref.Ref[Int]
@@ -72,10 +79,7 @@ fn RawInputCoordinator::RawInputCoordinator(
 ) -> RawInputCoordinator {
   {
     unmatched_before_input: @ref.Ref(None),
-    pending_before_input: @ref.Ref(None),
-    pending_source: @ref.Ref(None),
-    pending_selection: @ref.Ref(None),
-    pending_count: @ref.Ref(0),
+    pending: @ref.Ref(None),
     scheduled: @ref.Ref(false),
     schedule_generation: @ref.Ref(0),
     capture_generation: @ref.Ref(0),
@@ -243,8 +247,8 @@ fn RawInputCoordinator::display_source(
   self : RawInputCoordinator,
   committed_source : String,
 ) -> String {
-  match self.pending_source.val {
-    Some(source) => source
+  match self.pending.val {
+    Some(pending) => pending.source
     None =>
       match self.in_flight_source.val {
         Some(source) => source
@@ -318,8 +322,8 @@ fn RawInputCoordinator::capture_native_before_input(
     self.cancel_pending()
     return @rabbita_runtime.none
   }
-  match self.pending_before_input.val {
-    Some(first) => return self.capture_before_input(first)
+  match self.pending.val {
+    Some(pending) => return self.capture_before_input(pending.before_input)
     None => ()
   }
   let selection = match read_raw_selection() {
@@ -378,18 +382,13 @@ fn RawInputCoordinator::flush(
   emit : @cmd.Emit[DriverEvent],
 ) -> Unit {
   self.scheduled.val = false
-  match
-    (
-      self.pending_before_input.val,
-      self.pending_source.val,
-      self.pending_selection.val,
-    ) {
-    (Some(before_input), Some(source), Some(post_input_selection)) => {
-      self.pending_before_input.val = None
-      self.pending_source.val = None
-      self.pending_selection.val = None
-      let input_count = self.pending_count.val
-      self.pending_count.val = 0
+  match self.pending.val {
+    Some(pending) => {
+      self.pending.val = None
+      let before_input = pending.before_input
+      let source = pending.source
+      let post_input_selection = pending.post_input_selection
+      let input_count = pending.input_count
       let token = self.next_token.val
       self.next_token.val = token + 1
       self.in_flight_token.val = Some(token)
@@ -436,7 +435,7 @@ fn RawInputCoordinator::flush(
         ),
       )
     }
-    _ => self.cancel_pending()
+    None => self.cancel_pending()
   }
 }
 
@@ -484,26 +483,31 @@ fn RawInputCoordinator::enqueue(
     self.cancel_pending()
     return @rabbita_runtime.none
   }
-  match self.pending_before_input.val {
-    Some(first) if first.selection.document_id !=
+  let source = raw_textarea_value(source)
+  let pending = match self.pending.val {
+    Some(pending) if pending.before_input.selection.document_id !=
       before_input.selection.document_id ||
-      first.selection.version != before_input.selection.version => {
+      pending.before_input.selection.version != before_input.selection.version => {
       self.cancel_pending()
       return @rabbita_runtime.none
     }
-    None => self.pending_before_input.val = Some(before_input)
-    Some(_) => ()
-  }
-  if self.pending_count.val == 0 {
-    match self.telemetry {
-      Some(telemetry) =>
-        telemetry.pending_input_received_at.val = Some(raw_input_now_ms())
-      None => ()
+    Some(pending) =>
+      {
+        ..pending,
+        source,
+        post_input_selection,
+        input_count: pending.input_count + 1,
+      }
+    None => {
+      match self.telemetry {
+        Some(telemetry) =>
+          telemetry.pending_input_received_at.val = Some(raw_input_now_ms())
+        None => ()
+      }
+      { before_input, source, post_input_selection, input_count: 1 }
     }
   }
-  self.pending_count.val += 1
-  self.pending_source.val = Some(raw_textarea_value(source))
-  self.pending_selection.val = Some(post_input_selection)
+  self.pending.val = Some(pending)
   self.schedule(emit)
 }
 
@@ -558,10 +562,7 @@ fn RawInputCoordinator::cancel_pending(self : RawInputCoordinator) -> Unit {
   self.capture_generation.val += 1
   self.scheduled.val = false
   self.unmatched_before_input.val = None
-  self.pending_before_input.val = None
-  self.pending_source.val = None
-  self.pending_selection.val = None
-  self.pending_count.val = 0
+  self.pending.val = None
   match self.telemetry {
     Some(telemetry) => {
       telemetry.pending_input_received_at.val = None

--- a/apps/loomark/internal/rabbita/text_control_repair.mbt
+++ b/apps/loomark/internal/rabbita/text_control_repair.mbt
@@ -48,25 +48,21 @@ fn rejected_text_selection(
 const RAW_INPUT_DEBOUNCE_MS : Int = 50
 
 ///|
-/// Keep the latest native Raw value while one deferred commit is in flight.
-/// The browser can continue updating the textarea without queuing stale
-/// canonical-source commits behind an expensive editor transaction.
-///
-/// The token and one-shot retry preserve the existing rejected-edit behavior:
-/// if the transaction fails, the latest native value gets one more chance
-/// instead of being lost by coalescing.
+/// Coalesce native textarea events into one delayed, tokenized Raw transaction.
+/// Custom-driver RawInput events bypass this coordinator and remain token-less.
 priv struct RawInputCoordinator {
+  unmatched_before_input : @ref.Ref[RawBeforeInputCandidate?]
+  pending_before_input : @ref.Ref[RawBeforeInputCandidate?]
   pending_source : @ref.Ref[String?]
+  pending_selection : @ref.Ref[@dom_boundary.TextSelection?]
   pending_count : @ref.Ref[Int]
   scheduled : @ref.Ref[Bool]
   schedule_generation : @ref.Ref[Int]
-  retry_budget : @ref.Ref[Int]
-  repair_pending : @ref.Ref[Bool]
-  retry_selection : @ref.Ref[@dom_boundary.TextSelection?]
-  input_epoch : @ref.Ref[Int]
+  capture_generation : @ref.Ref[Int]
   next_token : @ref.Ref[Int]
   in_flight_token : @ref.Ref[Int?]
-  in_flight_count : @ref.Ref[Int?]
+  in_flight_source : @ref.Ref[String?]
+  suppress_unmatched_repair : @ref.Ref[Bool]
   telemetry : RawInputTelemetry?
 }
 
@@ -75,17 +71,18 @@ fn RawInputCoordinator::RawInputCoordinator(
   telemetry : RawInputTelemetry?,
 ) -> RawInputCoordinator {
   {
+    unmatched_before_input: @ref.Ref(None),
+    pending_before_input: @ref.Ref(None),
     pending_source: @ref.Ref(None),
+    pending_selection: @ref.Ref(None),
     pending_count: @ref.Ref(0),
     scheduled: @ref.Ref(false),
     schedule_generation: @ref.Ref(0),
-    retry_budget: @ref.Ref(0),
-    repair_pending: @ref.Ref(false),
-    retry_selection: @ref.Ref(None),
-    input_epoch: @ref.Ref(0),
+    capture_generation: @ref.Ref(0),
     next_token: @ref.Ref(0),
     in_flight_token: @ref.Ref(None),
-    in_flight_count: @ref.Ref(None),
+    in_flight_source: @ref.Ref(None),
+    suppress_unmatched_repair: @ref.Ref(false),
     telemetry,
   }
 }
@@ -238,7 +235,7 @@ fn RawInputCoordinator::phase_json(self : RawInputCoordinator) -> Json? {
 
 ///|
 fn RawInputCoordinator::epoch(self : RawInputCoordinator) -> Int {
-  self.input_epoch.val
+  self.capture_generation.val
 }
 
 ///|
@@ -248,8 +245,103 @@ fn RawInputCoordinator::display_source(
 ) -> String {
   match self.pending_source.val {
     Some(source) => source
-    None => committed_source
+    None =>
+      match self.in_flight_source.val {
+        Some(source) => source
+        None => committed_source
+      }
   }
+}
+
+///|
+#cfg(target="js")
+fn raw_input_event_is_composing(event : @dom.InputEvent) -> Bool {
+  event.is_composing()
+}
+
+///|
+#cfg(not(target="js"))
+fn raw_input_event_is_composing(event : @dom.InputEvent) -> Bool {
+  ignore(event)
+  false
+}
+
+///|
+#cfg(target="js")
+fn raw_input_event_type(event : @dom.InputEvent) -> String {
+  event.input_type()
+}
+
+///|
+#cfg(not(target="js"))
+fn raw_input_event_type(event : @dom.InputEvent) -> String {
+  ignore(event)
+  ""
+}
+
+///|
+/// Store a candidate synchronously and expire only this unmatched capture.
+fn RawInputCoordinator::capture_before_input(
+  self : RawInputCoordinator,
+  candidate : RawBeforeInputCandidate,
+) -> @cmd.Cmd {
+  self.capture_generation.val += 1
+  let generation = self.capture_generation.val
+  self.unmatched_before_input.val = Some(candidate)
+  @cmd.delay(
+    @cmd.custom_cmd(scheduler => {
+      ignore(scheduler)
+      self.expire_before_input(generation)
+    }),
+    0,
+  )
+}
+
+///|
+fn RawInputCoordinator::expire_before_input(
+  self : RawInputCoordinator,
+  generation : Int,
+) -> Unit {
+  if self.capture_generation.val == generation {
+    self.unmatched_before_input.val = None
+  }
+}
+
+///|
+/// Capture beforeinput while the DOM still exposes the pre-edit selection.
+fn RawInputCoordinator::capture_native_before_input(
+  self : RawInputCoordinator,
+  model : DriverModel,
+  event : @dom.InputEvent,
+) -> @cmd.Cmd {
+  if raw_input_event_is_composing(event) {
+    self.cancel_pending()
+    return @rabbita_runtime.none
+  }
+  match self.pending_before_input.val {
+    Some(first) => return self.capture_before_input(first)
+    None => ()
+  }
+  let selection = match read_raw_selection() {
+    Some(selection) => selection
+    None => {
+      self.cancel_pending()
+      return @rabbita_runtime.none
+    }
+  }
+  let selection = versioned_raw_selection_from_dom(model, selection) catch {
+    _ => {
+      self.cancel_pending()
+      return @rabbita_runtime.none
+    }
+  }
+  self.capture_before_input(
+    RawBeforeInputCandidate::RawBeforeInputCandidate(
+      selection~,
+      input_type=raw_input_event_type(event),
+      is_composing=false,
+    ),
+  )
 }
 
 ///|
@@ -257,7 +349,6 @@ fn RawInputCoordinator::schedule(
   self : RawInputCoordinator,
   emit : @cmd.Emit[DriverEvent],
 ) -> @cmd.Cmd {
-  guard !self.scheduled.val else { return @rabbita_runtime.none }
   self.schedule_generation.val += 1
   let generation = self.schedule_generation.val
   self.scheduled.val = true
@@ -269,17 +360,6 @@ fn RawInputCoordinator::schedule(
     }),
     RAW_INPUT_DEBOUNCE_MS,
   )
-}
-
-///|
-/// Move the trailing edge when a newer native value arrives.
-fn RawInputCoordinator::reschedule(
-  self : RawInputCoordinator,
-  emit : @cmd.Emit[DriverEvent],
-) -> @cmd.Cmd {
-  self.schedule_generation.val += 1
-  self.scheduled.val = false
-  self.schedule(emit)
 }
 
 ///|
@@ -298,28 +378,36 @@ fn RawInputCoordinator::flush(
   emit : @cmd.Emit[DriverEvent],
 ) -> Unit {
   self.scheduled.val = false
-  match self.pending_source.val {
-    None => ()
-    Some(source) => {
+  match
+    (
+      self.pending_before_input.val,
+      self.pending_source.val,
+      self.pending_selection.val,
+    ) {
+    (Some(before_input), Some(source), Some(post_input_selection)) => {
+      self.pending_before_input.val = None
       self.pending_source.val = None
+      self.pending_selection.val = None
       let input_count = self.pending_count.val
       self.pending_count.val = 0
       let token = self.next_token.val
       self.next_token.val = token + 1
+      self.in_flight_token.val = Some(token)
+      self.in_flight_source.val = Some(source)
       match self.telemetry {
         Some(telemetry) => {
-          let debounce_fired_at = raw_input_now_ms()
+          let now = raw_input_now_ms()
           let input_received_at = match
             telemetry.pending_input_received_at.val {
             Some(at) => at
-            None => debounce_fired_at
+            None => now
           }
           telemetry.pending_input_received_at.val = None
           telemetry.phase.val = Some({
             token,
             input_count,
             input_received_at,
-            debounce_fired_at,
+            debounce_fired_at: now,
             reducer_started_at: None,
             reducer_finished_at: None,
             editor_started_at: None,
@@ -333,134 +421,146 @@ fn RawInputCoordinator::flush(
         }
         None => ()
       }
-      self.in_flight_token.val = Some(token)
-      self.in_flight_count.val = Some(input_count)
-      let selection = match self.retry_selection.val {
-        Some(selection) => {
-          self.retry_selection.val = None
-          Some(selection)
-        }
-        None => read_raw_selection()
-      }
-      scheduler.add(emit(Editing(RawInput(source, selection, Some(token)))))
+      scheduler.add(
+        emit(
+          Editing(
+            RawNativeInput(
+              token~,
+              candidate=RawNativeInputCandidate::RawNativeInputCandidate(
+                before_input~,
+                source~,
+                post_input_selection~,
+              ),
+            ),
+          ),
+        ),
+      )
     }
+    _ => self.cancel_pending()
   }
+}
+
+///|
+fn RawInputCoordinator::has_captured_before_input(
+  self : RawInputCoordinator,
+) -> Bool {
+  self.unmatched_before_input.val is Some(_)
+}
+
+///|
+fn RawInputCoordinator::suppress_composing_input_repair(
+  self : RawInputCoordinator,
+) -> Unit {
+  self.cancel_pending()
+  self.suppress_unmatched_repair.val = true
+}
+
+///|
+fn RawInputCoordinator::take_unmatched_input_repair(
+  self : RawInputCoordinator,
+) -> Bool {
+  let repair = !self.suppress_unmatched_repair.val
+  self.suppress_unmatched_repair.val = false
+  repair
 }
 
 ///|
 fn RawInputCoordinator::enqueue(
   self : RawInputCoordinator,
   source : String,
+  post_input_selection : @dom_boundary.TextSelection,
   emit : @cmd.Emit[DriverEvent],
 ) -> @cmd.Cmd {
-  self.input_epoch.val += 1
-  match self.telemetry {
-    Some(telemetry) =>
-      telemetry.pending_input_received_at.val = Some(raw_input_now_ms())
-    None => ()
+  self.capture_generation.val += 1
+  let before_input = match self.unmatched_before_input.val {
+    Some(before_input) => before_input
+    None => {
+      self.cancel_pending()
+      return @rabbita_runtime.none
+    }
   }
-  match self.pending_source.val {
-    None => self.pending_count.val = 1
-    Some(_) => self.pending_count.val += 1
+  self.unmatched_before_input.val = None
+  guard !before_input.is_composing else {
+    self.cancel_pending()
+    return @rabbita_runtime.none
   }
-  self.pending_source.val = Some(source)
-  self.retry_selection.val = None
-  self.retry_budget.val = 1
-  self.reschedule(emit)
+  match self.pending_before_input.val {
+    Some(first) if first.selection.document_id !=
+      before_input.selection.document_id ||
+      first.selection.version != before_input.selection.version => {
+      self.cancel_pending()
+      return @rabbita_runtime.none
+    }
+    None => self.pending_before_input.val = Some(before_input)
+    Some(_) => ()
+  }
+  if self.pending_count.val == 0 {
+    match self.telemetry {
+      Some(telemetry) =>
+        telemetry.pending_input_received_at.val = Some(raw_input_now_ms())
+      None => ()
+    }
+  }
+  self.pending_count.val += 1
+  self.pending_source.val = Some(raw_textarea_value(source))
+  self.pending_selection.val = Some(post_input_selection)
+  self.schedule(emit)
 }
 
 ///|
-/// Complete a deferred transaction and retry one rejected native value.
-fn RawInputCoordinator::complete(
+/// Finish a normalized native transaction after its resulting render. The
+/// phase remains available for the outer publish and is copied to last_phase.
+fn RawInputCoordinator::finish(
   self : RawInputCoordinator,
   token : Int,
-  source : String,
-  selection : @dom_boundary.TextSelection?,
-  accepted : Bool,
-  repair_check : () -> Bool,
-  after_render_publish : () -> Unit,
+  latest_model : @ref.Ref[DriverModel?],
   emit : @cmd.Emit[DriverEvent],
 ) -> @cmd.Cmd {
   guard self.in_flight_token.val == Some(token) else {
     return @rabbita_runtime.none
   }
   self.in_flight_token.val = None
-  let input_count = self.in_flight_count.val
-  self.in_flight_count.val = None
-  let can_retry = match input_count {
-    Some(count) => count > 1
-    None => false
-  }
-  if accepted {
-    let needs_repair = self.repair_pending.val &&
-      self.pending_source.val is None
-    self.retry_budget.val = 0
-    self.repair_pending.val = false
-    let repair_epoch = self.input_epoch.val
-    let command = match self.pending_source.val {
-      Some(_) => self.schedule(emit)
-      None => @rabbita_runtime.none
+  self.in_flight_source.val = None
+  after_render(
+    scheduler => {
+      ignore(scheduler)
+      self.mark_rendered(token)
+      match latest_model.val {
+        Some(model) => publish(model, Some(self), None)
+        None => ()
+      }
+    },
+    emit,
+  )
+}
+
+///|
+/// Discard a native transaction that could not be normalized or was canceled.
+fn RawInputCoordinator::discard(
+  self : RawInputCoordinator,
+  token : Int,
+) -> Unit {
+  if self.in_flight_token.val == Some(token) {
+    self.in_flight_token.val = None
+    self.in_flight_source.val = None
+    match self.telemetry {
+      Some(telemetry) => telemetry.phase.val = None
+      None => ()
     }
-    let render_measurement = after_render(
-      scheduler => {
-        ignore(scheduler)
-        self.mark_rendered(token)
-        after_render_publish()
-      },
-      emit,
-    )
-    if needs_repair {
-      @cmd.batch([
-        command,
-        render_measurement,
-        after_render(
-          scheduler => {
-            ignore(scheduler)
-            if self.input_epoch.val != repair_epoch || !repair_check() {
-              return
-            }
-            @dom_boundary.write_text_value_id("loomark-input", source)
-            match selection {
-              Some(selection) =>
-                @dom_boundary.write_text_selection_id(
-                  "loomark-input", selection,
-                )
-              None => ()
-            }
-          },
-          emit,
-        ),
-      ])
-    } else {
-      @cmd.batch([command, render_measurement])
-    }
-  } else if self.retry_budget.val > 0 && can_retry {
-    self.input_epoch.val += 1
-    self.retry_budget.val -= 1
-    self.repair_pending.val = true
-    self.retry_selection.val = selection
-    if self.pending_source.val is None {
-      self.pending_count.val = 1
-      self.pending_source.val = Some(source)
-    }
-    self.schedule(emit)
-  } else {
-    self.pending_source.val = None
-    self.repair_pending.val = false
-    self.retry_selection.val = None
-    @rabbita_runtime.none
   }
 }
 
 ///|
 /// Drop native input that is superseded by an external canonical-source
-/// operation. The generation invalidates the already-created timer without
-/// requiring timer cancellation support from the command layer.
+/// operation. Generations invalidate already-created timers and captures.
 fn RawInputCoordinator::cancel_pending(self : RawInputCoordinator) -> Unit {
-  self.input_epoch.val += 1
   self.schedule_generation.val += 1
+  self.capture_generation.val += 1
   self.scheduled.val = false
+  self.unmatched_before_input.val = None
+  self.pending_before_input.val = None
   self.pending_source.val = None
+  self.pending_selection.val = None
   self.pending_count.val = 0
   match self.telemetry {
     Some(telemetry) => {
@@ -469,11 +569,9 @@ fn RawInputCoordinator::cancel_pending(self : RawInputCoordinator) -> Unit {
     }
     None => ()
   }
-  self.retry_budget.val = 0
-  self.repair_pending.val = false
-  self.retry_selection.val = None
   self.in_flight_token.val = None
-  self.in_flight_count.val = None
+  self.in_flight_source.val = None
+  self.suppress_unmatched_repair.val = false
 }
 
 ///|
@@ -487,26 +585,8 @@ fn RawInputCoordinator::is_active(
 ///|
 fn RawInputCoordinator::cancel(self : RawInputCoordinator, token : Int) -> Unit {
   if self.in_flight_token.val == Some(token) {
-    self.input_epoch.val += 1
-    self.in_flight_token.val = None
-    self.in_flight_count.val = None
-    match self.telemetry {
-      Some(telemetry) => telemetry.phase.val = None
-      None => ()
-    }
-    self.repair_pending.val = false
-    self.retry_selection.val = None
+    self.cancel_pending()
   }
-}
-
-///|
-/// Defer Raw input handling and retain only the latest native value.
-fn raw_input_command(
-  source : String,
-  coordinator : RawInputCoordinator,
-  emit : @cmd.Emit[DriverEvent],
-) -> @cmd.Cmd {
-  coordinator.enqueue(source, emit)
 }
 
 ///|

--- a/apps/loomark/internal/rabbita/text_control_repair_wbtest.mbt
+++ b/apps/loomark/internal/rabbita/text_control_repair_wbtest.mbt
@@ -100,14 +100,14 @@ test "Raw coordinator keeps the first backward base and latest collapsed caret" 
       emit,
     ),
   )
-  guard coordinator.pending_before_input.val is Some(first) else {
+  guard coordinator.pending.val is Some(pending) else {
     fail("first capture must remain the batch base")
   }
-  assert_eq(first.selection.selection.anchor(), 4)
-  assert_eq(first.selection.selection.head(), 2)
-  assert_eq(coordinator.pending_source.val, Some("abxyZef"))
-  assert_eq(coordinator.pending_selection.val.unwrap().start(), 5)
-  assert_eq(coordinator.pending_count.val, 2)
+  assert_eq(pending.before_input.selection.selection.anchor(), 4)
+  assert_eq(pending.before_input.selection.selection.head(), 2)
+  assert_eq(pending.source, "abxyZef")
+  assert_eq(pending.post_input_selection.start(), 5)
+  assert_eq(pending.input_count, 2)
 }
 
 ///|
@@ -149,9 +149,7 @@ test "Raw coordinator discards a batch on version or document mismatch" {
       emit,
     ),
   )
-  assert_true(coordinator.pending_before_input.val is None)
-  assert_true(coordinator.pending_source.val is None)
-  assert_eq(coordinator.pending_count.val, 0)
+  assert_true(coordinator.pending.val is None)
 
   ignore(coordinator.capture_before_input(capture(context.selection(1, 1))))
   ignore(
@@ -172,9 +170,7 @@ test "Raw coordinator discards a batch on version or document mismatch" {
       emit,
     ),
   )
-  assert_true(coordinator.pending_before_input.val is None)
-  assert_true(coordinator.pending_source.val is None)
-  assert_eq(coordinator.pending_count.val, 0)
+  assert_true(coordinator.pending.val is None)
 }
 
 ///|
@@ -207,9 +203,7 @@ test "Raw coordinator input without capture discards a pending batch" {
       emit,
     ),
   )
-  assert_true(coordinator.pending_before_input.val is None)
-  assert_true(coordinator.pending_source.val is None)
-  assert_eq(coordinator.pending_count.val, 0)
+  assert_true(coordinator.pending.val is None)
 }
 
 ///|
@@ -236,9 +230,7 @@ test "Raw coordinator discards a composition-intermediate capture" {
     ),
   )
   assert_true(coordinator.unmatched_before_input.val is None)
-  assert_true(coordinator.pending_before_input.val is None)
-  assert_true(coordinator.pending_source.val is None)
-  assert_eq(coordinator.pending_count.val, 0)
+  assert_true(coordinator.pending.val is None)
 }
 
 ///|
@@ -276,8 +268,11 @@ test "Raw coordinator capture expiry clears only an unmatched capture" {
   let generation = coordinator.capture_generation.val
   coordinator.expire_before_input(generation)
   assert_true(coordinator.unmatched_before_input.val is None)
-  assert_eq(coordinator.pending_source.val, Some("aXbc"))
-  assert_eq(coordinator.pending_count.val, 1)
+  guard coordinator.pending.val is Some(pending) else {
+    fail("capture expiry must preserve the pending batch")
+  }
+  assert_eq(pending.source, "aXbc")
+  assert_eq(pending.input_count, 1)
 }
 
 ///|
@@ -318,10 +313,7 @@ test "Raw coordinator cancel clears all state and invalidates capture expiry" {
   coordinator.cancel_pending()
   coordinator.expire_before_input(expiry_generation)
   assert_true(coordinator.unmatched_before_input.val is None)
-  assert_true(coordinator.pending_before_input.val is None)
-  assert_true(coordinator.pending_source.val is None)
-  assert_true(coordinator.pending_selection.val is None)
-  assert_eq(coordinator.pending_count.val, 0)
+  assert_true(coordinator.pending.val is None)
   assert_true(coordinator.in_flight_token.val is None)
   assert_true(coordinator.in_flight_source.val is None)
   assert_false(coordinator.scheduled.val)

--- a/apps/loomark/internal/rabbita/text_control_repair_wbtest.mbt
+++ b/apps/loomark/internal/rabbita/text_control_repair_wbtest.mbt
@@ -52,3 +52,277 @@ test "Raw coordinator without telemetry keeps phase snapshots empty" {
     fail("standalone Raw coordinator must not expose phase telemetry")
   }
 }
+
+///|
+test "Raw coordinator suppresses only the matching composition repair" {
+  let coordinator = RawInputCoordinator::RawInputCoordinator(None)
+  coordinator.suppress_composing_input_repair()
+  assert_false(coordinator.take_unmatched_input_repair())
+  assert_true(coordinator.take_unmatched_input_repair())
+}
+
+///|
+test "Raw coordinator keeps the first backward base and latest collapsed caret" {
+  let context = RawSelectionTestContext::RawSelectionTestContext(
+    "coordinator-pairing", "abcdef",
+  )
+  let coordinator = RawInputCoordinator::RawInputCoordinator(None)
+  let emit : @cmd.Emit[DriverEvent] = @cmd.Emit(_ => @rabbita_runtime.none)
+  ignore(
+    coordinator.capture_before_input(
+      RawBeforeInputCandidate::RawBeforeInputCandidate(
+        selection=context.selection(4, 2),
+        input_type="insertText",
+        is_composing=false,
+      ),
+    ),
+  )
+  ignore(
+    coordinator.enqueue(
+      "abxyef",
+      @dom_boundary.TextSelection(4, 4, @dom_boundary.NoDirection),
+      emit,
+    ),
+  )
+  ignore(
+    coordinator.capture_before_input(
+      RawBeforeInputCandidate::RawBeforeInputCandidate(
+        selection=context.selection(4, 4),
+        input_type="insertText",
+        is_composing=false,
+      ),
+    ),
+  )
+  ignore(
+    coordinator.enqueue(
+      "abxyZef",
+      @dom_boundary.TextSelection(5, 5, @dom_boundary.NoDirection),
+      emit,
+    ),
+  )
+  guard coordinator.pending_before_input.val is Some(first) else {
+    fail("first capture must remain the batch base")
+  }
+  assert_eq(first.selection.selection.anchor(), 4)
+  assert_eq(first.selection.selection.head(), 2)
+  assert_eq(coordinator.pending_source.val, Some("abxyZef"))
+  assert_eq(coordinator.pending_selection.val.unwrap().start(), 5)
+  assert_eq(coordinator.pending_count.val, 2)
+}
+
+///|
+test "Raw coordinator discards a batch on version or document mismatch" {
+  let context = RawSelectionTestContext::RawSelectionTestContext(
+    "coordinator-frontier-mismatch", "abc",
+  )
+  let coordinator = RawInputCoordinator::RawInputCoordinator(None)
+  let emit : @cmd.Emit[DriverEvent] = @cmd.Emit(_ => @rabbita_runtime.none)
+  let capture = selection => {
+    RawBeforeInputCandidate::RawBeforeInputCandidate(
+      selection~,
+      input_type="insertText",
+      is_composing=false,
+    )
+  }
+  ignore(coordinator.capture_before_input(capture(context.selection(1, 1))))
+  ignore(
+    coordinator.enqueue(
+      "aXbc",
+      @dom_boundary.TextSelection(2, 2, @dom_boundary.NoDirection),
+      emit,
+    ),
+  )
+  let (advanced_model, _) = context.commit(
+    context.model,
+    context.selection(0, 0),
+    "q",
+  )
+  let advanced = {
+    ..context.selection(1, 1),
+    version: advanced_model.document_version,
+  }
+  ignore(coordinator.capture_before_input(capture(advanced)))
+  ignore(
+    coordinator.enqueue(
+      "aXYbc",
+      @dom_boundary.TextSelection(3, 3, @dom_boundary.NoDirection),
+      emit,
+    ),
+  )
+  assert_true(coordinator.pending_before_input.val is None)
+  assert_true(coordinator.pending_source.val is None)
+  assert_eq(coordinator.pending_count.val, 0)
+
+  ignore(coordinator.capture_before_input(capture(context.selection(1, 1))))
+  ignore(
+    coordinator.enqueue(
+      "aXbc",
+      @dom_boundary.TextSelection(2, 2, @dom_boundary.NoDirection),
+      emit,
+    ),
+  )
+  let other = RawSelectionTestContext::RawSelectionTestContext(
+    "coordinator-other-document", "abc",
+  )
+  ignore(coordinator.capture_before_input(capture(other.selection(1, 1))))
+  ignore(
+    coordinator.enqueue(
+      "aXYbc",
+      @dom_boundary.TextSelection(3, 3, @dom_boundary.NoDirection),
+      emit,
+    ),
+  )
+  assert_true(coordinator.pending_before_input.val is None)
+  assert_true(coordinator.pending_source.val is None)
+  assert_eq(coordinator.pending_count.val, 0)
+}
+
+///|
+test "Raw coordinator input without capture discards a pending batch" {
+  let context = RawSelectionTestContext::RawSelectionTestContext(
+    "coordinator-no-capture", "abc",
+  )
+  let coordinator = RawInputCoordinator::RawInputCoordinator(None)
+  let emit : @cmd.Emit[DriverEvent] = @cmd.Emit(_ => @rabbita_runtime.none)
+  ignore(
+    coordinator.capture_before_input(
+      RawBeforeInputCandidate::RawBeforeInputCandidate(
+        selection=context.selection(1, 1),
+        input_type="insertText",
+        is_composing=false,
+      ),
+    ),
+  )
+  ignore(
+    coordinator.enqueue(
+      "aXbc",
+      @dom_boundary.TextSelection(2, 2, @dom_boundary.NoDirection),
+      emit,
+    ),
+  )
+  ignore(
+    coordinator.enqueue(
+      "aXYbc",
+      @dom_boundary.TextSelection(3, 3, @dom_boundary.NoDirection),
+      emit,
+    ),
+  )
+  assert_true(coordinator.pending_before_input.val is None)
+  assert_true(coordinator.pending_source.val is None)
+  assert_eq(coordinator.pending_count.val, 0)
+}
+
+///|
+test "Raw coordinator discards a composition-intermediate capture" {
+  let context = RawSelectionTestContext::RawSelectionTestContext(
+    "coordinator-composition", "abc",
+  )
+  let coordinator = RawInputCoordinator::RawInputCoordinator(None)
+  let emit : @cmd.Emit[DriverEvent] = @cmd.Emit(_ => @rabbita_runtime.none)
+  ignore(
+    coordinator.capture_before_input(
+      RawBeforeInputCandidate::RawBeforeInputCandidate(
+        selection=context.selection(1, 1),
+        input_type="insertCompositionText",
+        is_composing=true,
+      ),
+    ),
+  )
+  ignore(
+    coordinator.enqueue(
+      "aXbc",
+      @dom_boundary.TextSelection(2, 2, @dom_boundary.NoDirection),
+      emit,
+    ),
+  )
+  assert_true(coordinator.unmatched_before_input.val is None)
+  assert_true(coordinator.pending_before_input.val is None)
+  assert_true(coordinator.pending_source.val is None)
+  assert_eq(coordinator.pending_count.val, 0)
+}
+
+///|
+test "Raw coordinator capture expiry clears only an unmatched capture" {
+  let context = RawSelectionTestContext::RawSelectionTestContext(
+    "coordinator-expiry", "abc",
+  )
+  let coordinator = RawInputCoordinator::RawInputCoordinator(None)
+  let emit : @cmd.Emit[DriverEvent] = @cmd.Emit(_ => @rabbita_runtime.none)
+  ignore(
+    coordinator.capture_before_input(
+      RawBeforeInputCandidate::RawBeforeInputCandidate(
+        selection=context.selection(1, 1),
+        input_type="insertText",
+        is_composing=false,
+      ),
+    ),
+  )
+  ignore(
+    coordinator.enqueue(
+      "aXbc",
+      @dom_boundary.TextSelection(2, 2, @dom_boundary.NoDirection),
+      emit,
+    ),
+  )
+  ignore(
+    coordinator.capture_before_input(
+      RawBeforeInputCandidate::RawBeforeInputCandidate(
+        selection=context.selection(2, 2),
+        input_type="insertText",
+        is_composing=false,
+      ),
+    ),
+  )
+  let generation = coordinator.capture_generation.val
+  coordinator.expire_before_input(generation)
+  assert_true(coordinator.unmatched_before_input.val is None)
+  assert_eq(coordinator.pending_source.val, Some("aXbc"))
+  assert_eq(coordinator.pending_count.val, 1)
+}
+
+///|
+test "Raw coordinator cancel clears all state and invalidates capture expiry" {
+  let context = RawSelectionTestContext::RawSelectionTestContext(
+    "coordinator-cancel", "abc",
+  )
+  let coordinator = RawInputCoordinator::RawInputCoordinator(None)
+  let emit : @cmd.Emit[DriverEvent] = @cmd.Emit(_ => @rabbita_runtime.none)
+  ignore(
+    coordinator.capture_before_input(
+      RawBeforeInputCandidate::RawBeforeInputCandidate(
+        selection=context.selection(1, 1),
+        input_type="insertText",
+        is_composing=false,
+      ),
+    ),
+  )
+  ignore(
+    coordinator.enqueue(
+      "aXbc",
+      @dom_boundary.TextSelection(2, 2, @dom_boundary.NoDirection),
+      emit,
+    ),
+  )
+  ignore(
+    coordinator.capture_before_input(
+      RawBeforeInputCandidate::RawBeforeInputCandidate(
+        selection=context.selection(2, 2),
+        input_type="insertText",
+        is_composing=false,
+      ),
+    ),
+  )
+  let expiry_generation = coordinator.capture_generation.val
+  coordinator.in_flight_token.val = Some(7)
+  coordinator.in_flight_source.val = Some("in-flight")
+  coordinator.cancel_pending()
+  coordinator.expire_before_input(expiry_generation)
+  assert_true(coordinator.unmatched_before_input.val is None)
+  assert_true(coordinator.pending_before_input.val is None)
+  assert_true(coordinator.pending_source.val is None)
+  assert_true(coordinator.pending_selection.val is None)
+  assert_eq(coordinator.pending_count.val, 0)
+  assert_true(coordinator.in_flight_token.val is None)
+  assert_true(coordinator.in_flight_source.val is None)
+  assert_false(coordinator.scheduled.val)
+}

--- a/scripts/install-local-warren.sh
+++ b/scripts/install-local-warren.sh
@@ -5,7 +5,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 RABBITA_ROOT="$PROJECT_ROOT/deps/rabbita"
 RABBITA_REMOTE="$(git -C "$PROJECT_ROOT" config -f .gitmodules --get submodule.rabbita.url)"
-EXPECTED_RABBITA="09968c4402c51645186d75c5044cf4d9346f9f06"
+EXPECTED_RABBITA="539002a5a3fbd114097de1fedc758a92182cdfa7"
 BIN_DIR="${1:-$PROJECT_ROOT/_build/tools/bin}"
 
 actual_remote="$(git -C "$RABBITA_ROOT" remote get-url origin)"


### PR DESCRIPTION
Closes #1204.

## Summary

- Capture the first directed Raw selection synchronously at `beforeinput`, bind it to the document ID/version, and pair it only with the matching same-task native `input`.
- Keep the existing 50 ms trailing debounce, retain the first pre-input selection plus the latest native source/caret, and lower the aggregate change through the existing `RawSelectionEditRequest` / `MarkdownEditRequest::ReplaceText` path.
- Reject or repair unmatched, malformed, stale, mode-superseded, canceled, and failed batches without guessing a canonical edit; composition-intermediate DOM remains uncommitted for #1076.
- Point Rabbita and the pinned Warren installer at the reachable Canopy-compatible `beforeinput` integration commit.
- Keep each pending batch as one private immutable `PendingRawInput` value, eliminating partially populated coordinator states.

## UI and review evidence

N/A for visual changes: labels, layout, bounds, and styling are unchanged. Browser E2E covers Raw focus, directed selection, caret restoration, mode changes, split Preview convergence, and narrow production output.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `commit_raw_selection_edit` / `RawSelectionEditRequest` | `apps/loomark/internal/rabbita/raw_selection_transaction.mbt` | Yes | Keeps native input on the existing versioned Session commit boundary. |
| `MarkdownEditRequest::ReplaceText` / `MarkdownEditor::commit_with_receipt` | `modules/canopy/editor/markdown/editor.mbt` | Yes | Performs one canonical replacement and preserves existing receipt/history rules. |
| `@text_change.compute_text_change` | `deps/loom/text-change/text_change.mbt` | Yes | Computes the aggregate net change for collapsed input bursts. |
| Raw DOM/source conversion and `rejected_text_selection` | `raw_selection_transaction.mbt`, `text_control_repair.mbt` | Yes | Preserves CRLF/CR offsets, direction, grapheme bounds, and safe repair. |
| MoonBit `String` / `StringView` (`sub`, `has_prefix`, `has_suffix`) | MoonBit core | Yes | Extracts replacement text for the trusted non-collapsed pre-input range without a manual loop. |
| MoonBit `Option`, `Ref`, and `Int::clamp` | MoonBit core | Yes | Represents optional captures, owns imperative coordinator state, and bounds repaired offsets. |
| `Map`, `Set`, `Bytes`, `Buffer`, `Array`, `Iter` | MoonBit core | No | The change is a single UTF-16 text transaction, not keyed, byte-oriented, builder, or collection processing. |

New helpers added (if any):

- Private `RawBeforeInputCandidate` and `RawNativeInputCandidate` bind browser metadata to the existing versioned Raw selection; no public API was added.
- Private `PendingRawInput` atomically groups the first base, latest source/caret, and input count behind one `Ref[Option]` instead of four independently mutable fields.
- `normalize_raw_input_candidate` is the deterministic boundary from paired browser state to one existing `RawSelectionEditRequest`.
- `RawInputCoordinator` capture/enqueue/expiry methods are the imperative shell for same-task pairing, trailing scheduling, cancellation, and telemetry.
- `rejected_raw_input_after_render` performs the guarded DOM-only repair after a matched batch fails.
- TypeScript native-event helpers are test-only and replace unrealistic bare `input` dispatches.

## Validation scope

Boundary matrix / first failing regression:

- First backward replacement plus later collapsed input retains direction and commits once with the latest caret.
- Insert bursts, delete→insert, insert→delete, and net no-op batches lower from the aggregate old→latest source change.
- LF, CRLF, lone CR, EOF, emoji/grapheme boundaries, full replacements, and mid-document replacements preserve canonical offsets.
- Missing/expired `beforeinput`, malformed matched source, wrong document/version, mode change, external edit, snapshot restore, Raw closure, fatal state, editor failure, and composition-intermediate input do not overwrite canonical state.
- Rejected batches repair only while the capture epoch, document frontier, and Raw control remain current; failed commits are not retried automatically.

Target packages:

- `apps/loomark/internal/rabbita`

Additional conditional gates:

- `moon test --target js apps/loomark/internal/rabbita`: 82/82.
- Loomark dev-host Playwright E2E: 95/95.
- Loomark standalone Playwright E2E: 12/12.
- Independent MoonBit/browser review: PASS after fixes and again after rebase.
- Rabbita `539002a5a3fbd114097de1fedc758a92182cdfa7` is pushed and reachable; its `beforeinput` patch is the same three-file change validated on the upstream-main feature commit with MoonBit 0.1.20260803 (JS 393/393, native 61/61). The Canopy-compatible ancestry is validated by the pinned workspace toolchain and PR-ready gate.
- A throwaway 19,530-character browser benchmark kept all tested 50 ms trailing scenarios at one commit. A 32 ms trailing trial committed during the 10 ms input stream and failed convergence, so this PR intentionally retains 50 ms; 24/16 ms were not attempted. Middle replacement commit time remained about 119 ms and should be investigated separately before shortening the debounce.

## PR-ready evidence

Validated HEAD: `2afdc985ea58b78f230bcbea403bf7d3daa13745`

Validated base: `origin/main@283eb46daf292e323ce1abb8d3a6e5abeb17043e`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh \
  --target apps/loomark/internal/rabbita
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for the exact HEAD and base above.
- [x] The base was fetched again and `--verify-evidence` passed immediately before this PR was opened, updated, or merged.
- [x] The committed `.mbti` diff against the validated base was reviewed for unintended API or trait-bound changes.
- [x] Any changed submodule commit is pushed and reachable from its remote.
- [x] Validation was rerun after every commit, amend, rebase, cherry-pick, submodule-pointer, manifest, or generated-interface change.
- [x] Independent review findings were resolved before the final validation.
