### PR TITLE
feat(loomark): preserve IME composition input

### DIFF
--- a/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
+++ b/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
@@ -2247,6 +2247,618 @@ test("composition-intermediate Raw input does not commit", async ({ browser }) =
   }
 })
 
+test("Raw IME composition commits the accepted final value once", async ({ browser }) => {
+  const host = await mountHost(browser, "start")
+  try {
+    const input = host.page.locator("#loomark-input")
+    await input.focus()
+    await input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.setSelectionRange(5, 5)
+    })
+    const session = await host.context.newCDPSession(host.page)
+
+    await session.send("Input.imeSetComposition", {
+      text: "かんじ",
+      selectionStart: 3,
+      selectionEnd: 3,
+    })
+    await expect(input).toHaveValue("startかんじ")
+    expect(await snapshot(host.page)).toMatchObject({
+      source: "start",
+      committed_change_count: 0,
+      error_code: null,
+    })
+
+    await session.send("Input.insertText", { text: "漢字" })
+
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("start漢字")
+    expect(await snapshot(host.page)).toMatchObject({
+      committed_change_count: 1,
+      error_code: null,
+    })
+    await expect(input).toHaveValue("start漢字")
+    await expect(input).toBeFocused()
+    await expect.poll(() => input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      return [textarea.selectionStart, textarea.selectionEnd]
+    })).toEqual([7, 7])
+
+    await dispatchRawNativeEdits(input, [{
+      value: "start漢字",
+      beforeStart: 7,
+      beforeEnd: 7,
+      afterStart: 7,
+      afterEnd: 7,
+      inputType: "insertFromComposition",
+      data: "漢字",
+    }])
+    expect(await snapshot(host.page)).toMatchObject({
+      source: "start漢字",
+      committed_change_count: 1,
+      error_code: null,
+    })
+    await expect(input).toHaveValue("start漢字")
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("Raw IME composition includes ordinary input pending from the same task", async ({ browser }) => {
+  const host = await mountHost(browser, "start")
+  try {
+    const input = host.page.locator("#loomark-input")
+    await input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.setSelectionRange(5, 5)
+      textarea.dispatchEvent(new InputEvent("beforeinput", {
+        bubbles: true,
+        cancelable: true,
+        data: "X",
+        inputType: "insertText",
+      }))
+      textarea.value = "startX"
+      textarea.setSelectionRange(6, 6)
+      textarea.dispatchEvent(new InputEvent("input", {
+        bubbles: true,
+        data: "X",
+        inputType: "insertText",
+      }))
+      textarea.dispatchEvent(new CompositionEvent("compositionstart", {
+        bubbles: true,
+        data: "",
+      }))
+      textarea.dispatchEvent(new InputEvent("beforeinput", {
+        bubbles: true,
+        cancelable: true,
+        data: "漢",
+        inputType: "insertCompositionText",
+        isComposing: true,
+      }))
+      textarea.value = "startX漢"
+      textarea.setSelectionRange(7, 7)
+      textarea.dispatchEvent(new InputEvent("input", {
+        bubbles: true,
+        data: "漢",
+        inputType: "insertCompositionText",
+        isComposing: true,
+      }))
+      textarea.dispatchEvent(new CompositionEvent("compositionend", {
+        bubbles: true,
+        data: "漢",
+      }))
+    })
+
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("startX漢")
+    expect(await snapshot(host.page)).toMatchObject({
+      committed_change_count: 1,
+      error_code: null,
+    })
+    await expect(input).toHaveValue("startX漢")
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("Raw IME preserves pending ordinary input when composition ends without input", async ({ browser }) => {
+  const host = await mountHost(browser, "start")
+  try {
+    const input = host.page.locator("#loomark-input")
+    await input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.setSelectionRange(5, 5)
+      textarea.dispatchEvent(new InputEvent("beforeinput", {
+        bubbles: true,
+        cancelable: true,
+        data: "X",
+        inputType: "insertText",
+      }))
+      textarea.value = "startX"
+      textarea.setSelectionRange(6, 6)
+      textarea.dispatchEvent(new InputEvent("input", {
+        bubbles: true,
+        data: "X",
+        inputType: "insertText",
+      }))
+      textarea.dispatchEvent(new CompositionEvent("compositionstart", {
+        bubbles: true,
+        data: "",
+      }))
+      textarea.dispatchEvent(new CompositionEvent("compositionend", {
+        bubbles: true,
+        data: "",
+      }))
+    })
+
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("startX")
+    expect(await snapshot(host.page)).toMatchObject({
+      committed_change_count: 1,
+      error_code: null,
+    })
+    await expect(input).toHaveValue("startX")
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("Block IME composition commits the accepted final value once", async ({ browser }) => {
+  const host = await mountHost(browser, "start")
+  try {
+    await selectBlock(host.page)
+    const input = host.page.locator("#loomark-block-input")
+    await input.focus()
+    await input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.setSelectionRange(5, 5)
+    })
+    const session = await host.context.newCDPSession(host.page)
+
+    await session.send("Input.imeSetComposition", {
+      text: "かんじ",
+      selectionStart: 3,
+      selectionEnd: 3,
+    })
+    await expect(input).toHaveValue("startかんじ")
+    expect(await snapshot(host.page)).toMatchObject({
+      source: "start",
+      committed_change_count: 0,
+      error_code: null,
+    })
+
+    await session.send("Input.insertText", { text: "漢字" })
+
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("start漢字")
+    expect(await snapshot(host.page)).toMatchObject({
+      committed_change_count: 1,
+      error_code: null,
+    })
+    await expect(input).toHaveValue("start漢字")
+    await expect(input).toBeFocused()
+    await expect.poll(() => input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      return [textarea.selectionStart, textarea.selectionEnd]
+    })).toEqual([7, 7])
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("Block IME composition supersedes ordinary input pending from the same task", async ({ browser }) => {
+  const host = await mountHost(browser, "start")
+  try {
+    await selectBlock(host.page)
+    const input = host.page.locator("#loomark-block-input")
+    await input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.value = "startX"
+      textarea.setSelectionRange(6, 6)
+      textarea.dispatchEvent(new InputEvent("input", {
+        bubbles: true,
+        data: "X",
+        inputType: "insertText",
+      }))
+      textarea.dispatchEvent(new CompositionEvent("compositionstart", {
+        bubbles: true,
+        data: "",
+      }))
+      textarea.value = "startX漢"
+      textarea.setSelectionRange(7, 7)
+      textarea.dispatchEvent(new InputEvent("input", {
+        bubbles: true,
+        data: "漢",
+        inputType: "insertCompositionText",
+        isComposing: true,
+      }))
+      textarea.dispatchEvent(new CompositionEvent("compositionend", {
+        bubbles: true,
+        data: "漢",
+      }))
+    })
+
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("startX漢")
+    expect(await snapshot(host.page)).toMatchObject({
+      committed_change_count: 1,
+      error_code: null,
+    })
+    await expect(input).toHaveValue("startX漢")
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("Block IME preserves pending ordinary input when composition ends without input", async ({ browser }) => {
+  const host = await mountHost(browser, "start")
+  try {
+    await selectBlock(host.page)
+    const input = host.page.locator("#loomark-block-input")
+    await input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.value = "startX"
+      textarea.setSelectionRange(6, 6)
+      textarea.dispatchEvent(new InputEvent("input", {
+        bubbles: true,
+        data: "X",
+        inputType: "insertText",
+      }))
+      textarea.dispatchEvent(new CompositionEvent("compositionstart", {
+        bubbles: true,
+        data: "",
+      }))
+      textarea.dispatchEvent(new CompositionEvent("compositionend", {
+        bubbles: true,
+        data: "",
+      }))
+    })
+
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("startX")
+    expect(await snapshot(host.page)).toMatchObject({
+      committed_change_count: 1,
+      error_code: null,
+    })
+    await expect(input).toHaveValue("startX")
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("Block IME preserves paragraph, heading, list, and code syntax", async ({ browser }) => {
+  const initial = "# Title\n\n- item\n\n~~~moonbit\ncode\n~~~\n\nparagraph\n"
+  const host = await mountHost(browser, initial)
+  try {
+    await selectBlock(host.page)
+    const session = await host.context.newCDPSession(host.page)
+    const composeAtEnd = async (
+      input: Locator,
+      currentText: string,
+      expectedSource: string,
+    ): Promise<void> => {
+      await input.focus()
+      await input.evaluate((element, offset) => {
+        const textarea = element as HTMLTextAreaElement
+        textarea.setSelectionRange(offset, offset)
+      }, currentText.length)
+      await session.send("Input.imeSetComposition", {
+        text: "漢",
+        selectionStart: 1,
+        selectionEnd: 1,
+      })
+      await session.send("Input.insertText", { text: "漢" })
+      await expect.poll(async () => (await snapshot(host.page)).source).toBe(expectedSource)
+    }
+
+    let source = "# Title漢\n\n- item\n\n~~~moonbit\ncode\n~~~\n\nparagraph\n"
+    await composeAtEnd(
+      host.page.locator('[data-loomark-block-kind="heading"]'),
+      "Title",
+      source,
+    )
+    source = "# Title漢\n\n- item漢\n\n~~~moonbit\ncode\n~~~\n\nparagraph\n"
+    await composeAtEnd(
+      host.page.locator('[data-loomark-block-kind="unordered-list-item"]'),
+      "item",
+      source,
+    )
+    source = "# Title漢\n\n- item漢\n\n~~~moonbit\ncode漢\n~~~\n\nparagraph\n"
+    await composeAtEnd(
+      host.page.locator('[data-loomark-block-kind="code"]'),
+      "code",
+      source,
+    )
+    source = "# Title漢\n\n- item漢\n\n~~~moonbit\ncode漢\n~~~\n\nparagraph漢\n"
+    await composeAtEnd(
+      host.page.locator('[data-loomark-block-kind="paragraph"]'),
+      "paragraph",
+      source,
+    )
+
+    expect(await snapshot(host.page)).toMatchObject({
+      source,
+      committed_change_count: 4,
+      error_code: null,
+    })
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("canceling Raw IME composition preserves canonical source and focus", async ({ browser }) => {
+  const host = await mountHost(browser, "start")
+  try {
+    const input = host.page.locator("#loomark-input")
+    await input.focus()
+    await input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.setSelectionRange(5, 5)
+    })
+    const session = await host.context.newCDPSession(host.page)
+    await session.send("Input.imeSetComposition", {
+      text: "取消",
+      selectionStart: 2,
+      selectionEnd: 2,
+    })
+    await expect(input).toHaveValue("start取消")
+
+    await session.send("Input.imeSetComposition", {
+      text: "",
+      selectionStart: 0,
+      selectionEnd: 0,
+    })
+
+    expect(await snapshot(host.page)).toMatchObject({
+      source: "start",
+      committed_change_count: 0,
+      error_code: null,
+    })
+    await expect(input).toHaveValue("start")
+    await expect(input).toBeFocused()
+    await expect.poll(() => input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      return [textarea.selectionStart, textarea.selectionEnd]
+    })).toEqual([5, 5])
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("failed Raw IME finalization restores canonical text and caret once", async ({ browser }) => {
+  const host = await mountHost(browser, "start")
+  try {
+    const input = host.page.locator("#loomark-input")
+    await input.focus()
+    await input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.setSelectionRange(5, 5)
+    })
+    await forceEditorFailure(host.page)
+    await expect.poll(async () => (await snapshot(host.page)).editor_failure_armed).toBe(true)
+    const session = await host.context.newCDPSession(host.page)
+    await session.send("Input.imeSetComposition", {
+      text: "漢",
+      selectionStart: 1,
+      selectionEnd: 1,
+    })
+
+    await session.send("Input.insertText", { text: "漢" })
+
+    await expect.poll(async () => (await snapshot(host.page)).error_code).toBe("editor-commit-failed")
+    expect(await snapshot(host.page)).toMatchObject({
+      source: "start",
+      committed_change_count: 0,
+      editor_failure_armed: false,
+      error_count: 1,
+    })
+    await expect(input).toHaveValue("start")
+    await expect(input).toBeFocused()
+    await expect.poll(() => input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      return [textarea.selectionStart, textarea.selectionEnd]
+    })).toEqual([5, 5])
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("canceling Block IME composition preserves canonical source and focus", async ({ browser }) => {
+  const host = await mountHost(browser, "start")
+  try {
+    await selectBlock(host.page)
+    const input = host.page.locator("#loomark-block-input")
+    await input.focus()
+    await input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.setSelectionRange(5, 5)
+    })
+    const session = await host.context.newCDPSession(host.page)
+    await session.send("Input.imeSetComposition", {
+      text: "取消",
+      selectionStart: 2,
+      selectionEnd: 2,
+    })
+    await expect(input).toHaveValue("start取消")
+
+    await session.send("Input.imeSetComposition", {
+      text: "",
+      selectionStart: 0,
+      selectionEnd: 0,
+    })
+
+    expect(await snapshot(host.page)).toMatchObject({
+      source: "start",
+      committed_change_count: 0,
+      error_code: null,
+    })
+    await expect(input).toHaveValue("start")
+    await expect(input).toBeFocused()
+    await expect.poll(() => input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      return [textarea.selectionStart, textarea.selectionEnd]
+    })).toEqual([5, 5])
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("Raw IME replacement preserves a non-BMP grapheme boundary", async ({ browser }) => {
+  const host = await mountHost(browser, "A😀B")
+  try {
+    const input = host.page.locator("#loomark-input")
+    await input.focus()
+    await input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.setSelectionRange(1, 3, "backward")
+    })
+    const session = await host.context.newCDPSession(host.page)
+    await session.send("Input.imeSetComposition", {
+      text: "😀",
+      selectionStart: 2,
+      selectionEnd: 2,
+    })
+    expect(await snapshot(host.page)).toMatchObject({
+      source: "A😀B",
+      committed_change_count: 0,
+    })
+
+    await session.send("Input.insertText", { text: "👨‍👩‍👧‍👦" })
+
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("A👨‍👩‍👧‍👦B")
+    expect(await snapshot(host.page)).toMatchObject({
+      committed_change_count: 1,
+      error_code: null,
+    })
+    await expect(input).toHaveValue("A👨‍👩‍👧‍👦B")
+    await expect.poll(() => input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      return [textarea.selectionStart, textarea.selectionEnd]
+    })).toEqual([12, 12])
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("a Raw mode click accepts composition before changing mode", async ({ browser }) => {
+  const host = await mountHost(browser, "start")
+  try {
+    const input = host.page.locator("#loomark-input")
+    await input.focus()
+    await input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.setSelectionRange(5, 5)
+    })
+    const session = await host.context.newCDPSession(host.page)
+    await session.send("Input.imeSetComposition", {
+      text: "漢",
+      selectionStart: 1,
+      selectionEnd: 1,
+    })
+
+    await host.page.locator("#loomark-mode-block").click()
+
+    await expect.poll(async () => (await snapshot(host.page)).mode).toBe("block")
+    expect(await snapshot(host.page)).toMatchObject({
+      source: "start漢",
+      committed_change_count: 1,
+      error_code: null,
+    })
+    await expect(host.page.locator("#loomark-block-input")).toHaveValue("start漢")
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("a Block mode click accepts composition before changing mode", async ({ browser }) => {
+  const host = await mountHost(browser, "start")
+  try {
+    await selectBlock(host.page)
+    const input = host.page.locator("#loomark-block-input")
+    await input.focus()
+    await input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.setSelectionRange(5, 5)
+    })
+    const session = await host.context.newCDPSession(host.page)
+    await session.send("Input.imeSetComposition", {
+      text: "漢",
+      selectionStart: 1,
+      selectionEnd: 1,
+    })
+
+    await host.page.locator("#loomark-mode-raw").click()
+
+    await expect.poll(async () => (await snapshot(host.page)).mode).toBe("raw")
+    expect(await snapshot(host.page)).toMatchObject({
+      source: "start漢",
+      committed_change_count: 1,
+      error_code: null,
+    })
+    await expect(host.page.locator("#loomark-input")).toHaveValue("start漢")
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("a synthetic mode change cancels unfinished Raw composition", async ({ browser }) => {
+  const host = await mountHost(browser, "start")
+  try {
+    const input = host.page.locator("#loomark-input")
+    await input.focus()
+    await input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.setSelectionRange(5, 5)
+    })
+    const session = await host.context.newCDPSession(host.page)
+    await session.send("Input.imeSetComposition", {
+      text: "未確定",
+      selectionStart: 3,
+      selectionEnd: 3,
+    })
+    await expect(input).toHaveValue("start未確定")
+
+    await selectBlock(host.page)
+
+    await expect.poll(async () => (await snapshot(host.page)).mode).toBe("block")
+    expect(await snapshot(host.page)).toMatchObject({
+      source: "start",
+      committed_change_count: 0,
+      error_code: null,
+    })
+    await expect(host.page.locator("#loomark-block-input")).toHaveValue("start")
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("a synthetic mode change cancels unfinished Block composition", async ({ browser }) => {
+  const host = await mountHost(browser, "start")
+  try {
+    await selectBlock(host.page)
+    const input = host.page.locator("#loomark-block-input")
+    await input.focus()
+    await input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.setSelectionRange(5, 5)
+    })
+    const session = await host.context.newCDPSession(host.page)
+    await session.send("Input.imeSetComposition", {
+      text: "未確定",
+      selectionStart: 3,
+      selectionEnd: 3,
+    })
+    await expect(input).toHaveValue("start未確定")
+
+    await selectRaw(host.page)
+
+    await expect.poll(async () => (await snapshot(host.page)).mode).toBe("raw")
+    expect(await snapshot(host.page)).toMatchObject({
+      source: "start",
+      committed_change_count: 0,
+      error_code: null,
+    })
+    await expect(host.page.locator("#loomark-input")).toHaveValue("start")
+  } finally {
+    await host.context.close()
+  }
+})
+
 test("mode change discards pending normalized Raw input", async ({ browser }) => {
   const host = await mountHost(browser, "start")
   try {

--- a/apps/loomark/examples/vanilla/tests/standalone.spec.ts
+++ b/apps/loomark/examples/vanilla/tests/standalone.spec.ts
@@ -54,6 +54,58 @@ test("first standalone visit stores a complete baseline archive", async ({ page 
   expect(baseline.history).toBeTruthy()
 })
 
+test("standalone IME commits one non-BMP final value and ignores cancellation", async ({ page }) => {
+  await page.goto("/")
+  await expect.poll(() => page.evaluate(() => (
+    JSON.parse(localStorage.getItem("loomark.active-document-archive") ?? "{}").portable_markdown as string | undefined
+  ))).toBe("")
+  const input = page.locator("#loomark-input")
+  await input.focus()
+  await input.evaluate(element => {
+    const textarea = element as HTMLTextAreaElement
+    textarea.setSelectionRange(0, 0)
+  })
+  const session = await page.context().newCDPSession(page)
+
+  await session.send("Input.imeSetComposition", {
+    text: "😀",
+    selectionStart: 2,
+    selectionEnd: 2,
+  })
+  await expect(input).toHaveValue("😀")
+  expect(await page.evaluate(() => (
+    JSON.parse(localStorage.getItem("loomark.active-document-archive") ?? "{}").portable_markdown as string
+  ))).toBe("")
+
+  await session.send("Input.insertText", { text: "👨‍👩‍👧‍👦" })
+
+  await expect.poll(() => page.evaluate(() => (
+    JSON.parse(localStorage.getItem("loomark.active-document-archive") ?? "{}").portable_markdown as string
+  ))).toBe("👨‍👩‍👧‍👦")
+  await expect(input).toHaveValue("👨‍👩‍👧‍👦")
+  await expect(input).toBeFocused()
+  await expect.poll(() => input.evaluate(element => {
+    const textarea = element as HTMLTextAreaElement
+    return [textarea.selectionStart, textarea.selectionEnd]
+  })).toEqual([11, 11])
+
+  await session.send("Input.imeSetComposition", {
+    text: "取消",
+    selectionStart: 2,
+    selectionEnd: 2,
+  })
+  await session.send("Input.imeSetComposition", {
+    text: "",
+    selectionStart: 0,
+    selectionEnd: 0,
+  })
+
+  expect(await page.evaluate(() => (
+    JSON.parse(localStorage.getItem("loomark.active-document-archive") ?? "{}").portable_markdown as string
+  ))).toBe("👨‍👩‍👧‍👦")
+  await expect(input).toHaveValue("👨‍👩‍👧‍👦")
+})
+
 test("standalone edit replaces the archive and reload restores the durable source", async ({ page }) => {
   await page.goto("/")
   await expect.poll(() => page.evaluate(() => (

--- a/apps/loomark/internal/rabbita/application.mbt
+++ b/apps/loomark/internal/rabbita/application.mbt
@@ -376,6 +376,24 @@ fn raw_editor_view(
       rows=4,
       attrs=@html.Attrs::build()
         .aria_label("Raw Markdown source")
+        .on_compositionstart(_ => {
+          match read_raw_selection() {
+            Some(selection) =>
+              ignore(
+                raw_input_coordinator.begin_native_composition(
+                  model, source, selection,
+                ),
+              )
+            None => raw_input_coordinator.cancel_pending()
+          }
+          @rabbita_runtime.none
+        })
+        .on_compositionend(_ => {
+          raw_input_coordinator.finish_composition(
+            model.document.source(),
+            emit,
+          )
+        })
         .on_beforeinput(event => {
           raw_input_coordinator.capture_native_before_input(model, event)
         })
@@ -390,42 +408,45 @@ fn raw_editor_view(
       ],
       on_input=@cmd.Emit(source => {
         match read_raw_selection() {
-          Some(selection) => {
-            let matched = raw_input_coordinator.has_captured_before_input()
-            let repair_unmatched = raw_input_coordinator.take_unmatched_input_repair()
-            let input_command = raw_input_coordinator.enqueue(
-              source, selection, emit,
-            )
-            if matched || !repair_unmatched {
-              input_command
+          Some(selection) =>
+            if raw_input_coordinator.update_composition(source, selection) {
+              @rabbita_runtime.none
             } else {
-              let repair_epoch = raw_input_coordinator.epoch()
-              let repair_selection = rejected_text_selection(
-                model.document.source(),
-                source,
-                selection,
+              let matched = raw_input_coordinator.has_captured_before_input()
+              let repair_unmatched = raw_input_coordinator.take_unmatched_input_repair()
+              let input_command = raw_input_coordinator.enqueue(
+                source, selection, emit,
               )
-              @cmd.batch([
-                input_command,
-                after_render(
-                  scheduler => {
-                    ignore(scheduler)
-                    guard raw_input_coordinator.epoch() == repair_epoch else {
-                      return
-                    }
-                    @dom_boundary.write_text_value_id(
-                      "loomark-input",
-                      raw_textarea_value(model.document.source()),
-                    )
-                    @dom_boundary.write_text_selection_id(
-                      "loomark-input", repair_selection,
-                    )
-                  },
-                  emit,
-                ),
-              ])
+              if matched || !repair_unmatched {
+                input_command
+              } else {
+                let repair_epoch = raw_input_coordinator.epoch()
+                let repair_selection = rejected_text_selection(
+                  model.document.source(),
+                  source,
+                  selection,
+                )
+                @cmd.batch([
+                  input_command,
+                  after_render(
+                    scheduler => {
+                      ignore(scheduler)
+                      guard raw_input_coordinator.epoch() == repair_epoch else {
+                        return
+                      }
+                      @dom_boundary.write_text_value_id(
+                        "loomark-input",
+                        raw_textarea_value(model.document.source()),
+                      )
+                      @dom_boundary.write_text_selection_id(
+                        "loomark-input", repair_selection,
+                      )
+                    },
+                    emit,
+                  ),
+                ])
+              }
             }
-          }
           None => {
             raw_input_coordinator.cancel_pending()
             @rabbita_runtime.none
@@ -1686,6 +1707,7 @@ fn update_editing(
 fn update_navigation(
   attachment : @md_markdown.MarkdownSemanticAttachment,
   raw_input_coordinator : RawInputCoordinator,
+  block_input_coordinator : BlockInputCoordinator,
   model : DriverModel,
   latest_model : @ref.Ref[DriverModel?],
   event : NavigationEvent,
@@ -1704,6 +1726,7 @@ fn update_navigation(
       }
       if mode != model.state.mode() {
         raw_input_coordinator.cancel_pending()
+        block_input_coordinator.cancel_pending()
       }
       let transition = @core.reduce(
         model.state,
@@ -2209,7 +2232,8 @@ fn update_model(
       )
     Navigation(nav_event) =>
       update_navigation(
-        attachment, raw_input_coordinator, model, latest_model, nav_event, emit,
+        attachment, raw_input_coordinator, block_input_coordinator, model, latest_model,
+        nav_event, emit,
       )
     Probe(probe_event) => update_probe(model, latest_model, probe_event, emit)
     Lifecycle(life_event) =>

--- a/apps/loomark/internal/rabbita/block_input_coordinator.mbt
+++ b/apps/loomark/internal/rabbita/block_input_coordinator.mbt
@@ -101,11 +101,20 @@ priv struct BlockInputState {
   generation : Int
   next_token : Int
   in_flight : BlockInputDelivery?
+  composition : PendingBlockInput?
+  composition_final : PendingBlockInput?
 }
 
 ///|
 fn BlockInputState::BlockInputState() -> BlockInputState {
-  { pending: None, generation: 0, next_token: 0, in_flight: None }
+  {
+    pending: None,
+    generation: 0,
+    next_token: 0,
+    in_flight: None,
+    composition: None,
+    composition_final: None,
+  }
 }
 
 ///|
@@ -143,6 +152,58 @@ fn BlockInputState::flush(
 }
 
 ///|
+fn BlockInputState::begin_composition(
+  self : BlockInputState,
+  input : PendingBlockInput,
+) -> (BlockInputState, Bool) {
+  guard self.in_flight is None else { return (self, false) }
+  let input = match self.pending {
+    Some(pending) if pending.matches(
+        input.document_id,
+        input.expected_version,
+        input.node_id,
+        input.input_id,
+      ) => { ..pending, selection: input.selection }
+    _ => input
+  }
+  (
+    {
+      ..self,
+      pending: None,
+      generation: self.generation + 1,
+      composition: Some(input),
+      composition_final: None,
+    },
+    true,
+  )
+}
+
+///|
+fn BlockInputState::has_composition(
+  self : BlockInputState,
+  input_id : String,
+) -> Bool {
+  match self.composition {
+    Some(input) => input.input_id == input_id
+    None => false
+  }
+}
+
+///|
+fn BlockInputState::update_composition(
+  self : BlockInputState,
+  input_id : String,
+  text : String,
+  selection : @dom_boundary.TextSelection,
+) -> (BlockInputState, Bool) {
+  match self.composition {
+    Some(input) if input.input_id == input_id =>
+      ({ ..self, composition: Some({ ..input, text, selection }) }, true)
+    _ => (self, false)
+  }
+}
+
+///|
 fn PendingBlockInput::matches(
   self : PendingBlockInput,
   document_id : @archive.LoomarkDocumentId,
@@ -165,9 +226,13 @@ fn BlockInputState::display_text(
   input_id~ : String,
   committed_text~ : String,
 ) -> String {
-  let input = match self.pending {
+  let input = match self.composition {
     Some(input) => Some(input)
-    None => self.in_flight.map(delivery => delivery.input)
+    None =>
+      match self.pending {
+        Some(input) => Some(input)
+        None => self.in_flight.map(delivery => delivery.input)
+      }
   }
   match input {
     Some(input) if input.matches(document_id, version, node_id, input_id) =>
@@ -192,6 +257,8 @@ fn BlockInputState::cancel(self : BlockInputState) -> BlockInputState {
     generation: self.generation + 1,
     next_token: self.next_token,
     in_flight: None,
+    composition: None,
+    composition_final: None,
   }
 }
 
@@ -251,9 +318,84 @@ fn BlockInputCoordinator::enqueue(
   input : PendingBlockInput,
   emit : @cmd.Emit[DriverEvent],
 ) -> @cmd.Cmd {
+  let duplicate_final = match self.state.val.composition_final {
+    Some(final_input) =>
+      final_input.matches(
+        input.document_id,
+        input.expected_version,
+        input.node_id,
+        input.input_id,
+      ) &&
+      final_input.text == input.text
+    None => false
+  }
+  self.state.val = { ..self.state.val, composition_final: None }
+  if duplicate_final {
+    return @rabbita_runtime.none
+  }
   let (state, schedule) = self.state.val.enqueue(input)
   self.state.val = state
   self.schedule(schedule, emit)
+}
+
+///|
+fn BlockInputCoordinator::begin_composition(
+  self : BlockInputCoordinator,
+  input : PendingBlockInput,
+) -> Bool {
+  let (state, accepted) = self.state.val.begin_composition(input)
+  self.state.val = state
+  accepted
+}
+
+///|
+fn BlockInputCoordinator::has_composition(
+  self : BlockInputCoordinator,
+  input_id : String,
+) -> Bool {
+  self.state.val.has_composition(input_id)
+}
+
+///|
+fn BlockInputCoordinator::update_composition(
+  self : BlockInputCoordinator,
+  input_id : String,
+  text : String,
+  selection : @dom_boundary.TextSelection,
+) -> Bool {
+  let (state, updated) = self.state.val.update_composition(
+    input_id, text, selection,
+  )
+  self.state.val = state
+  updated
+}
+
+///|
+fn BlockInputCoordinator::finish_composition(
+  self : BlockInputCoordinator,
+  input_id : String,
+  committed_text : String,
+  emit : @cmd.Emit[DriverEvent],
+) -> @cmd.Cmd {
+  let input = match self.state.val.composition {
+    Some(input) if input.input_id == input_id => input
+    _ => return @rabbita_runtime.none
+  }
+  self.state.val = { ..self.state.val, composition: None }
+  guard input.text != committed_text else { return @rabbita_runtime.none }
+  let (state, schedule) = self.state.val.enqueue(input)
+  let (state, delivery) = state.flush(schedule)
+  self.state.val = state
+  match delivery {
+    Some(delivery) => {
+      self.state.val = {
+        ..self.state.val,
+        composition_final: Some(delivery.input),
+      }
+      emit(Editing(BlockInput(token=delivery.token, input=delivery.input)))
+    }
+    None => @rabbita_runtime.none
+  }
 }
 
 ///|

--- a/apps/loomark/internal/rabbita/block_input_coordinator_wbtest.mbt
+++ b/apps/loomark/internal/rabbita/block_input_coordinator_wbtest.mbt
@@ -156,6 +156,219 @@ test "Block input batching keeps the latest input and ignores an old schedule" {
 }
 
 ///|
+test "Block composition keeps intermediate DOM state out of pending input" {
+  let context = BlockInputTestContext::BlockInputTestContext(
+    "block-composition-intermediate", "start",
+  )
+  let coordinator = BlockInputCoordinator::BlockInputCoordinator()
+  assert_true(coordinator.begin_composition(context.caret_input("start", 5)))
+  assert_true(
+    coordinator.update_composition(
+      "loomark-block-input",
+      "start漢",
+      @dom_boundary.TextSelection(6, 6, @dom_boundary.NoDirection),
+    ),
+  )
+
+  assert_eq(
+    coordinator.display_text(
+      document_id=context.document_id,
+      version=context.editor.version(),
+      node_id=context.node_id,
+      input_id="loomark-block-input",
+      committed_text="start",
+    ),
+    "start漢",
+  )
+  assert_true(coordinator.state.val.pending is None)
+  assert_true(coordinator.state.val.in_flight is None)
+}
+
+///|
+test "Block composition end delivers changed text immediately with its caret" {
+  let context = BlockInputTestContext::BlockInputTestContext(
+    "block-composition-final", "start",
+  )
+  let coordinator = BlockInputCoordinator::BlockInputCoordinator()
+  assert_true(coordinator.begin_composition(context.caret_input("start", 5)))
+  assert_true(
+    coordinator.update_composition(
+      "loomark-block-input",
+      "start漢",
+      @dom_boundary.TextSelection(6, 6, @dom_boundary.NoDirection),
+    ),
+  )
+  let emit : @cmd.Emit[DriverEvent] = @cmd.Emit(_ => @rabbita_runtime.none)
+  ignore(coordinator.finish_composition("loomark-block-input", "start", emit))
+
+  guard coordinator.state.val.composition is None else {
+    fail("composition must be cleared at compositionend")
+  }
+  guard coordinator.state.val.pending is None else {
+    fail("immediate composition delivery must not remain pending")
+  }
+  guard coordinator.state.val.in_flight is Some(delivery) else {
+    fail("changed composition must become active immediately")
+  }
+  assert_eq(delivery.input.text, "start漢")
+  assert_eq(delivery.input.selection.start(), 6)
+  assert_eq(delivery.input.selection.end(), 6)
+}
+
+///|
+test "Block composition ignores one same-value final input while delivery is active" {
+  let context = BlockInputTestContext::BlockInputTestContext(
+    "block-composition-duplicate-final", "start",
+  )
+  let coordinator = BlockInputCoordinator::BlockInputCoordinator()
+  let emit : @cmd.Emit[DriverEvent] = @cmd.Emit(_ => @rabbita_runtime.none)
+  assert_true(coordinator.begin_composition(context.caret_input("start", 5)))
+  assert_true(
+    coordinator.update_composition(
+      "loomark-block-input",
+      "start漢",
+      @dom_boundary.TextSelection(6, 6, @dom_boundary.NoDirection),
+    ),
+  )
+  ignore(coordinator.finish_composition("loomark-block-input", "start", emit))
+
+  ignore(coordinator.enqueue(context.caret_input("start漢", 6), emit))
+
+  assert_true(coordinator.state.val.pending is None)
+  guard coordinator.state.val.in_flight is Some(delivery) else {
+    fail("the original composition delivery must remain active")
+  }
+  assert_eq(delivery.token, 0)
+  assert_eq(delivery.input.text, "start漢")
+}
+
+///|
+test "Block input keeps latest same-value text after a different pending value" {
+  let context = BlockInputTestContext::BlockInputTestContext(
+    "block-latest-same-as-active", "x",
+  )
+  let coordinator = BlockInputCoordinator::BlockInputCoordinator()
+  let emit : @cmd.Emit[DriverEvent] = @cmd.Emit(_ => @rabbita_runtime.none)
+  let (state, first_schedule) = coordinator.state.val.enqueue(
+    context.caret_input("A", 1),
+  )
+  let (state, first_delivery) = state.flush(first_schedule)
+  guard first_delivery is Some(_) else {
+    fail("first value must become active")
+  }
+  coordinator.state.val = state
+
+  ignore(coordinator.enqueue(context.caret_input("B", 1), emit))
+  ignore(coordinator.enqueue(context.caret_input("A", 1), emit))
+
+  guard coordinator.state.val.pending is Some(pending) else {
+    fail("latest value must remain pending")
+  }
+  assert_eq(pending.text, "A")
+}
+
+///|
+test "Canceled Block composition is a no-op" {
+  let context = BlockInputTestContext::BlockInputTestContext(
+    "block-composition-cancel", "start",
+  )
+  let coordinator = BlockInputCoordinator::BlockInputCoordinator()
+  assert_true(coordinator.begin_composition(context.caret_input("start", 5)))
+  assert_true(
+    coordinator.update_composition(
+      "loomark-block-input",
+      "start",
+      @dom_boundary.TextSelection(5, 5, @dom_boundary.NoDirection),
+    ),
+  )
+  let emit : @cmd.Emit[DriverEvent] = @cmd.Emit(_ => @rabbita_runtime.none)
+  ignore(coordinator.finish_composition("loomark-block-input", "start", emit))
+
+  assert_true(coordinator.state.val.composition is None)
+  assert_true(coordinator.state.val.pending is None)
+  assert_true(coordinator.state.val.in_flight is None)
+}
+
+///|
+test "Block composition invalidates a pre-existing schedule before delivery" {
+  let context = BlockInputTestContext::BlockInputTestContext(
+    "block-composition-schedule", "start",
+  )
+  let coordinator = BlockInputCoordinator::BlockInputCoordinator()
+  let (state, old_schedule) = coordinator.state.val.enqueue(
+    context.caret_input("pending", 7),
+  )
+  coordinator.state.val = state
+  assert_true(coordinator.begin_composition(context.caret_input("start", 7)))
+  assert_eq(
+    coordinator.display_text(
+      document_id=context.document_id,
+      version=context.editor.version(),
+      node_id=context.node_id,
+      input_id="loomark-block-input",
+      committed_text="start",
+    ),
+    "pending",
+  )
+  let (_, old_delivery) = coordinator.state.val.flush(old_schedule)
+  guard old_delivery is None else {
+    fail("compositionstart must invalidate the old delayed delivery")
+  }
+  let emit : @cmd.Emit[DriverEvent] = @cmd.Emit(_ => @rabbita_runtime.none)
+  ignore(coordinator.finish_composition("loomark-block-input", "start", emit))
+
+  guard coordinator.state.val.in_flight is Some(delivery) else {
+    fail("promoted input must produce one delivery without composition input")
+  }
+  assert_eq(delivery.input.text, "pending")
+  let (_, duplicate) = coordinator.state.val.flush(old_schedule)
+  guard duplicate is None else {
+    fail("the old schedule must never deliver the composition twice")
+  }
+}
+
+///|
+test "Block input cancellation clears live composition" {
+  let context = BlockInputTestContext::BlockInputTestContext(
+    "block-composition-cancel-pending", "start",
+  )
+  let coordinator = BlockInputCoordinator::BlockInputCoordinator()
+  assert_true(coordinator.begin_composition(context.caret_input("start", 5)))
+  assert_true(
+    coordinator.update_composition(
+      "loomark-block-input",
+      "start漢",
+      @dom_boundary.TextSelection(6, 6, @dom_boundary.NoDirection),
+    ),
+  )
+  assert_eq(
+    coordinator.display_text(
+      document_id=context.document_id,
+      version=context.editor.version(),
+      node_id=context.node_id,
+      input_id="loomark-block-input",
+      committed_text="start",
+    ),
+    "start漢",
+  )
+  coordinator.cancel_pending()
+
+  assert_true(coordinator.state.val.composition is None)
+  assert_true(coordinator.state.val.pending is None)
+  assert_true(coordinator.state.val.in_flight is None)
+  assert_eq(
+    coordinator.display_text(
+      document_id=context.document_id,
+      version=context.editor.version(),
+      node_id=context.node_id,
+      input_id="loomark-block-input",
+      committed_text="start",
+    ),
+    "start",
+  )
+}
+
+///|
 test "Block input batching keeps the pending value through redraw and never retries it" {
   let context = BlockInputTestContext::BlockInputTestContext(
     "block-input-display-test", "x",

--- a/apps/loomark/internal/rabbita/block_view.mbt
+++ b/apps/loomark/internal/rabbita/block_view.mbt
@@ -410,11 +410,51 @@ fn block_input(
     rows=1,
     slot="block-editor-input",
     style=block_input_style(block.kind()),
-    attrs~,
+    attrs=attrs
+      .on_compositionstart(_ => {
+        let selection = @dom_boundary.read_text_selection_id(input_id) catch {
+          error => {
+            coordinator.cancel_pending()
+            return emit(Navigation(EffectFailed(error.message())))
+          }
+        }
+        ignore(
+          coordinator.begin_composition(
+            PendingBlockInput::PendingBlockInput(
+              document_id~,
+              expected_version=version,
+              node_id=block.node_id(),
+              input_id~,
+              text=input_value,
+              selection~,
+            ),
+          ),
+        )
+        @rabbita_runtime.none
+      })
+      .on_compositionend(_ => {
+        coordinator.finish_composition(input_id, block.text(), emit)
+      }),
     on_input=@cmd.Emit(text => {
-      block_input_command(
-        block, input_id, text, document_id, version, coordinator, emit,
-      )
+      if coordinator.has_composition(input_id) {
+        let selection = @dom_boundary.read_text_selection_id(input_id) catch {
+          error => {
+            coordinator.cancel_pending()
+            return emit(Navigation(EffectFailed(error.message())))
+          }
+        }
+        if coordinator.update_composition(input_id, text, selection) {
+          @rabbita_runtime.none
+        } else {
+          block_input_command(
+            block, input_id, text, document_id, version, coordinator, emit,
+          )
+        }
+      } else {
+        block_input_command(
+          block, input_id, text, document_id, version, coordinator, emit,
+        )
+      }
     }),
   )
   @html.div(

--- a/apps/loomark/internal/rabbita/text_control_repair.mbt
+++ b/apps/loomark/internal/rabbita/text_control_repair.mbt
@@ -70,6 +70,8 @@ priv struct RawInputCoordinator {
   in_flight_token : @ref.Ref[Int?]
   in_flight_source : @ref.Ref[String?]
   suppress_unmatched_repair : @ref.Ref[Bool]
+  composition : @ref.Ref[PendingRawInput?]
+  composition_final_source : @ref.Ref[String?]
   telemetry : RawInputTelemetry?
 }
 
@@ -87,6 +89,8 @@ fn RawInputCoordinator::RawInputCoordinator(
     in_flight_token: @ref.Ref(None),
     in_flight_source: @ref.Ref(None),
     suppress_unmatched_repair: @ref.Ref(false),
+    composition: @ref.Ref(None),
+    composition_final_source: @ref.Ref(None),
     telemetry,
   }
 }
@@ -247,13 +251,133 @@ fn RawInputCoordinator::display_source(
   self : RawInputCoordinator,
   committed_source : String,
 ) -> String {
-  match self.pending.val {
-    Some(pending) => pending.source
+  match self.composition.val {
+    Some(input) => input.source
     None =>
-      match self.in_flight_source.val {
-        Some(source) => source
-        None => committed_source
+      match self.pending.val {
+        Some(pending) => pending.source
+        None =>
+          match self.in_flight_source.val {
+            Some(source) => source
+            None => committed_source
+          }
       }
+  }
+}
+
+///|
+/// Begin browser ownership from the exact accepted Raw selection. A pending
+/// ordinary batch keeps its earlier beforeinput base and becomes part of the
+/// final composition transaction.
+fn RawInputCoordinator::begin_composition(
+  self : RawInputCoordinator,
+  before_input : RawBeforeInputCandidate,
+  source : String,
+  selection : @dom_boundary.TextSelection,
+) -> Bool {
+  guard self.in_flight_token.val is None else { return false }
+  let input = match self.pending.val {
+    Some(pending) if pending.before_input.selection.document_id ==
+      before_input.selection.document_id &&
+      pending.before_input.selection.version == before_input.selection.version =>
+      { ..pending, post_input_selection: selection }
+    _ =>
+      {
+        before_input,
+        source: raw_textarea_value(source),
+        post_input_selection: selection,
+        input_count: 0,
+      }
+  }
+  self.schedule_generation.val += 1
+  self.capture_generation.val += 1
+  self.scheduled.val = false
+  self.unmatched_before_input.val = None
+  self.pending.val = None
+  self.suppress_unmatched_repair.val = false
+  self.composition.val = Some(input)
+  self.composition_final_source.val = None
+  true
+}
+
+///|
+/// Keep the latest browser-owned text and caret without exposing it as a
+/// committable pending Raw input.
+fn RawInputCoordinator::begin_native_composition(
+  self : RawInputCoordinator,
+  model : DriverModel,
+  source : String,
+  selection : @dom_boundary.TextSelection,
+) -> Bool {
+  let before_input = match self.pending.val {
+    Some(pending) if pending.before_input.selection.document_id ==
+      model.document_id &&
+      pending.before_input.selection.version == model.document_version =>
+      pending.before_input
+    _ => {
+      let versioned = versioned_raw_selection_from_dom(model, selection) catch {
+        _ => return false
+      }
+      RawBeforeInputCandidate::RawBeforeInputCandidate(
+        selection=versioned,
+        input_type="insertCompositionText",
+        is_composing=false,
+      )
+    }
+  }
+  self.begin_composition(before_input, source, selection)
+}
+
+///|
+fn RawInputCoordinator::update_composition(
+  self : RawInputCoordinator,
+  source : String,
+  selection : @dom_boundary.TextSelection,
+) -> Bool {
+  match self.composition.val {
+    Some(input) => {
+      self.composition.val = Some({
+        ..input,
+        source: raw_textarea_value(source),
+        post_input_selection: selection,
+        input_count: input.input_count + 1,
+      })
+      true
+    }
+    None => false
+  }
+}
+
+///|
+/// Resolve composition at its browser boundary. A net no-op never reaches the
+/// editor; a changed final value becomes one immediate native transaction so a
+/// following blur or mode click cannot cancel accepted IME text.
+fn RawInputCoordinator::finish_composition(
+  self : RawInputCoordinator,
+  accepted_source : String,
+  emit : @cmd.Emit[DriverEvent],
+) -> @cmd.Cmd {
+  guard self.composition.val is Some(input) else {
+    return @rabbita_runtime.none
+  }
+  self.composition.val = None
+  if input.source == raw_textarea_value(accepted_source) {
+    match self.telemetry {
+      Some(telemetry) => telemetry.pending_input_received_at.val = None
+      None => ()
+    }
+    return @rabbita_runtime.none
+  }
+  self.pending.val = Some(input)
+  self.composition_final_source.val = Some(input.source)
+  let expiry_command = self.capture_before_input(input.before_input)
+  match self.take_pending_delivery() {
+    Some((token, candidate)) =>
+      @cmd.batch([
+        emit(Editing(RawNativeInput(token~, candidate~))),
+        expiry_command,
+      ])
+    None => expiry_command
   }
 }
 
@@ -308,6 +432,7 @@ fn RawInputCoordinator::expire_before_input(
 ) -> Unit {
   if self.capture_generation.val == generation {
     self.unmatched_before_input.val = None
+    self.composition_final_source.val = None
   }
 }
 
@@ -319,7 +444,9 @@ fn RawInputCoordinator::capture_native_before_input(
   event : @dom.InputEvent,
 ) -> @cmd.Cmd {
   if raw_input_event_is_composing(event) {
-    self.cancel_pending()
+    if self.composition.val is None {
+      self.cancel_pending()
+    }
     return @rabbita_runtime.none
   }
   match self.pending.val {
@@ -376,65 +503,63 @@ fn read_raw_selection() -> @dom_boundary.TextSelection? {
 }
 
 ///|
+fn RawInputCoordinator::take_pending_delivery(
+  self : RawInputCoordinator,
+) -> (Int, RawNativeInputCandidate)? {
+  guard self.pending.val is Some(pending) else { return None }
+  self.pending.val = None
+  let token = self.next_token.val
+  self.next_token.val = token + 1
+  self.in_flight_token.val = Some(token)
+  self.in_flight_source.val = Some(pending.source)
+  match self.telemetry {
+    Some(telemetry) => {
+      let now = raw_input_now_ms()
+      let input_received_at = match telemetry.pending_input_received_at.val {
+        Some(at) => at
+        None => now
+      }
+      telemetry.pending_input_received_at.val = None
+      telemetry.phase.val = Some({
+        token,
+        input_count: pending.input_count,
+        input_received_at,
+        debounce_fired_at: now,
+        reducer_started_at: None,
+        reducer_finished_at: None,
+        editor_started_at: None,
+        editor_finished_at: None,
+        preview_started_at: None,
+        preview_finished_at: None,
+        publish_started_at: None,
+        publish_finished_at: None,
+        rendered_at: None,
+      })
+    }
+    None => ()
+  }
+  Some(
+    (
+      token,
+      RawNativeInputCandidate::RawNativeInputCandidate(
+        before_input=pending.before_input,
+        source=pending.source,
+        post_input_selection=pending.post_input_selection,
+      ),
+    ),
+  )
+}
+
+///|
 fn RawInputCoordinator::flush(
   self : RawInputCoordinator,
   scheduler : &@cmd.Scheduler,
   emit : @cmd.Emit[DriverEvent],
 ) -> Unit {
   self.scheduled.val = false
-  match self.pending.val {
-    Some(pending) => {
-      self.pending.val = None
-      let before_input = pending.before_input
-      let source = pending.source
-      let post_input_selection = pending.post_input_selection
-      let input_count = pending.input_count
-      let token = self.next_token.val
-      self.next_token.val = token + 1
-      self.in_flight_token.val = Some(token)
-      self.in_flight_source.val = Some(source)
-      match self.telemetry {
-        Some(telemetry) => {
-          let now = raw_input_now_ms()
-          let input_received_at = match
-            telemetry.pending_input_received_at.val {
-            Some(at) => at
-            None => now
-          }
-          telemetry.pending_input_received_at.val = None
-          telemetry.phase.val = Some({
-            token,
-            input_count,
-            input_received_at,
-            debounce_fired_at: now,
-            reducer_started_at: None,
-            reducer_finished_at: None,
-            editor_started_at: None,
-            editor_finished_at: None,
-            preview_started_at: None,
-            preview_finished_at: None,
-            publish_started_at: None,
-            publish_finished_at: None,
-            rendered_at: None,
-          })
-        }
-        None => ()
-      }
-      scheduler.add(
-        emit(
-          Editing(
-            RawNativeInput(
-              token~,
-              candidate=RawNativeInputCandidate::RawNativeInputCandidate(
-                before_input~,
-                source~,
-                post_input_selection~,
-              ),
-            ),
-          ),
-        ),
-      )
-    }
+  match self.take_pending_delivery() {
+    Some((token, candidate)) =>
+      scheduler.add(emit(Editing(RawNativeInput(token~, candidate~))))
     None => self.cancel_pending()
   }
 }
@@ -450,8 +575,10 @@ fn RawInputCoordinator::has_captured_before_input(
 fn RawInputCoordinator::suppress_composing_input_repair(
   self : RawInputCoordinator,
 ) -> Unit {
-  self.cancel_pending()
-  self.suppress_unmatched_repair.val = true
+  if self.composition.val is None {
+    self.cancel_pending()
+    self.suppress_unmatched_repair.val = true
+  }
 }
 
 ///|
@@ -471,6 +598,17 @@ fn RawInputCoordinator::enqueue(
   emit : @cmd.Emit[DriverEvent],
 ) -> @cmd.Cmd {
   self.capture_generation.val += 1
+  let source = raw_textarea_value(source)
+  match self.composition_final_source.val {
+    Some(final_source) => {
+      self.composition_final_source.val = None
+      if final_source == source {
+        self.unmatched_before_input.val = None
+        return @rabbita_runtime.none
+      }
+    }
+    None => ()
+  }
   let before_input = match self.unmatched_before_input.val {
     Some(before_input) => before_input
     None => {
@@ -483,7 +621,6 @@ fn RawInputCoordinator::enqueue(
     self.cancel_pending()
     return @rabbita_runtime.none
   }
-  let source = raw_textarea_value(source)
   let pending = match self.pending.val {
     Some(pending) if pending.before_input.selection.document_id !=
       before_input.selection.document_id ||
@@ -573,6 +710,8 @@ fn RawInputCoordinator::cancel_pending(self : RawInputCoordinator) -> Unit {
   self.in_flight_token.val = None
   self.in_flight_source.val = None
   self.suppress_unmatched_repair.val = false
+  self.composition.val = None
+  self.composition_final_source.val = None
 }
 
 ///|

--- a/apps/loomark/internal/rabbita/text_control_repair_wbtest.mbt
+++ b/apps/loomark/internal/rabbita/text_control_repair_wbtest.mbt
@@ -62,6 +62,290 @@ test "Raw coordinator suppresses only the matching composition repair" {
 }
 
 ///|
+test "Raw composition keeps intermediate DOM state out of pending input" {
+  let context = RawSelectionTestContext::RawSelectionTestContext(
+    "raw-composition-intermediate", "start",
+  )
+  let coordinator = RawInputCoordinator::RawInputCoordinator(None)
+  let before_input = RawBeforeInputCandidate::RawBeforeInputCandidate(
+    selection=context.selection(5, 5),
+    input_type="insertCompositionText",
+    is_composing=false,
+  )
+
+  assert_true(
+    coordinator.begin_composition(
+      before_input,
+      "start",
+      @dom_boundary.TextSelection(5, 5, @dom_boundary.NoDirection),
+    ),
+  )
+  assert_true(
+    coordinator.update_composition(
+      "startか",
+      @dom_boundary.TextSelection(6, 6, @dom_boundary.NoDirection),
+    ),
+  )
+
+  assert_eq(coordinator.display_source("start"), "startか")
+  assert_true(coordinator.pending.val is None)
+  assert_true(coordinator.in_flight_token.val is None)
+}
+
+///|
+test "Raw composition end releases one immediate final transaction" {
+  let context = RawSelectionTestContext::RawSelectionTestContext(
+    "raw-composition-final", "start",
+  )
+  let coordinator = RawInputCoordinator::RawInputCoordinator(None)
+  let emit : @cmd.Emit[DriverEvent] = @cmd.Emit(_ => @rabbita_runtime.none)
+  assert_true(
+    coordinator.begin_composition(
+      RawBeforeInputCandidate::RawBeforeInputCandidate(
+        selection=context.selection(5, 5),
+        input_type="insertCompositionText",
+        is_composing=false,
+      ),
+      "start",
+      @dom_boundary.TextSelection(5, 5, @dom_boundary.NoDirection),
+    ),
+  )
+  assert_true(
+    coordinator.update_composition(
+      "start漢字",
+      @dom_boundary.TextSelection(7, 7, @dom_boundary.NoDirection),
+    ),
+  )
+
+  ignore(coordinator.finish_composition("start", emit))
+
+  assert_true(coordinator.composition.val is None)
+  assert_true(coordinator.pending.val is None)
+  assert_eq(coordinator.in_flight_token.val, Some(0))
+  assert_eq(coordinator.in_flight_source.val, Some("start漢字"))
+}
+
+///|
+test "Canceled Raw composition never becomes an editor transaction" {
+  let context = RawSelectionTestContext::RawSelectionTestContext(
+    "raw-composition-cancel", "start",
+  )
+  let coordinator = RawInputCoordinator::RawInputCoordinator(None)
+  let emit : @cmd.Emit[DriverEvent] = @cmd.Emit(_ => @rabbita_runtime.none)
+  assert_true(
+    coordinator.begin_composition(
+      RawBeforeInputCandidate::RawBeforeInputCandidate(
+        selection=context.selection(5, 5),
+        input_type="insertCompositionText",
+        is_composing=false,
+      ),
+      "start",
+      @dom_boundary.TextSelection(5, 5, @dom_boundary.NoDirection),
+    ),
+  )
+  assert_true(
+    coordinator.update_composition(
+      "start",
+      @dom_boundary.TextSelection(5, 5, @dom_boundary.NoDirection),
+    ),
+  )
+
+  ignore(coordinator.finish_composition("start", emit))
+
+  assert_true(coordinator.composition.val is None)
+  assert_true(coordinator.pending.val is None)
+  assert_true(coordinator.in_flight_token.val is None)
+  assert_true(coordinator.unmatched_before_input.val is None)
+}
+
+///|
+test "Raw composition ignores one same-value final input while delivery is active" {
+  let context = RawSelectionTestContext::RawSelectionTestContext(
+    "raw-composition-duplicate-final", "start",
+  )
+  let coordinator = RawInputCoordinator::RawInputCoordinator(None)
+  let emit : @cmd.Emit[DriverEvent] = @cmd.Emit(_ => @rabbita_runtime.none)
+  assert_true(
+    coordinator.begin_composition(
+      RawBeforeInputCandidate::RawBeforeInputCandidate(
+        selection=context.selection(5, 5),
+        input_type="insertCompositionText",
+        is_composing=false,
+      ),
+      "start",
+      @dom_boundary.TextSelection(5, 5, @dom_boundary.NoDirection),
+    ),
+  )
+  assert_true(
+    coordinator.update_composition(
+      "start漢字",
+      @dom_boundary.TextSelection(7, 7, @dom_boundary.NoDirection),
+    ),
+  )
+  ignore(coordinator.finish_composition("start", emit))
+  coordinator.unmatched_before_input.val = None
+
+  ignore(
+    coordinator.enqueue(
+      "start漢字",
+      @dom_boundary.TextSelection(7, 7, @dom_boundary.NoDirection),
+      emit,
+    ),
+  )
+
+  assert_true(coordinator.pending.val is None)
+  assert_eq(coordinator.in_flight_token.val, Some(0))
+  assert_eq(coordinator.in_flight_source.val, Some("start漢字"))
+}
+
+///|
+test "Raw input keeps latest same-value text after a different pending value" {
+  let context = RawSelectionTestContext::RawSelectionTestContext(
+    "raw-latest-same-as-active", "x",
+  )
+  let coordinator = RawInputCoordinator::RawInputCoordinator(None)
+  let emit : @cmd.Emit[DriverEvent] = @cmd.Emit(_ => @rabbita_runtime.none)
+  let capture = () => {
+    coordinator.capture_before_input(
+      RawBeforeInputCandidate::RawBeforeInputCandidate(
+        selection=context.selection(1, 1),
+        input_type="insertText",
+        is_composing=false,
+      ),
+    )
+  }
+  ignore(capture())
+  ignore(
+    coordinator.enqueue(
+      "A",
+      @dom_boundary.TextSelection(1, 1, @dom_boundary.NoDirection),
+      emit,
+    ),
+  )
+  guard coordinator.take_pending_delivery() is Some((0, _)) else {
+    fail("first value must become active")
+  }
+  ignore(capture())
+  ignore(
+    coordinator.enqueue(
+      "B",
+      @dom_boundary.TextSelection(1, 1, @dom_boundary.NoDirection),
+      emit,
+    ),
+  )
+  ignore(capture())
+  ignore(
+    coordinator.enqueue(
+      "A",
+      @dom_boundary.TextSelection(1, 1, @dom_boundary.NoDirection),
+      emit,
+    ),
+  )
+
+  guard coordinator.pending.val is Some(pending) else {
+    fail("latest value must remain pending")
+  }
+  assert_eq(pending.source, "A")
+}
+
+///|
+test "Raw composition releases promoted input without a composition input" {
+  let context = RawSelectionTestContext::RawSelectionTestContext(
+    "raw-composition-no-input", "abcdef",
+  )
+  let coordinator = RawInputCoordinator::RawInputCoordinator(None)
+  let emit : @cmd.Emit[DriverEvent] = @cmd.Emit(_ => @rabbita_runtime.none)
+  ignore(
+    coordinator.capture_before_input(
+      RawBeforeInputCandidate::RawBeforeInputCandidate(
+        selection=context.selection(4, 2),
+        input_type="insertText",
+        is_composing=false,
+      ),
+    ),
+  )
+  ignore(
+    coordinator.enqueue(
+      "abxyef",
+      @dom_boundary.TextSelection(4, 4, @dom_boundary.NoDirection),
+      emit,
+    ),
+  )
+  assert_true(
+    coordinator.begin_composition(
+      RawBeforeInputCandidate::RawBeforeInputCandidate(
+        selection=context.selection(4, 4),
+        input_type="insertCompositionText",
+        is_composing=false,
+      ),
+      "abcdef",
+      @dom_boundary.TextSelection(4, 4, @dom_boundary.NoDirection),
+    ),
+  )
+
+  ignore(coordinator.finish_composition("abcdef", emit))
+
+  assert_true(coordinator.composition.val is None)
+  assert_eq(coordinator.in_flight_source.val, Some("abxyef"))
+  assert_eq(coordinator.in_flight_token.val, Some(0))
+}
+
+///|
+test "Raw composition keeps a pending ordinary input as its transaction base" {
+  let context = RawSelectionTestContext::RawSelectionTestContext(
+    "raw-composition-pending-base", "abcdef",
+  )
+  let coordinator = RawInputCoordinator::RawInputCoordinator(None)
+  let emit : @cmd.Emit[DriverEvent] = @cmd.Emit(_ => @rabbita_runtime.none)
+  ignore(
+    coordinator.capture_before_input(
+      RawBeforeInputCandidate::RawBeforeInputCandidate(
+        selection=context.selection(4, 2),
+        input_type="insertText",
+        is_composing=false,
+      ),
+    ),
+  )
+  ignore(
+    coordinator.enqueue(
+      "abxyef",
+      @dom_boundary.TextSelection(4, 4, @dom_boundary.NoDirection),
+      emit,
+    ),
+  )
+  assert_true(
+    coordinator.begin_composition(
+      RawBeforeInputCandidate::RawBeforeInputCandidate(
+        selection=context.selection(4, 4),
+        input_type="insertCompositionText",
+        is_composing=false,
+      ),
+      "abcdef",
+      @dom_boundary.TextSelection(4, 4, @dom_boundary.NoDirection),
+    ),
+  )
+  guard coordinator.composition.val is Some(started) else {
+    fail("composition must promote the pending ordinary input")
+  }
+  assert_eq(started.source, "abxyef")
+  assert_true(
+    coordinator.update_composition(
+      "abxy漢ef",
+      @dom_boundary.TextSelection(5, 5, @dom_boundary.NoDirection),
+    ),
+  )
+
+  guard coordinator.composition.val is Some(input) else {
+    fail("composition must retain one complete final transaction")
+  }
+  assert_eq(input.before_input.selection.selection.anchor(), 4)
+  assert_eq(input.before_input.selection.selection.head(), 2)
+  assert_eq(input.source, "abxy漢ef")
+  assert_eq(input.post_input_selection.start(), 5)
+  assert_true(coordinator.pending.val is None)
+}
+
+///|
 test "Raw coordinator keeps the first backward base and latest collapsed caret" {
   let context = RawSelectionTestContext::RawSelectionTestContext(
     "coordinator-pairing", "abcdef",
@@ -231,6 +515,39 @@ test "Raw coordinator discards a composition-intermediate capture" {
   )
   assert_true(coordinator.unmatched_before_input.val is None)
   assert_true(coordinator.pending.val is None)
+}
+
+///|
+test "Raw input cancellation clears live composition" {
+  let context = RawSelectionTestContext::RawSelectionTestContext(
+    "raw-composition-cancel-pending", "start",
+  )
+  let coordinator = RawInputCoordinator::RawInputCoordinator(None)
+  assert_true(
+    coordinator.begin_composition(
+      RawBeforeInputCandidate::RawBeforeInputCandidate(
+        selection=context.selection(5, 5),
+        input_type="insertCompositionText",
+        is_composing=false,
+      ),
+      "start",
+      @dom_boundary.TextSelection(5, 5, @dom_boundary.NoDirection),
+    ),
+  )
+  assert_true(
+    coordinator.update_composition(
+      "start漢",
+      @dom_boundary.TextSelection(6, 6, @dom_boundary.NoDirection),
+    ),
+  )
+  assert_eq(coordinator.display_source("start"), "start漢")
+
+  coordinator.cancel_pending()
+
+  assert_true(coordinator.composition.val is None)
+  assert_true(coordinator.pending.val is None)
+  assert_true(coordinator.in_flight_token.val is None)
+  assert_eq(coordinator.display_source("start"), "start")
 }
 
 ///|


### PR DESCRIPTION
## Summary

- keep Raw and Block IME intermediate DOM values out of canonical source and history
- commit the accepted composition result exactly once through the existing versioned Raw/Block transaction paths, while preserving cancel, failure, mode-change, focus, and caret behavior
- cover pending ordinary input, duplicate final input, Block syntax forms, and non-BMP/UTF-16 boundaries in MoonBit and production-browser tests

Closes #1076

## UI and review evidence

N/A — this changes text-input event handling without changing labels, layout, styling, pointer behavior, or viewport behavior.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `RawInputCoordinator`, `RawBeforeInputCandidate`, `PendingRawInput` | `apps/loomark/internal/rabbita/text_control_repair.mbt` | Yes | Retains the versioned pre-input selection and routes the accepted result through the existing normalized Raw transaction. |
| `BlockInputCoordinator`, `PendingBlockInput` | `apps/loomark/internal/rabbita/block_input_coordinator.mbt` | Yes | Extends the existing latest-value scheduler rather than adding a second Block commit path. |
| `commit_raw_selection_edit` / `MarkdownEditRequest::ReplaceText` | Loomark application and Markdown editor façade | Yes | Keeps Canopy as the canonical source/history owner. |
| `@moji` grapheme checks and existing UTF-16 selection conversion | Loomark Raw/Block transaction code | Yes | Rejects mid-surrogate and mid-grapheme boundaries without new JavaScript offset logic. |
| Core `Option`, `Ref`, `String`/`StringView` | MoonBit core | Yes | Models optional private composition state, browser-shell mutation, and existing text conversion. |
| Core `Map`, `Set`, `Array`, `Bytes`/`BytesView`, `Buffer`/`StringBuilder`, `Result` | MoonBit core | No | Composition owns one active text-control value; it needs no keyed collection, binary representation, text builder, or new fallible boundary. Existing transaction results remain unchanged. |

New helpers added (if any):

- private Raw composition methods (`begin_native_composition`, `begin_composition`, `update_composition`, `finish_composition`) isolate browser lifecycle handling from canonical commit normalization
- `RawInputCoordinator::take_pending_delivery` shares generation/token/telemetry handling between delayed ordinary input and immediate composition finalization
- private Block composition methods mirror the existing pure `BlockInputState` plus imperative `BlockInputCoordinator` boundary; no public type or API was added

Remaining mutation is confined to coordinator refs and DOM-event shell wiring. Pure Block state transitions and existing canonical transaction functions retain validation and commit decisions.

## Validation scope

Boundary matrix / first failing regression:

- Raw and Block: composition start, intermediate input, accepted end, cancel-like no-op, duplicate final input, and lifecycle cancellation
- ordinary input pending before composition, composition ending without a composing input, and ordinary last-writer-wins (`active A -> pending B -> latest A`)
- successful and failed Raw final commit, guarded DOM repair, focus/caret preservation, mode click after accepted composition, and synthetic mode cancellation
- Block paragraph, heading, list, and fenced-code controls
- emoji UTF-16 replacement and family ZWJ grapheme in dev-host and standalone production output; existing lower-layer tests retain shared-high-surrogate and regional-indicator boundary coverage

Target packages:

- `apps/loomark/internal/rabbita`

Additional conditional gates:

- `./scripts/test-loomark-dev-host-e2e.sh`: 110/110 passed
- `./scripts/test-loomark-standalone-e2e.sh`: 13/13 passed
- `moon bench apps/loomark/internal/rabbita --release`: 5/5 passed
- independent MoonBit review after final base sync: PASS

## PR-ready evidence

Validated HEAD: `8f2f6c20039ffcaa4d0dbcc2bd669b09df33a032`

Validated base: `origin/main@74d448e2ecdcbbd72c260769f254b6c069d1ddef`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh \
  --target apps/loomark/internal/rabbita
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for the exact HEAD and base above.
- [x] The base was fetched again and `--verify-evidence` passed immediately before this PR was opened, updated, or merged.
- [x] The committed `.mbti` diff against the validated base was reviewed for unintended API or trait-bound changes; there is no `.mbti` diff.
- [x] Any changed submodule commit is pushed and reachable from its remote; this PR changes no submodule pointer.
- [x] Validation was rerun after every commit, amend, rebase, cherry-pick, submodule-pointer, manifest, or generated-interface change.
- [x] Independent review findings were resolved before the final validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved IME support across Raw and Block editors.
  - Composition previews no longer commit prematurely or overwrite saved content.
  - Finalized input is committed once, while canceled or rejected compositions restore the correct content.
  - Preserved Unicode characters, syntax, selection, focus, and caret position during composition.
  - Improved behavior when switching editing modes during active composition.
  - Prevented duplicate input events and ensured committed content persists correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->