### PR TITLE
test(loomark): await Block input before merge rejection

### DIFF
--- a/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
+++ b/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
@@ -1490,7 +1490,8 @@ test("Backspace preserves focus when an unsupported predecessor rejects merge", 
     const input = host.page.locator("#loomark-block-input-1")
     await input.fill("")
     await expect(input).toHaveValue("")
-    const source = (await snapshot(host.page)).source
+    const source = "First\n\n---\n\n\n"
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe(source)
 
     await input.press("Backspace")
 


### PR DESCRIPTION
## Summary

- wait for the cleared Block payload to reach canonical Markdown before sending the follow-up Backspace
- preserve the existing rejected-merge, source, focus, and caret assertions while removing the Playwright/0 ms coordinator race seen in CI

## UI and review evidence

N/A — test-only synchronization change; no rendered UI or interaction behavior changed.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `snapshot(page)` | `apps/loomark/examples/vanilla/tests/dev-host.spec.ts` | Yes | Observes the canonical dev-host source at the existing browser boundary. |
| `expect.poll` | Playwright test API | Yes | Waits on the explicit canonical readiness condition without a fixed timeout. |

New helpers added (if any):

None.

## Validation scope

Boundary matrix / first failing regression:

- empty Block payload before Backspace with an unsupported thematic-break predecessor
- CI failure: Backspace ran before canonical settlement and `error_code` remained `null`
- deterministic same-task diagnostic: pending empty input followed by Backspace produced `block-selection-rejected`; waiting for canonical source produced the intended `editor-commit-failed` path
- existing only-Block clearing case already waits for its canonical empty source

Target packages:

`--no-target "Playwright-only synchronization fix; no MoonBit package changed"`

Additional conditional gates:

- affected two-test stress loop: 200/200 with 8 workers
- full Loomark dev-host Playwright suite: 95/95
- dev-host TypeScript typecheck: passed
- independent reviewer: PASS

## PR-ready evidence

Validated HEAD: `74eba818be63554baff55c4c7347e1fff0d6c863`

Validated base: `origin/main@2a0d2a87912d2391815ef82ce74827c5d8d353de`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh \
  --no-target "Playwright-only synchronization fix; no MoonBit package changed"
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for the exact HEAD and base above.
- [x] The base was fetched again and `--verify-evidence` passed immediately
      before this PR was opened, updated, or merged.
- [x] The committed `.mbti` diff against the validated base was reviewed for
      unintended API or trait-bound changes.
- [x] Any changed submodule commit is pushed and reachable from its remote.
- [x] Validation was rerun after every commit, amend, rebase, cherry-pick,
      submodule-pointer, manifest, or generated-interface change.
- [x] Independent review findings were resolved before the final validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated merge behavior coverage to verify the exact resulting source after clearing a block.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->