### PR TITLE
perf(ideal): apply local CodeMirror deltas incrementally

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,5 +17,6 @@ apps/loomark/internal/archive_storage/js/pkg.generated.mbti whitespace=-blank-at
 apps/loomark/internal/archive_storage/pkg.generated.mbti whitespace=-blank-at-eof
 apps/loomark/repository/pkg.generated.mbti whitespace=-blank-at-eof
 
-# Existing Ideal Playwright files use CRLF line endings.
+# Preserve the existing CRLF line endings in Ideal Playwright specs while
+# treating their line terminators as valid whitespace in diff checks.
 apps/ideal/web/e2e/*.ts whitespace=cr-at-eol

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -47,6 +47,9 @@ jobs:
               - 'scripts/run-moon-module.sh'
             run_editor_response:
               - 'apps/ideal/**'
+              - 'modules/canopy/editor/**'
+              - 'modules/rabbita_codemirror/**'
+              - 'tools/**'
               - 'apps/web/vite-plugin-moonbit.ts'
               - '.github/actions/setup-moonbit/**'
               - '.github/workflows/benchmark.yml'

--- a/apps/ideal/main/bridge_ffi.mbt
+++ b/apps/ideal/main/bridge_ffi.mbt
@@ -242,26 +242,4 @@ extern "js" fn js_focus_tree_rows() -> Unit =
   #|   if (el) el.focus();
   #| }
 
-///|
-/// Start a named browser perf span for the current benchmark sample.
-extern "js" fn js_perf_begin(name : String) -> Unit =
-  #| function(name) {
-  #|   var perf = globalThis.__canopy_bridge?.perfCurrent;
-  #|   if (!perf || !perf.spans) return;
-  #|   if (!perf._starts) perf._starts = {};
-  #|   perf._starts[name] = performance.now();
-  #| }
-
-///|
-/// End a named browser perf span for the current benchmark sample.
-extern "js" fn js_perf_end(name : String) -> Unit =
-  #| function(name) {
-  #|   var perf = globalThis.__canopy_bridge?.perfCurrent;
-  #|   if (!perf || !perf.spans || !perf._starts) return;
-  #|   var start = perf._starts[name];
-  #|   if (typeof start !== 'number') return;
-  #|   perf.spans[name] = (perf.spans[name] || 0) + performance.now() - start;
-  #|   delete perf._starts[name];
-  #| }
-
 // Note: editor event wiring is done in main.ts wireEditorEvents() — not here.

--- a/apps/ideal/main/crdt_reexport.mbt
+++ b/apps/ideal/main/crdt_reexport.mbt
@@ -176,7 +176,19 @@ pub fn handle_text_intent(
   insert : String,
   timestamp_ms : Int,
 ) -> Unit raise {
-  @ffi.handle_text_intent(handle, from, deleted_len, insert, timestamp_ms)
+  js_perf_begin("handleTextIntent")
+  js_perf_begin("crdtMutation")
+  try {
+    @ffi.handle_text_intent(handle, from, deleted_len, insert, timestamp_ms)
+    js_perf_end("crdtMutation")
+    js_perf_end("handleTextIntent")
+  } catch {
+    error => {
+      js_perf_end("crdtMutation")
+      js_perf_end("handleTextIntent")
+      raise error
+    }
+  }
 }
 
 ///|
@@ -192,9 +204,23 @@ pub fn handle_text_intent_checked(
   insert : String,
   timestamp_ms : Int,
 ) -> Bool raise {
-  @ffi.handle_text_intent_checked(
-    handle, from, deleted_len, insert, timestamp_ms,
-  )
+  js_perf_begin("handleTextIntentChecked")
+  js_perf_begin("crdtMutation")
+  let accepted = try {
+    let result = @ffi.handle_text_intent_checked(
+      handle, from, deleted_len, insert, timestamp_ms,
+    )
+    js_perf_end("crdtMutation")
+    js_perf_end("handleTextIntentChecked")
+    result
+  } catch {
+    error => {
+      js_perf_end("crdtMutation")
+      js_perf_end("handleTextIntentChecked")
+      raise error
+    }
+  }
+  accepted
 }
 
 ///|

--- a/apps/ideal/main/init.mbt
+++ b/apps/ideal/main/init.mbt
@@ -76,8 +76,8 @@ fn subscriptions(model : Model, emit : Emit[Msg]) -> Sub {
   let cm_events = if model.mounted {
     @cm.listen(
       model.cm_id,
-      doc=emit.map(text => CmDocChanged(text)),
       selection=emit.map(range => CmSelectionChanged(range)),
+      on_change_with_doc=emit.map(event => CmChanges(event)),
     )
   } else {
     @sub.none

--- a/apps/ideal/main/msg.mbt
+++ b/apps/ideal/main/msg.mbt
@@ -57,7 +57,7 @@ enum Msg {
   StructureStructuralEdit(op~ : String, node_id~ : String)
   ExternalCrdtChanged
   CmMounted
-  CmDocChanged(String)
+  CmChanges(@cm.ChangeEvent)
   CmSelectionChanged(@cm.SelRange)
   CmFocusChanged(Bool)
 }

--- a/apps/ideal/main/perf_probe_regular_js.mbt
+++ b/apps/ideal/main/perf_probe_regular_js.mbt
@@ -1,0 +1,1 @@
+../../../tools/perf_probe_regular_js.mbt

--- a/apps/ideal/main/update_codemirror.mbt
+++ b/apps/ideal/main/update_codemirror.mbt
@@ -1,4 +1,28 @@
 ///|
+fn apply_code_mirror_changes(
+  editor : @editor.SyncEditor[@ast.Term],
+  changes : Array[@cm.ChangeDelta],
+  timestamp_ms : Int,
+) -> Bool raise Failure {
+  let cursor = editor.get_cursor()
+  guard changes.length() == 1 else { return false }
+  let change = changes[0]
+  let accepted = editor.apply_text_edit_exact(
+    change.from,
+    change.to - change.from,
+    change.insert,
+    timestamp_ms,
+  ) catch {
+    error => {
+      editor.move_cursor(cursor)
+      raise error
+    }
+  }
+  editor.move_cursor(cursor)
+  accepted
+}
+
+///|
 fn handle_codemirror(
   emit : Emit[Msg],
   msg : Msg,
@@ -10,22 +34,68 @@ fn handle_codemirror(
       let new_model = { ..model, mounted: true }
       Some((sync_after_external_crdt_change(new_model), new_model))
     }
-    CmDocChanged(text) => {
-      model.editor.set_text_and_record(text, js_now_ms())
-      let new_model = refresh({
-        ..model,
-        next_timestamp: model.next_timestamp + 1,
-      })
-      let actual_text = new_model.editor.get_text()
-      let sync_cmd = if actual_text != text {
-        @cm.set_doc(model.cm_id, actual_text)
-      } else {
-        none
+    CmChanges(event) => {
+      // Local single-range CodeMirror transactions already carry an exact
+      // pre-transaction splice. Apply that directly; use the transaction's
+      // captured document snapshot for multi-range or rejected transactions.
+      let changes = event.changes
+      js_perf_begin("cmDocChangedHandler")
+      js_perf_begin("syncEditorApply")
+      let timestamp_ms = js_now_ms()
+      let fallback_text = try {
+        js_perf_begin("incrementalTextApply")
+        let applied = apply_code_mirror_changes(
+          model.editor,
+          changes,
+          timestamp_ms,
+        )
+        js_perf_end("incrementalTextApply")
+        if applied {
+          None
+        } else {
+          model.editor.set_text_and_record(event.doc, timestamp_ms)
+          Some(event.doc)
+        }
+      } catch {
+        error => {
+          js_perf_end("incrementalTextApply")
+          js_perf_end("syncEditorApply")
+          js_perf_end("cmDocChangedHandler")
+          raise error
+        }
       }
-      let cmd = @rabbita.batch([
-        sync_cmd,
-        @rabbita.effect(fn() { js_after_local_text_edit() }),
-      ])
+      js_perf_end("syncEditorApply")
+      js_perf_begin("projectionRefresh")
+      let new_model = try {
+        let next = refresh({ ..model, next_timestamp: model.next_timestamp + 1 })
+        js_perf_end("projectionRefresh")
+        next
+      } catch {
+        error => {
+          js_perf_end("projectionRefresh")
+          js_perf_end("cmDocChangedHandler")
+          raise error
+        }
+      }
+      let actual_text = new_model.editor.get_text()
+      js_perf_begin("publicationPrepare")
+      let sync_cmd = match fallback_text {
+        Some(text) =>
+          if actual_text != text {
+            @cm.set_doc(model.cm_id, actual_text)
+          } else {
+            none
+          }
+        None => none
+      }
+      let publication_effect = @rabbita.effect(fn() {
+        js_perf_begin("localPublicationEffect")
+        js_after_local_text_edit()
+        js_perf_end("localPublicationEffect")
+      })
+      let cmd = @rabbita.batch([sync_cmd, publication_effect])
+      js_perf_end("publicationPrepare")
+      js_perf_end("cmDocChangedHandler")
       Some((cmd, new_model))
     }
     CmSelectionChanged(range) =>

--- a/apps/ideal/web/e2e/editor-features.spec.ts
+++ b/apps/ideal/web/e2e/editor-features.spec.ts
@@ -359,25 +359,36 @@ test.describe('Undo / Redo', () => {
     expect(realErrors).toEqual([]);
   });
 
-  test('undo reverts typed text', async ({ page }) => {
+  test('undo and redo round-trip typed text through the CRDT', async ({ page }) => {
     await waitForEditor(page);
-    await page.getByRole('button', { name: 'Basics' }).click();
-    await page.waitForTimeout(200);
 
-    // Type something in the editor
+    const before = await page.evaluate(() => {
+      const bridge = (window as any).__canopy_bridge;
+      return bridge.crdt.get_text(bridge.crdtHandle);
+    });
     await page.evaluate(() => {
       const cm = document.querySelector('#canopy-text-editor .cm-content') as HTMLElement;
       cm?.focus();
     });
     await page.keyboard.press('End');
     await page.keyboard.type('z', { delay: 50 });
-    await page.waitForTimeout(300);
+    const after = await page.evaluate(() => {
+      const bridge = (window as any).__canopy_bridge;
+      return bridge.crdt.get_text(bridge.crdtHandle);
+    });
+    expect(after).not.toBe(before);
 
-    // Undo the typed character via Ctrl+Z in CM6
-    await page.keyboard.press('Control+z');
-    await page.waitForTimeout(300);
+    await page.getByRole('button', { name: 'Undo' }).click();
+    await page.waitForFunction((text) => {
+      const bridge = (window as any).__canopy_bridge;
+      return bridge?.crdt?.get_text(bridge.crdtHandle) === text;
+    }, before);
 
-    // Editor should not crash
+    await page.getByRole('button', { name: 'Redo' }).click();
+    await page.waitForFunction((text) => {
+      const bridge = (window as any).__canopy_bridge;
+      return bridge?.crdt?.get_text(bridge.crdtHandle) === text;
+    }, after);
     await expect(page.getByLabel('Code editor')).toBeVisible();
   });
 });

--- a/apps/ideal/web/e2e/editor-response.perf.spec.ts
+++ b/apps/ideal/web/e2e/editor-response.perf.spec.ts
@@ -24,6 +24,11 @@ type ResponseSummary = {
   phases: Record<string, Stats>;
 };
 
+type DirectIntentSample = {
+  elapsedMs: number;
+  phases: Record<string, number>;
+};
+
 // Read a numeric env override, falling back to `fallback` when unset/empty. A
 // malformed value (non-finite, e.g. "80ms" or a stray space) is a
 // misconfiguration: fail fast with a clear message rather than silently
@@ -70,6 +75,26 @@ const MAX_PAINT_BUDGET_MS = numericEnv('EDITOR_RESPONSE_MAX_BUDGET_MS', 250);
 // trimmed mean rises by ~this value. Default 0 = off. Validate the detector with
 // e.g. EDITOR_RESPONSE_INJECT_PAINT_MS=80 (a ~2x local regression) -> gate FAILS.
 const INJECT_PAINT_MS = numericEnv('EDITOR_RESPONSE_INJECT_PAINT_MS', 0);
+const REQUIRED_PHASES = [
+  'cmDocChangedHandler',
+  'syncEditorApply',
+  'projectionRefresh',
+  'refreshTotal',
+  'publicationPrepare',
+  'localPublicationEffect',
+] as const;
+const REQUIRED_TEXT_EDIT_PHASES = [
+  'applyEditOldSnapshot',
+  'applyEditPolicy',
+  'crdtReplace',
+  'applyEditNewSnapshot',
+  'localTextChange',
+  'resolveAppliedEditDiff',
+  'peerCursorAdjust',
+  'parserSync',
+  'documentVersionUpdate',
+  'parserApply',
+] as const;
 
 async function waitForEditor(page: Page) {
   await page.goto(`/#perf-${Date.now()}`);
@@ -106,7 +131,10 @@ async function seedEditor(page: Page, source: string) {
     const content = document.querySelector('#canopy-text-editor .cm-content');
     const visible = content?.textContent ?? '';
     const lines = String(text).split('\n');
-    return visible.includes(lines[0]) || visible.includes(lines[lines.length - 1]);
+    const bridge = (window as any).__canopy_bridge;
+    return bridge?.crdt && bridge.crdtHandle != null &&
+      bridge.crdt.get_text(bridge.crdtHandle) === text &&
+      (visible.includes(lines[0]) || visible.includes(lines[lines.length - 1]));
   }, source);
   await page.evaluate(() => {
     const content = document.querySelector('#canopy-text-editor .cm-content') as HTMLElement | null;
@@ -129,6 +157,7 @@ async function measureTextInput(page: Page, text: string, injectMs: number = INJ
     let start = 0;
     let cancelled = false;
     let pollRafId: number | null = null;
+    let paintRafId: number | null = null;
     const timeout = window.setTimeout(() => {
       cancelled = true;
       const b0 = (window as any).__canopy_bridge;
@@ -142,23 +171,27 @@ async function measureTextInput(page: Page, text: string, injectMs: number = INJ
         window.cancelAnimationFrame(pollRafId);
         pollRafId = null;
       }
+      if (paintRafId !== null) {
+        window.cancelAnimationFrame(paintRafId);
+        paintRafId = null;
+      }
     };
     const complete = () => {
       if (cancelled) return;
       cancelled = true;
       const textChangedAt = performance.now();
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
-          // Positive-control injection: a synchronous busy-wait in the measured
-          // paint window simulates a uniform paint regression. Placed after
-          // textChangedAt so it affects only inputToPaintMs, not the text-change
-          // latency. No-op when injectPaintMs is 0 (the default).
-          if (injectPaintMs > 0) {
-            const spinUntil = performance.now() + injectPaintMs;
-            while (performance.now() < spinUntil) {
-              // busy-wait
-            }
+      paintRafId = requestAnimationFrame(() => {
+        paintRafId = null;
+        // Inject before the second frame so the delay is part of the next
+        // browser paint, not work performed after that paint's callback.
+        if (injectPaintMs > 0) {
+          const spinUntil = performance.now() + injectPaintMs;
+          while (performance.now() < spinUntil) {
+            // busy-wait
           }
+        }
+        paintRafId = requestAnimationFrame(() => {
+          paintRafId = null;
           const perf = (window as any).__canopy_bridge?.perfCurrent;
           const phases = { ...(perf?.spans ?? {}) };
           const b1 = (window as any).__canopy_bridge;
@@ -182,17 +215,45 @@ async function measureTextInput(page: Page, text: string, injectMs: number = INJ
     };
 
     const b2 = (window as any).__canopy_bridge;
-    if (b2) b2.perfCurrent = { spans: {} };
+    if (b2) b2.perfCurrent = { spans: {}, profileTextEdit: true };
     start = performance.now();
     const inserted = document.execCommand('insertText', false, insertText);
     if (!inserted) {
       cancelled = true;
+      const b0 = (window as any).__canopy_bridge;
+      if (b0) b0.perfCurrent = null;
       cleanup();
       reject(new Error('insertText command failed'));
       return;
     }
     requestAnimationFrame(poll);
   }), { insertText: text, injectPaintMs: injectMs });
+}
+
+async function measureDirectTextIntent(page: Page): Promise<DirectIntentSample> {
+  return page.evaluate(() => {
+    const bridge = (window as any).__canopy_bridge;
+    if (!bridge?.crdt || bridge.crdtHandle == null) {
+      throw new Error('Canopy CRDT bridge is not mounted');
+    }
+    const before = bridge.crdt.get_text(bridge.crdtHandle);
+    bridge.perfCurrent = { spans: {} };
+    try {
+      const start = performance.now();
+      bridge.crdt.handle_text_intent(
+        bridge.crdtHandle,
+        before.length,
+        0,
+        'a',
+        0,
+      );
+      const elapsedMs = performance.now() - start;
+      const phases = { ...(bridge.perfCurrent?.spans ?? {}) };
+      return { elapsedMs, phases };
+    } finally {
+      bridge.perfCurrent = null;
+    }
+  });
 }
 
 function mean(values: number[]): number {
@@ -226,6 +287,19 @@ function roundStats(s: Stats): Stats {
 }
 
 function summarize(scenario: string, sourceChars: number, samples: ResponseSample[]): ResponseSummary {
+  for (const sample of samples) {
+    for (const phase of [...REQUIRED_PHASES, ...REQUIRED_TEXT_EDIT_PHASES]) {
+      if (typeof sample.phases[phase] !== 'number') {
+        throw new Error(`${scenario}: missing phase ${phase}`);
+      }
+    }
+    const hasIncrementalEntry = typeof sample.phases.incrementalTextApply === 'number';
+    const hasFullTextEntry = typeof sample.phases.setTextFullDiff === 'number' &&
+      typeof sample.phases.setTextApply === 'number';
+    if (!hasIncrementalEntry && !hasFullTextEntry) {
+      throw new Error(`${scenario}: missing incremental or full-text entry phase`);
+    }
+  }
   const phaseNames = new Set<string>();
   for (const sample of samples) {
     for (const phase of Object.keys(sample.phases)) {
@@ -263,6 +337,162 @@ async function runScenario(page: Page, scenario: string, definitions: number): P
 }
 
 test.describe('realistic editor response benchmark', () => {
+  test('direct handle_text_intent reports CRDT mutation phases', async ({ page }) => {
+    test.setTimeout(60_000);
+    await waitForEditor(page);
+    await seedEditor(page, lambdaSource(500));
+
+    for (let i = 0; i < WARMUP_KEYSTROKES; i += 1) {
+      await measureDirectTextIntent(page);
+    }
+    const samples: DirectIntentSample[] = [];
+    for (let i = 0; i < MEASURED_KEYSTROKES; i += 1) {
+      samples.push(await measureDirectTextIntent(page));
+    }
+
+    const phaseNames = new Set<string>();
+    for (const sample of samples) {
+      for (const phase of Object.keys(sample.phases)) phaseNames.add(phase);
+    }
+    const phases: Record<string, Stats> = {};
+    for (const phase of [...phaseNames].sort()) {
+      phases[phase] = roundStats(stats(samples.map((sample) => sample.phases[phase] ?? 0)));
+    }
+    const summary = {
+      scenario: 'direct handle_text_intent',
+      sourceChars: lambdaSource(500).length,
+      samples: samples.length,
+      elapsed: roundStats(stats(samples.map((sample) => sample.elapsedMs))),
+      phases,
+    };
+    console.log(`[editor-response-intent] ${JSON.stringify(summary)}`);
+    expect(phases.handleTextIntent, 'handle_text_intent phase was not recorded').toBeDefined();
+    expect(phases.crdtMutation, 'CRDT mutation phase was not recorded').toBeDefined();
+  });
+
+  test('local CodeMirror transactions use the incremental text path', async ({ page }) => {
+    test.setTimeout(60_000);
+    await waitForEditor(page);
+    const source = lambdaSource(20);
+    await seedEditor(page, source);
+    const position = 5;
+    const expected = source.slice(0, position) + 'Z' + source.slice(position);
+
+    await page.evaluate(() => {
+      const bridge = (window as any).__canopy_bridge;
+      if (bridge) bridge.perfCurrent = { spans: {}, profileTextEdit: true };
+      const content = document.querySelector('#canopy-text-editor .cm-content') as HTMLElement | null;
+      content?.focus();
+    });
+    await page.keyboard.press('Control+Home');
+    for (let i = 0; i < position; i += 1) {
+      await page.keyboard.press('ArrowRight');
+    }
+    await page.keyboard.insertText('Z');
+    await page.waitForFunction((text) => {
+      const bridge = (window as any).__canopy_bridge;
+      return bridge?.crdt && bridge.crdtHandle != null &&
+        bridge.crdt.get_text(bridge.crdtHandle) === text;
+    }, expected);
+
+    const phases = await page.evaluate(() => {
+      const bridge = (window as any).__canopy_bridge;
+      const phases = { ...(bridge?.perfCurrent?.spans ?? {}) };
+      if (bridge) bridge.perfCurrent = null;
+      return phases;
+    });
+    expect(phases.incrementalTextApply, 'incremental edit phase was not recorded').toBeDefined();
+    expect(phases.setTextFullDiff, 'full-document diff should not run for a local CM transaction').toBeUndefined();
+  });
+
+  test('local CodeMirror replacements and Unicode edits stay incremental', async ({ page }) => {
+    test.setTimeout(60_000);
+    await waitForEditor(page);
+
+    const assertIncremental = async (expected: string, edit: () => Promise<void>) => {
+      await page.evaluate(() => {
+        const bridge = (window as any).__canopy_bridge;
+        if (bridge) bridge.perfCurrent = { spans: {}, profileTextEdit: true };
+        const content = document.querySelector('#canopy-text-editor .cm-content') as HTMLElement | null;
+        content?.focus();
+      });
+      await edit();
+      await page.waitForFunction((text) => {
+        const bridge = (window as any).__canopy_bridge;
+        return bridge?.crdt && bridge.crdtHandle != null &&
+          bridge.crdt.get_text(bridge.crdtHandle) === text;
+      }, expected);
+      const phases = await page.evaluate(() => {
+        const bridge = (window as any).__canopy_bridge;
+        const phases = { ...(bridge?.perfCurrent?.spans ?? {}) };
+        if (bridge) bridge.perfCurrent = null;
+        return phases;
+      });
+      expect(phases.incrementalTextApply, 'incremental edit phase was not recorded').toBeDefined();
+      expect(phases.setTextFullDiff, 'full-document diff should not run for a local CM transaction').toBeUndefined();
+    };
+
+    const source = lambdaSource(20);
+    const position = 5;
+    await seedEditor(page, source);
+    await assertIncremental(
+      source.slice(0, position) + 'Q' + source.slice(position + 1),
+      async () => {
+        await page.keyboard.press('Control+Home');
+        for (let i = 0; i < position; i += 1) await page.keyboard.press('ArrowRight');
+        await page.keyboard.press('Shift+ArrowRight');
+        await page.keyboard.insertText('Q');
+      },
+    );
+
+    await seedEditor(page, 'a😀b');
+    await assertIncremental('ab', async () => {
+      await page.keyboard.press('Control+Home');
+      await page.keyboard.press('ArrowRight');
+      await page.keyboard.press('Delete');
+    });
+  });
+
+  test('multi-range transactions use their captured fallback snapshot', async ({ page }) => {
+    test.setTimeout(60_000);
+    await waitForEditor(page);
+    const source = lambdaSource(20);
+    await seedEditor(page, source);
+
+    const expected = await page.evaluate(() => {
+      const bridge = (window as any).__canopy_bridge;
+      if (bridge) bridge.perfCurrent = { spans: {}, profileTextEdit: true };
+      const root = document.querySelector('#canopy-text-editor .cm-editor');
+      const EditorView = (globalThis as any).__canopy_codemirror?.EditorView;
+      const view = EditorView?.findFromDOM(root);
+      if (!view) throw new Error('CodeMirror view is unavailable');
+      const before = view.state.doc.toString();
+      view.dispatch({
+        changes: [
+          { from: 0, to: 0, insert: 'X' },
+          { from: before.length, to: before.length, insert: 'Y' },
+        ],
+      });
+      // Queue a second transaction immediately. The first fallback must use
+      // its own captured document rather than this later current document.
+      view.dispatch({ changes: { from: 0, to: 0, insert: 'Z' } });
+      return view.state.doc.toString();
+    });
+
+    await page.waitForFunction((text) => {
+      const bridge = (window as any).__canopy_bridge;
+      return bridge?.crdt && bridge.crdtHandle != null &&
+        bridge.crdt.get_text(bridge.crdtHandle) === text;
+    }, expected);
+    const phases = await page.evaluate(() => {
+      const bridge = (window as any).__canopy_bridge;
+      const phases = { ...(bridge?.perfCurrent?.spans ?? {}) };
+      if (bridge) bridge.perfCurrent = null;
+      return phases;
+    });
+    expect(phases.setTextFullDiff, 'multi-range edit should use the full-text fallback').toBeDefined();
+  });
+
   test('text-mode typing updates CRDT, projection, and browser paint within budget', async ({ page }) => {
     // ~90 measureTextInput calls (warmup + measured, both scenarios), plus the
     // optional positive-control busy-wait, can approach Playwright's 30s default
@@ -284,6 +514,9 @@ test.describe('realistic editor response benchmark', () => {
         samples: summary.samples,
         phases: summary.phases,
       })}`);
+      for (const phase of REQUIRED_PHASES) {
+        expect(summary.phases[phase], `${summary.scenario} phase ${phase} was not recorded`).toBeDefined();
+      }
       // Gated metrics: trimmedMean (primary, noise-robust) and max (catastrophe
       // backstop). p50/p95/mean are computed and logged for observability only —
       // do not assert on them without an empirical per-metric baseline.

--- a/modules/canopy/editor/moon.pkg
+++ b/modules/canopy/editor/moon.pkg
@@ -41,6 +41,8 @@ warnings = "-7-29"
 options(
   is_main: false,
   targets: {
+    "sync_editor_perf_probe_js.mbt": [ "js" ],
+    "sync_editor_perf_probe_native.mbt": [ "not", "js" ],
     "error_path_wbtest.mbt": [ "not", "js" ],
     "sync_editor_ws_wbtest.mbt": [ "not", "js" ],
     "test_ws_helper_js_wbtest.mbt": [ "js" ],

--- a/modules/canopy/editor/sync_editor_parser.mbt
+++ b/modules/canopy/editor/sync_editor_parser.mbt
@@ -37,25 +37,29 @@ fn[T : Eq] SyncEditor::sync_parser_after_text_change(
   known_edit : @loom_core.Edit?,
 ) -> Unit raise Failure {
   self.ensure_parser_healthy()
-  self.document_version.set(self.doc.version())
+  editor_perf_measure("documentVersionUpdate", () => {
+    self.document_version.set(self.doc.version())
+  })
   // Short-circuits mark_projection_dirty; Parser does its own identity check.
   guard old_source != new_source else { return }
-  try {
-    if new_source == "" {
-      self.parser.set_source(new_source)
-    } else {
-      let edit = match known_edit {
-        Some(edit) => edit
-        None => compute_edit(old_source, new_source)
+  editor_perf_measure("parserApply", () => {
+    try {
+      if new_source == "" {
+        self.parser.set_source(new_source)
+      } else {
+        let edit = match known_edit {
+          Some(edit) => edit
+          None => compute_edit(old_source, new_source)
+        }
+        self.parser.apply_edit(edit, new_source)
       }
-      self.parser.apply_edit(edit, new_source)
+    } catch {
+      Failure::Failure(_) as failure => {
+        self.parser_failure = Some(failure)
+        raise failure
+      }
     }
-  } catch {
-    Failure::Failure(_) as failure => {
-      self.parser_failure = Some(failure)
-      raise failure
-    }
-  }
+  })
   self.mark_projection_dirty()
 }
 
@@ -95,11 +99,13 @@ fn resolve_applied_edit(
   old_source : String,
   new_source : String,
   known_edit : @loom_core.Edit?,
-) -> @loom_core.Edit? {
+) -> @loom_core.Edit? raise Failure {
   match known_edit {
     None => None
     Some(edit) => {
-      let actual = compute_edit(old_source, new_source)
+      let actual = editor_perf_measure("resolveAppliedEditDiff", () => {
+        compute_edit(old_source, new_source)
+      })
       if edit.start() == actual.start() &&
         edit.old_len() == actual.old_len() &&
         edit.new_len() == actual.new_len() {
@@ -119,10 +125,14 @@ fn[T : Eq] SyncEditor::apply_local_text_change(
   known_edit : @loom_core.Edit?,
 ) -> Unit raise Failure {
   let applied_edit = resolve_applied_edit(old_source, new_source, known_edit)
-  self.adjust_peer_cursors_after_text_change(
-    old_source, new_source, applied_edit,
-  )
-  self.sync_parser_after_text_change(old_source, new_source, applied_edit)
+  editor_perf_measure("peerCursorAdjust", () => {
+    self.adjust_peer_cursors_after_text_change(
+      old_source, new_source, applied_edit,
+    )
+  })
+  editor_perf_measure("parserSync", () => {
+    self.sync_parser_after_text_change(old_source, new_source, applied_edit)
+  })
 }
 
 ///|

--- a/modules/canopy/editor/sync_editor_perf_probe.mbt
+++ b/modules/canopy/editor/sync_editor_perf_probe.mbt
@@ -1,0 +1,57 @@
+// Shared measurement helper for the browser-only phase probe.
+
+///|
+let editor_perf_profile_depth : Ref[Int] = Ref(0)
+
+///|
+fn editor_perf_begin(name : String) -> Unit {
+  if editor_perf_profile_depth.val > 0 {
+    js_perf_detail_begin(name)
+  }
+}
+
+///|
+fn editor_perf_end(name : String) -> Unit {
+  if editor_perf_profile_depth.val > 0 {
+    js_perf_detail_end(name)
+  }
+}
+
+///|
+fn[T] editor_perf_scope(action : () -> T raise Failure) -> T raise Failure {
+  if !js_perf_detail_enabled() {
+    return action()
+  }
+  editor_perf_profile_depth.val += 1
+  try {
+    let result = action()
+    editor_perf_profile_depth.val -= 1
+    result
+  } catch {
+    error => {
+      editor_perf_profile_depth.val -= 1
+      raise error
+    }
+  }
+}
+
+///|
+fn[T] editor_perf_measure(
+  name : String,
+  action : () -> T raise Failure,
+) -> T raise Failure {
+  if editor_perf_profile_depth.val == 0 {
+    return action()
+  }
+  editor_perf_begin(name)
+  try {
+    let result = action()
+    editor_perf_end(name)
+    result
+  } catch {
+    error => {
+      editor_perf_end(name)
+      raise error
+    }
+  }
+}

--- a/modules/canopy/editor/sync_editor_perf_probe_js.mbt
+++ b/modules/canopy/editor/sync_editor_perf_probe_js.mbt
@@ -1,0 +1,1 @@
+../../../tools/perf_probe_detail_js.mbt

--- a/modules/canopy/editor/sync_editor_perf_probe_native.mbt
+++ b/modules/canopy/editor/sync_editor_perf_probe_native.mbt
@@ -1,0 +1,16 @@
+// Native fallback for the browser-only phase probe.
+
+///|
+fn js_perf_detail_enabled() -> Bool {
+  false
+}
+
+///|
+fn js_perf_detail_begin(_name : String) -> Unit {
+
+}
+
+///|
+fn js_perf_detail_end(_name : String) -> Unit {
+
+}

--- a/modules/canopy/editor/sync_editor_text.mbt
+++ b/modules/canopy/editor/sync_editor_text.mbt
@@ -275,8 +275,11 @@ fn[T : Eq] SyncEditor::apply_text_edit_with_policy(
   policy : SplicePolicy,
 ) -> Bool raise Failure {
   self.ensure_parser_healthy()
-  let old_source = self.doc.text()
+  let old_source = editor_perf_measure("applyEditOldSnapshot", () => {
+    self.doc.text()
+  })
   let text_len = old_source.length()
+  editor_perf_begin("applyEditPolicy")
   let (safe_start, safe_delete_len) = match policy {
     ExactBoundaries => {
       if start < 0 ||
@@ -285,6 +288,7 @@ fn[T : Eq] SyncEditor::apply_text_edit_with_policy(
         start + deleted_len > text_len ||
         !@moji.is_grapheme_boundary(old_source, start) ||
         !@moji.is_grapheme_boundary(old_source, start + deleted_len) {
+        editor_perf_end("applyEditPolicy")
         return false
       }
       (start, deleted_len)
@@ -311,14 +315,19 @@ fn[T : Eq] SyncEditor::apply_text_edit_with_policy(
       }
     }
   }
+  editor_perf_end("applyEditPolicy")
   // Funnel all bulk text mutation through one helper so CRDT range-edit and
   // undo behavior stay aligned at a single boundary.
-  guard self.apply_replace_span(
-    old_source, safe_start, safe_delete_len, inserted, timestamp_ms, record_undo,
-  ) else {
+  guard editor_perf_measure("crdtReplace", () => {
+    self.apply_replace_span(
+      old_source, safe_start, safe_delete_len, inserted, timestamp_ms, record_undo,
+    )
+  }) else {
     return false
   }
-  let new_text = self.doc.text()
+  let new_text = editor_perf_measure("applyEditNewSnapshot", () => {
+    self.doc.text()
+  })
   if move_cursor_to_edit_end {
     self.cursor = @moji.next_grapheme_boundary(
       new_text,
@@ -330,11 +339,13 @@ fn[T : Eq] SyncEditor::apply_text_edit_with_policy(
       clamp_utf16_offset(new_text, self.cursor),
     )
   }
-  self.apply_local_text_change(
-    old_source,
-    new_text,
-    Some(@loom_core.Edit::new(safe_start, safe_delete_len, inserted.length())),
-  )
+  editor_perf_measure("localTextChange", () => {
+    self.apply_local_text_change(
+      old_source,
+      new_text,
+      Some(@loom_core.Edit::new(safe_start, safe_delete_len, inserted.length())),
+    )
+  })
   true
 }
 
@@ -390,17 +401,19 @@ pub fn[T : Eq] SyncEditor::apply_text_edit_exact(
   inserted : String,
   timestamp_ms : Int,
 ) -> Bool raise Failure {
-  self.ensure_parser_healthy()
-  self.taint_pending_transforms()
-  self.apply_text_edit_with_policy(
-    start,
-    deleted_len,
-    inserted,
-    timestamp_ms,
-    true,
-    true,
-    ExactBoundaries,
-  )
+  editor_perf_scope(() => {
+    self.ensure_parser_healthy()
+    self.taint_pending_transforms()
+    self.apply_text_edit_with_policy(
+      start,
+      deleted_len,
+      inserted,
+      timestamp_ms,
+      true,
+      true,
+      ExactBoundaries,
+    )
+  })
 }
 
 ///|
@@ -538,21 +551,34 @@ pub fn[T : Eq] SyncEditor::set_text_and_record(
   new_text : String,
   timestamp_ms : Int,
 ) -> Unit raise Failure {
+  editor_perf_scope(() => self.set_text_and_record_impl(new_text, timestamp_ms))
+}
+
+///|
+fn[T : Eq] SyncEditor::set_text_and_record_impl(
+  self : SyncEditor[T],
+  new_text : String,
+  timestamp_ms : Int,
+) -> Unit raise Failure {
   self.ensure_parser_healthy()
-  let old_text = self.doc.text()
+  let old_text = editor_perf_measure("setTextOldSnapshot", () => self.doc.text())
   if old_text == new_text {
     return
   }
   self.taint_pending_transforms()
-  let splice = @text_change.compute_text_change(old_text, new_text)
+  let splice = editor_perf_measure("setTextFullDiff", () => {
+    @text_change.compute_text_change(old_text, new_text)
+  })
   ignore(
-    self.apply_text_edit_internal(
-      splice.start,
-      splice.delete_len,
-      splice.inserted,
-      timestamp_ms,
-      true,
-      false,
-    ),
+    editor_perf_measure("setTextApply", () => {
+      self.apply_text_edit_internal(
+        splice.start,
+        splice.delete_len,
+        splice.inserted,
+        timestamp_ms,
+        true,
+        false,
+      )
+    }),
   )
 }

--- a/modules/rabbita_codemirror/codemirror.mbt
+++ b/modules/rabbita_codemirror/codemirror.mbt
@@ -216,6 +216,7 @@ fn no_op_update_listener(
     _ => (),
     _ => (),
     _ => (),
+    include_doc=false,
     include_change_doc=false,
   )
 }
@@ -382,6 +383,7 @@ fn cm_sub_loader(
       let mut focus_tagger = focus
       let mut changes_tagger = changes
       let mut changes_with_doc_tagger = changes_with_doc
+      let include_doc = doc is Some(_)
       let include_change_doc = changes_with_doc is Some(_)
 
       fn on_doc(value : @js_value.Value) {
@@ -423,6 +425,7 @@ fn cm_sub_loader(
         on_selection,
         on_focus,
         on_changes,
+        include_doc~,
         include_change_doc~,
       )
       editors[id] = { ..entry, update_disposable: disposable }

--- a/modules/rabbita_codemirror/codemirror.mbt
+++ b/modules/rabbita_codemirror/codemirror.mbt
@@ -51,6 +51,24 @@ pub fn ChangeDelta::new(from : Int, to : Int, insert : String) -> ChangeDelta {
 }
 
 ///|
+/// A CodeMirror document transaction together with its post-transaction
+/// document snapshot. The snapshot is captured by the update listener so a
+/// delayed consumer can use the document that belongs to this transaction.
+pub struct ChangeEvent {
+  changes : Array[ChangeDelta]
+  doc : String
+} derive(Eq, Debug)
+
+///|
+/// Construct a transaction event from its ordered changes and final document.
+pub fn ChangeEvent::new(
+  changes : Array[ChangeDelta],
+  doc : String,
+) -> ChangeEvent {
+  { changes, doc }
+}
+
+///|
 #cfg(target="js")
 priv struct CmEntry {
   view : @js_ffi.CmView
@@ -75,7 +93,8 @@ priv suberror CmSubscription {
     doc~ : @cmd.Emit[String]?,
     selection~ : @cmd.Emit[SelRange]?,
     focus~ : @cmd.Emit[Bool]?,
-    changes~ : @cmd.Emit[Array[ChangeDelta]]?
+    changes~ : @cmd.Emit[Array[ChangeDelta]]?,
+    changes_with_doc~ : @cmd.Emit[ChangeEvent]?
   )
 }
 
@@ -190,9 +209,15 @@ fn no_op_update_listener(
   view : @js_ffi.CmView,
   compartment : @js_ffi.Compartment,
 ) -> @js_ffi.Disposable {
-  @js_ffi.js_add_update_listener(view, compartment, _ => (), _ => (), _ => (), _ => {
-    ()
-  })
+  @js_ffi.js_add_update_listener(
+    view,
+    compartment,
+    _ => (),
+    _ => (),
+    _ => (),
+    _ => (),
+    include_change_doc=false,
+  )
 }
 
 ///|
@@ -271,6 +296,15 @@ fn change_deltas_from_value(value : @js_value.Value) -> Array[ChangeDelta] {
 
 ///|
 #cfg(target="js")
+fn change_event_from_value(value : @js_value.Value) -> ChangeEvent {
+  ChangeEvent::new(
+    change_deltas_from_value(value.get_with_string("changes")),
+    value.get_with_string("doc"),
+  )
+}
+
+///|
+#cfg(target="js")
 fn reconfigure(
   view : @js_ffi.CmView,
   compartment : @js_ffi.Compartment,
@@ -328,8 +362,9 @@ fn build_listen_key(
   has_selection : Bool,
   has_focus : Bool,
   has_changes : Bool,
+  has_changes_with_doc : Bool,
 ) -> String {
-  "codemirror.listen(id=\{id},doc=\{has_doc},selection=\{has_selection},focus=\{has_focus},changes=\{has_changes})"
+  "codemirror.listen(id=\{id},doc=\{has_doc},selection=\{has_selection},focus=\{has_focus},changes=\{has_changes},changes_with_doc=\{has_changes_with_doc})"
 }
 
 ///|
@@ -339,13 +374,15 @@ fn cm_sub_loader(
   scheduler : &@cmd.Scheduler,
 ) -> @sub.RunningSub? {
   match payload {
-    CmListen(id, doc~, selection~, focus~, changes~) => {
+    CmListen(id, doc~, selection~, focus~, changes~, changes_with_doc~) => {
       guard editors.get(id) is Some(entry) else { return None }
 
       let mut doc_tagger = doc
       let mut selection_tagger = selection
       let mut focus_tagger = focus
       let mut changes_tagger = changes
+      let mut changes_with_doc_tagger = changes_with_doc
+      let include_change_doc = changes_with_doc is Some(_)
 
       fn on_doc(value : @js_value.Value) {
         guard doc_tagger is Some(msg) else { return }
@@ -360,8 +397,22 @@ fn cm_sub_loader(
         scheduler.add(msg(value.cast()))
       }
       fn on_changes(value : @js_value.Value) {
-        guard changes_tagger is Some(msg) else { return }
-        scheduler.add(msg(change_deltas_from_value(value)))
+        if include_change_doc {
+          let event = change_event_from_value(value)
+          match changes_tagger {
+            Some(msg) => scheduler.add(msg(event.changes))
+            None => ()
+          }
+          match changes_with_doc_tagger {
+            Some(msg) => scheduler.add(msg(event))
+            None => ()
+          }
+        } else {
+          match changes_tagger {
+            Some(msg) => scheduler.add(msg(change_deltas_from_value(value)))
+            None => ()
+          }
+        }
       }
 
       entry.update_disposable.dispose()
@@ -372,19 +423,29 @@ fn cm_sub_loader(
         on_selection,
         on_focus,
         on_changes,
+        include_change_doc~,
       )
       editors[id] = { ..entry, update_disposable: disposable }
 
       Some({
         unload: fn(_) { disposable.dispose() },
         update_tagger: fn(payload) {
-          guard payload is CmListen(_, doc~, selection~, focus~, changes~) else {
+          guard payload
+            is CmListen(
+              _,
+              doc~,
+              selection~,
+              focus~,
+              changes~,
+              changes_with_doc~
+            ) else {
             return
           }
           doc_tagger = doc
           selection_tagger = selection
           focus_tagger = focus
           changes_tagger = changes
+          changes_with_doc_tagger = changes_with_doc
         },
       })
     }
@@ -689,6 +750,10 @@ pub fn set_line_wrapping(
 /// the existing whole-document `doc` callback untouched. A consumer that only
 /// wants the post-change text keeps using `doc`; one that needs to replay the
 /// transaction as discrete edits subscribes to `on_change`.
+///
+/// `on_change_with_doc` delivers the same transaction together with the
+/// post-transaction document captured by the CodeMirror update listener. It is
+/// intended for delayed consumers that need a stable fallback snapshot.
 #cfg(target="js")
 pub fn listen(
   id : String,
@@ -696,18 +761,35 @@ pub fn listen(
   selection? : @cmd.Emit[SelRange],
   focus? : @cmd.Emit[Bool],
   on_change? : @cmd.Emit[Array[ChangeDelta]],
+  on_change_with_doc? : @cmd.Emit[ChangeEvent],
 ) -> @sub.Sub {
   let has_doc = doc is Some(_)
   let has_selection = selection is Some(_)
   let has_focus = focus is Some(_)
   let has_changes = on_change is Some(_)
+  let has_changes_with_doc = on_change_with_doc is Some(_)
 
-  guard has_doc || has_selection || has_focus || has_changes else { @sub.none }
-  let key = build_listen_key(id, has_doc, has_selection, has_focus, has_changes)
+  guard has_doc ||
+    has_selection ||
+    has_focus ||
+    has_changes ||
+    has_changes_with_doc else {
+    @sub.none
+  }
+  let key = build_listen_key(
+    id, has_doc, has_selection, has_focus, has_changes, has_changes_with_doc,
+  )
   @sub.custom_sub(
     key,
     Local,
-    CmListen(id, doc~, selection~, focus~, changes=on_change),
+    CmListen(
+      id,
+      doc~,
+      selection~,
+      focus~,
+      changes=on_change,
+      changes_with_doc=on_change_with_doc,
+    ),
     cm_sub_loader,
   )
 }

--- a/modules/rabbita_codemirror/codemirror_test.mbt
+++ b/modules/rabbita_codemirror/codemirror_test.mbt
@@ -6,6 +6,13 @@ test "SelRange constructor exposes selection offsets to consumers" {
 }
 
 ///|
+test "ChangeEvent preserves its transaction snapshot" {
+  let event = ChangeEvent::new([ChangeDelta::new(1, 1, "x")], "after")
+  inspect(event.changes.length(), content="1")
+  inspect(event.doc, content="after")
+}
+
+///|
 test "mount accepts extension factory" {
   let factory : (@js_value.Value) -> @js_ffi.Extension raise = fn(_cm) {
     @js_ffi.js_extension_combine([])

--- a/modules/rabbita_codemirror/codemirror_wbtest.mbt
+++ b/modules/rabbita_codemirror/codemirror_wbtest.mbt
@@ -1,16 +1,16 @@
 ///|
 test "listen key format" {
   inspect(
-    build_listen_key("a", true, true, false, true),
-    content="codemirror.listen(id=a,doc=true,selection=true,focus=false,changes=true)",
+    build_listen_key("a", true, true, false, true, false),
+    content="codemirror.listen(id=a,doc=true,selection=true,focus=false,changes=true,changes_with_doc=false)",
   )
 }
 
 ///|
 test "listen key deterministic" {
   inspect(
-    build_listen_key("a", true, false, false, false) ==
-    build_listen_key("a", true, false, false, false),
+    build_listen_key("a", true, false, false, false, false) ==
+    build_listen_key("a", true, false, false, false, false),
     content="true",
   )
 }
@@ -18,8 +18,8 @@ test "listen key deterministic" {
 ///|
 test "listen key id matters" {
   inspect(
-    build_listen_key("a", true, false, false, false) ==
-    build_listen_key("b", true, false, false, false),
+    build_listen_key("a", true, false, false, false, false) ==
+    build_listen_key("b", true, false, false, false, false),
     content="false",
   )
 }
@@ -27,8 +27,8 @@ test "listen key id matters" {
 ///|
 test "listen key doc flag matters" {
   inspect(
-    build_listen_key("a", true, false, false, false) ==
-    build_listen_key("a", false, false, false, false),
+    build_listen_key("a", true, false, false, false, false) ==
+    build_listen_key("a", false, false, false, false, false),
     content="false",
   )
 }
@@ -36,8 +36,8 @@ test "listen key doc flag matters" {
 ///|
 test "listen key selection and focus flags matter" {
   inspect(
-    build_listen_key("a", false, true, false, false) ==
-    build_listen_key("a", false, false, true, false),
+    build_listen_key("a", false, true, false, false, false) ==
+    build_listen_key("a", false, false, true, false, false),
     content="false",
   )
 }
@@ -45,8 +45,17 @@ test "listen key selection and focus flags matter" {
 ///|
 test "listen key changes flag matters" {
   inspect(
-    build_listen_key("a", false, false, false, false) ==
-    build_listen_key("a", false, false, false, true),
+    build_listen_key("a", false, false, false, false, false) ==
+    build_listen_key("a", false, false, false, true, false),
+    content="false",
+  )
+}
+
+///|
+test "listen key snapshot flag matters" {
+  inspect(
+    build_listen_key("a", false, false, false, false, false) ==
+    build_listen_key("a", false, false, false, false, true),
     content="false",
   )
 }

--- a/modules/rabbita_codemirror/js/codemirror.mbt
+++ b/modules/rabbita_codemirror/js/codemirror.mbt
@@ -343,8 +343,9 @@ extern "js" fn js_add_update_listener_raw(
   on_selection : (@js_value.Value) -> Unit,
   on_focus_change : (@js_value.Value) -> Unit,
   on_changes : (@js_value.Value) -> Unit,
+  include_change_doc : Bool,
 ) -> () -> Unit =
-  #| (view, compartment, onDoc, onSelection, onFocusChange, onChanges) => {
+  #| (view, compartment, onDoc, onSelection, onFocusChange, onChanges, includeChangeDoc) => {
   #|   const key = Symbol.for("dowdiness.rabbita_codemirror");
   #|   const slot = globalThis[key];
   #|   const cm = view._cmModule;
@@ -364,7 +365,9 @@ extern "js" fn js_add_update_listener_raw(
   #|       update.changes.iterChanges((fromA, toA, _fromB, _toB, inserted) => {
   #|         deltas.push({ from: fromA, to: toA, insert: inserted.toString() });
   #|       }, true);
-  #|       onChanges(deltas);
+  #|       onChanges(includeChangeDoc
+  #|         ? { changes: deltas, doc: update.state.doc.toString() }
+  #|         : deltas);
   #|     }
   #|     if ((update.selectionSet || update.docChanged) && !isApplying()) {
   #|       const sel = update.state.selection.main;
@@ -416,6 +419,7 @@ pub fn js_add_update_listener(
   on_selection : (@js_value.Value) -> Unit,
   on_focus_change : (@js_value.Value) -> Unit,
   on_changes : (@js_value.Value) -> Unit,
+  include_change_doc? : Bool = false,
 ) -> Disposable {
   Disposable(
     js_add_update_listener_raw(
@@ -425,6 +429,7 @@ pub fn js_add_update_listener(
       on_selection,
       on_focus_change,
       on_changes,
+      include_change_doc,
     ),
   )
 }

--- a/modules/rabbita_codemirror/js/codemirror.mbt
+++ b/modules/rabbita_codemirror/js/codemirror.mbt
@@ -343,9 +343,10 @@ extern "js" fn js_add_update_listener_raw(
   on_selection : (@js_value.Value) -> Unit,
   on_focus_change : (@js_value.Value) -> Unit,
   on_changes : (@js_value.Value) -> Unit,
+  include_doc : Bool,
   include_change_doc : Bool,
 ) -> () -> Unit =
-  #| (view, compartment, onDoc, onSelection, onFocusChange, onChanges, includeChangeDoc) => {
+  #| (view, compartment, onDoc, onSelection, onFocusChange, onChanges, includeDoc, includeChangeDoc) => {
   #|   const key = Symbol.for("dowdiness.rabbita_codemirror");
   #|   const slot = globalThis[key];
   #|   const cm = view._cmModule;
@@ -355,9 +356,10 @@ extern "js" fn js_add_update_listener_raw(
   #|   const isApplying = () => !!slot.applying.get(view)?.value;
   #|   const listener = cm.EditorView.updateListener.of(update => {
   #|     if (update.docChanged && !isApplying()) {
-  #|       onDoc(update.state.doc.toString());
-  #|     }
-  #|     if (update.docChanged && !isApplying()) {
+  #|       const changedDoc = (includeDoc || includeChangeDoc)
+  #|         ? update.state.doc.toString()
+  #|         : null;
+  #|       if (includeDoc) onDoc(changedDoc);
   #|       const deltas = [];
   #|       // `individual = true` keeps adjacent changes as separate ranges;
   #|       // the default (false) coalesces neighbours into one merged range,
@@ -366,7 +368,7 @@ extern "js" fn js_add_update_listener_raw(
   #|         deltas.push({ from: fromA, to: toA, insert: inserted.toString() });
   #|       }, true);
   #|       onChanges(includeChangeDoc
-  #|         ? { changes: deltas, doc: update.state.doc.toString() }
+  #|         ? { changes: deltas, doc: changedDoc }
   #|         : deltas);
   #|     }
   #|     if ((update.selectionSet || update.docChanged) && !isApplying()) {
@@ -419,6 +421,7 @@ pub fn js_add_update_listener(
   on_selection : (@js_value.Value) -> Unit,
   on_focus_change : (@js_value.Value) -> Unit,
   on_changes : (@js_value.Value) -> Unit,
+  include_doc? : Bool = false,
   include_change_doc? : Bool = false,
 ) -> Disposable {
   Disposable(
@@ -429,6 +432,7 @@ pub fn js_add_update_listener(
       on_selection,
       on_focus_change,
       on_changes,
+      include_doc,
       include_change_doc,
     ),
   )

--- a/modules/rabbita_codemirror/js/pkg.generated.mbti
+++ b/modules/rabbita_codemirror/js/pkg.generated.mbti
@@ -4,7 +4,7 @@ package "dowdiness/rabbita_codemirror/js"
 // Values
 pub fn cm_module_of(@moonbit-community/rabbita/js.Value) -> CmModule
 
-pub fn js_add_update_listener(CmView, Compartment, (@moonbit-community/rabbita/js.Value) -> Unit, (@moonbit-community/rabbita/js.Value) -> Unit, (@moonbit-community/rabbita/js.Value) -> Unit, (@moonbit-community/rabbita/js.Value) -> Unit, include_change_doc? : Bool) -> Disposable
+pub fn js_add_update_listener(CmView, Compartment, (@moonbit-community/rabbita/js.Value) -> Unit, (@moonbit-community/rabbita/js.Value) -> Unit, (@moonbit-community/rabbita/js.Value) -> Unit, (@moonbit-community/rabbita/js.Value) -> Unit, include_doc? : Bool, include_change_doc? : Bool) -> Disposable
 
 pub fn js_compartment_new(CmModule) -> Compartment
 

--- a/modules/rabbita_codemirror/js/pkg.generated.mbti
+++ b/modules/rabbita_codemirror/js/pkg.generated.mbti
@@ -4,7 +4,7 @@ package "dowdiness/rabbita_codemirror/js"
 // Values
 pub fn cm_module_of(@moonbit-community/rabbita/js.Value) -> CmModule
 
-pub fn js_add_update_listener(CmView, Compartment, (@moonbit-community/rabbita/js.Value) -> Unit, (@moonbit-community/rabbita/js.Value) -> Unit, (@moonbit-community/rabbita/js.Value) -> Unit, (@moonbit-community/rabbita/js.Value) -> Unit) -> Disposable
+pub fn js_add_update_listener(CmView, Compartment, (@moonbit-community/rabbita/js.Value) -> Unit, (@moonbit-community/rabbita/js.Value) -> Unit, (@moonbit-community/rabbita/js.Value) -> Unit, (@moonbit-community/rabbita/js.Value) -> Unit, include_change_doc? : Bool) -> Disposable
 
 pub fn js_compartment_new(CmModule) -> Compartment
 

--- a/modules/rabbita_codemirror/pkg.generated.mbti
+++ b/modules/rabbita_codemirror/pkg.generated.mbti
@@ -12,7 +12,7 @@ import {
 // Values
 pub fn insert(String, Int, String, failed? : @cmd.Emit[String]) -> @cmd.Cmd
 
-pub fn listen(String, doc? : @cmd.Emit[String], selection? : @cmd.Emit[SelRange], focus? : @cmd.Emit[Bool], on_change? : @cmd.Emit[Array[ChangeDelta]]) -> @sub.Sub
+pub fn listen(String, doc? : @cmd.Emit[String], selection? : @cmd.Emit[SelRange], focus? : @cmd.Emit[Bool], on_change? : @cmd.Emit[Array[ChangeDelta]], on_change_with_doc? : @cmd.Emit[ChangeEvent]) -> @sub.Sub
 
 pub fn mount(String, String, init_doc? : String, source? : String, initial_theme? : @theme.Theme?, initial_readonly? : Bool, initial_keymap? : @keymap.Keymap?, initial_line_numbers? : Bool, initial_line_wrapping? : Bool, on_mounted? : @cmd.Cmd, failed? : @cmd.Emit[String], initial_extension? : ((@moonbit-community/rabbita/js.Value) -> @dowdiness/rabbita_codemirror/js.Extension raise)?) -> @cmd.Cmd
 
@@ -45,6 +45,12 @@ pub struct ChangeDelta {
   insert : String
 } derive(Eq, @debug.Debug)
 pub fn ChangeDelta::new(Int, Int, String) -> Self
+
+pub struct ChangeEvent {
+  changes : Array[ChangeDelta]
+  doc : String
+} derive(Eq, @debug.Debug)
+pub fn ChangeEvent::new(Array[ChangeDelta], String) -> Self
 
 pub struct SelRange {
   from : Int

--- a/tools/perf_probe_detail_js.mbt
+++ b/tools/perf_probe_detail_js.mbt
@@ -1,0 +1,26 @@
+// Shared browser timing hooks used by the Canopy editor's optional
+// set_text_and_record phase probe.
+
+///|
+extern "js" fn js_perf_detail_enabled() -> Bool =
+  #| () => Boolean(globalThis.__canopy_bridge?.perfCurrent?.profileTextEdit)
+
+///|
+extern "js" fn js_perf_detail_begin(name : String) -> Unit =
+  #| function(name) {
+  #|   var perf = globalThis.__canopy_bridge?.perfCurrent;
+  #|   if (!perf || !perf.spans || !perf.profileTextEdit) return;
+  #|   if (!perf._starts) perf._starts = {};
+  #|   perf._starts[name] = performance.now();
+  #| }
+
+///|
+extern "js" fn js_perf_detail_end(name : String) -> Unit =
+  #| function(name) {
+  #|   var perf = globalThis.__canopy_bridge?.perfCurrent;
+  #|   if (!perf || !perf.spans || !perf.profileTextEdit || !perf._starts) return;
+  #|   var start = perf._starts[name];
+  #|   if (typeof start !== 'number') return;
+  #|   perf.spans[name] = (perf.spans[name] || 0) + performance.now() - start;
+  #|   delete perf._starts[name];
+  #| }

--- a/tools/perf_probe_regular_js.mbt
+++ b/tools/perf_probe_regular_js.mbt
@@ -1,0 +1,21 @@
+// Shared browser timing hooks used by the Ideal editor's existing phase probe.
+
+///|
+extern "js" fn js_perf_begin(name : String) -> Unit =
+  #| function(name) {
+  #|   var perf = globalThis.__canopy_bridge?.perfCurrent;
+  #|   if (!perf || !perf.spans) return;
+  #|   if (!perf._starts) perf._starts = {};
+  #|   perf._starts[name] = performance.now();
+  #| }
+
+///|
+extern "js" fn js_perf_end(name : String) -> Unit =
+  #| function(name) {
+  #|   var perf = globalThis.__canopy_bridge?.perfCurrent;
+  #|   if (!perf || !perf.spans || !perf._starts) return;
+  #|   var start = perf._starts[name];
+  #|   if (typeof start !== 'number') return;
+  #|   perf.spans[name] = (perf.spans[name] || 0) + performance.now() - start;
+  #|   delete perf._starts[name];
+  #| }


### PR DESCRIPTION
## Summary

- Apply local single-range CodeMirror transactions directly through `SyncEditor::apply_text_edit_exact`, avoiding `set_text_and_record` full-document diffing on the normal Ideal Text path.
- Keep multi-range and rejected transactions on the captured full-text fallback path, with an event-time `ChangeEvent.doc` snapshot rather than a later `get_doc` read.
- Avoid an additional full-document snapshot when no legacy `doc` subscriber is present.
- Add opt-in phase instrumentation and browser regression/response tests, including Unicode, multi-range queued fallback, undo/redo, and external CRDT cursor behavior.

This PR is intentionally scoped to the Ideal Text/CodeMirror path. Loomark Raw uses a separate textarea/RawInputCoordinator path; follow-up profiling is tracked in #1211. Remote source/version guarding for an accepted single delta is tracked in #1210.

## UI and review evidence

N/A — no visual design or layout changes.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `SyncEditor::apply_text_edit_exact` | `modules/canopy/editor/sync_editor_text.mbt` | Yes | Preserves CRDT range mutation, grapheme-boundary validation, undo recording, cursor repair, and parser synchronization. |
| `@cm.listen` / `ChangeDelta` | `modules/rabbita_codemirror/codemirror.mbt` | Yes and extended | Existing per-transaction delta contract is retained; `on_change_with_doc` is additive for delayed fallback consumers. |
| `@moji.is_grapheme_boundary` and `String::length` | Loom/Canopy editor core | Yes indirectly | Existing exact-boundary and UTF-16 offset semantics remain in the editor API. |
| `Array::map` / `Option` matching | MoonBit core / existing binding code | Yes | Used for event decoding and optional callback routing; no replacement collection helper was added. |
| `@text_change.compute_text_change` | Loom text-change package | Yes on fallback | Retained for full-text fallback and existing synchronization semantics; not duplicated in the fast path. |

New helpers and types:

- `ChangeEvent`: public binding value carrying transaction deltas and the post-transaction snapshot; required because a delayed consumer cannot safely re-read the mutable CodeMirror document.
- `apply_code_mirror_changes`: Ideal adapter boundary for the single-range exact splice; it deliberately rejects multi-range transactions and delegates those to the existing full-text path.
- `editor_perf_scope` / `editor_perf_measure`: opt-in measurement shell; native builds use no-op fallbacks and normal browser editing does not create detailed per-phase spans unless `profileTextEdit` is enabled.

## Validation scope

Boundary matrix covered:

- single-range insertion, central replacement, and Unicode grapheme deletion;
- multi-range transaction followed immediately by another transaction, proving fallback uses the captured event snapshot;
- undo and redo round-trip through the CRDT;
- external CRDT replacement followed by local typing and cursor preservation;
- existing full-text file-load/fallback behavior.

Target packages:

- `apps/ideal/main`
- `modules/canopy/editor`
- `modules/rabbita_codemirror`
- `modules/rabbita_codemirror/js`

Additional conditional gates:

- Ideal browser E2E: local CodeMirror incremental, replacement/Unicode, multi-range fallback, undo/redo, and external-sync tests passed.
- Ideal response benchmark: 5-scenario suite passed; representative low-load run measured large-edit `syncEditorApply` around p50 6.2 ms / p95 6.9 ms. Later p95 samples remained host/GC-sensitive, so p95 is reported rather than used as an unpaired hard claim.
- `moon build --target js --release` and Ideal web production build passed.

## PR-ready evidence

Validated HEAD: `3a88f7fc72cc81de121a30ef2b938b4119ee528e`

Validated base: `origin/main@47926800d9a65da4def7166cf2464bb95d736cab`

```bash
./scripts/validate-pr-ready.sh \
  --target apps/ideal/main \
  --target modules/canopy/editor \
  --target modules/rabbita_codemirror \
  --target modules/rabbita_codemirror/js
```

The full validator passed for the exact HEAD and base above. The final `--verify-evidence` check also passed immediately before pushing this branch.

- [x] The full validator passed for the exact HEAD and base above.
- [x] The base was fetched again and `--verify-evidence` passed after the rebase and before pushing the updated branch.
- [x] The committed `.mbti` diff was reviewed; changes are limited to the additive `ChangeEvent`, optional listener callback, and optional raw listener flag.
- [x] No submodule pointer changed.
- [x] Validation was rerun after the final commit/amend and generated-interface update.

Related: #1210, #1211


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved editor responsiveness for replacements, Unicode input, and multi-range edits.
  - Enhanced document synchronization and recovery when incremental updates cannot be applied directly.
  - Preserved cursor position more reliably during editor updates.
  - Added support for receiving editor changes with the resulting document snapshot.
  - Improved performance measurement for text editing and synchronization workflows.

- **Bug Fixes**
  - Undo and Redo now reliably restore original and edited text.

- **Testing**
  - Expanded end-to-end coverage for editing, synchronization, and performance measurements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
