### PR TITLE
fix(loomark): preserve same-character Raw insertion

### DIFF
--- a/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
+++ b/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
@@ -2013,6 +2013,145 @@ test("Raw input retains the first backward selection and latest native caret", a
   }
 })
 
+test("Raw input preserves same-character insertion at the trusted caret", async ({ browser }) => {
+  const host = await mountHost(browser, "x")
+  try {
+    const input = host.page.locator("#loomark-input")
+    await input.focus()
+    await input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.setSelectionRange(0, 0)
+    })
+
+    await host.page.keyboard.type("x")
+
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("xx")
+    expect(await snapshot(host.page)).toMatchObject({
+      source: "xx",
+      committed_change_count: 1,
+      error_code: null,
+    })
+    await expect(input).toHaveValue("xx")
+    await expect(input).toBeFocused()
+    await expect.poll(() => input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      return `${textarea.selectionStart}:${textarea.selectionEnd}`
+    })).toBe("1:1")
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("failed same-character Raw insertion restores canonical text and caret", async ({ browser }) => {
+  const host = await mountHost(browser, "x")
+  try {
+    const input = host.page.locator("#loomark-input")
+    await input.focus()
+    await input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.setSelectionRange(0, 0)
+    })
+    await forceEditorFailure(host.page)
+    await expect.poll(async () => (await snapshot(host.page)).editor_failure_armed).toBe(true)
+
+    await host.page.keyboard.type("x")
+
+    await expect.poll(async () => (await snapshot(host.page)).error_code)
+      .toBe("editor-commit-failed")
+    expect(await snapshot(host.page)).toMatchObject({
+      source: "x",
+      committed_change_count: 0,
+      error_code: "editor-commit-failed",
+    })
+    await expect(input).toHaveValue("x")
+    await expect(input).toBeFocused()
+    await expect.poll(() => input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      return `${textarea.selectionStart}:${textarea.selectionEnd}`
+    })).toBe("0:0")
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("Raw input preserves same-character insertion in the middle", async ({ browser }) => {
+  const host = await mountHost(browser, "aba")
+  try {
+    const input = host.page.locator("#loomark-input")
+    await input.focus()
+    await input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.setSelectionRange(2, 2)
+    })
+
+    await host.page.keyboard.type("a")
+
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("abaa")
+    expect(await snapshot(host.page)).toMatchObject({
+      source: "abaa",
+      committed_change_count: 1,
+      error_code: null,
+    })
+    await expect(input).toHaveValue("abaa")
+    await expect(input).toBeFocused()
+    await expect.poll(() => input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      return `${textarea.selectionStart}:${textarea.selectionEnd}`
+    })).toBe("3:3")
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("Raw input coalesces same-character and mixed prefix input once", async ({ browser }) => {
+  const host = await mountHost(browser, "x")
+  try {
+    const input = host.page.locator("#loomark-input")
+    await input.focus()
+    await dispatchRawNativeEdits(input, [
+      {
+        value: "xx",
+        beforeStart: 0,
+        beforeEnd: 0,
+        afterStart: 1,
+        afterEnd: 1,
+        data: "x",
+      },
+      {
+        value: "xxx",
+        beforeStart: 1,
+        beforeEnd: 1,
+        afterStart: 2,
+        afterEnd: 2,
+        data: "x",
+      },
+      {
+        value: "xxyx",
+        beforeStart: 2,
+        beforeEnd: 2,
+        afterStart: 3,
+        afterEnd: 3,
+        data: "y",
+      },
+    ])
+
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("xxyx")
+    expect(await snapshot(host.page)).toMatchObject({
+      source: "xxyx",
+      committed_change_count: 1,
+      error_code: null,
+    })
+    await expect(input).toHaveValue("xxyx")
+    await expect(input).toBeFocused()
+    await expect.poll(() => input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      return `${textarea.selectionStart}:${textarea.selectionEnd}`
+    })).toBe("3:3")
+  } finally {
+    await host.context.close()
+  }
+})
+
 test("Raw input coalesces a same-task burst into one commit", async ({ browser }) => {
   const host = await mountHost(browser, "start")
   try {
@@ -2412,6 +2551,48 @@ test("Raw IME composition commits the accepted final value once", async ({ brows
       error_code: null,
     })
     await expect(input).toHaveValue("start漢字")
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("Raw IME composition preserves same-character final placement", async ({ browser }) => {
+  const host = await mountHost(browser, "漢")
+  try {
+    const input = host.page.locator("#loomark-input")
+    await input.focus()
+    await input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.setSelectionRange(0, 0)
+    })
+    const session = await host.context.newCDPSession(host.page)
+
+    await session.send("Input.imeSetComposition", {
+      text: "かん",
+      selectionStart: 2,
+      selectionEnd: 2,
+    })
+    await expect(input).toHaveValue("かん漢")
+    expect(await snapshot(host.page)).toMatchObject({
+      source: "漢",
+      committed_change_count: 0,
+      error_code: null,
+    })
+
+    await session.send("Input.insertText", { text: "漢" })
+
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("漢漢")
+    expect(await snapshot(host.page)).toMatchObject({
+      source: "漢漢",
+      committed_change_count: 1,
+      error_code: null,
+    })
+    await expect(input).toHaveValue("漢漢")
+    await expect(input).toBeFocused()
+    await expect.poll(() => input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      return `${textarea.selectionStart}:${textarea.selectionEnd}`
+    })).toBe("1:1")
   } finally {
     await host.context.close()
   }

--- a/apps/loomark/internal/rabbita/raw_input_frontier_wbtest.mbt
+++ b/apps/loomark/internal/rabbita/raw_input_frontier_wbtest.mbt
@@ -10,11 +10,17 @@ test "Raw frontier reducer keeps deferred input ahead of the active delivery" {
     RawInputFrontierEvent::CaptureDeferredBeforeInput({
       base_source: "startX",
       input_type: "insertText",
+      selection: @dom_boundary.TextSelection(6, 6, @dom_boundary.NoDirection),
     }),
   )
   let deferred = {
     base_source: "startX",
     input_type: "insertText",
+    before_input_selection: @dom_boundary.TextSelection(
+      6,
+      6,
+      @dom_boundary.NoDirection,
+    ),
     source: "startXY",
     post_input_selection: @dom_boundary.TextSelection(
       7,
@@ -49,6 +55,11 @@ test "Raw frontier reducer keeps composition behind the active delivery" {
     RawInputFrontierEvent::BeginDeferredComposition({
       base_source: "startX",
       input_type: "insertCompositionText",
+      before_input_selection: @dom_boundary.TextSelection(
+        6,
+        6,
+        @dom_boundary.NoDirection,
+      ),
       source: "startX",
       post_input_selection: @dom_boundary.TextSelection(
         6,
@@ -91,6 +102,7 @@ test "Raw frontier reducer rejects capture without an active delivery" {
     RawInputFrontierEvent::CaptureDeferredBeforeInput({
       base_source: "start",
       input_type: "insertText",
+      selection: @dom_boundary.TextSelection(5, 5, @dom_boundary.NoDirection),
     }),
   )
   assert_true(next.deferred_before_input is None)
@@ -143,6 +155,7 @@ test "Raw frontier reducer cancellation clears deferred and active state" {
     RawInputFrontierEvent::CaptureDeferredBeforeInput({
       base_source: "startX",
       input_type: "insertText",
+      selection: @dom_boundary.TextSelection(6, 6, @dom_boundary.NoDirection),
     }),
   )
   let canceled = reduce_raw_input_frontier(

--- a/apps/loomark/internal/rabbita/raw_selection_transaction.mbt
+++ b/apps/loomark/internal/rabbita/raw_selection_transaction.mbt
@@ -78,6 +78,7 @@ fn RawNativeInputCandidate::authorized(
 priv struct DeferredRawInput {
   base_source : String
   input_type : String
+  before_input_selection : @dom_boundary.TextSelection
   source : String
   post_input_selection : @dom_boundary.TextSelection
   input_count : Int
@@ -88,6 +89,7 @@ priv struct DeferredRawInput {
 priv struct DeferredRawInputCapture {
   base_source : String
   input_type : String
+  selection : @dom_boundary.TextSelection
 }
 
 ///|
@@ -319,11 +321,21 @@ fn normalize_raw_input_candidate(
       .to_owned()
     (dom_selection.start(), dom_selection.end(), inserted)
   } else {
-    let change = @text_change.compute_text_change(old_value, latest_value)
-    let old_end = change.start + change.delete_len
     let caret = dom_selection.start()
-    guard change.start <= caret && caret <= old_end else { return None }
-    (change.start, old_end, change.inserted)
+    let prefix = old_value.sub(end=caret)
+    let suffix = old_value.sub(start=caret)
+    let inserted_end = latest_value.length() - suffix.length()
+    if latest_value.has_prefix(prefix) &&
+      latest_value.has_suffix(suffix) &&
+      inserted_end > caret {
+      let inserted = latest_value.sub(start=caret, end=inserted_end).to_owned()
+      (caret, caret, inserted)
+    } else {
+      let change = @text_change.compute_text_change(old_value, latest_value)
+      let old_end = change.start + change.delete_len
+      guard change.start <= caret && caret <= old_end else { return None }
+      (change.start, old_end, change.inserted)
+    }
   }
   guard post_offset == change_start + inserted.length() else { return None }
   let request_selection = if !selection.is_collapsed() {
@@ -363,18 +375,9 @@ fn rebase_deferred_raw_input(
   model : DriverModel,
   deferred : DeferredRawInput,
 ) -> RawBeforeInputCandidate? {
-  let old_source = model.document.source()
-  let old_value = raw_textarea_value(old_source)
-  let latest_value = raw_textarea_value(deferred.source)
-  let change = @text_change.compute_text_change(old_value, latest_value)
-  let start = match raw_source_offset_from_dom(old_source, change.start) {
-    Some(offset) => offset
-    None => return None
-  }
-  let selection = @markdown.MarkdownDocumentUtf16Selection(
+  let selection = markdown_document_utf16_selection_from_dom(
     model.document,
-    anchor=start,
-    head=start,
+    deferred.before_input_selection,
   ) catch {
     _ => return None
   }

--- a/apps/loomark/internal/rabbita/raw_selection_transaction_wbtest.mbt
+++ b/apps/loomark/internal/rabbita/raw_selection_transaction_wbtest.mbt
@@ -126,6 +126,119 @@ test "native Raw pairing accepts two collapsed insertions as one change" {
 }
 
 ///|
+test "native Raw pairing preserves same-character insertion at trusted caret" {
+  let context = RawSelectionTestContext::RawSelectionTestContext(
+    "raw-native-same-character-insertion", "x",
+  )
+  let candidate = RawNativeInputCandidate::RawNativeInputCandidate(
+    before_input=RawBeforeInputCandidate::RawBeforeInputCandidate(
+      selection=context.selection(0, 0),
+      input_type="insertText",
+      is_composing=false,
+    ),
+    source="xx",
+    post_input_selection=@dom_boundary.TextSelection(
+      1,
+      1,
+      @dom_boundary.NoDirection,
+    ),
+  )
+  guard normalize_raw_input_candidate(context.model, candidate) is Some(request) else {
+    abort("same-character insertion must use the trusted native caret")
+  }
+  assert_eq(request.selection.selection.anchor(), 0)
+  assert_eq(request.selection.selection.head(), 0)
+  assert_eq(request.inserted, "x")
+}
+
+///|
+test "native Raw pairing keeps trusted placement for ambiguous insertion bursts" {
+  for
+    case in [
+      ("raw-native-identical-middle", "aba", 2, "abaa", 3, "a"),
+      ("raw-native-identical-prefix-burst", "x", 0, "xxxx", 3, "xxx"),
+      ("raw-native-mixed-prefix-burst", "x", 0, "xxyx", 3, "xxy"),
+      ("raw-native-identical-emoji", "😀", 0, "😀😀", 2, "😀"),
+      (
+        "raw-native-identical-zwj", "👨‍👩‍👧‍👦", 0, "👨‍👩‍👧‍👦👨‍👩‍👧‍👦",
+        11, "👨‍👩‍👧‍👦",
+      ),
+      (
+        "raw-native-identical-flag", "🇯🇵", 0, "🇯🇵🇯🇵", 4, "🇯🇵",
+      ),
+    ] {
+    let (agent_id, source, caret, native_source, post_caret, inserted) = case
+    let context = RawSelectionTestContext::RawSelectionTestContext(
+      agent_id, source,
+    )
+    let candidate = RawNativeInputCandidate::RawNativeInputCandidate(
+      before_input=RawBeforeInputCandidate::RawBeforeInputCandidate(
+        selection=context.selection(caret, caret),
+        input_type="insertText",
+        is_composing=false,
+      ),
+      source=native_source,
+      post_input_selection=@dom_boundary.TextSelection(
+        post_caret,
+        post_caret,
+        @dom_boundary.NoDirection,
+      ),
+    )
+    guard normalize_raw_input_candidate(context.model, candidate)
+      is Some(request) else {
+      abort("ambiguous insertion burst must use its trusted native caret")
+    }
+    assert_eq(request.selection.selection.anchor(), caret)
+    assert_eq(request.selection.selection.head(), caret)
+    assert_eq(request.inserted, inserted)
+  }
+}
+
+///|
+test "deferred Raw rebase preserves trusted same-character placement" {
+  let context = RawSelectionTestContext::RawSelectionTestContext(
+    "raw-deferred-same-character-insertion", "xx",
+  )
+  let deferred : DeferredRawInput = {
+    base_source: "xx",
+    input_type: "insertText",
+    before_input_selection: @dom_boundary.TextSelection(
+      1,
+      1,
+      @dom_boundary.NoDirection,
+    ),
+    source: "xxx",
+    post_input_selection: @dom_boundary.TextSelection(
+      2,
+      2,
+      @dom_boundary.NoDirection,
+    ),
+    input_count: 1,
+  }
+  guard rebase_deferred_raw_input(context.model, deferred) is Some(before_input) else {
+    abort("deferred input must rebase from its trusted beforeinput selection")
+  }
+  assert_eq(before_input.selection.document_id, context.model.document_id)
+  assert_eq(before_input.selection.version, context.model.document_version)
+  assert_eq(before_input.selection.selection.anchor(), 1)
+  assert_eq(before_input.selection.selection.head(), 1)
+
+  let candidate = RawNativeInputCandidate::authorized(
+    before_input~,
+    source=deferred.source,
+    post_input_selection=deferred.post_input_selection,
+  )
+  guard normalize_raw_input_candidate(context.model, candidate) is Some(request) else {
+    abort(
+      "deferred same-character insertion must normalize at its trusted caret",
+    )
+  }
+  assert_eq(request.selection.selection.anchor(), 1)
+  assert_eq(request.selection.selection.head(), 1)
+  assert_eq(request.inserted, "x")
+}
+
+///|
 test "native Raw pairing normalizes a ten-character collapsed burst" {
   let context = RawSelectionTestContext::RawSelectionTestContext(
     "raw-native-collapsed-burst", "start",

--- a/apps/loomark/internal/rabbita/text_control_repair.mbt
+++ b/apps/loomark/internal/rabbita/text_control_repair.mbt
@@ -328,18 +328,21 @@ fn RawInputCoordinator::begin_native_composition(
   if self.has_active_delivery() {
     let frontier = self.frontier.val
     self.deferred_composition_finished.val = false
-    let (base_source, frontier_source) = match frontier.deferred {
-      Some(deferred) => (deferred.base_source, deferred.source)
+    let (base_source, frontier_source, before_input_selection) = match
+      frontier.deferred {
+      Some(deferred) =>
+        (deferred.base_source, deferred.source, deferred.before_input_selection)
       None =>
         match frontier.in_flight {
-          Some(delivery) => (delivery.source, delivery.source)
-          None => (model.document.source(), model.document.source())
+          Some(delivery) => (delivery.source, delivery.source, selection)
+          None => (model.document.source(), model.document.source(), selection)
         }
     }
     self.reduce_frontier(
       RawInputFrontierEvent::BeginDeferredComposition({
         base_source,
         input_type: "insertCompositionText",
+        before_input_selection,
         source: raw_textarea_value(frontier_source),
         post_input_selection: selection,
         input_count: 0,
@@ -507,6 +510,14 @@ fn RawInputCoordinator::capture_deferred_before_input(
   model : DriverModel,
   event : @dom.InputEvent,
 ) -> @cmd.Cmd {
+  let selection = match read_raw_selection() {
+    Some(selection) => selection
+    None => {
+      self.capture_generation.val += 1
+      self.reduce_frontier(RawInputFrontierEvent::ClearDeferredCapture)
+      return @rabbita_runtime.none
+    }
+  }
   let base_source = match self.frontier.val.deferred {
     Some(deferred) => deferred.base_source
     None =>
@@ -520,6 +531,7 @@ fn RawInputCoordinator::capture_deferred_before_input(
     RawInputFrontierEvent::CaptureDeferredBeforeInput({
       base_source,
       input_type: raw_input_event_type(event),
+      selection,
     }),
   )
   @rabbita_runtime.none
@@ -706,19 +718,25 @@ fn RawInputCoordinator::defer_native_input(
     None => return false
   }
   let existing = frontier.deferred
-  let base_source = capture.base_source
-  let input_type = capture.input_type
+  let (base_source, input_type, before_input_selection, input_count) = match
+    existing {
+    Some(deferred) =>
+      (
+        deferred.base_source,
+        deferred.input_type,
+        deferred.before_input_selection,
+        deferred.input_count + 1,
+      )
+    None => (capture.base_source, capture.input_type, capture.selection, 1)
+  }
   self.capture_generation.val += 1
   self.unmatched_before_input.val = None
   let source = raw_textarea_value(source)
-  let input_count = match existing {
-    Some(deferred) => deferred.input_count + 1
-    None => 1
-  }
   self.reduce_frontier(
     RawInputFrontierEvent::StoreDeferred({
       base_source,
       input_type,
+      before_input_selection,
       source,
       post_input_selection,
       input_count,

--- a/apps/loomark/internal/rabbita/text_control_repair_wbtest.mbt
+++ b/apps/loomark/internal/rabbita/text_control_repair_wbtest.mbt
@@ -394,6 +394,109 @@ test "Raw coordinator keeps an active delivery for unpaired input" {
 }
 
 ///|
+test "Raw coordinator keeps the first deferred selection and latest native value" {
+  let coordinator = RawInputCoordinator::RawInputCoordinator(None)
+  coordinator.reduce_frontier(
+    RawInputFrontierEvent::BeginDelivery({ token: 1, source: "xx" }),
+  )
+  coordinator.reduce_frontier(
+    RawInputFrontierEvent::CaptureDeferredBeforeInput({
+      base_source: "xx",
+      input_type: "insertText",
+      selection: @dom_boundary.TextSelection(1, 1, @dom_boundary.NoDirection),
+    }),
+  )
+  assert_true(
+    coordinator.defer_native_input(
+      "xxx",
+      @dom_boundary.TextSelection(2, 2, @dom_boundary.NoDirection),
+    ),
+  )
+  coordinator.reduce_frontier(
+    RawInputFrontierEvent::CaptureDeferredBeforeInput({
+      base_source: "xx",
+      input_type: "insertFromPaste",
+      selection: @dom_boundary.TextSelection(2, 2, @dom_boundary.NoDirection),
+    }),
+  )
+  assert_true(
+    coordinator.defer_native_input(
+      "xxyx",
+      @dom_boundary.TextSelection(3, 3, @dom_boundary.NoDirection),
+    ),
+  )
+
+  guard coordinator.frontier.val.deferred is Some(deferred) else {
+    fail("paired native input must remain deferred")
+  }
+  assert_eq(deferred.input_type, "insertText")
+  assert_eq(deferred.before_input_selection.start(), 1)
+  assert_eq(deferred.before_input_selection.end(), 1)
+  assert_eq(deferred.source, "xxyx")
+  assert_eq(deferred.post_input_selection.start(), 3)
+  assert_eq(deferred.input_count, 2)
+}
+
+///|
+test "deferred Raw composition keeps the first ordinary input selection" {
+  let context = RawSelectionTestContext::RawSelectionTestContext(
+    "raw-deferred-composition-selection", "xx",
+  )
+  let coordinator = RawInputCoordinator::RawInputCoordinator(None)
+  coordinator.reduce_frontier(
+    RawInputFrontierEvent::BeginDelivery({ token: 1, source: "xx" }),
+  )
+  coordinator.reduce_frontier(
+    RawInputFrontierEvent::CaptureDeferredBeforeInput({
+      base_source: "xx",
+      input_type: "insertText",
+      selection: @dom_boundary.TextSelection(1, 1, @dom_boundary.NoDirection),
+    }),
+  )
+  assert_true(
+    coordinator.defer_native_input(
+      "xxx",
+      @dom_boundary.TextSelection(2, 2, @dom_boundary.NoDirection),
+    ),
+  )
+  assert_true(
+    coordinator.begin_native_composition(
+      context.model,
+      "xxx",
+      @dom_boundary.TextSelection(2, 2, @dom_boundary.NoDirection),
+    ),
+  )
+  assert_true(
+    coordinator.update_composition(
+      "xxyx",
+      @dom_boundary.TextSelection(3, 3, @dom_boundary.NoDirection),
+    ),
+  )
+
+  guard coordinator.frontier.val.deferred_composition is Some(composition) else {
+    fail("composition must replace the ordinary deferred frontier")
+  }
+  assert_true(coordinator.frontier.val.deferred is None)
+  assert_eq(composition.before_input_selection.start(), 1)
+  assert_eq(composition.before_input_selection.end(), 1)
+  guard rebase_deferred_raw_input(context.model, composition)
+    is Some(before_input) else {
+    fail("deferred composition must rebase from the ordinary input selection")
+  }
+  let candidate = RawNativeInputCandidate::authorized(
+    before_input~,
+    source=composition.source,
+    post_input_selection=composition.post_input_selection,
+  )
+  guard normalize_raw_input_candidate(context.model, candidate) is Some(request) else {
+    fail("rebased deferred composition must normalize")
+  }
+  assert_eq(request.selection.selection.anchor(), 1)
+  assert_eq(request.selection.selection.head(), 1)
+  assert_eq(request.inserted, "xy")
+}
+
+///|
 test "Raw coordinator clears a canceled deferred capture before rebase" {
   let context = RawSelectionTestContext::RawSelectionTestContext(
     "coordinator-deferred-cancel", "startX",
@@ -406,12 +509,18 @@ test "Raw coordinator clears a canceled deferred capture before rebase" {
     RawInputFrontierEvent::CaptureDeferredBeforeInput({
       base_source: "startX",
       input_type: "insertText",
+      selection: @dom_boundary.TextSelection(6, 6, @dom_boundary.NoDirection),
     }),
   )
   coordinator.reduce_frontier(
     RawInputFrontierEvent::StoreDeferred({
       base_source: "startX",
       input_type: "insertText",
+      before_input_selection: @dom_boundary.TextSelection(
+        6,
+        6,
+        @dom_boundary.NoDirection,
+      ),
       source: "startXY",
       post_input_selection: @dom_boundary.TextSelection(
         7,


### PR DESCRIPTION
## Summary

- resolve ambiguous same-character insertion placement from the first trusted `beforeinput` selection instead of the arbitrary placement selected by a whole-value diff
- retain the first trusted selection while aggregating the latest textarea value and caret across ordinary, in-flight, and deferred-composition input
- keep mixed/deletion fallback, snapshot revalidation, guarded DOM repair, the 50 ms trailing window, and applied-edit reconciliation unchanged

Closes #1224.

## UI and review evidence

N/A — no visual or interaction-design changes. Browser tests exercise the existing textarea interaction, focus, caret, canonical source, history count, and failure repair.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `normalize_raw_input_candidate` and `RawNativeInputCandidate::authorized` | `apps/loomark/internal/rabbita/raw_selection_transaction.mbt` | Yes | Existing normalization and authorization boundary remains the only Raw commit entry. |
| `markdown_document_utf16_selection_from_dom` / `raw_source_offset_from_dom` | `apps/loomark/internal/rabbita/raw_selection_transaction.mbt` | Yes | Preserve textarea-LF to canonical LF/CRLF/CR conversion and snapshot-bound selection construction. |
| `@text_change.compute_text_change` | `deps/loom/text-change/text_change.mbt` | Yes | Retained as the fallback for deletion, replacement, and mixed bursts; only unambiguous collapsed insertion uses the trusted caret. |
| `String::sub`, `String::has_prefix`, `String::has_suffix` | MoonBit core `String` API | Yes | Validate the native value around the trusted caret without adding a manual loop or copying through an intermediate collection. |
| `StringView`, `Array`, `Iter`, `Map`, `Set`, `Bytes`/`BytesView`, `Buffer`/`StringBuilder`, `cmp`/`math` | MoonBit core | No | The operation is two direct substring boundary checks on an owning `String`; collection, byte, builder, and ordering APIs do not fit the data shape. |
| `Option` and pattern matching | MoonBit core | Yes | Existing fallible DOM/source conversion and normalization continue to reject invalid boundaries without mutation. |

New helpers added (if any):

None. The change adds private selection fields to the existing deferred capture/input records; no public type, helper, or API was introduced. Existing reducer-owned `Ref` state remains the imperative browser shell.

## Validation scope

Boundary matrix / first failing regression:

- First red case: canonical `x`, trusted collapsed selection `0:0`, native value `xx`, post-input caret `1:1`; the old whole-value diff selected offset 1 and normalization rejected the edit.
- Prefix and middle identical-character insertion; same-character and mixed same-task bursts.
- Deferred input and deferred composition retain the first trusted selection while taking the latest native value/caret.
- LF, CRLF, lone CR, EOF, emoji, ZWJ sequences, regional indicators, invalid grapheme boundaries, and IME finalization.
- Stale/wrong-document/mode-stale snapshots, missing `beforeinput`, commit failure, no retry, guarded text/caret repair, focus, and history count.

Target packages:

- `apps/loomark/internal/rabbita`

Additional conditional gates:

- `moon check --deny-warn apps/loomark/internal/rabbita`
- `moon test --target js --release apps/loomark/internal/rabbita` — 112/112
- `./scripts/test-loomark-dev-host-e2e.sh` — 120/120
- `./scripts/test-loomark-standalone-e2e.sh` — 13/13
- independent `moonbit-reviewer` review — PASS after replacing a timing-dependent proposed test with deterministic deferred-composition coverage
- `moon fmt && moon info`; committed `.mbti` diff is empty

## PR-ready evidence

Validated HEAD: `50ec674717e067e3f46a2160c5bdc7c59c61edd0`

Validated base: `origin/main@23bbea242ff308758d6cdc462df14766ec3e3bb0`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh \
  --target apps/loomark/internal/rabbita
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for the exact HEAD and base above.
- [x] The base was fetched again and `--verify-evidence` passed immediately before this PR was opened, updated, or merged.
- [x] The committed `.mbti` diff against the validated base was reviewed for unintended API or trait-bound changes.
- [x] Any changed submodule commit is pushed and reachable from its remote. (No submodule pointer changed.)
- [x] Validation was rerun after every commit, amend, rebase, cherry-pick, submodule-pointer, manifest, or generated-interface change.
- [x] Independent review findings were resolved before the final validation.
