### PR TITLE
fix(loomark): preserve Raw input across render races

### DIFF
--- a/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
+++ b/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
@@ -2044,6 +2044,119 @@ test("Raw input coalesces a same-task burst into one commit", async ({ browser }
   }
 })
 
+test("Raw preserves native input across an in-flight commit", async ({ browser }) => {
+  for (let attempt = 0; attempt < 6; attempt += 1) {
+    const host = await mountHost(browser, "start")
+    try {
+      const input = host.page.locator("#loomark-input")
+      await input.focus()
+      await input.evaluate(element => {
+        const textarea = element as HTMLTextAreaElement
+        textarea.setSelectionRange(textarea.value.length, textarea.value.length)
+      })
+      await host.page.keyboard.type("XY", { delay: 52 })
+
+      await expect.poll(async () => (await snapshot(host.page)).source, {
+        timeout: 1500,
+      }).toBe("startXY")
+      await expect(input).toHaveValue("startXY")
+      await expect.poll(() => input.evaluate(element => {
+        const textarea = element as HTMLTextAreaElement
+        return `${textarea.selectionStart}:${textarea.selectionEnd}`
+      })).toBe("7:7")
+    } finally {
+      await host.context.close()
+    }
+  }
+})
+
+test("Raw preserves caret order across two in-flight frontier inputs", async ({ browser }) => {
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    const host = await mountHost(browser, "start")
+    try {
+      const input = host.page.locator("#loomark-input")
+      await input.focus()
+      await input.evaluate(element => {
+        const textarea = element as HTMLTextAreaElement
+        textarea.setSelectionRange(textarea.value.length, textarea.value.length)
+      })
+      await host.page.keyboard.type("XYZ", { delay: 52 })
+
+      await expect.poll(async () => (await snapshot(host.page)).source, {
+        timeout: 2000,
+      }).toBe("startXYZ")
+      await expect(input).toHaveValue("startXYZ")
+      await expect.poll(() => input.evaluate(element => {
+        const textarea = element as HTMLTextAreaElement
+        return `${textarea.selectionStart}:${textarea.selectionEnd}`
+      })).toBe("8:8")
+    } finally {
+      await host.context.close()
+    }
+  }
+})
+
+test("Raw preserves native input and caret at a mid-document in-flight boundary", async ({ browser }) => {
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    const host = await mountHost(browser, "abcdef")
+    try {
+      const input = host.page.locator("#loomark-input")
+      await input.focus()
+      await input.evaluate(element => {
+        const textarea = element as HTMLTextAreaElement
+        textarea.setSelectionRange(3, 3)
+      })
+      await host.page.keyboard.type("XY", { delay: 52 })
+
+      await expect.poll(async () => (await snapshot(host.page)).source, {
+        timeout: 1500,
+      }).toBe("abcXYdef")
+      await expect(input).toHaveValue("abcXYdef")
+      await expect.poll(() => input.evaluate(element => {
+        const textarea = element as HTMLTextAreaElement
+        return `${textarea.selectionStart}:${textarea.selectionEnd}`
+      })).toBe("5:5")
+    } finally {
+      await host.context.close()
+    }
+  }
+})
+
+test("Raw clears a canceled in-flight beforeinput capture", async ({ browser }) => {
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    const host = await mountHost(browser, "start")
+    try {
+      const input = host.page.locator("#loomark-input")
+      await input.evaluate(element => {
+        element.addEventListener("beforeinput", event => {
+          const inputEvent = event as InputEvent
+          if (inputEvent.data === "Y") event.preventDefault()
+        })
+      })
+      await input.focus()
+      await input.evaluate(element => {
+        const textarea = element as HTMLTextAreaElement
+        textarea.setSelectionRange(textarea.value.length, textarea.value.length)
+      })
+      await host.page.keyboard.type("XY", { delay: 52 })
+
+      await expect.poll(async () => (await snapshot(host.page)).source, {
+        timeout: 1500,
+      }).toBe("startX")
+      await expect(input).toHaveValue("startX")
+
+      await input.focus()
+      await host.page.keyboard.type("Z")
+      await expect.poll(async () => (await snapshot(host.page)).source, {
+        timeout: 1500,
+      }).toBe("startXZ")
+      await expect(input).toHaveValue("startXZ")
+    } finally {
+      await host.context.close()
+    }
+  }
+})
+
 test("Raw input coalesces delete then insert into one replacement", async ({ browser }) => {
   const host = await mountHost(browser, "start")
   try {
@@ -2762,6 +2875,41 @@ test("a Raw mode click accepts composition before changing mode", async ({ brows
     await expect(host.page.locator("#loomark-block-input")).toHaveValue("start漢")
   } finally {
     await host.context.close()
+  }
+})
+
+test("a Raw mode click preserves composition behind an active delivery", async ({ browser }) => {
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    const host = await mountHost(browser, "start")
+    try {
+      const input = host.page.locator("#loomark-input")
+      await input.focus()
+      await input.evaluate(element => {
+        const textarea = element as HTMLTextAreaElement
+        textarea.setSelectionRange(5, 5)
+      })
+      const session = await host.context.newCDPSession(host.page)
+      await host.page.keyboard.type("X")
+      await host.page.waitForTimeout(52)
+      await host.page.keyboard.type("Y")
+      await session.send("Input.imeSetComposition", {
+        text: "漢",
+        selectionStart: 1,
+        selectionEnd: 1,
+      })
+      await expect(input).toHaveValue("startXY漢")
+
+      await host.page.locator("#loomark-mode-block").click()
+      await expect.poll(async () => (await snapshot(host.page)).mode).toBe("block")
+      await expect.poll(async () => (await snapshot(host.page)).source).toBe("startXY漢")
+      expect(await snapshot(host.page)).toMatchObject({
+        committed_change_count: 2,
+        error_code: null,
+      })
+      await expect(host.page.locator("#loomark-block-input")).toHaveValue("startXY漢")
+    } finally {
+      await host.context.close()
+    }
   }
 })
 

--- a/apps/loomark/internal/rabbita/application.mbt
+++ b/apps/loomark/internal/rabbita/application.mbt
@@ -389,10 +389,13 @@ fn raw_editor_view(
           @rabbita_runtime.none
         })
         .on_compositionend(_ => {
-          raw_input_coordinator.finish_composition(
-            model.document.source(),
-            emit,
-          )
+          @cmd.batch([
+            raw_input_coordinator.finish_composition(
+              model.document.source(),
+              emit,
+            ),
+            raw_input_coordinator.finalize_deferred_composition(model, emit),
+          ])
         })
         .on_beforeinput(event => {
           raw_input_coordinator.capture_native_before_input(model, event)
@@ -414,10 +417,16 @@ fn raw_editor_view(
             } else {
               let matched = raw_input_coordinator.has_captured_before_input()
               let repair_unmatched = raw_input_coordinator.take_unmatched_input_repair()
-              let input_command = raw_input_coordinator.enqueue(
-                source, selection, emit,
+              let deferred = raw_input_coordinator.defer_native_input(
+                source, selection,
               )
-              if matched || !repair_unmatched {
+              let active_delivery = raw_input_coordinator.has_active_delivery()
+              let input_command = if deferred {
+                @rabbita_runtime.none
+              } else {
+                raw_input_coordinator.enqueue(source, selection, emit)
+              }
+              if deferred || matched || !repair_unmatched || active_delivery {
                 input_command
               } else {
                 let repair_epoch = raw_input_coordinator.epoch()
@@ -1035,18 +1044,22 @@ fn update_editing(
                 preview_finished=() => {
                   raw_input_coordinator.mark_preview_finished(token)
                 },
+                raw_mode_authorized=candidate.raw_mode_authorized,
               )
               let (next, selection_command, repair_command) = match outcome {
                 RawSelectionEditOutcome::Applied(selection)
                 | RawSelectionEditOutcome::Unchanged(selection) =>
                   (
                     next,
-                    raw_selection_after_render(latest_model, selection, emit),
+                    raw_native_selection_after_render(
+                      latest_model, raw_input_coordinator, selection, emit,
+                    ),
                     @rabbita_runtime.none,
                   )
                 RawSelectionEditOutcome::Rejected(
                   RawSelectionEditRejection::EditorCommitFailed
                 ) => {
+                  raw_input_coordinator.discard_deferred()
                   let repair_epoch = raw_input_coordinator.epoch()
                   let expected = candidate.before_input.selection
                   (
@@ -1058,8 +1071,10 @@ fn update_editing(
                     ),
                   )
                 }
-                RawSelectionEditOutcome::Rejected(_) =>
+                RawSelectionEditOutcome::Rejected(_) => {
+                  raw_input_coordinator.discard_deferred()
                   (next, @rabbita_runtime.none, @rabbita_runtime.none)
+                }
               }
               let finish_command = raw_input_coordinator.finish(
                 token, latest_model, emit,
@@ -1725,7 +1740,7 @@ fn update_navigation(
         _ => @core.Raw
       }
       if mode != model.state.mode() {
-        raw_input_coordinator.cancel_pending()
+        raw_input_coordinator.cancel_pending_for_navigation()
         block_input_coordinator.cancel_pending()
       }
       let transition = @core.reduce(
@@ -1743,7 +1758,7 @@ fn update_navigation(
     }
     ToggleSplitPreview => {
       if model.state.mode() == @core.Preview && model.split_preview_open {
-        raw_input_coordinator.cancel_pending()
+        raw_input_coordinator.cancel_pending_for_navigation()
       }
       let old_requested = preview_requested(model)
       let next = update_preview_document(

--- a/apps/loomark/internal/rabbita/focus_runtime.mbt
+++ b/apps/loomark/internal/rabbita/focus_runtime.mbt
@@ -239,6 +239,35 @@ fn raw_selection_after_render(
 }
 
 ///|
+/// Install a native-input caret only while no newer browser frontier is ahead
+/// of the accepted document. A deferred value must not receive this older
+/// transaction's selection.
+fn raw_native_selection_after_render(
+  latest_model : @ref.Ref[DriverModel?],
+  raw_input_coordinator : RawInputCoordinator,
+  selection : VersionedRawSelection,
+  emit : @cmd.Emit[DriverEvent],
+) -> @cmd.Cmd {
+  after_render(
+    scheduler => {
+      ignore(scheduler)
+      guard latest_model.val is Some(latest) else { return }
+      guard raw_input_coordinator.native_selection_frontier_is_current(
+        latest.document.source(),
+      ) else {
+        return
+      }
+      match raw_selection_effect_value(Some(latest), selection) {
+        Some(selection) =>
+          @dom_boundary.write_text_selection_id("loomark-input", selection)
+        None => ()
+      }
+    },
+    emit,
+  )
+}
+
+///|
 /// Restore canonical Raw text and the trusted pre-input selection after a
 /// matched native batch is rejected. A newer capture or document frontier
 /// supersedes this repair before it can write to the DOM.

--- a/apps/loomark/internal/rabbita/raw_input_frontier.mbt
+++ b/apps/loomark/internal/rabbita/raw_input_frontier.mbt
@@ -1,0 +1,122 @@
+///|
+/// The native Raw frontier that can be ahead of the committed document.
+///
+/// This is the functional core of the browser-input race: DOM snapshots move
+/// from an active delivery into a deferred snapshot, then back to pending at
+/// the newly accepted document frontier. Scheduler commands and DOM effects
+/// remain in RawInputCoordinator as the imperative shell.
+priv struct RawInputFrontierState {
+  deferred_before_input : DeferredRawInputCapture?
+  deferred : DeferredRawInput?
+  deferred_composition : DeferredRawInput?
+  in_flight : RawInputDelivery?
+}
+
+///|
+priv struct RawInputDelivery {
+  token : Int
+  source : String
+}
+
+///|
+fn RawInputFrontierState::initial() -> RawInputFrontierState {
+  {
+    deferred_before_input: None,
+    deferred: None,
+    deferred_composition: None,
+    in_flight: None,
+  }
+}
+
+///|
+priv enum RawInputFrontierEvent {
+  CaptureDeferredBeforeInput(DeferredRawInputCapture)
+  StoreDeferred(DeferredRawInput)
+  BeginDeferredComposition(DeferredRawInput)
+  UpdateDeferredComposition(DeferredRawInput)
+  ClearDeferredCapture
+  ClearDeferred
+  ClearDeferredComposition
+  BeginDelivery(RawInputDelivery)
+  FinishDelivery(Int)
+  DiscardDelivery(Int)
+  Cancel
+}
+
+///|
+/// Pure transition function for the browser-visible Raw frontier.
+fn reduce_raw_input_frontier(
+  state : RawInputFrontierState,
+  event : RawInputFrontierEvent,
+) -> RawInputFrontierState {
+  match event {
+    RawInputFrontierEvent::CaptureDeferredBeforeInput(capture) =>
+      if (state.in_flight is Some(_) || state.deferred is Some(_)) &&
+        state.deferred_composition is None {
+        { ..state, deferred_before_input: Some(capture) }
+      } else {
+        state
+      }
+    RawInputFrontierEvent::StoreDeferred(deferred) =>
+      if state.in_flight is Some(_) &&
+        state.deferred_before_input is Some(_) &&
+        state.deferred_composition is None {
+        { ..state, deferred_before_input: None, deferred: Some(deferred) }
+      } else {
+        state
+      }
+    RawInputFrontierEvent::BeginDeferredComposition(composition) =>
+      if state.in_flight is Some(_) && state.deferred_composition is None {
+        {
+          ..state,
+          deferred: None,
+          deferred_before_input: None,
+          deferred_composition: Some(composition),
+        }
+      } else {
+        state
+      }
+    RawInputFrontierEvent::UpdateDeferredComposition(composition) =>
+      if state.deferred_composition is Some(_) {
+        { ..state, deferred_composition: Some(composition) }
+      } else {
+        state
+      }
+    RawInputFrontierEvent::ClearDeferredCapture =>
+      { ..state, deferred_before_input: None }
+    RawInputFrontierEvent::ClearDeferred =>
+      { ..state, deferred_before_input: None, deferred: None }
+    RawInputFrontierEvent::ClearDeferredComposition =>
+      { ..state, deferred_composition: None }
+    RawInputFrontierEvent::BeginDelivery(delivery) =>
+      if state.in_flight is None {
+        { ..state, in_flight: Some(delivery) }
+      } else {
+        state
+      }
+    RawInputFrontierEvent::FinishDelivery(token) =>
+      match state.in_flight {
+        Some(delivery) if delivery.token == token =>
+          { ..state, in_flight: None }
+        _ => state
+      }
+    RawInputFrontierEvent::DiscardDelivery(token) =>
+      match state.in_flight {
+        Some(delivery) if delivery.token == token =>
+          {
+            deferred_before_input: None,
+            deferred: None,
+            deferred_composition: None,
+            in_flight: None,
+          }
+        _ => state
+      }
+    RawInputFrontierEvent::Cancel =>
+      {
+        deferred_before_input: None,
+        deferred: None,
+        deferred_composition: None,
+        in_flight: None,
+      }
+  }
+}

--- a/apps/loomark/internal/rabbita/raw_input_frontier_wbtest.mbt
+++ b/apps/loomark/internal/rabbita/raw_input_frontier_wbtest.mbt
@@ -1,0 +1,155 @@
+///|
+test "Raw frontier reducer keeps deferred input ahead of the active delivery" {
+  let state = RawInputFrontierState::initial()
+  let active = reduce_raw_input_frontier(
+    state,
+    RawInputFrontierEvent::BeginDelivery({ token: 4, source: "startX" }),
+  )
+  let captured = reduce_raw_input_frontier(
+    active,
+    RawInputFrontierEvent::CaptureDeferredBeforeInput({
+      base_source: "startX",
+      input_type: "insertText",
+    }),
+  )
+  let deferred = {
+    base_source: "startX",
+    input_type: "insertText",
+    source: "startXY",
+    post_input_selection: @dom_boundary.TextSelection(
+      7,
+      7,
+      @dom_boundary.NoDirection,
+    ),
+    input_count: 1,
+  }
+  let next = reduce_raw_input_frontier(
+    captured,
+    RawInputFrontierEvent::StoreDeferred(deferred),
+  )
+  guard next.in_flight is Some(delivery) else {
+    fail("storing deferred input must retain the active delivery")
+  }
+  assert_eq(delivery.token, 4)
+  guard next.deferred is Some(input) else {
+    fail("storing deferred input must retain its latest snapshot")
+  }
+  assert_eq(input.source, "startXY")
+  assert_true(next.deferred_before_input is None)
+}
+
+///|
+test "Raw frontier reducer keeps composition behind the active delivery" {
+  let active = reduce_raw_input_frontier(
+    RawInputFrontierState::initial(),
+    RawInputFrontierEvent::BeginDelivery({ token: 4, source: "startX" }),
+  )
+  let composition = reduce_raw_input_frontier(
+    active,
+    RawInputFrontierEvent::BeginDeferredComposition({
+      base_source: "startX",
+      input_type: "insertCompositionText",
+      source: "startX",
+      post_input_selection: @dom_boundary.TextSelection(
+        6,
+        6,
+        @dom_boundary.NoDirection,
+      ),
+      input_count: 0,
+    }),
+  )
+  guard composition.deferred_composition is Some(input) else {
+    fail("active composition must be retained behind the delivery")
+  }
+  assert_eq(input.source, "startX")
+  let updated = reduce_raw_input_frontier(
+    composition,
+    RawInputFrontierEvent::UpdateDeferredComposition({
+      ..input,
+      source: "startX漢",
+      post_input_selection: @dom_boundary.TextSelection(
+        7,
+        7,
+        @dom_boundary.NoDirection,
+      ),
+      input_count: 1,
+    }),
+  )
+  guard updated.deferred_composition is Some(latest) else {
+    fail("composition updates must retain the deferred frontier")
+  }
+  assert_eq(latest.source, "startX漢")
+  assert_true(updated.in_flight is Some(_))
+  assert_true(updated.deferred is None)
+}
+
+///|
+test "Raw frontier reducer rejects capture without an active delivery" {
+  let state = RawInputFrontierState::initial()
+  let next = reduce_raw_input_frontier(
+    state,
+    RawInputFrontierEvent::CaptureDeferredBeforeInput({
+      base_source: "start",
+      input_type: "insertText",
+    }),
+  )
+  assert_true(next.deferred_before_input is None)
+  assert_true(next.in_flight is None)
+}
+
+///|
+test "Raw frontier reducer does not overwrite an active delivery" {
+  let state = reduce_raw_input_frontier(
+    RawInputFrontierState::initial(),
+    RawInputFrontierEvent::BeginDelivery({ token: 4, source: "startX" }),
+  )
+  let next = reduce_raw_input_frontier(
+    state,
+    RawInputFrontierEvent::BeginDelivery({ token: 5, source: "startY" }),
+  )
+  guard next.in_flight is Some(delivery) else {
+    fail("active delivery must remain present")
+  }
+  assert_eq(delivery.token, 4)
+  assert_eq(delivery.source, "startX")
+}
+
+///|
+test "Raw frontier reducer finishes only the matching delivery" {
+  let state = reduce_raw_input_frontier(
+    RawInputFrontierState::initial(),
+    RawInputFrontierEvent::BeginDelivery({ token: 4, source: "startX" }),
+  )
+  let unchanged = reduce_raw_input_frontier(
+    state,
+    RawInputFrontierEvent::FinishDelivery(3),
+  )
+  assert_true(unchanged.in_flight is Some(_))
+  let finished = reduce_raw_input_frontier(
+    unchanged,
+    RawInputFrontierEvent::FinishDelivery(4),
+  )
+  assert_true(finished.in_flight is None)
+}
+
+///|
+test "Raw frontier reducer cancellation clears deferred and active state" {
+  let state = reduce_raw_input_frontier(
+    RawInputFrontierState::initial(),
+    RawInputFrontierEvent::BeginDelivery({ token: 4, source: "startX" }),
+  )
+  let captured = reduce_raw_input_frontier(
+    state,
+    RawInputFrontierEvent::CaptureDeferredBeforeInput({
+      base_source: "startX",
+      input_type: "insertText",
+    }),
+  )
+  let canceled = reduce_raw_input_frontier(
+    captured,
+    RawInputFrontierEvent::Cancel,
+  )
+  assert_true(canceled.in_flight is None)
+  assert_true(canceled.deferred is None)
+  assert_true(canceled.deferred_before_input is None)
+}

--- a/apps/loomark/internal/rabbita/raw_selection_transaction.mbt
+++ b/apps/loomark/internal/rabbita/raw_selection_transaction.mbt
@@ -47,6 +47,7 @@ priv struct RawNativeInputCandidate {
   before_input : RawBeforeInputCandidate
   source : String
   post_input_selection : @dom_boundary.TextSelection
+  raw_mode_authorized : Bool
 }
 
 ///|
@@ -55,7 +56,38 @@ fn RawNativeInputCandidate::RawNativeInputCandidate(
   source~ : String,
   post_input_selection~ : @dom_boundary.TextSelection,
 ) -> RawNativeInputCandidate {
-  { before_input, source, post_input_selection }
+  { before_input, source, post_input_selection, raw_mode_authorized: false }
+}
+
+///|
+fn RawNativeInputCandidate::authorized(
+  before_input~ : RawBeforeInputCandidate,
+  source~ : String,
+  post_input_selection~ : @dom_boundary.TextSelection,
+) -> RawNativeInputCandidate {
+  let candidate = RawNativeInputCandidate::RawNativeInputCandidate(
+    before_input~,
+    source~,
+    post_input_selection~,
+  )
+  { ..candidate, raw_mode_authorized: true }
+}
+
+///|
+/// Native input observed while an earlier Raw transaction is still in flight.
+priv struct DeferredRawInput {
+  base_source : String
+  input_type : String
+  source : String
+  post_input_selection : @dom_boundary.TextSelection
+  input_count : Int
+}
+
+///|
+/// The pre-input frontier needed to complete one deferred native input.
+priv struct DeferredRawInputCapture {
+  base_source : String
+  input_type : String
 }
 
 ///|
@@ -246,7 +278,9 @@ fn normalize_raw_input_candidate(
   }
   guard before.selection.document_id == model.document_id else { return None }
   guard before.selection.version == model.document_version else { return None }
-  guard raw_selection_mode_applicable(model) else { return None }
+  guard candidate.raw_mode_authorized || raw_selection_mode_applicable(model) else {
+    return None
+  }
 
   let selection = @markdown.MarkdownDocumentUtf16Selection(
     model.document,
@@ -322,6 +356,42 @@ fn normalize_raw_input_candidate(
 }
 
 ///|
+/// Rebase a deferred native snapshot onto the model that accepted the
+/// preceding in-flight transaction. The version guard remains intact because
+/// this creates a new candidate at the current document frontier.
+fn rebase_deferred_raw_input(
+  model : DriverModel,
+  deferred : DeferredRawInput,
+) -> RawBeforeInputCandidate? {
+  let old_source = model.document.source()
+  let old_value = raw_textarea_value(old_source)
+  let latest_value = raw_textarea_value(deferred.source)
+  let change = @text_change.compute_text_change(old_value, latest_value)
+  let start = match raw_source_offset_from_dom(old_source, change.start) {
+    Some(offset) => offset
+    None => return None
+  }
+  let selection = @markdown.MarkdownDocumentUtf16Selection(
+    model.document,
+    anchor=start,
+    head=start,
+  ) catch {
+    _ => return None
+  }
+  Some(
+    RawBeforeInputCandidate::RawBeforeInputCandidate(
+      selection=VersionedRawSelection::VersionedRawSelection(
+        document_id=model.document_id,
+        version=model.document_version,
+        selection~,
+      ),
+      input_type=deferred.input_type,
+      is_composing=false,
+    ),
+  )
+}
+
+///|
 fn versioned_raw_selection_from_dom(
   model : DriverModel,
   selection : @dom_boundary.TextSelection,
@@ -375,6 +445,7 @@ fn commit_raw_selection_edit(
   editor_finished? : () -> Unit = () => (),
   preview_started? : () -> Unit = () => (),
   preview_finished? : () -> Unit = () => (),
+  raw_mode_authorized? : Bool = false,
 ) -> (DriverModel, RawSelectionEditOutcome, @cmd.Cmd) raise {
   let bound = request.selection
   guard bound.document_id == model.document_id else {
@@ -386,7 +457,7 @@ fn commit_raw_selection_edit(
       @rabbita_runtime.none,
     )
   }
-  guard raw_selection_mode_applicable(model) else {
+  guard raw_mode_authorized || raw_selection_mode_applicable(model) else {
     return (
       model,
       RawSelectionEditOutcome::Rejected(RawSelectionEditRejection::ModeStale),

--- a/apps/loomark/internal/rabbita/raw_selection_transaction_wbtest.mbt
+++ b/apps/loomark/internal/rabbita/raw_selection_transaction_wbtest.mbt
@@ -413,6 +413,47 @@ test "native Raw pairing silently rejects stale and mode-stale captures" {
 }
 
 ///|
+test "capture-authorized Raw input survives a mode transition" {
+  let context = RawSelectionTestContext::RawSelectionTestContext(
+    "raw-authorized-mode-transition", "start",
+  )
+  let candidate = RawNativeInputCandidate::RawNativeInputCandidate(
+    before_input=RawBeforeInputCandidate::RawBeforeInputCandidate(
+      selection=context.selection(5, 5),
+      input_type="insertText",
+      is_composing=false,
+    ),
+    source="start漢",
+    post_input_selection=@dom_boundary.TextSelection(
+      6,
+      6,
+      @dom_boundary.NoDirection,
+    ),
+  )
+  let block_model = {
+    ..context.model,
+    state: @core.ApplicationState::ApplicationState(@core.Block),
+  }
+  let authorized_candidate = { ..candidate, raw_mode_authorized: true }
+  guard normalize_raw_input_candidate(block_model, authorized_candidate)
+    is Some(request) else {
+    abort("capture-authorized Raw input must normalize after mode transition")
+  }
+  let emit : @cmd.Emit[DriverEvent] = @cmd.Emit(_ => @rabbita_runtime.none)
+  let (_, outcome, _) = try! commit_raw_selection_edit(
+    context.editor,
+    context.attachment,
+    block_model,
+    request,
+    emit,
+    raw_mode_authorized=true,
+  )
+  guard outcome is RawSelectionEditOutcome::Applied(_) else {
+    abort("capture-authorized Raw input must commit after mode transition")
+  }
+}
+
+///|
 test "directed cross-block Raw selections commit one ReplaceText transaction" {
   for
     case in [

--- a/apps/loomark/internal/rabbita/text_control_repair.mbt
+++ b/apps/loomark/internal/rabbita/text_control_repair.mbt
@@ -61,17 +61,17 @@ priv struct PendingRawInput {
 /// Coalesce native textarea events into one delayed, tokenized Raw transaction.
 /// Custom-driver RawInput events bypass this coordinator and remain token-less.
 priv struct RawInputCoordinator {
+  frontier : @ref.Ref[RawInputFrontierState]
   unmatched_before_input : @ref.Ref[RawBeforeInputCandidate?]
   pending : @ref.Ref[PendingRawInput?]
   scheduled : @ref.Ref[Bool]
   schedule_generation : @ref.Ref[Int]
   capture_generation : @ref.Ref[Int]
   next_token : @ref.Ref[Int]
-  in_flight_token : @ref.Ref[Int?]
-  in_flight_source : @ref.Ref[String?]
   suppress_unmatched_repair : @ref.Ref[Bool]
   composition : @ref.Ref[PendingRawInput?]
   composition_final_source : @ref.Ref[String?]
+  deferred_composition_finished : @ref.Ref[Bool]
   telemetry : RawInputTelemetry?
 }
 
@@ -80,19 +80,27 @@ fn RawInputCoordinator::RawInputCoordinator(
   telemetry : RawInputTelemetry?,
 ) -> RawInputCoordinator {
   {
+    frontier: @ref.Ref(RawInputFrontierState::initial()),
     unmatched_before_input: @ref.Ref(None),
     pending: @ref.Ref(None),
     scheduled: @ref.Ref(false),
     schedule_generation: @ref.Ref(0),
     capture_generation: @ref.Ref(0),
     next_token: @ref.Ref(0),
-    in_flight_token: @ref.Ref(None),
-    in_flight_source: @ref.Ref(None),
     suppress_unmatched_repair: @ref.Ref(false),
     composition: @ref.Ref(None),
     composition_final_source: @ref.Ref(None),
+    deferred_composition_finished: @ref.Ref(false),
     telemetry,
   }
+}
+
+///|
+fn RawInputCoordinator::reduce_frontier(
+  self : RawInputCoordinator,
+  event : RawInputFrontierEvent,
+) -> Unit {
+  self.frontier.val = reduce_raw_input_frontier(self.frontier.val, event)
 }
 
 ///|
@@ -257,9 +265,17 @@ fn RawInputCoordinator::display_source(
       match self.pending.val {
         Some(pending) => pending.source
         None =>
-          match self.in_flight_source.val {
-            Some(source) => source
-            None => committed_source
+          match self.frontier.val.deferred_composition {
+            Some(composition) => composition.source
+            None =>
+              match self.frontier.val.deferred {
+                Some(deferred) => deferred.source
+                None =>
+                  match self.frontier.val.in_flight {
+                    Some(delivery) => delivery.source
+                    None => committed_source
+                  }
+              }
           }
       }
   }
@@ -275,7 +291,7 @@ fn RawInputCoordinator::begin_composition(
   source : String,
   selection : @dom_boundary.TextSelection,
 ) -> Bool {
-  guard self.in_flight_token.val is None else { return false }
+  guard !self.has_active_delivery() else { return false }
   let input = match self.pending.val {
     Some(pending) if pending.before_input.selection.document_id ==
       before_input.selection.document_id &&
@@ -309,6 +325,28 @@ fn RawInputCoordinator::begin_native_composition(
   source : String,
   selection : @dom_boundary.TextSelection,
 ) -> Bool {
+  if self.has_active_delivery() {
+    let frontier = self.frontier.val
+    self.deferred_composition_finished.val = false
+    let (base_source, frontier_source) = match frontier.deferred {
+      Some(deferred) => (deferred.base_source, deferred.source)
+      None =>
+        match frontier.in_flight {
+          Some(delivery) => (delivery.source, delivery.source)
+          None => (model.document.source(), model.document.source())
+        }
+    }
+    self.reduce_frontier(
+      RawInputFrontierEvent::BeginDeferredComposition({
+        base_source,
+        input_type: "insertCompositionText",
+        source: raw_textarea_value(frontier_source),
+        post_input_selection: selection,
+        input_count: 0,
+      }),
+    )
+    return true
+  }
   let before_input = match self.pending.val {
     Some(pending) if pending.before_input.selection.document_id ==
       model.document_id &&
@@ -344,7 +382,21 @@ fn RawInputCoordinator::update_composition(
       })
       true
     }
-    None => false
+    None =>
+      match self.frontier.val.deferred_composition {
+        Some(input) => {
+          self.reduce_frontier(
+            RawInputFrontierEvent::UpdateDeferredComposition({
+              ..input,
+              source: raw_textarea_value(source),
+              post_input_selection: selection,
+              input_count: input.input_count + 1,
+            }),
+          )
+          true
+        }
+        None => false
+      }
   }
 }
 
@@ -357,6 +409,18 @@ fn RawInputCoordinator::finish_composition(
   accepted_source : String,
   emit : @cmd.Emit[DriverEvent],
 ) -> @cmd.Cmd {
+  match self.frontier.val.deferred_composition {
+    Some(input) => {
+      if input.source == raw_textarea_value(input.base_source) {
+        self.reduce_frontier(RawInputFrontierEvent::ClearDeferredComposition)
+        self.deferred_composition_finished.val = false
+      } else {
+        self.deferred_composition_finished.val = true
+      }
+      return @rabbita_runtime.none
+    }
+    None => ()
+  }
   guard self.composition.val is Some(input) else {
     return @rabbita_runtime.none
   }
@@ -437,6 +501,31 @@ fn RawInputCoordinator::expire_before_input(
 }
 
 ///|
+/// Keep a native input separate while the DOM is ahead of the committed model.
+fn RawInputCoordinator::capture_deferred_before_input(
+  self : RawInputCoordinator,
+  model : DriverModel,
+  event : @dom.InputEvent,
+) -> @cmd.Cmd {
+  let base_source = match self.frontier.val.deferred {
+    Some(deferred) => deferred.base_source
+    None =>
+      match self.frontier.val.in_flight {
+        Some(delivery) => delivery.source
+        None => model.document.source()
+      }
+  }
+  self.capture_generation.val += 1
+  self.reduce_frontier(
+    RawInputFrontierEvent::CaptureDeferredBeforeInput({
+      base_source,
+      input_type: raw_input_event_type(event),
+    }),
+  )
+  @rabbita_runtime.none
+}
+
+///|
 /// Capture beforeinput while the DOM still exposes the pre-edit selection.
 fn RawInputCoordinator::capture_native_before_input(
   self : RawInputCoordinator,
@@ -444,10 +533,19 @@ fn RawInputCoordinator::capture_native_before_input(
   event : @dom.InputEvent,
 ) -> @cmd.Cmd {
   if raw_input_event_is_composing(event) {
-    if self.composition.val is None {
+    if self.composition.val is None &&
+      self.frontier.val.deferred_composition is None &&
+      !self.has_active_delivery() {
       self.cancel_pending()
     }
     return @rabbita_runtime.none
+  }
+  if self.frontier.val.deferred_composition is Some(_) {
+    return @rabbita_runtime.none
+  }
+  if self.frontier.val.in_flight is Some(_) ||
+    self.frontier.val.deferred is Some(_) {
+    return self.capture_deferred_before_input(model, event)
   }
   match self.pending.val {
     Some(pending) => return self.capture_before_input(pending.before_input)
@@ -506,12 +604,13 @@ fn read_raw_selection() -> @dom_boundary.TextSelection? {
 fn RawInputCoordinator::take_pending_delivery(
   self : RawInputCoordinator,
 ) -> (Int, RawNativeInputCandidate)? {
+  guard self.frontier.val.in_flight is None else { return None }
   guard self.pending.val is Some(pending) else { return None }
   self.pending.val = None
   let token = self.next_token.val
   self.next_token.val = token + 1
-  self.in_flight_token.val = Some(token)
-  self.in_flight_source.val = Some(pending.source)
+  let source = pending.source
+  self.reduce_frontier(RawInputFrontierEvent::BeginDelivery({ token, source }))
   match self.telemetry {
     Some(telemetry) => {
       let now = raw_input_now_ms()
@@ -541,9 +640,9 @@ fn RawInputCoordinator::take_pending_delivery(
   Some(
     (
       token,
-      RawNativeInputCandidate::RawNativeInputCandidate(
+      RawNativeInputCandidate::authorized(
         before_input=pending.before_input,
-        source=pending.source,
+        source~,
         post_input_selection=pending.post_input_selection,
       ),
     ),
@@ -575,8 +674,11 @@ fn RawInputCoordinator::has_captured_before_input(
 fn RawInputCoordinator::suppress_composing_input_repair(
   self : RawInputCoordinator,
 ) -> Unit {
-  if self.composition.val is None {
-    self.cancel_pending()
+  if self.composition.val is None &&
+    self.frontier.val.deferred_composition is None {
+    if !self.has_active_delivery() {
+      self.cancel_pending()
+    }
     self.suppress_unmatched_repair.val = true
   }
 }
@@ -588,6 +690,41 @@ fn RawInputCoordinator::take_unmatched_input_repair(
   let repair = !self.suppress_unmatched_repair.val
   self.suppress_unmatched_repair.val = false
   repair
+}
+
+///|
+/// Store the latest native value without attempting to interpret it against a
+/// committed document that is older than the value visible in the textarea.
+fn RawInputCoordinator::defer_native_input(
+  self : RawInputCoordinator,
+  source : String,
+  post_input_selection : @dom_boundary.TextSelection,
+) -> Bool {
+  let frontier = self.frontier.val
+  let capture = match frontier.deferred_before_input {
+    Some(capture) => capture
+    None => return false
+  }
+  let existing = frontier.deferred
+  let base_source = capture.base_source
+  let input_type = capture.input_type
+  self.capture_generation.val += 1
+  self.unmatched_before_input.val = None
+  let source = raw_textarea_value(source)
+  let input_count = match existing {
+    Some(deferred) => deferred.input_count + 1
+    None => 1
+  }
+  self.reduce_frontier(
+    RawInputFrontierEvent::StoreDeferred({
+      base_source,
+      input_type,
+      source,
+      post_input_selection,
+      input_count,
+    }),
+  )
+  true
 }
 
 ///|
@@ -612,6 +749,9 @@ fn RawInputCoordinator::enqueue(
   let before_input = match self.unmatched_before_input.val {
     Some(before_input) => before_input
     None => {
+      if self.has_active_delivery() {
+        return @rabbita_runtime.none
+      }
       self.cancel_pending()
       return @rabbita_runtime.none
     }
@@ -649,26 +789,139 @@ fn RawInputCoordinator::enqueue(
 }
 
 ///|
-/// Finish a normalized native transaction after its resulting render. The
-/// phase remains available for the outer publish and is copied to last_phase.
+/// Rebase the latest native value after the preceding transaction has rendered.
+fn RawInputCoordinator::enqueue_deferred(
+  self : RawInputCoordinator,
+  model : DriverModel,
+  emit : @cmd.Emit[DriverEvent],
+) -> @cmd.Cmd {
+  let deferred = match self.frontier.val.deferred {
+    Some(deferred) => deferred
+    None => return @rabbita_runtime.none
+  }
+  self.reduce_frontier(RawInputFrontierEvent::ClearDeferred)
+  guard raw_textarea_value(model.document.source()) ==
+    raw_textarea_value(deferred.base_source) else {
+    return @rabbita_runtime.none
+  }
+  let before_input = match rebase_deferred_raw_input(model, deferred) {
+    Some(before_input) => before_input
+    None => return @rabbita_runtime.none
+  }
+  self.capture_generation.val += 1
+  self.unmatched_before_input.val = Some(before_input)
+  let command = self.enqueue(
+    deferred.source,
+    deferred.post_input_selection,
+    emit,
+  )
+  match self.pending.val {
+    Some(pending) =>
+      self.pending.val = Some({ ..pending, input_count: deferred.input_count })
+    None => ()
+  }
+  command
+}
+
+///|
+fn RawInputCoordinator::enqueue_deferred_composition(
+  self : RawInputCoordinator,
+  model : DriverModel,
+  emit : @cmd.Emit[DriverEvent],
+) -> @cmd.Cmd {
+  let deferred = match self.frontier.val.deferred_composition {
+    Some(deferred) => deferred
+    None => {
+      self.deferred_composition_finished.val = false
+      return @rabbita_runtime.none
+    }
+  }
+  self.reduce_frontier(RawInputFrontierEvent::ClearDeferredComposition)
+  guard raw_textarea_value(model.document.source()) ==
+    raw_textarea_value(deferred.base_source) else {
+    self.deferred_composition_finished.val = false
+    return @rabbita_runtime.none
+  }
+  let before_input = match rebase_deferred_raw_input(model, deferred) {
+    Some(before_input) => before_input
+    None => {
+      self.deferred_composition_finished.val = false
+      return @rabbita_runtime.none
+    }
+  }
+  self.capture_generation.val += 1
+  self.unmatched_before_input.val = None
+  self.pending.val = Some({
+    before_input,
+    source: deferred.source,
+    post_input_selection: deferred.post_input_selection,
+    input_count: deferred.input_count,
+  })
+  match self.take_pending_delivery() {
+    Some((token, candidate)) =>
+      emit(Editing(RawNativeInput(token~, candidate~)))
+    None => @rabbita_runtime.none
+  }
+}
+
+///|
+fn RawInputCoordinator::finalize_deferred_composition(
+  self : RawInputCoordinator,
+  model : DriverModel,
+  emit : @cmd.Emit[DriverEvent],
+) -> @cmd.Cmd {
+  guard self.deferred_composition_finished.val else {
+    return @rabbita_runtime.none
+  }
+  guard !self.has_active_delivery() else { return @rabbita_runtime.none }
+  self.enqueue_deferred_composition(model, emit)
+}
+
+///|
+fn RawInputCoordinator::discard_deferred(self : RawInputCoordinator) -> Unit {
+  self.reduce_frontier(RawInputFrontierEvent::ClearDeferred)
+  self.reduce_frontier(RawInputFrontierEvent::ClearDeferredComposition)
+  self.deferred_composition_finished.val = false
+}
+
+///|
+/// Finish a normalized native transaction after its resulting render. Keep the
+/// token and source active until AfterRender so a native input that arrives
+/// before the controlled DOM repaint can be deferred against this frontier.
 fn RawInputCoordinator::finish(
   self : RawInputCoordinator,
   token : Int,
   latest_model : @ref.Ref[DriverModel?],
   emit : @cmd.Emit[DriverEvent],
 ) -> @cmd.Cmd {
-  guard self.in_flight_token.val == Some(token) else {
-    return @rabbita_runtime.none
-  }
-  self.in_flight_token.val = None
-  self.in_flight_source.val = None
+  guard self.is_active(token) else { return @rabbita_runtime.none }
   after_render(
     scheduler => {
-      ignore(scheduler)
+      guard self.is_active(token) else { return }
       self.mark_rendered(token)
+      let has_deferred = self.frontier.val.deferred is Some(_)
+      let has_deferred_composition = self.frontier.val.deferred_composition
+        is Some(_) &&
+        self.deferred_composition_finished.val
+      self.reduce_frontier(RawInputFrontierEvent::ClearDeferredCapture)
       match latest_model.val {
-        Some(model) => publish(model, Some(self), None)
-        None => ()
+        Some(model) => {
+          publish(model, Some(self), None)
+          self.reduce_frontier(RawInputFrontierEvent::FinishDelivery(token))
+          if has_deferred_composition {
+            scheduler.add(self.enqueue_deferred_composition(model, emit))
+          } else if has_deferred {
+            scheduler.add(self.enqueue_deferred(model, emit))
+          }
+        }
+        None => {
+          self.discard_deferred()
+          self.reduce_frontier(RawInputFrontierEvent::ClearDeferredComposition)
+          self.reduce_frontier(RawInputFrontierEvent::FinishDelivery(token))
+        }
+      }
+      if !has_deferred_composition && self.pending.val is None {
+        self.deferred_composition_finished.val = false
       }
     },
     emit,
@@ -681,9 +934,9 @@ fn RawInputCoordinator::discard(
   self : RawInputCoordinator,
   token : Int,
 ) -> Unit {
-  if self.in_flight_token.val == Some(token) {
-    self.in_flight_token.val = None
-    self.in_flight_source.val = None
+  if self.is_active(token) {
+    self.reduce_frontier(RawInputFrontierEvent::DiscardDelivery(token))
+    self.deferred_composition_finished.val = false
     match self.telemetry {
       Some(telemetry) => telemetry.phase.val = None
       None => ()
@@ -707,11 +960,52 @@ fn RawInputCoordinator::cancel_pending(self : RawInputCoordinator) -> Unit {
     }
     None => ()
   }
-  self.in_flight_token.val = None
-  self.in_flight_source.val = None
+  self.reduce_frontier(RawInputFrontierEvent::Cancel)
   self.suppress_unmatched_repair.val = false
   self.composition.val = None
   self.composition_final_source.val = None
+  self.deferred_composition_finished.val = false
+}
+
+///|
+fn RawInputCoordinator::has_active_delivery(self : RawInputCoordinator) -> Bool {
+  self.frontier.val.in_flight is Some(_)
+}
+
+///|
+fn RawInputCoordinator::has_deferred_composition(
+  self : RawInputCoordinator,
+) -> Bool {
+  self.frontier.val.deferred_composition is Some(_)
+}
+
+///|
+/// A mode transition must not cancel an IME snapshot that is waiting behind
+/// an already active native delivery.
+fn RawInputCoordinator::cancel_pending_for_navigation(
+  self : RawInputCoordinator,
+) -> Unit {
+  if self.deferred_composition_finished.val ||
+    (self.has_active_delivery() && self.has_deferred_composition()) {
+    return
+  }
+  self.cancel_pending()
+}
+
+///|
+/// An accepted native caret is still current only when no newer browser
+/// frontier is waiting to be committed or composing.
+fn RawInputCoordinator::native_selection_frontier_is_current(
+  self : RawInputCoordinator,
+  committed_source : String,
+) -> Bool {
+  self.pending.val is None &&
+  self.composition.val is None &&
+  self.frontier.val.deferred_before_input is None &&
+  self.frontier.val.deferred is None &&
+  self.frontier.val.deferred_composition is None &&
+  raw_textarea_value(self.display_source(committed_source)) ==
+  raw_textarea_value(committed_source)
 }
 
 ///|
@@ -719,12 +1013,15 @@ fn RawInputCoordinator::is_active(
   self : RawInputCoordinator,
   token : Int,
 ) -> Bool {
-  self.in_flight_token.val == Some(token)
+  match self.frontier.val.in_flight {
+    Some(delivery) => delivery.token == token
+    None => false
+  }
 }
 
 ///|
 fn RawInputCoordinator::cancel(self : RawInputCoordinator, token : Int) -> Unit {
-  if self.in_flight_token.val == Some(token) {
+  if self.is_active(token) {
     self.cancel_pending()
   }
 }

--- a/apps/loomark/internal/rabbita/text_control_repair_wbtest.mbt
+++ b/apps/loomark/internal/rabbita/text_control_repair_wbtest.mbt
@@ -1,4 +1,20 @@
 ///|
+fn test_in_flight_token(coordinator : RawInputCoordinator) -> Int? {
+  match coordinator.frontier.val.in_flight {
+    Some(delivery) => Some(delivery.token)
+    None => None
+  }
+}
+
+///|
+fn test_in_flight_source(coordinator : RawInputCoordinator) -> String? {
+  match coordinator.frontier.val.in_flight {
+    Some(delivery) => Some(delivery.source)
+    None => None
+  }
+}
+
+///|
 test "rejected insertion maps a non-BMP UTF-16 text cursor back to accepted source" {
   let selection = rejected_text_selection(
     "A😀B",
@@ -89,7 +105,7 @@ test "Raw composition keeps intermediate DOM state out of pending input" {
 
   assert_eq(coordinator.display_source("start"), "startか")
   assert_true(coordinator.pending.val is None)
-  assert_true(coordinator.in_flight_token.val is None)
+  assert_true(test_in_flight_token(coordinator) is None)
 }
 
 ///|
@@ -121,8 +137,8 @@ test "Raw composition end releases one immediate final transaction" {
 
   assert_true(coordinator.composition.val is None)
   assert_true(coordinator.pending.val is None)
-  assert_eq(coordinator.in_flight_token.val, Some(0))
-  assert_eq(coordinator.in_flight_source.val, Some("start漢字"))
+  assert_eq(test_in_flight_token(coordinator), Some(0))
+  assert_eq(test_in_flight_source(coordinator), Some("start漢字"))
 }
 
 ///|
@@ -154,7 +170,7 @@ test "Canceled Raw composition never becomes an editor transaction" {
 
   assert_true(coordinator.composition.val is None)
   assert_true(coordinator.pending.val is None)
-  assert_true(coordinator.in_flight_token.val is None)
+  assert_true(test_in_flight_token(coordinator) is None)
   assert_true(coordinator.unmatched_before_input.val is None)
 }
 
@@ -194,8 +210,8 @@ test "Raw composition ignores one same-value final input while delivery is activ
   )
 
   assert_true(coordinator.pending.val is None)
-  assert_eq(coordinator.in_flight_token.val, Some(0))
-  assert_eq(coordinator.in_flight_source.val, Some("start漢字"))
+  assert_eq(test_in_flight_token(coordinator), Some(0))
+  assert_eq(test_in_flight_source(coordinator), Some("start漢字"))
 }
 
 ///|
@@ -286,8 +302,8 @@ test "Raw composition releases promoted input without a composition input" {
   ignore(coordinator.finish_composition("abcdef", emit))
 
   assert_true(coordinator.composition.val is None)
-  assert_eq(coordinator.in_flight_source.val, Some("abxyef"))
-  assert_eq(coordinator.in_flight_token.val, Some(0))
+  assert_eq(test_in_flight_source(coordinator), Some("abxyef"))
+  assert_eq(test_in_flight_token(coordinator), Some(0))
 }
 
 ///|
@@ -343,6 +359,75 @@ test "Raw composition keeps a pending ordinary input as its transaction base" {
   assert_eq(input.source, "abxy漢ef")
   assert_eq(input.post_input_selection.start(), 5)
   assert_true(coordinator.pending.val is None)
+}
+
+///|
+test "Raw coordinator does not guess an unpaired in-flight input" {
+  let coordinator = RawInputCoordinator::RawInputCoordinator(None)
+  coordinator.reduce_frontier(
+    RawInputFrontierEvent::BeginDelivery({ token: 1, source: "startX" }),
+  )
+  let deferred = coordinator.defer_native_input(
+    "startXY",
+    @dom_boundary.TextSelection(7, 7, @dom_boundary.NoDirection),
+  )
+  assert_false(deferred)
+  assert_true(coordinator.frontier.val.deferred is None)
+}
+
+///|
+test "Raw coordinator keeps an active delivery for unpaired input" {
+  let coordinator = RawInputCoordinator::RawInputCoordinator(None)
+  coordinator.reduce_frontier(
+    RawInputFrontierEvent::BeginDelivery({ token: 1, source: "startX" }),
+  )
+  let emit : @cmd.Emit[DriverEvent] = @cmd.Emit(_ => @rabbita_runtime.none)
+  ignore(
+    coordinator.enqueue(
+      "startXY",
+      @dom_boundary.TextSelection(7, 7, @dom_boundary.NoDirection),
+      emit,
+    ),
+  )
+  assert_eq(test_in_flight_token(coordinator), Some(1))
+  assert_eq(test_in_flight_source(coordinator), Some("startX"))
+}
+
+///|
+test "Raw coordinator clears a canceled deferred capture before rebase" {
+  let context = RawSelectionTestContext::RawSelectionTestContext(
+    "coordinator-deferred-cancel", "startX",
+  )
+  let coordinator = RawInputCoordinator::RawInputCoordinator(None)
+  coordinator.reduce_frontier(
+    RawInputFrontierEvent::BeginDelivery({ token: 1, source: "startX" }),
+  )
+  coordinator.reduce_frontier(
+    RawInputFrontierEvent::CaptureDeferredBeforeInput({
+      base_source: "startX",
+      input_type: "insertText",
+    }),
+  )
+  coordinator.reduce_frontier(
+    RawInputFrontierEvent::StoreDeferred({
+      base_source: "startX",
+      input_type: "insertText",
+      source: "startXY",
+      post_input_selection: @dom_boundary.TextSelection(
+        7,
+        7,
+        @dom_boundary.NoDirection,
+      ),
+      input_count: 1,
+    }),
+  )
+  let emit : @cmd.Emit[DriverEvent] = @cmd.Emit(_ => @rabbita_runtime.none)
+  ignore(coordinator.enqueue_deferred(context.model, emit))
+  assert_true(coordinator.frontier.val.deferred_before_input is None)
+  guard coordinator.pending.val is Some(pending) else {
+    fail("deferred input must become pending after rebase")
+  }
+  assert_eq(pending.source, "startXY")
 }
 
 ///|
@@ -546,7 +631,7 @@ test "Raw input cancellation clears live composition" {
 
   assert_true(coordinator.composition.val is None)
   assert_true(coordinator.pending.val is None)
-  assert_true(coordinator.in_flight_token.val is None)
+  assert_true(test_in_flight_token(coordinator) is None)
   assert_eq(coordinator.display_source("start"), "start")
 }
 
@@ -625,13 +710,14 @@ test "Raw coordinator cancel clears all state and invalidates capture expiry" {
     ),
   )
   let expiry_generation = coordinator.capture_generation.val
-  coordinator.in_flight_token.val = Some(7)
-  coordinator.in_flight_source.val = Some("in-flight")
+  coordinator.reduce_frontier(
+    RawInputFrontierEvent::BeginDelivery({ token: 7, source: "in-flight" }),
+  )
   coordinator.cancel_pending()
   coordinator.expire_before_input(expiry_generation)
   assert_true(coordinator.unmatched_before_input.val is None)
   assert_true(coordinator.pending.val is None)
-  assert_true(coordinator.in_flight_token.val is None)
-  assert_true(coordinator.in_flight_source.val is None)
+  assert_true(test_in_flight_token(coordinator) is None)
+  assert_true(test_in_flight_source(coordinator) is None)
   assert_false(coordinator.scheduled.val)
 }


### PR DESCRIPTION
## Summary

- Integrate the Loomark Raw input race fix with `origin/main` (#1217 and #1218).
- Model the browser-visible Raw frontier with an explicit reducer.
- Preserve ordinary input and IME composition across in-flight renders without guessing unpaired input.
- Suppress stale caret restoration and carry capture-time Raw authorization through mode transitions.

## Validation

- `./scripts/validate-pr-ready.sh --target apps/loomark/internal/rabbita`
- `./scripts/validate-pr-ready.sh --verify-evidence`
- MoonBit: 2697 JS + 70 native tests passed
- Rabbita package: 107 tests passed
- Dev Host E2E: 115 passed
- Standalone E2E: 13 passed
- TypeScript checks, release build, format, and `moon info` passed
- No `.mbti` drift or submodule changes

## Review

Independent `moonbit-reviewer` review completed with no Critical or Warning findings.

This branch is a single squash-ready commit: `f1c6d88c`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Raw editor handling for rapid and overlapping input, including queued edits, mid-document changes, and canceled input events.
  * Preserved caret position more reliably while edits are being processed and rendered.
  * Improved IME composition behavior when switching modes or navigating split previews.
  * Ensured authorized Raw edits complete correctly when the editor mode changes.

* **Tests**
  * Added end-to-end and regression coverage for input ordering, caret preservation, composition handling, cancellation, and mode transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->