### PR TITLE
test(loomark): make Raw frontier E2E deterministic

### DIFF
--- a/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
+++ b/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
@@ -102,7 +102,7 @@ async function dispatchRawNativeEdits(input: Locator, edits: RawNativeEdit[]): P
         edit.beforeEnd,
         edit.beforeDirection ?? "none",
       )
-      textarea.dispatchEvent(new InputEvent("beforeinput", init))
+      if (!textarea.dispatchEvent(new InputEvent("beforeinput", init))) continue
       textarea.value = edit.value
       textarea.setSelectionRange(
         edit.afterStart,
@@ -112,6 +112,22 @@ async function dispatchRawNativeEdits(input: Locator, edits: RawNativeEdit[]): P
       textarea.dispatchEvent(new InputEvent("input", init))
     }
   }, edits)
+}
+
+async function armRawRenderBarrier(page: Page): Promise<void> {
+  await page.evaluate(moduleUrl =>
+    import(moduleUrl).then(module => module.dev_host_arm_raw_render_barrier()), moduleUrl)
+  await expect.poll(async () => (await snapshot(page)).raw_render_barrier_armed).toBe(true)
+}
+
+async function waitForRawRenderBarrier(page: Page): Promise<void> {
+  await expect.poll(async () => (await snapshot(page)).raw_render_barrier_waiting).toBe(true)
+}
+
+async function releaseRawRenderBarrier(page: Page): Promise<void> {
+  await page.evaluate(moduleUrl =>
+    import(moduleUrl).then(module => module.dev_host_release_raw_render_barrier()), moduleUrl)
+  await expect.poll(async () => (await snapshot(page)).raw_render_barrier_armed).toBe(false)
 }
 
 async function replaceRawValue(input: Locator, value: string): Promise<void> {
@@ -2044,116 +2060,210 @@ test("Raw input coalesces a same-task burst into one commit", async ({ browser }
   }
 })
 
-test("Raw preserves native input across an in-flight commit", async ({ browser }) => {
-  for (let attempt = 0; attempt < 6; attempt += 1) {
-    const host = await mountHost(browser, "start")
-    try {
-      const input = host.page.locator("#loomark-input")
-      await input.focus()
-      await input.evaluate(element => {
-        const textarea = element as HTMLTextAreaElement
-        textarea.setSelectionRange(textarea.value.length, textarea.value.length)
-      })
-      await host.page.keyboard.type("XY", { delay: 52 })
+test("Raw deterministically preserves native input across an in-flight commit", async ({ browser }) => {
+  const host = await mountHost(browser, "start")
+  let barrierArmed = false
+  try {
+    const input = host.page.locator("#loomark-input")
+    await armRawRenderBarrier(host.page)
+    barrierArmed = true
+    await input.focus()
+    await input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.setSelectionRange(5, 5)
+    })
 
-      await expect.poll(async () => (await snapshot(host.page)).source, {
-        timeout: 1500,
-      }).toBe("startXY")
-      await expect(input).toHaveValue("startXY")
-      await expect.poll(() => input.evaluate(element => {
-        const textarea = element as HTMLTextAreaElement
-        return `${textarea.selectionStart}:${textarea.selectionEnd}`
-      })).toBe("7:7")
-    } finally {
-      await host.context.close()
-    }
+    await dispatchRawNativeEdits(input, [{
+      value: "startX",
+      beforeStart: 5,
+      beforeEnd: 5,
+      afterStart: 6,
+      afterEnd: 6,
+      data: "X",
+    }])
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("startX")
+    await waitForRawRenderBarrier(host.page)
+
+    await dispatchRawNativeEdits(input, [{
+      value: "startXY",
+      beforeStart: 6,
+      beforeEnd: 6,
+      afterStart: 7,
+      afterEnd: 7,
+      data: "Y",
+    }])
+    await releaseRawRenderBarrier(host.page)
+    barrierArmed = false
+
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("startXY")
+    await expect(input).toHaveValue("startXY")
+    await expect.poll(() => input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      return `${textarea.selectionStart}:${textarea.selectionEnd}`
+    })).toBe("7:7")
+  } finally {
+    if (barrierArmed) await releaseRawRenderBarrier(host.page)
+    await host.context.close()
   }
 })
 
