### PR TITLE
fix(ideal): guard CodeMirror deltas by source version

### DIFF
--- a/apps/ideal/main/commands.mbt
+++ b/apps/ideal/main/commands.mbt
@@ -34,14 +34,22 @@ fn cm_mount_cmd(emit : Emit[Msg], model : Model) -> Cmd {
 ///|
 fn sync_after_local_model_change(model : Model, text : String) -> Cmd {
   @rabbita.batch([
-    @cm.set_doc(model.cm_id, text),
+    @cm.set_doc(
+      model.cm_id,
+      text,
+      source_version=@ffi.get_version_json(model.handle),
+    ),
     @rabbita.effect(fn() { js_after_local_text_edit() }),
   ])
 }
 
 ///|
 fn sync_after_external_crdt_change(model : Model) -> Cmd {
-  @cm.set_doc(model.cm_id, model.editor.get_text())
+  @cm.set_doc(
+    model.cm_id,
+    model.editor.get_text(),
+    source_version=@ffi.get_version_json(model.handle),
+  )
 }
 
 ///|

--- a/apps/ideal/main/init.mbt
+++ b/apps/ideal/main/init.mbt
@@ -78,6 +78,7 @@ fn subscriptions(model : Model, emit : Emit[Msg]) -> Sub {
       model.cm_id,
       selection=emit.map(range => CmSelectionChanged(range)),
       on_change_with_doc=emit.map(event => CmChanges(event)),
+      source_version=() => @ffi.get_version_json(model.handle),
     )
   } else {
     @sub.none

--- a/apps/ideal/main/update_codemirror.mbt
+++ b/apps/ideal/main/update_codemirror.mbt
@@ -1,4 +1,12 @@
 ///|
+fn code_mirror_source_version_matches(
+  event_source_version : String,
+  current_source_version : String,
+) -> Bool {
+  event_source_version != "" && event_source_version == current_source_version
+}
+
+///|
 fn apply_code_mirror_changes(
   editor : @editor.SyncEditor[@ast.Term],
   changes : Array[@cm.ChangeDelta],
@@ -36,19 +44,24 @@ fn handle_codemirror(
     }
     CmChanges(event) => {
       // Local single-range CodeMirror transactions already carry an exact
-      // pre-transaction splice. Apply that directly; use the transaction's
-      // captured document snapshot for multi-range or rejected transactions.
+      // pre-transaction splice. Apply that directly only while the CRDT source
+      // version still matches the source currently displayed in CodeMirror;
+      // otherwise use the transaction's captured document snapshot fallback.
       let changes = event.changes
+      let current_source_version = @ffi.get_version_json(model.handle)
       js_perf_begin("cmDocChangedHandler")
       js_perf_begin("syncEditorApply")
       let timestamp_ms = js_now_ms()
       let fallback_text = try {
         js_perf_begin("incrementalTextApply")
-        let applied = apply_code_mirror_changes(
-          model.editor,
-          changes,
-          timestamp_ms,
-        )
+        let applied = if code_mirror_source_version_matches(
+            event.source_version,
+            current_source_version,
+          ) {
+          apply_code_mirror_changes(model.editor, changes, timestamp_ms)
+        } else {
+          false
+        }
         js_perf_end("incrementalTextApply")
         if applied {
           None
@@ -78,15 +91,16 @@ fn handle_codemirror(
         }
       }
       let actual_text = new_model.editor.get_text()
+      let source_version = @ffi.get_version_json(model.handle)
       js_perf_begin("publicationPrepare")
       let sync_cmd = match fallback_text {
         Some(text) =>
           if actual_text != text {
-            @cm.set_doc(model.cm_id, actual_text)
+            @cm.set_doc(model.cm_id, actual_text, source_version~)
           } else {
-            none
+            @cm.set_source_version(model.cm_id, source_version)
           }
-        None => none
+        None => @cm.set_source_version(model.cm_id, source_version)
       }
       let publication_effect = @rabbita.effect(fn() {
         js_perf_begin("localPublicationEffect")

--- a/apps/ideal/main/update_codemirror_wbtest.mbt
+++ b/apps/ideal/main/update_codemirror_wbtest.mbt
@@ -1,0 +1,6 @@
+///|
+test "CodeMirror source version guard rejects unknown and mismatched events" {
+  inspect(code_mirror_source_version_matches("v1", "v1"), content="true")
+  inspect(code_mirror_source_version_matches("v1", "v2"), content="false")
+  inspect(code_mirror_source_version_matches("", "v2"), content="false")
+}

--- a/apps/ideal/web/e2e/editor-features.spec.ts
+++ b/apps/ideal/web/e2e/editor-features.spec.ts
@@ -226,6 +226,78 @@ test.describe('External Sync', () => {
     expect(text.startsWith('let remote = 0\n')).toBe(true);
     expect(text.endsWith('z')).toBe(true);
   });
+
+  test('falls back when a remote CRDT update precedes a CodeMirror edit', async ({ page }) => {
+    await waitForEditor(page);
+    const source = 'let x = 1\nx';
+    await page.evaluate((text) => {
+      const b = (globalThis as any).__canopy_bridge;
+      b.crdt!.set_text(b.crdtHandle!, text);
+    }, source);
+    await dispatchExternalCrdtChanged(page);
+    await page.waitForFunction((text) => {
+      const b = (globalThis as any).__canopy_bridge;
+      const visible = document.querySelector('#canopy-text-editor .cm-content')?.textContent ?? '';
+      return b?.crdt?.get_text(b.crdtHandle) === text && visible.includes('let x');
+    }, source);
+
+    const result = await page.evaluate((expectedSource) => {
+      const b = (globalThis as any).__canopy_bridge;
+      const root = document.querySelector('#canopy-text-editor .cm-editor');
+      const EditorView = (globalThis as any).__canopy_codemirror?.EditorView;
+      const view = EditorView?.findFromDOM(root);
+      if (!b?.crdt || b.crdtHandle == null || !view) {
+        throw new Error('CodeMirror or CRDT bridge is unavailable');
+      }
+      const primary = b.crdtHandle as number;
+      const remote = b.crdt.create_editor_with_undo(`remote-${Date.now()}`, 500);
+      const initial = b.crdt.export_all_json(primary);
+      if (b.crdt.apply_sync_json(remote, initial) !== 'ok') {
+        throw new Error('failed to seed remote editor');
+      }
+      if (!b.crdt.handle_text_intent_checked(remote, 0, 0, 'R', 1)) {
+        throw new Error('failed to create remote edit');
+      }
+      const remoteState = b.crdt.export_all_json(remote);
+      if (b.crdt.apply_sync_json(primary, remoteState) !== 'ok') {
+        throw new Error('failed to apply remote edit');
+      }
+      const remoteText = b.crdt.get_text(primary);
+      // The remote operation has advanced the CRDT while CodeMirror still
+      // displays the pre-remote source. The local transaction must therefore
+      // take the snapshot fallback rather than applying its stale range.
+      view.dispatch({ changes: { from: 0, to: 0, insert: 'L' } });
+      return {
+        remoteHandle: remote,
+        remoteText,
+        expected: `L${expectedSource}`,
+      };
+    }, source);
+
+    expect(result.remoteText).not.toBe(result.expected);
+    expect(result.remoteText).toContain('R');
+    await page.waitForFunction((expected) => {
+      const b = (globalThis as any).__canopy_bridge;
+      const root = document.querySelector('#canopy-text-editor .cm-editor');
+      const EditorView = (globalThis as any).__canopy_codemirror?.EditorView;
+      const view = EditorView?.findFromDOM(root);
+      return b?.crdt?.get_text(b.crdtHandle) === expected &&
+        view?.state.doc.toString() === expected;
+    }, result.expected);
+
+    const convergence = await page.evaluate(({ remoteHandle, expected }) => {
+      const b = (globalThis as any).__canopy_bridge;
+      const status = b.crdt.apply_sync_json(
+        remoteHandle,
+        b.crdt.export_all_json(b.crdtHandle),
+      );
+      const text = b.crdt.get_text(remoteHandle);
+      b.crdt.try_destroy_editor?.(remoteHandle);
+      return { status, text, expected };
+    }, { remoteHandle: result.remoteHandle, expected: result.expected });
+    expect(convergence.status).toBe('ok');
+    expect(convergence.text).toBe(convergence.expected);
+  });
 });
 
 // ── Panel Toggles ────────────────────────────────────────────

--- a/modules/rabbita_codemirror/codemirror.mbt
+++ b/modules/rabbita_codemirror/codemirror.mbt
@@ -52,11 +52,12 @@ pub fn ChangeDelta::new(from : Int, to : Int, insert : String) -> ChangeDelta {
 
 ///|
 /// A CodeMirror document transaction together with its post-transaction
-/// document snapshot. The snapshot is captured by the update listener so a
-/// delayed consumer can use the document that belongs to this transaction.
+/// document snapshot. The source version identifies the CRDT source that was
+/// synchronized into CodeMirror before the transaction was captured.
 pub struct ChangeEvent {
   changes : Array[ChangeDelta]
   doc : String
+  source_version : String
 } derive(Eq, Debug)
 
 ///|
@@ -64,8 +65,9 @@ pub struct ChangeEvent {
 pub fn ChangeEvent::new(
   changes : Array[ChangeDelta],
   doc : String,
+  source_version? : String = "",
 ) -> ChangeEvent {
-  { changes, doc }
+  { changes, doc, source_version }
 }
 
 ///|
@@ -94,7 +96,8 @@ priv suberror CmSubscription {
     selection~ : @cmd.Emit[SelRange]?,
     focus~ : @cmd.Emit[Bool]?,
     changes~ : @cmd.Emit[Array[ChangeDelta]]?,
-    changes_with_doc~ : @cmd.Emit[ChangeEvent]?
+    changes_with_doc~ : @cmd.Emit[ChangeEvent]?,
+    source_version~ : () -> String
   )
 }
 
@@ -216,6 +219,7 @@ fn no_op_update_listener(
     _ => (),
     _ => (),
     _ => (),
+    source_version=() => "",
     include_doc=false,
     include_change_doc=false,
   )
@@ -301,6 +305,7 @@ fn change_event_from_value(value : @js_value.Value) -> ChangeEvent {
   ChangeEvent::new(
     change_deltas_from_value(value.get_with_string("changes")),
     value.get_with_string("doc"),
+    source_version=value.get_with_string("sourceVersion"),
   )
 }
 
@@ -375,7 +380,15 @@ fn cm_sub_loader(
   scheduler : &@cmd.Scheduler,
 ) -> @sub.RunningSub? {
   match payload {
-    CmListen(id, doc~, selection~, focus~, changes~, changes_with_doc~) => {
+    CmListen(
+      id,
+      doc~,
+      selection~,
+      focus~,
+      changes~,
+      changes_with_doc~,
+      source_version~
+    ) => {
       guard editors.get(id) is Some(entry) else { return None }
 
       let mut doc_tagger = doc
@@ -383,6 +396,7 @@ fn cm_sub_loader(
       let mut focus_tagger = focus
       let mut changes_tagger = changes
       let mut changes_with_doc_tagger = changes_with_doc
+      let mut source_version_tagger = source_version
       let include_doc = doc is Some(_)
       let include_change_doc = changes_with_doc is Some(_)
 
@@ -425,6 +439,7 @@ fn cm_sub_loader(
         on_selection,
         on_focus,
         on_changes,
+        source_version=source_version_tagger,
         include_doc~,
         include_change_doc~,
       )
@@ -440,7 +455,8 @@ fn cm_sub_loader(
               selection~,
               focus~,
               changes~,
-              changes_with_doc~
+              changes_with_doc~,
+              source_version~
             ) else {
             return
           }
@@ -449,6 +465,7 @@ fn cm_sub_loader(
           focus_tagger = focus
           changes_tagger = changes
           changes_with_doc_tagger = changes_with_doc
+          source_version_tagger = source_version
         },
       })
     }
@@ -562,6 +579,23 @@ pub fn unmount(id : String, failed? : @cmd.Emit[String]) -> @cmd.Cmd {
 }
 
 ///|
+/// Update the source-version provenance associated with the current
+/// CodeMirror document without changing its text. An empty version means the
+/// provenance is unknown and guarded consumers must use their fallback path.
+#cfg(target="js")
+pub fn set_source_version(
+  id : String,
+  source_version : String,
+  failed? : @cmd.Emit[String],
+) -> @cmd.Cmd {
+  @cmd.custom_cmd(kind=Immediately, scheduler => {
+    with_entry(id, failed, scheduler, entry => {
+      @js_ffi.js_set_source_version(entry.view, source_version)
+    })
+  })
+}
+
+///|
 /// Replace the document with a minimal single-range change, skipping echo
 /// dispatches when the document is already current.
 #cfg(target="js")
@@ -569,12 +603,17 @@ pub fn set_doc(
   id : String,
   doc : String,
   failed? : @cmd.Emit[String],
+  source_version? : String,
 ) -> @cmd.Cmd {
   @cmd.custom_cmd(kind=Immediately, scheduler => {
     with_entry(id, failed, scheduler, entry => {
       let current = @js_ffi.js_state_doc(entry.view)
       if doc != current {
         @js_ffi.js_replace_doc_minimal(entry.view, doc)
+      }
+      match source_version {
+        Some(version) => @js_ffi.js_set_source_version(entry.view, version)
+        None => @js_ffi.js_set_source_version(entry.view, "")
       }
     })
   })
@@ -757,6 +796,10 @@ pub fn set_line_wrapping(
 /// `on_change_with_doc` delivers the same transaction together with the
 /// post-transaction document captured by the CodeMirror update listener. It is
 /// intended for delayed consumers that need a stable fallback snapshot.
+///
+/// `source_version` identifies the source currently synchronized into
+/// CodeMirror. When supplied, it is carried by `ChangeEvent` so delayed
+/// consumers can reject a stale incremental edit after remote synchronization.
 #cfg(target="js")
 pub fn listen(
   id : String,
@@ -765,6 +808,7 @@ pub fn listen(
   focus? : @cmd.Emit[Bool],
   on_change? : @cmd.Emit[Array[ChangeDelta]],
   on_change_with_doc? : @cmd.Emit[ChangeEvent],
+  source_version? : () -> String = () => "",
 ) -> @sub.Sub {
   let has_doc = doc is Some(_)
   let has_selection = selection is Some(_)
@@ -792,6 +836,7 @@ pub fn listen(
       focus~,
       changes=on_change,
       changes_with_doc=on_change_with_doc,
+      source_version~,
     ),
     cm_sub_loader,
   )

--- a/modules/rabbita_codemirror/codemirror_test.mbt
+++ b/modules/rabbita_codemirror/codemirror_test.mbt
@@ -6,10 +6,15 @@ test "SelRange constructor exposes selection offsets to consumers" {
 }
 
 ///|
-test "ChangeEvent preserves its transaction snapshot" {
-  let event = ChangeEvent::new([ChangeDelta::new(1, 1, "x")], "after")
+test "ChangeEvent preserves its transaction snapshot and source version" {
+  let event = ChangeEvent::new(
+    [ChangeDelta::new(1, 1, "x")],
+    "after",
+    source_version="v1",
+  )
   inspect(event.changes.length(), content="1")
   inspect(event.doc, content="after")
+  inspect(event.source_version, content="v1")
 }
 
 ///|

--- a/modules/rabbita_codemirror/js/codemirror.mbt
+++ b/modules/rabbita_codemirror/js/codemirror.mbt
@@ -96,6 +96,7 @@ pub extern "js" fn load_codemirror(
   #|   const slot = globalThis[key] ?? (globalThis[key] = {
   #|     modules: new Map(),
   #|     applying: new WeakMap(),
+  #|     sourceVersions: new WeakMap(),
   #|   });
   #|   if (!slot.modules.has(source)) {
   #|     const load = source.startsWith('global:')
@@ -149,10 +150,13 @@ extern "js" fn js_create_view_raw(
   #|   const slot = globalThis[key] ?? (globalThis[key] = {
   #|     modules: new Map(),
   #|     applying: new WeakMap(),
+  #|     sourceVersions: new WeakMap(),
   #|   });
   #|   if (!slot.applying.has(view)) {
   #|     slot.applying.set(view, { value: false });
   #|   }
+  #|   if (!slot.sourceVersions) slot.sourceVersions = new WeakMap();
+  #|   slot.sourceVersions.set(view, "");
   #|   return view;
   #| }
 
@@ -176,17 +180,23 @@ extern "js" fn js_dispatch_raw(
   #|   const slot = globalThis[key] ?? (globalThis[key] = {
   #|     modules: new Map(),
   #|     applying: new WeakMap(),
+  #|     sourceVersions: new WeakMap(),
   #|   });
   #|   let cell = slot.applying.get(view);
   #|   if (!cell) {
   #|     cell = { value: false };
   #|     slot.applying.set(view, cell);
   #|   }
+  #|   const before = view.state.doc;
   #|   cell.value = true;
   #|   try {
   #|     view.dispatch(spec);
   #|   } finally {
   #|     cell.value = false;
+  #|     if (view.state.doc !== before) {
+  #|       if (!slot.sourceVersions) slot.sourceVersions = new WeakMap();
+  #|       slot.sourceVersions.set(view, "");
+  #|     }
   #|   }
   #| }
 
@@ -226,6 +236,7 @@ extern "js" fn js_replace_doc_minimal_raw(
   #|   const slot = globalThis[key] ?? (globalThis[key] = {
   #|     modules: new Map(),
   #|     applying: new WeakMap(),
+  #|     sourceVersions: new WeakMap(),
   #|   });
   #|   let cell = slot.applying.get(view);
   #|   if (!cell) {
@@ -241,8 +252,30 @@ extern "js" fn js_replace_doc_minimal_raw(
   #| }
 
 ///|
+extern "js" fn js_set_source_version_raw(
+  view : @js_value.Value,
+  source_version : String,
+) -> Unit =
+  #| (view, sourceVersion) => {
+  #|   const key = Symbol.for("dowdiness.rabbita_codemirror");
+  #|   const slot = globalThis[key] ?? (globalThis[key] = {
+  #|     modules: new Map(),
+  #|     applying: new WeakMap(),
+  #|     sourceVersions: new WeakMap(),
+  #|   });
+  #|   if (!slot.sourceVersions) slot.sourceVersions = new WeakMap();
+  #|   slot.sourceVersions.set(view, sourceVersion);
+  #| }
+
+///|
+pub fn js_set_source_version(view : CmView, source_version : String) -> Unit {
+  js_set_source_version_raw(view.0, source_version)
+}
+
+///|
 pub fn js_replace_doc_minimal(view : CmView, doc : String) -> Unit {
   js_replace_doc_minimal_raw(view.0, doc)
+  js_set_source_version_raw(view.0, "")
 }
 
 ///|
@@ -343,19 +376,23 @@ extern "js" fn js_add_update_listener_raw(
   on_selection : (@js_value.Value) -> Unit,
   on_focus_change : (@js_value.Value) -> Unit,
   on_changes : (@js_value.Value) -> Unit,
+  get_source_version : () -> String,
   include_doc : Bool,
   include_change_doc : Bool,
 ) -> () -> Unit =
-  #| (view, compartment, onDoc, onSelection, onFocusChange, onChanges, includeDoc, includeChangeDoc) => {
+  #| (view, compartment, onDoc, onSelection, onFocusChange, onChanges, getSourceVersion, includeDoc, includeChangeDoc) => {
   #|   const key = Symbol.for("dowdiness.rabbita_codemirror");
   #|   const slot = globalThis[key];
   #|   const cm = view._cmModule;
   #|   if (!cm) {
   #|     throw new Error("Listener attach requires a view created via js_create_view");
   #|   }
+  #|   if (!slot.sourceVersions) slot.sourceVersions = new WeakMap();
+  #|   slot.sourceVersions.set(view, getSourceVersion());
   #|   const isApplying = () => !!slot.applying.get(view)?.value;
   #|   const listener = cm.EditorView.updateListener.of(update => {
   #|     if (update.docChanged && !isApplying()) {
+  #|       const sourceVersion = slot.sourceVersions.get(view) ?? "";
   #|       const changedDoc = (includeDoc || includeChangeDoc)
   #|         ? update.state.doc.toString()
   #|         : null;
@@ -368,7 +405,7 @@ extern "js" fn js_add_update_listener_raw(
   #|         deltas.push({ from: fromA, to: toA, insert: inserted.toString() });
   #|       }, true);
   #|       onChanges(includeChangeDoc
-  #|         ? { changes: deltas, doc: changedDoc }
+  #|         ? { changes: deltas, doc: changedDoc, sourceVersion }
   #|         : deltas);
   #|     }
   #|     if ((update.selectionSet || update.docChanged) && !isApplying()) {
@@ -423,6 +460,7 @@ pub fn js_add_update_listener(
   on_changes : (@js_value.Value) -> Unit,
   include_doc? : Bool = false,
   include_change_doc? : Bool = false,
+  source_version? : () -> String = () => "",
 ) -> Disposable {
   Disposable(
     js_add_update_listener_raw(
@@ -432,6 +470,7 @@ pub fn js_add_update_listener(
       on_selection,
       on_focus_change,
       on_changes,
+      source_version,
       include_doc,
       include_change_doc,
     ),

--- a/modules/rabbita_codemirror/js/pkg.generated.mbti
+++ b/modules/rabbita_codemirror/js/pkg.generated.mbti
@@ -4,7 +4,7 @@ package "dowdiness/rabbita_codemirror/js"
 // Values
 pub fn cm_module_of(@moonbit-community/rabbita/js.Value) -> CmModule
 
-pub fn js_add_update_listener(CmView, Compartment, (@moonbit-community/rabbita/js.Value) -> Unit, (@moonbit-community/rabbita/js.Value) -> Unit, (@moonbit-community/rabbita/js.Value) -> Unit, (@moonbit-community/rabbita/js.Value) -> Unit, include_doc? : Bool, include_change_doc? : Bool) -> Disposable
+pub fn js_add_update_listener(CmView, Compartment, (@moonbit-community/rabbita/js.Value) -> Unit, (@moonbit-community/rabbita/js.Value) -> Unit, (@moonbit-community/rabbita/js.Value) -> Unit, (@moonbit-community/rabbita/js.Value) -> Unit, include_doc? : Bool, include_change_doc? : Bool, source_version? : () -> String) -> Disposable
 
 pub fn js_compartment_new(CmModule) -> Compartment
 
@@ -19,6 +19,8 @@ pub fn js_dispatch(CmView, TransactionSpec) -> Unit
 pub fn js_extension_combine(Array[Extension]) -> Extension
 
 pub fn js_replace_doc_minimal(CmView, String) -> Unit
+
+pub fn js_set_source_version(CmView, String) -> Unit
 
 pub fn js_state_doc(CmView) -> String
 

--- a/modules/rabbita_codemirror/pkg.generated.mbti
+++ b/modules/rabbita_codemirror/pkg.generated.mbti
@@ -12,13 +12,13 @@ import {
 // Values
 pub fn insert(String, Int, String, failed? : @cmd.Emit[String]) -> @cmd.Cmd
 
-pub fn listen(String, doc? : @cmd.Emit[String], selection? : @cmd.Emit[SelRange], focus? : @cmd.Emit[Bool], on_change? : @cmd.Emit[Array[ChangeDelta]], on_change_with_doc? : @cmd.Emit[ChangeEvent]) -> @sub.Sub
+pub fn listen(String, doc? : @cmd.Emit[String], selection? : @cmd.Emit[SelRange], focus? : @cmd.Emit[Bool], on_change? : @cmd.Emit[Array[ChangeDelta]], on_change_with_doc? : @cmd.Emit[ChangeEvent], source_version? : () -> String) -> @sub.Sub
 
 pub fn mount(String, String, init_doc? : String, source? : String, initial_theme? : @theme.Theme?, initial_readonly? : Bool, initial_keymap? : @keymap.Keymap?, initial_line_numbers? : Bool, initial_line_wrapping? : Bool, on_mounted? : @cmd.Cmd, failed? : @cmd.Emit[String], initial_extension? : ((@moonbit-community/rabbita/js.Value) -> @dowdiness/rabbita_codemirror/js.Extension raise)?) -> @cmd.Cmd
 
 pub fn replace(String, Int, Int, String, failed? : @cmd.Emit[String]) -> @cmd.Cmd
 
-pub fn set_doc(String, String, failed? : @cmd.Emit[String]) -> @cmd.Cmd
+pub fn set_doc(String, String, failed? : @cmd.Emit[String], source_version? : String) -> @cmd.Cmd
 
 pub fn set_extension(String, (@moonbit-community/rabbita/js.Value) -> @dowdiness/rabbita_codemirror/js.Extension raise, failed? : @cmd.Emit[String]) -> @cmd.Cmd
 
@@ -31,6 +31,8 @@ pub fn set_line_wrapping(String, Bool, failed? : @cmd.Emit[String]) -> @cmd.Cmd
 pub fn set_readonly(String, Bool, failed? : @cmd.Emit[String]) -> @cmd.Cmd
 
 pub fn set_selection(String, SelRange, scroll_into_view? : Bool, failed? : @cmd.Emit[String]) -> @cmd.Cmd
+
+pub fn set_source_version(String, String, failed? : @cmd.Emit[String]) -> @cmd.Cmd
 
 pub fn set_theme(String, @theme.Theme, failed? : @cmd.Emit[String]) -> @cmd.Cmd
 
@@ -49,8 +51,9 @@ pub fn ChangeDelta::new(Int, Int, String) -> Self
 pub struct ChangeEvent {
   changes : Array[ChangeDelta]
   doc : String
+  source_version : String
 } derive(Eq, @debug.Debug)
-pub fn ChangeEvent::new(Array[ChangeDelta], String) -> Self
+pub fn ChangeEvent::new(Array[ChangeDelta], String, source_version? : String) -> Self
 
 pub struct SelRange {
   from : Int


### PR DESCRIPTION
## Summary

- Add source-version provenance to CodeMirror change events and keep it per editor view.
- Use the incremental single-range path only when the transaction's source version still matches the current CRDT source.
- Fall back to the transaction-time document snapshot for unknown, mismatched, rejected, or multi-range changes.
- Add a deterministic remote-before-local regression test and verify replica convergence.

Refs #1210

## UI and review evidence

N/A — this change affects the CodeMirror/CRDT synchronization path and does not change the rendered UI.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `SyncEditor::apply_text_edit_exact` | `modules/canopy/editor/sync_editor_text.mbt` | Yes | Existing exact single-range CRDT mutation remains the guarded fast path. |
| `SyncEditor::set_text_and_record` | `modules/canopy/editor/sync_editor_text.mbt` | Yes | Existing transaction-snapshot fallback preserves the authoritative document semantics. |
| `@ffi.get_version_json` | `apps/ideal/main/bridge_ffi.mbt` | Yes | Existing CRDT version-vector serialization is used as the opaque provenance token. |
| MoonBit `String` equality | core `String` operations | Yes | The guard compares opaque version tokens without parsing or duplicating version-vector logic. |
| MoonBit `Option` / optional parameters | core option handling | Yes | Missing source provenance is represented conservatively as an unknown/empty token. |
| MoonBit `Array` | core `Array` operations | Existing use retained | The existing one-range cardinality guard remains; no new collection helper was introduced. |

New helpers added:

- `code_mirror_source_version_matches`: a pure, conservative token predicate that keeps provenance validation separate from editor mutation and I/O.
- `ChangeEvent.source_version`: additive transaction provenance; existing `on_change` consumers remain unchanged.

## Validation scope

Boundary matrix / first failing regression:

- Remote CRDT update precedes a CodeMirror local edit while CodeMirror still displays the pre-remote source.
- Matching, mismatched, and empty source-version predicate cases.
- Snapshot fallback and primary/replica convergence after the guarded edit.
- Existing baseline coverage retained for Unicode, replacements, undo/redo, external sync, queued transactions, and multi-range fallback behavior.
- CRLF/CR and the broader differential interleave matrix remain suitable follow-up expansion areas; the new regression is intentionally deterministic and focused on the previously unguarded race.

Target packages:

- `apps/ideal/main`
- `modules/rabbita_codemirror`
- `modules/rabbita_codemirror/js`

Additional conditional gates:

- JavaScript release build
- Ideal Web Playwright E2E: 113 passed
- Editor response benchmark: 6 passed
- Independent post-fix MoonBit review: no critical findings

## PR-ready evidence

Validated HEAD: `24fb1e284658fcd0cd42b2b41f63cdf3f7d4b05c`

Validated base: `origin/main@af0304979025e4e907f26b5130f031c170c7443d`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh \
  --target apps/ideal/main \
  --target modules/rabbita_codemirror \
  --target modules/rabbita_codemirror/js
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for the exact HEAD and base above.
- [x] The base was fetched again and `--verify-evidence` passed immediately before this PR was opened.
- [x] The committed `.mbti` diff against the validated base was reviewed for intended additive API changes only.
- [x] No submodule commit changed.
- [x] Validation was rerun after the final amend and generated-interface changes.
- [x] Independent review findings were resolved before final validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization between the editor and collaborative document state when remote updates arrive before local edits.
  * Prevented stale editor changes from overwriting newer remote content.
  * Preserved editor and document convergence across replicas.

* **Enhancements**
  * Added source-version tracking to editor change events and document updates for more reliable synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->