-test("Raw preserves caret order across two in-flight frontier inputs", async ({ browser }) => {
-  for (let attempt = 0; attempt < 4; attempt += 1) {
-    const host = await mountHost(browser, "start")
-    try {
-      const input = host.page.locator("#loomark-input")
-      await input.focus()
-      await input.evaluate(element => {
-        const textarea = element as HTMLTextAreaElement
-        textarea.setSelectionRange(textarea.value.length, textarea.value.length)
-      })
-      await host.page.keyboard.type("XYZ", { delay: 52 })
+test("Raw deterministically preserves caret order across two in-flight frontier inputs", async ({ browser }) => {
+  const host = await mountHost(browser, "start")
+  let barrierArmed = false
+  try {
+    const input = host.page.locator("#loomark-input")
+    await armRawRenderBarrier(host.page)
+    barrierArmed = true
+    await input.focus()
+    await input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.setSelectionRange(5, 5)
+    })
+    await dispatchRawNativeEdits(input, [{
+      value: "startX",
+      beforeStart: 5,
+      beforeEnd: 5,
+      afterStart: 6,
+      afterEnd: 6,
+      data: "X",
+    }])
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("startX")
+    await waitForRawRenderBarrier(host.page)
 
-      await expect.poll(async () => (await snapshot(host.page)).source, {
-        timeout: 2000,
-      }).toBe("startXYZ")
-      await expect(input).toHaveValue("startXYZ")
-      await expect.poll(() => input.evaluate(element => {
-        const textarea = element as HTMLTextAreaElement
-        return `${textarea.selectionStart}:${textarea.selectionEnd}`
-      })).toBe("8:8")
-    } finally {
-      await host.context.close()
-    }
+    await dispatchRawNativeEdits(input, [
+      {
+        value: "startXY",
+        beforeStart: 6,
+        beforeEnd: 6,
+        afterStart: 7,
+        afterEnd: 7,
+        data: "Y",
+      },
+      {
+        value: "startXYZ",
+        beforeStart: 7,
+        beforeEnd: 7,
+        afterStart: 8,
+        afterEnd: 8,
+        data: "Z",
+      },
+    ])
+    await releaseRawRenderBarrier(host.page)
+    barrierArmed = false
+
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("startXYZ")
+    await expect(input).toHaveValue("startXYZ")
+    await expect.poll(() => input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      return `${textarea.selectionStart}:${textarea.selectionEnd}`
+    })).toBe("8:8")
+  } finally {
+    if (barrierArmed) await releaseRawRenderBarrier(host.page)
+    await host.context.close()
   }
 })
 
-test("Raw preserves native input and caret at a mid-document in-flight boundary", async ({ browser }) => {
-  for (let attempt = 0; attempt < 4; attempt += 1) {
-    const host = await mountHost(browser, "abcdef")
-    try {
-      const input = host.page.locator("#loomark-input")
-      await input.focus()
-      await input.evaluate(element => {
-        const textarea = element as HTMLTextAreaElement
-        textarea.setSelectionRange(3, 3)
-      })
-      await host.page.keyboard.type("XY", { delay: 52 })
+test("Raw deterministically preserves native input and caret at a mid-document boundary", async ({ browser }) => {
+  const host = await mountHost(browser, "abcdef")
+  let barrierArmed = false
+  try {
+    const input = host.page.locator("#loomark-input")
+    await armRawRenderBarrier(host.page)
+    barrierArmed = true
+    await input.focus()
+    await input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.setSelectionRange(3, 3)
+    })
+    await dispatchRawNativeEdits(input, [{
+      value: "abcXdef",
+      beforeStart: 3,
+      beforeEnd: 3,
+      afterStart: 4,
+      afterEnd: 4,
+      data: "X",
+    }])
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("abcXdef")
+    await waitForRawRenderBarrier(host.page)
 
-      await expect.poll(async () => (await snapshot(host.page)).source, {
-        timeout: 1500,
-      }).toBe("abcXYdef")
-      await expect(input).toHaveValue("abcXYdef")
-      await expect.poll(() => input.evaluate(element => {
-        const textarea = element as HTMLTextAreaElement
-        return `${textarea.selectionStart}:${textarea.selectionEnd}`
-      })).toBe("5:5")
-    } finally {
-      await host.context.close()
-    }
+    await dispatchRawNativeEdits(input, [{
+      value: "abcXYdef",
+      beforeStart: 4,
+      beforeEnd: 4,
+      afterStart: 5,
+      afterEnd: 5,
+      data: "Y",
+    }])
+    await releaseRawRenderBarrier(host.page)
+    barrierArmed = false
+
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("abcXYdef")
+    await expect(input).toHaveValue("abcXYdef")
+    await expect.poll(() => input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      return `${textarea.selectionStart}:${textarea.selectionEnd}`
+    })).toBe("5:5")
+  } finally {
+    if (barrierArmed) await releaseRawRenderBarrier(host.page)
+    await host.context.close()
   }
 })
 
-test("Raw clears a canceled in-flight beforeinput capture", async ({ browser }) => {
-  for (let attempt = 0; attempt < 4; attempt += 1) {
-    const host = await mountHost(browser, "start")
-    try {
-      const input = host.page.locator("#loomark-input")
-      await input.evaluate(element => {
-        element.addEventListener("beforeinput", event => {
-          const inputEvent = event as InputEvent
-          if (inputEvent.data === "Y") event.preventDefault()
-        })
+test("Raw deterministically clears a canceled in-flight beforeinput capture", async ({ browser }) => {
+  const host = await mountHost(browser, "start")
+  let barrierArmed = false
+  try {
+    const input = host.page.locator("#loomark-input")
+    await input.evaluate(element => {
+      element.addEventListener("beforeinput", event => {
+        const inputEvent = event as InputEvent
+        if (inputEvent.data === "Y") event.preventDefault()
       })
-      await input.focus()
-      await input.evaluate(element => {
-        const textarea = element as HTMLTextAreaElement
-        textarea.setSelectionRange(textarea.value.length, textarea.value.length)
-      })
-      await host.page.keyboard.type("XY", { delay: 52 })
+    })
+    await armRawRenderBarrier(host.page)
+    barrierArmed = true
+    await input.focus()
+    await input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.setSelectionRange(5, 5)
+    })
+    await dispatchRawNativeEdits(input, [{
+      value: "startX",
+      beforeStart: 5,
+      beforeEnd: 5,
+      afterStart: 6,
+      afterEnd: 6,
+      data: "X",
+    }])
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("startX")
+    await waitForRawRenderBarrier(host.page)
 
-      await expect.poll(async () => (await snapshot(host.page)).source, {
-        timeout: 1500,
-      }).toBe("startX")
-      await expect(input).toHaveValue("startX")
+    await dispatchRawNativeEdits(input, [{
+      value: "startXY",
+      beforeStart: 6,
+      beforeEnd: 6,
+      afterStart: 7,
+      afterEnd: 7,
+      data: "Y",
+    }])
+    await releaseRawRenderBarrier(host.page)
+    barrierArmed = false
 
-      await input.focus()
-      await host.page.keyboard.type("Z")
-      await expect.poll(async () => (await snapshot(host.page)).source, {
-        timeout: 1500,
-      }).toBe("startXZ")
-      await expect(input).toHaveValue("startXZ")
-    } finally {
-      await host.context.close()
-    }
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("startX")
+    await expect(input).toHaveValue("startX")
+    await dispatchRawNativeEdits(input, [{
+      value: "startXZ",
+      beforeStart: 6,
+      beforeEnd: 6,
+      afterStart: 7,
+      afterEnd: 7,
+      data: "Z",
+    }])
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("startXZ")
+    await expect(input).toHaveValue("startXZ")
+  } finally {
+    if (barrierArmed) await releaseRawRenderBarrier(host.page)
+    await host.context.close()
   }
 })
 
@@ -2878,38 +2988,57 @@ test("a Raw mode click accepts composition before changing mode", async ({ brows
   }
 })
 
-test("a Raw mode click preserves composition behind an active delivery", async ({ browser }) => {
-  for (let attempt = 0; attempt < 4; attempt += 1) {
-    const host = await mountHost(browser, "start")
-    try {
-      const input = host.page.locator("#loomark-input")
-      await input.focus()
-      await input.evaluate(element => {
-        const textarea = element as HTMLTextAreaElement
-        textarea.setSelectionRange(5, 5)
-      })
-      const session = await host.context.newCDPSession(host.page)
-      await host.page.keyboard.type("X")
-      await host.page.waitForTimeout(52)
-      await host.page.keyboard.type("Y")
-      await session.send("Input.imeSetComposition", {
-        text: "漢",
-        selectionStart: 1,
-        selectionEnd: 1,
-      })
-      await expect(input).toHaveValue("startXY漢")
+test("a Raw mode click deterministically preserves composition behind an active delivery", async ({ browser }) => {
+  const host = await mountHost(browser, "start")
+  let barrierArmed = false
+  try {
+    const input = host.page.locator("#loomark-input")
+    await armRawRenderBarrier(host.page)
+    barrierArmed = true
+    await input.focus()
+    await input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.setSelectionRange(5, 5)
+    })
+    await dispatchRawNativeEdits(input, [{
+      value: "startX",
+      beforeStart: 5,
+      beforeEnd: 5,
+      afterStart: 6,
+      afterEnd: 6,
+      data: "X",
+    }])
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("startX")
+    await waitForRawRenderBarrier(host.page)
 
-      await host.page.locator("#loomark-mode-block").click()
-      await expect.poll(async () => (await snapshot(host.page)).mode).toBe("block")
-      await expect.poll(async () => (await snapshot(host.page)).source).toBe("startXY漢")
-      expect(await snapshot(host.page)).toMatchObject({
-        committed_change_count: 2,
-        error_code: null,
-      })
-      await expect(host.page.locator("#loomark-block-input")).toHaveValue("startXY漢")
-    } finally {
-      await host.context.close()
-    }
+    await dispatchRawNativeEdits(input, [{
+      value: "startXY",
+      beforeStart: 6,
+      beforeEnd: 6,
+      afterStart: 7,
+      afterEnd: 7,
+      data: "Y",
+    }])
+    const session = await host.context.newCDPSession(host.page)
+    await session.send("Input.imeSetComposition", {
+      text: "漢",
+      selectionStart: 1,
+      selectionEnd: 1,
+    })
+    await expect(input).toHaveValue("startXY漢")
+    await host.page.locator("#loomark-mode-block").click()
+    await expect.poll(async () => (await snapshot(host.page)).mode).toBe("block")
+    await releaseRawRenderBarrier(host.page)
+    barrierArmed = false
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("startXY漢")
+    expect(await snapshot(host.page)).toMatchObject({
+      committed_change_count: 2,
+      error_code: null,
+    })
+    await expect(host.page.locator("#loomark-block-input")).toHaveValue("startXY漢")
+  } finally {
+    if (barrierArmed) await releaseRawRenderBarrier(host.page)
+    await host.context.close()
   }
 })
 

--- a/apps/loomark/internal/dev_host/dev_host.mbt
+++ b/apps/loomark/internal/dev_host/dev_host.mbt
@@ -55,6 +55,16 @@ pub fn dev_host_force_reconstruction_failure() -> Unit {
 }
 
 ///|
+pub fn dev_host_arm_raw_render_barrier() -> Unit {
+  @app.arm_raw_render_barrier()
+}
+
+///|
+pub fn dev_host_release_raw_render_barrier() -> Unit {
+  @app.release_raw_render_barrier()
+}
+
+///|
 pub fn dev_host_focus_preview() -> Unit {
   @app.focus_preview()
 }

--- a/apps/loomark/internal/dev_host/moon.pkg
+++ b/apps/loomark/internal/dev_host/moon.pkg
@@ -18,6 +18,8 @@ options(
         "dev_host_force_editor_failure",
         "dev_host_force_parser_failure",
         "dev_host_force_reconstruction_failure",
+        "dev_host_arm_raw_render_barrier",
+        "dev_host_release_raw_render_barrier",
         "dev_host_focus_preview",
         "dev_host_focus_raw",
         "dev_host_focus_block",

--- a/apps/loomark/internal/dev_host/pkg.generated.mbti
+++ b/apps/loomark/internal/dev_host/pkg.generated.mbti
@@ -2,6 +2,8 @@
 package "dowdiness/loomark/internal/dev_host"
 
 // Values
+pub fn dev_host_arm_raw_render_barrier() -> Unit
+
 pub fn dev_host_capture_focus() -> String
 
 pub fn dev_host_fail(String) -> Unit
@@ -25,6 +27,8 @@ pub fn dev_host_measure_preview() -> Unit
 pub fn dev_host_probe_deleted_block_selection() -> Unit
 
 pub fn dev_host_probe_stale_block_selection() -> Unit
+
+pub fn dev_host_release_raw_render_barrier() -> Unit
 
 pub fn dev_host_request_source(String) -> Unit
 

--- a/apps/loomark/internal/rabbita/application.mbt
+++ b/apps/loomark/internal/rabbita/application.mbt
@@ -305,6 +305,14 @@ fn publish(
       }
       None => Json::null()
     },
+    "raw_render_barrier_armed": match raw_input_coordinator {
+      Some(coordinator) => coordinator.render_barrier_armed().to_json()
+      None => false.to_json()
+    },
+    "raw_render_barrier_waiting": match raw_input_coordinator {
+      Some(coordinator) => coordinator.render_barrier_waiting().to_json()
+      None => false.to_json()
+    },
     "event_detail": match model.event_detail {
       Some(detail) => detail.to_json()
       None => Json::null()
@@ -770,6 +778,8 @@ fn driver_event_name(event : DriverEvent) -> String {
         EditorFailure => "editor-failure"
         ForceParserFailure => "force-parser-failure"
         ForceReconstructionFailure => "force-reconstruction-failure"
+        ArmRawRenderBarrier => "arm-raw-render-barrier"
+        ReleaseRawRenderBarrier => "release-raw-render-barrier"
         RecoveryCopy => "recovery-copy"
         RecoveryDownload => "recovery-download"
         RecoveryReload => "recovery-reload"
@@ -838,6 +848,10 @@ fn parse_driver_event(detail : String) -> DriverEvent {
     Lifecycle(ForceParserFailure)
   } else if detail == "force-reconstruction-failure" {
     Lifecycle(ForceReconstructionFailure)
+  } else if detail == "arm-raw-render-barrier" {
+    Lifecycle(ArmRawRenderBarrier)
+  } else if detail == "release-raw-render-barrier" {
+    Lifecycle(ReleaseRawRenderBarrier)
   } else if detail == "recovery-copy" {
     Lifecycle(RecoveryCopy)
   } else if detail == "recovery-download" {
@@ -2047,6 +2061,12 @@ fn update_lifecycle(
       let next = { ..model, force_reconstruction_failure: true }
       (next, @rabbita_runtime.none)
     }
+    ArmRawRenderBarrier => {
+      raw_input_coordinator.arm_render_barrier()
+      (model, @rabbita_runtime.none)
+    }
+    ReleaseRawRenderBarrier =>
+      (model, raw_input_coordinator.release_render_barrier())
     RecoveryCopy =>
       (
         model,
@@ -2737,6 +2757,18 @@ pub fn force_editor_failure() -> Unit {
 /// Private dev-host control: the next normal edit fails after CRDT acceptance.
 pub fn force_parser_failure() -> Unit {
   dispatch_driver("force-parser-failure")
+}
+
+///|
+/// Private dev-host control: hold the next Raw transaction at AfterRender.
+pub fn arm_raw_render_barrier() -> Unit {
+  dispatch_driver("arm-raw-render-barrier")
+}
+
+///|
+/// Private dev-host control: release a held Raw AfterRender transaction.
+pub fn release_raw_render_barrier() -> Unit {
+  dispatch_driver("release-raw-render-barrier")
 }
 
 ///|

--- a/apps/loomark/internal/rabbita/driver_types.mbt
+++ b/apps/loomark/internal/rabbita/driver_types.mbt
@@ -66,6 +66,8 @@ priv enum LifecycleEvent {
   EditorFailure
   ForceParserFailure
   ForceReconstructionFailure
+  ArmRawRenderBarrier
+  ReleaseRawRenderBarrier
   RecoveryCopy
   RecoveryDownload
   RecoveryReload

--- a/apps/loomark/internal/rabbita/pkg.generated.mbti
+++ b/apps/loomark/internal/rabbita/pkg.generated.mbti
@@ -6,6 +6,8 @@ import {
 }
 
 // Values
+pub fn arm_raw_render_barrier() -> Unit
+
 pub fn capture_focus() -> String
 
 pub fn fail(String) -> Unit
@@ -33,6 +35,8 @@ pub fn mount_standalone(String, String) -> String
 pub fn probe_deleted_block_selection() -> Unit
 
 pub fn probe_stale_block_selection() -> Unit
+
+pub fn release_raw_render_barrier() -> Unit
 
 pub fn request_source(String) -> Unit
 

--- a/apps/loomark/internal/rabbita/text_control_repair.mbt
+++ b/apps/loomark/internal/rabbita/text_control_repair.mbt
@@ -72,6 +72,11 @@ priv struct RawInputCoordinator {
   composition : @ref.Ref[PendingRawInput?]
   composition_final_source : @ref.Ref[String?]
   deferred_composition_finished : @ref.Ref[Bool]
+  render_barrier_armed : @ref.Ref[Bool]
+  render_barrier_waiting : @ref.Ref[Bool]
+  render_barrier_token : @ref.Ref[Int?]
+  render_barrier_latest_model : @ref.Ref[@ref.Ref[DriverModel?]?]
+  render_barrier_emit : @ref.Ref[@cmd.Emit[DriverEvent]?]
   telemetry : RawInputTelemetry?
 }
 
@@ -91,6 +96,11 @@ fn RawInputCoordinator::RawInputCoordinator(
     composition: @ref.Ref(None),
     composition_final_source: @ref.Ref(None),
     deferred_composition_finished: @ref.Ref(false),
+    render_barrier_armed: @ref.Ref(false),
+    render_barrier_waiting: @ref.Ref(false),
+    render_barrier_token: @ref.Ref(None),
+    render_barrier_latest_model: @ref.Ref(None),
+    render_barrier_emit: @ref.Ref(None),
     telemetry,
   }
 }
@@ -885,6 +895,91 @@ fn RawInputCoordinator::discard_deferred(self : RawInputCoordinator) -> Unit {
 }
 
 ///|
+fn RawInputCoordinator::arm_render_barrier(self : RawInputCoordinator) -> Unit {
+  self.render_barrier_armed.val = true
+  self.render_barrier_waiting.val = false
+  self.render_barrier_token.val = None
+  self.render_barrier_latest_model.val = None
+  self.render_barrier_emit.val = None
+}
+
+///|
+fn RawInputCoordinator::render_barrier_armed(
+  self : RawInputCoordinator,
+) -> Bool {
+  self.render_barrier_armed.val
+}
+
+///|
+fn RawInputCoordinator::render_barrier_waiting(
+  self : RawInputCoordinator,
+) -> Bool {
+  self.render_barrier_waiting.val
+}
+
+///|
+fn RawInputCoordinator::release_render_barrier(
+  self : RawInputCoordinator,
+) -> @cmd.Cmd {
+  self.render_barrier_armed.val = false
+  guard self.render_barrier_waiting.val else { return @rabbita_runtime.none }
+  self.render_barrier_waiting.val = false
+  let token = self.render_barrier_token.val
+  let latest_model = self.render_barrier_latest_model.val
+  let emit = self.render_barrier_emit.val
+  self.render_barrier_token.val = None
+  self.render_barrier_latest_model.val = None
+  self.render_barrier_emit.val = None
+  match (token, latest_model, emit) {
+    (Some(token), Some(latest_model), Some(emit)) =>
+      @cmd.custom_cmd(scheduler => {
+        self.complete_after_render(token, latest_model, emit, scheduler)
+      })
+    _ => @rabbita_runtime.none
+  }
+}
+
+///|
+fn RawInputCoordinator::complete_after_render(
+  self : RawInputCoordinator,
+  token : Int,
+  latest_model : @ref.Ref[DriverModel?],
+  emit : @cmd.Emit[DriverEvent],
+  scheduler : &@cmd.Scheduler,
+) -> Unit {
+  guard self.is_active(token) else { return }
+  self.render_barrier_waiting.val = false
+  self.render_barrier_token.val = None
+  self.render_barrier_latest_model.val = None
+  self.render_barrier_emit.val = None
+  self.mark_rendered(token)
+  let has_deferred = self.frontier.val.deferred is Some(_)
+  let has_deferred_composition = self.frontier.val.deferred_composition
+    is Some(_) &&
+    self.deferred_composition_finished.val
+  self.reduce_frontier(RawInputFrontierEvent::ClearDeferredCapture)
+  match latest_model.val {
+    Some(model) => {
+      publish(model, Some(self), None)
+      self.reduce_frontier(RawInputFrontierEvent::FinishDelivery(token))
+      if has_deferred_composition {
+        scheduler.add(self.enqueue_deferred_composition(model, emit))
+      } else if has_deferred {
+        scheduler.add(self.enqueue_deferred(model, emit))
+      }
+    }
+    None => {
+      self.discard_deferred()
+      self.reduce_frontier(RawInputFrontierEvent::ClearDeferredComposition)
+      self.reduce_frontier(RawInputFrontierEvent::FinishDelivery(token))
+    }
+  }
+  if !has_deferred_composition && self.pending.val is None {
+    self.deferred_composition_finished.val = false
+  }
+}
+
+///|
 /// Finish a normalized native transaction after its resulting render. Keep the
 /// token and source active until AfterRender so a native input that arrives
 /// before the controlled DOM repaint can be deferred against this frontier.
@@ -898,31 +993,18 @@ fn RawInputCoordinator::finish(
   after_render(
     scheduler => {
       guard self.is_active(token) else { return }
-      self.mark_rendered(token)
-      let has_deferred = self.frontier.val.deferred is Some(_)
-      let has_deferred_composition = self.frontier.val.deferred_composition
-        is Some(_) &&
-        self.deferred_composition_finished.val
-      self.reduce_frontier(RawInputFrontierEvent::ClearDeferredCapture)
-      match latest_model.val {
-        Some(model) => {
-          publish(model, Some(self), None)
-          self.reduce_frontier(RawInputFrontierEvent::FinishDelivery(token))
-          if has_deferred_composition {
-            scheduler.add(self.enqueue_deferred_composition(model, emit))
-          } else if has_deferred {
-            scheduler.add(self.enqueue_deferred(model, emit))
-          }
+      if self.render_barrier_armed.val {
+        self.render_barrier_waiting.val = true
+        self.render_barrier_token.val = Some(token)
+        self.render_barrier_latest_model.val = Some(latest_model)
+        self.render_barrier_emit.val = Some(emit)
+        match latest_model.val {
+          Some(model) => publish(model, Some(self), None)
+          None => ()
         }
-        None => {
-          self.discard_deferred()
-          self.reduce_frontier(RawInputFrontierEvent::ClearDeferredComposition)
-          self.reduce_frontier(RawInputFrontierEvent::FinishDelivery(token))
-        }
+        return
       }
-      if !has_deferred_composition && self.pending.val is None {
-        self.deferred_composition_finished.val = false
-      }
+      self.complete_after_render(token, latest_model, emit, scheduler)
     },
     emit,
   )
@@ -937,6 +1019,11 @@ fn RawInputCoordinator::discard(
   if self.is_active(token) {
     self.reduce_frontier(RawInputFrontierEvent::DiscardDelivery(token))
     self.deferred_composition_finished.val = false
+    self.render_barrier_armed.val = false
+    self.render_barrier_waiting.val = false
+    self.render_barrier_token.val = None
+    self.render_barrier_latest_model.val = None
+    self.render_barrier_emit.val = None
     match self.telemetry {
       Some(telemetry) => telemetry.phase.val = None
       None => ()
@@ -965,6 +1052,11 @@ fn RawInputCoordinator::cancel_pending(self : RawInputCoordinator) -> Unit {
   self.composition.val = None
   self.composition_final_source.val = None
   self.deferred_composition_finished.val = false
+  self.render_barrier_armed.val = false
+  self.render_barrier_waiting.val = false
+  self.render_barrier_token.val = None
+  self.render_barrier_latest_model.val = None
+  self.render_barrier_emit.val = None
 }
 
 ///|


### PR DESCRIPTION
## Summary

- Replace timing-dependent Loomark Raw frontier E2E cases with a controlled dev-host AfterRender barrier.
- Preserve and explicitly test ordinary input, caret ordering, mid-document edits, canceled `beforeinput`, and IME composition during an in-flight delivery.
- Keep the barrier unarmed path identical to the existing Raw completion path and clear held state on cancellation/discard.

## UI and review evidence

N/A — this changes test instrumentation and race coverage; it does not change the intended production visual design.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `after_render` | `apps/loomark/internal/rabbita/focus_runtime.mbt` | Yes | Reused as the application-owned render boundary rather than stopping browser `requestAnimationFrame`. |
| `@cmd.custom_cmd` | `moonbit-community/rabbita/cmd` | Yes | Reused to release the held completion through the existing scheduler command boundary. |
| `@ref.Ref` | `moonbitlang/core/ref` | Yes | Reused for coordinator shell state and one-shot held token/model/emit slots. |
| `Option` / `T?` | `moonbitlang/core/option` | Yes | Used for optional held transaction state; explicit `match`/`guard` keeps one-shot transitions visible. |
| Timer/delay commands | Existing Rabbita command APIs | No | They would reintroduce the timing dependency this change removes. |

New helpers added:

- `RawInputCoordinator::complete_after_render`: shares the former normal AfterRender completion logic between the ordinary and barrier paths.
- `arm_render_barrier` / `release_render_barrier` and dev-host wrappers: private test controls for holding and releasing exactly one Raw AfterRender transaction.
- Playwright barrier helpers: state-polling controls replacing fixed delays.

The barrier is imperative-shell test instrumentation; scheduler, DOM, telemetry, and command execution remain outside the pure frontier reducer.

## Validation scope

Boundary matrix / first failing regression:

- Ordinary Raw input arriving during an in-flight commit (`start` + `X` + `Y`).
- Two deferred frontier inputs with final native caret ordering.
- Mid-document insertion and caret restoration.
- Canceled `beforeinput` capture without guessing a canonical edit.
- Active IME composition followed by Raw → Block mode change.
- Existing Raw/Block/IME/cancellation/rejection coverage remains in the full suite.

The original regression depended on `keyboard.type(..., { delay: 52 })` and could lose the second character (`startX` instead of `startXY`).

Target packages:

- `apps/loomark/internal/rabbita`
- `apps/loomark/internal/dev_host`

Additional conditional gates:

- MoonBit: 2698 JS tests and 70 native tests passed.
- Loomark Dev Host E2E: 115 passed.
- Loomark Standalone E2E: 13 passed.
- Dev-host and standalone TypeScript checks passed.
- Release JS build, formatting, `moon info`, whitespace checks, and independent review passed.

## PR-ready evidence

Validated HEAD: `ff4d242631a4bf07d2f33cb380d5a385e0b9643c`

Validated base: `origin/main@23bbea242ff308758d6cdc462df14766ec3e3bb0`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh \
  --target apps/loomark/internal/rabbita \
  --target apps/loomark/internal/dev_host
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for the exact HEAD and base above.
- [x] The base was fetched again and `--verify-evidence` passed immediately before opening this PR.
- [x] The committed `.mbti` diff against the validated base was reviewed for unintended API or trait-bound changes.
- [x] No submodule commit changed.
- [x] Validation was rerun after the commit and generated-interface changes.
- [x] Independent review findings were resolved; no Critical or Warning findings remained.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Canceled native input events no longer modify document content.
  - Improved handling of edits made during active rendering, including mid-document changes and caret positioning.
  - Composition input now remains consistent when editing modes change.
  - Improved reliability for rapid input and composition interactions, reducing timing-related inconsistencies.

- **Tests**
  - Expanded coverage for canceled edits, in-progress input, caret ordering, composition changes, and deferred rendering scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->