### PR TITLE
docs: define Markdown persistence authority

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -9,7 +9,7 @@ The Loomark-owned Markdown entity whose identity and causal history continue acr
 _Avoid_: Loomark document, logical document, file, buffer, session
 
 **Detached Editing Document**:
-An Editing Document with no active Writing instance lease. It retains causal state independently of an editor runtime and remains owned by the persistence shell until File durability or explicit recovery permits release.
+An Editing Document with no active Writing instance lease. It retains causal state independently of an editor runtime and remains owned by the persistence shell until the appropriate durability condition permits release — File durability for File-backed persistence, or acknowledged archive Local durability for Archive-backed persistence — or until explicit recovery permits release.
 _Avoid_: Closed file, snapshot, editor session
 
 **Persistence Coordinator**:
@@ -41,7 +41,7 @@ The human-readable `.md` file associated with an Editing Document for Git and ex
 _Avoid_: Save file, archive, document, exported copy
 
 **Archive-backed persistence**:
-A persistence capability in which no Markdown body file is associated with the Editing Document. The application-owned archive retains durable content and Metadata preserves the Causal Authority; exported Markdown remains an unassociated copy.
+A persistence capability in which no Markdown body file is associated with the Editing Document. One atomic application-owned archive replacement retains portable content and causal Metadata together; exported Markdown remains an unassociated copy.
 _Avoid_: Browser mode, File-backed persistence, temporary session
 
 **File-backed persistence**:
@@ -117,7 +117,7 @@ An explicit resolution of Missing file state or Committed pending file that writ
 _Avoid_: Save As, Duplicate, import
 
 **External file change**:
-A change to a Markdown body file made through Git, including branch checkout, or an external editor. Line-terminator conversion, final-newline changes, Unicode normalization, and visible whitespace changes are content changes; only a BOM-only change belongs to the File encoding profile. Loomark admits an external change automatically only when its current content equals the File baseline and no External concurrency uncertainty is active.
+A change to a Markdown body file made through Git, including branch checkout, or an external editor. Line-terminator conversion, final-newline changes, Unicode normalization, and visible whitespace changes are content changes; only a BOM-only change belongs to the File encoding profile. Loomark admits an external change automatically only when Loomark's accepted current content equals the File baseline and no External concurrency uncertainty is active.
 _Avoid_: Content conflict, remote edit, archive replacement
 
 **Observed external variant**:
@@ -125,7 +125,7 @@ The exact Markdown body file content successfully read by Loomark at an external
 _Avoid_: Watcher event, inferred version, filesystem history
 
 **External admission**:
-The deterministic bounded multi-span conversion of an admitted external file's final text, relative to the File baseline, into inferred causal edits that preserve unchanged spans and produce the exact external source. UTF-16 validation, a resource budget, and exact replay verification are mandatory; exceeding the budget falls back to one contiguous replacement. Admission preserves the Editing Document identity but never claims to recover the external editor's original operations or intent.
+The deterministic bounded multi-span conversion of an admitted external file's final text, relative to the File baseline, into inferred causal edits that preserve unchanged spans and produce the exact external source. UTF-16 validation, a resource budget, and exact replay verification are mandatory; exceeding the budget falls back to one contiguous replacement, which must also satisfy receiver admission limits before any mutation. If no inferred batch — including the contiguous-replacement fallback — fits within receiver admission limits, apply nothing, preserve the Observed external variant, and enter Content conflict. Admission preserves the Editing Document identity but never claims to recover the external editor's original operations or intent.
 _Avoid_: Import, whole-source replacement, exact operation reconstruction
 
 **Coordinator writer**:
@@ -169,7 +169,7 @@ A content-free, short-lived application record containing only an opaque documen
 _Avoid_: Metadata archive, recovery record, permanent tombstone
 
 **Content conflict**:
-The condition in which Loomark content and an Observed external variant both diverge from the same File baseline, or External concurrency uncertainty prevents proving that the external writer observed the Loomark variant. Every observed variant remains recoverable until deliberate resolution; none may be discarded by silent overwrite.
+The condition in which Loomark content and an Observed external variant both diverge from the same File baseline, External concurrency uncertainty prevents proving that the external writer observed the Loomark variant, or an otherwise eligible Observed external variant cannot be admitted atomically under UTF-16 validation, receiver admission limits, and exact replay. Every observed variant remains recoverable until deliberate resolution; none may be discarded by silent overwrite.
 _Avoid_: External file change, CRDT conflict, last-write-wins
 
 **Conflict state**:
@@ -189,7 +189,7 @@ The durable pre-publication record that preserves the Publication token, both co
 _Avoid_: Resolution transaction, Metadata durability, Applied, Autosave
 
 **Prepared resolution recovery**:
-The reopen classification that compares a Prepared resolution record, a Publication ledger entry bound to durable main history, and the current Markdown body file. Without durable commit evidence, matching candidate content may reconstruct the Resolution transaction; with ledger evidence, main mutation is never retried; unexpected file content becomes an Observed external variant and requires revalidation or a new Content conflict.
+The reopen classification that compares a Prepared resolution record, a Publication ledger entry bound to durable main history, and the current Markdown body file. Without ledger evidence, matching prepared or candidate content cannot prove whether main mutation was accepted; Loomark preserves the prepared state and requires reconciliation rather than reconstructing, retrying, or canceling the main mutation without durable idempotency evidence. With ledger evidence, main mutation is never retried; unexpected file content becomes an Observed external variant and requires revalidation or a new Content conflict.
 _Avoid_: Blind retry, archive restore, file overwrite
 
 **Resolution draft**:
@@ -229,7 +229,7 @@ The result when `Mark Reviewed` finds that the Markdown body file changed after 
 _Avoid_: Rejected edit, Content conflict, discarded review
 
 **Recovery Markdown file**:
-A human-readable content-only `.md` fallback containing the Loomark variant when normal file and Metadata durability cannot preserve it. It never claims to preserve Editing Document or draft identity, operation IDs, writer identities, causal frontier, collaborative undo, or Publication state. Loomark creates it without replacement under a unique name beside the Markdown body file, falls back to a user-chosen location when that directory is unwritable, and withholds close until recovery succeeds or the user explicitly discards the changes.
+A human-readable content-only `.md` fallback containing the Loomark variant when normal content and Metadata durability cannot preserve it. It never claims to preserve Editing Document or draft identity, operation IDs, writer identities, causal frontier, collaborative undo, or Publication state. In File-backed persistence, Loomark creates it without replacement under a unique name beside the Markdown body file and falls back to a user-chosen location when that directory is unwritable. In Archive-backed persistence, which has no body-file directory, Loomark requires a user-chosen location and unique name. Loomark withholds close until recovery succeeds or the user explicitly discards the changes.
 _Avoid_: Metadata, archive, causal recovery, backup, Autosave target
 
 **Close with content recovery**:
@@ -293,15 +293,15 @@ Confirmation that the Aggregate Markdown runtime causally applied the accepted w
 _Avoid_: Commit receipt, Repository acknowledgment, Saved status
 
 **Saving status**:
-The user-facing status after Aggregate acknowledgment while required Autosave or Metadata work remains incomplete. Aggregate synchronization never waits for the Autosave debounce.
+The user-facing status after Aggregate acknowledgment while required persistence work remains incomplete — Autosave file writes and Metadata work for File-backed persistence, or one atomic archive replacement for Archive-backed persistence. Aggregate synchronization never waits for the Autosave debounce.
 _Avoid_: Applied locally, Saved status, replicated
 
 **Saved status**:
-The user-facing confirmation of File durability. File durability keeps this status active when Metadata durability fails; Loomark separately warns that editing history was not preserved.
+The user-facing confirmation that content is durable — through File durability for File-backed persistence, or acknowledged archive Local durability for Archive-backed persistence. In File-backed mode, this status remains active when Metadata durability fails and Loomark separately warns that editing history was not preserved. Archive-backed mode reaches this status only when one atomic archive replacement durably carries both content and causal Metadata.
 _Avoid_: Metadata durability, repository acknowledgment, fully saved
 
 **Autosave**:
-The automatic persistence triggered by an accepted causal change. A source-changing commit establishes File durability before Metadata durability; a source-equal history change updates Metadata without rewriting an unchanged Markdown body file.
+The automatic persistence triggered by an accepted causal change. In File-backed persistence, a source-changing commit establishes File durability before Metadata durability; a source-equal history change updates Metadata without rewriting an unchanged Markdown body file. In Archive-backed persistence, one atomic archive replacement carries the accepted portable content and causal Metadata; acknowledgment establishes Local durability and Metadata durability together, without a Markdown body file or External change observation.
 _Avoid_: Repository acknowledgment, periodic backup, history no-op
 
 **Self-write acknowledgment**:
@@ -309,7 +309,7 @@ Recognition that an observed file change exactly matches one expected Autosave g
 _Avoid_: External admission, watcher timeout, ignored file event
 
 **External change observation**:
-The reread and fingerprint comparison that establishes an Observed external variant. A watcher reduces detection latency but never supplies correctness; observation is mandatory on focus or resume and immediately before Autosave, Causal seal, and `Mark Reviewed`, and a mismatch stops the pending write or seal.
+The reread and fingerprint comparison that establishes an Observed external variant. This applies only to File-backed persistence, which has a Markdown body file to observe; Archive-backed persistence has no body file and does not perform file observation. A watcher reduces detection latency but never supplies correctness; in File-backed mode, observation is mandatory on focus or resume and immediately before Autosave, Causal seal, and `Mark Reviewed`, and a mismatch stops the pending write or seal.
 _Avoid_: Watcher event, polling guarantee, cached stat
 
 **History-changing commit**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -49,7 +49,7 @@ A persistence capability with a continuing File association to a Markdown body f
 _Avoid_: Desktop mode, Archive-backed persistence, downloaded file
 
 **Safe file replacement**:
-The adapter capability required for writable File-backed persistence. Replacement never exposes partial content, preserves the original on failure, safely targets resolved symbolic links, supports exact readback for Self-write acknowledgment, and retains required file permissions. Without it, Loomark limits the association to read-only access and offers Archive-backed editing, Export Markdown, or Choose New Location.
+The adapter capability required for writable File-backed persistence. Replacement never exposes partial content, preserves the original on failure, safely targets resolved symbolic links, supports exact readback for Self-write acknowledgment, and retains required file permissions. It does not claim a portable compare-and-replace primitive against uncooperative external processes; the Observed external variant guarantee defines that limit. Without Safe file replacement, Loomark limits the association to read-only access and offers Archive-backed editing, Export Markdown, or Choose New Location.
 _Avoid_: Writable handle, in-place truncation, best-effort save
 
 **Export Markdown**:
@@ -133,7 +133,7 @@ The stable synthetic replica identity used by the Aggregate Markdown runtime to 
 _Avoid_: Writing instance, user identity, operation category, external editor identity
 
 **External admission transaction**:
-The atomic optimistic application of one inferred External admission batch against its expected causal version and File baseline. A match applies every inferred edit exactly once under the Coordinator writer and records one application-level undo group; a mismatch applies none, preserves the Observed external variant, and enters Content conflict without re-diffing against the newer Loomark source.
+The atomic optimistic application of one inferred External admission batch. Before mutation, Loomark validates its expected causal version, File baseline, and Observed external variant fingerprint. A match applies every inferred edit exactly once under the Coordinator writer and records one application-level undo group; a mismatch applies none, preserves every Observed external variant, and enters Content conflict without re-diffing against the newer Loomark source.
 _Avoid_: Automatic rebase, partial admission, structural commit
 
 **External admission undo**:
@@ -309,7 +309,7 @@ Recognition that an observed file change exactly matches one expected Autosave g
 _Avoid_: External admission, watcher timeout, ignored file event
 
 **External change observation**:
-The reread and fingerprint comparison that establishes an Observed external variant. This applies only to File-backed persistence, which has a Markdown body file to observe; Archive-backed persistence has no body file and does not perform file observation. A watcher reduces detection latency but never supplies correctness; in File-backed mode, observation is mandatory on focus or resume and immediately before Autosave, Causal seal, and `Mark Reviewed`, and a mismatch stops the pending write or seal.
+The reread and fingerprint comparison that establishes an Observed external variant. This applies only to File-backed persistence, which has a Markdown body file to observe; Archive-backed persistence has no body file and does not perform file observation. A watcher reduces detection latency but never supplies correctness; in File-backed mode, observation is mandatory on focus or resume, immediately before Autosave's physical replacement, and immediately before Causal seal or `Mark Reviewed`. A mismatch stops the pending write or seal.
 _Avoid_: Watcher event, polling guarantee, cached stat
 
 **History-changing commit**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,27 +1,263 @@
 # Canopy and Loomark
 
-Canopy provides incremental, causally ordered document editing; Loomark is the Markdown writing application built on it. This glossary distinguishes durable document ownership from one running editing session.
+Canopy provides incremental, causally ordered document editing; Loomark is the Markdown writing application built on it. This glossary distinguishes an Editing Document, its durable representations, and one running editing session.
 
 ## Language
 
-**Loomark document**:
-A logical Markdown document whose identity and causal history continue across writing instances.
-_Avoid_: File, buffer, session
+**Editing Document（編集ドキュメント）**:
+The Loomark-owned Markdown entity whose identity and causal history continue across writing instances. It contains Canopy Markdown causal state but is not identical to that state, its Markdown body file, Metadata, snapshot, or running session.
+_Avoid_: Loomark document, logical document, file, buffer, session
+
+**Detached Editing Document**:
+An Editing Document with no active Writing instance lease. It retains causal state independently of an editor runtime and remains owned by the persistence shell until File durability or explicit recovery permits release.
+_Avoid_: Closed file, snapshot, editor session
+
+**Persistence Coordinator**:
+The sole application shell for one Editing Document that owns an Aggregate Markdown runtime and coordinates Writing instance leases, EGW synchronization, File association, External change observation, Autosave, Metadata transactions, and recovery. Multiple windows never write the Markdown body file or Metadata independently.
+_Avoid_: Authority, editor runtime, Writing instance, file lock
+
+**Coordinator epoch**:
+The process-local generation of one Persistence Coordinator lifetime. Replacement invalidates commands and leases from the prior epoch; surviving Writing instances may re-register under the new epoch, but the epoch and active leases are never Metadata.
+_Avoid_: Causal version, Publication token, durable session
+
+**Writing instance lease**:
+The revocable, Coordinator-epoch-scoped lifecycle right for one Writing instance and replica identity to mutate an Editing Document through its mounted editor runtime. Its lifecycle is `Active`, `Draining`, then `Released`; a lease never transfers ownership of the Editing Document and is not persistence evidence.
+_Avoid_: Document ownership, writer identity, file lock, session snapshot
+
+**Mount**:
+The attachment of a fresh Writing instance lease and mounted editor runtime to an Editing Document. Multiple leases may coexist under one Persistence Coordinator; mounting does not consume a detached value or transfer Authority.
+_Avoid_: Open file, restore, ownership transfer
+
+**Unmount**:
+The idempotent request to release one Writing instance lease. A lease with unacknowledged Accepted causal handoff enters `Draining` and retains replay-safe evidence after its terminal runtime closes. It reaches `Released` after Aggregate acknowledgment, or after explicit Close with content recovery preserves portable text while acknowledging causal-history loss; only release of the last lease enters Detached Editing Document state, and no outcome implies save or persistence success.
+_Avoid_: Save, close file, return document, destroy editor
+
+**Draining lease**:
+The non-editable Writing instance lease waiting to finish accepted-evidence delivery to the Aggregate Markdown runtime. Repeated Unmount reports the current draining state; Coordinator unavailability routes close through explicit recovery rather than silently releasing the lease.
+_Avoid_: Active editor, Saving status, ghost lease
+
+**Markdown body file**:
+The human-readable `.md` file associated with an Editing Document for Git and external editors. In File-backed persistence it is the File Authority; only portable Markdown content belongs in it. An exported copy without a File association is not the Markdown body file.
+_Avoid_: Save file, archive, document, exported copy
+
+**Archive-backed persistence**:
+A persistence capability in which no Markdown body file is associated with the Editing Document. The application-owned archive retains durable content and Metadata preserves the Causal Authority; exported Markdown remains an unassociated copy.
+_Avoid_: Browser mode, File-backed persistence, temporary session
+
+**File-backed persistence**:
+A persistence capability with a continuing File association to a Markdown body file. File Authority, File baseline, external-change admission, and Content conflict behavior apply only in this mode; writable operation additionally requires Safe file replacement.
+_Avoid_: Desktop mode, Archive-backed persistence, downloaded file
+
+**Safe file replacement**:
+The adapter capability required for writable File-backed persistence. Replacement never exposes partial content, preserves the original on failure, safely targets resolved symbolic links, supports exact readback for Self-write acknowledgment, and retains required file permissions. Without it, Loomark limits the association to read-only access and offers Archive-backed editing, Export Markdown, or Choose New Location.
+_Avoid_: Writable handle, in-place truncation, best-effort save
+
+**Export Markdown**:
+The creation of an unassociated portable `.md` copy from an Editing Document. Export does not create File Authority, change identity, or alter persistence mode.
+_Avoid_: Save As, Autosave, Markdown body file
+
+**Import Markdown**:
+The creation of a new Editing Document and causal history baseline from portable Markdown content without continuing another Editing Document's identity. Opening a cloned Markdown body file without synchronized Metadata follows this rule even when another device edits equivalent content.
+_Avoid_: External admission, reopen, history restore
+
+**Join Existing Editing Document**:
+The explicit continuation of an Editing Document from its shared identity and causal history supplied by synchronized Metadata or another authorized participant. Path and content-hash similarity never imply a join.
+_Avoid_: Import Markdown, hash match, file association
+
+**File encoding profile**:
+The byte-level encoding retained for a Markdown body file. The initial profile accepts UTF-8 only, keeps an optional BOM outside the Editing Document source, performs no Unicode normalization, and rejects invalid UTF-8 without rewriting it; exact line terminators remain part of the Editing Document source.
+_Avoid_: Content format, Markdown syntax, automatic encoding detection
+
+**Metadata**:
+Durable application-managed information associated with an Editing Document but excluded from its Markdown body file, including logical identity and opaque causal history. It preserves the Causal Authority through Atomic Metadata transactions but is not itself an Authority, user-visible file, or Git artifact.
+_Avoid_: Sidecar, sidecar file, attached archive, metadata file
+
+**Authority**:
+A scope-specific rule that settles one kind of disagreement. No single representation is the Authority for file content, causal history, identity, and derived views at once.
+_Avoid_: 正本, source of truth, global authority
+
+**File Authority**:
+The Markdown body file's authority over portable content at file-backed open, save, and external-change admission. It does not determine causal history or Editing Document identity.
+_Avoid_: Causal Authority, current editor state, Metadata
+
+**Causal Authority**:
+The accepted operation history's authority over causal order, Editing Document identity, and writer identity. Metadata preserves it durably; a Markdown body file cannot reconstruct it.
+_Avoid_: File Authority, file history, Metadata
+
+**File association**:
+The relationship between an Editing Document and the current location and safely resolved physical target of its Markdown body file. A path change updates the association without changing the Editing Document's identity or causal history.
+_Avoid_: Editing Document identity, physical file identity, document path
+
+**Physical file identity**:
+A file-adapter capability used to recognize that multiple paths, including a safely resolved symbolic link and its target, address the same writable file and therefore require one Persistence Coordinator. It is device-local and never determines Editing Document identity.
+_Avoid_: Editing Document identity, File association, portable identity
+
+**Aliased file handling**:
+The capability-aware policy for file aliases. A safely resolved symbolic link preserves the link, associates its target, and shares one Coordinator with the target path; if safe resolution is unavailable, Loomark refuses file-backed editing and offers read-only open or Import Markdown. Hard-linked files are unsupported for initial file-backed editing because atomic replacement can split their shared physical identity.
+_Avoid_: Path-based identity, symlink replacement, independent alias writers
+
+**File baseline**:
+The Markdown body file content last acknowledged by Loomark as the shared ancestor of its current content and a later external file change.
+_Avoid_: Snapshot, saved version, latest file
+
+**External file relocation**:
+A rename or move of a Markdown body file by Git or an external tool. When recognized, it updates the File association without becoming a content change or a new Editing Document.
+_Avoid_: External file change, import, Save As
+
+**Ambiguous relocation**:
+The condition in which more than one file could be the relocated Markdown body file. Loomark requires an explicit user choice and never guesses which candidate inherits the File association.
+_Avoid_: Content conflict, duplicate, automatic relocation
+
+**Save As**:
+A new Editing Document and Markdown body file created from another Editing Document's current portable content. It receives a new identity, treats the copied content as its history baseline, and has an independent causal future; the original remains unchanged, and an existing target path is never replaced.
+_Avoid_: Duplicate, External file relocation, rename, Export Copy
+
+**Choose New Location**:
+An explicit resolution of Missing file state or Committed pending file that writes the current accepted content to a new, unoccupied path and moves the File association there. The Editing Document identity and causal history continue unchanged.
+_Avoid_: Save As, Duplicate, import
+
+**External file change**:
+A change to a Markdown body file made through Git, including branch checkout, or an external editor. Line-terminator conversion, final-newline changes, Unicode normalization, and visible whitespace changes are content changes; only a BOM-only change belongs to the File encoding profile. Loomark admits an external change automatically only when its current content equals the File baseline and no External concurrency uncertainty is active.
+_Avoid_: Content conflict, remote edit, archive replacement
+
+**Observed external variant**:
+The exact Markdown body file content successfully read by Loomark at an external-change or pre-publication check. Loomark preserves every observed variant; an intermediate write replaced before Loomark can observe it lies outside the guarantee of a portable plain-file workflow.
+_Avoid_: Watcher event, inferred version, filesystem history
+
+**External admission**:
+The deterministic bounded multi-span conversion of an admitted external file's final text, relative to the File baseline, into inferred causal edits that preserve unchanged spans and produce the exact external source. UTF-16 validation, a resource budget, and exact replay verification are mandatory; exceeding the budget falls back to one contiguous replacement. Admission preserves the Editing Document identity but never claims to recover the external editor's original operations or intent.
+_Avoid_: Import, whole-source replacement, exact operation reconstruction
+
+**Coordinator writer**:
+The stable synthetic replica identity used by the Aggregate Markdown runtime to generate application-originated main-history operations, including External admission and Resolution application. Operation category and provenance live in application records. It persists across reopen and never represents a person, external editor, or tool.
+_Avoid_: Writing instance, user identity, operation category, external editor identity
+
+**External admission transaction**:
+The atomic optimistic application of one inferred External admission batch against its expected causal version and File baseline. A match applies every inferred edit exactly once under the Coordinator writer and records one application-level undo group; a mismatch applies none, preserves the Observed external variant, and enters Content conflict without re-diffing against the newer Loomark source.
+_Avoid_: Automatic rebase, partial admission, structural commit
+
+**External admission undo**:
+The Persistence Coordinator-owned undo of the latest External admission as one group. Normal Undo may select it only while no later causal or file change has occurred and both the expected document version and file fingerprint still match; otherwise it makes no change and requires an explicit Revert External Change review.
+_Avoid_: Writing instance undo, selective historical undo, automatic rollback
+
+**Revert External Change**:
+An explicit reviewed causal change that reverses an older External admission without deleting its history. It is required after later document or file changes make External admission undo ineligible.
+_Avoid_: History deletion, normal Undo, file restore
+
+**External concurrency uncertainty**:
+The condition after a Loomark source change in an active Editing Document lifetime where a plain external file write cannot prove which prior content its writer observed. An external write enters Conflict state rather than silently replacing the Loomark variant; close and reopen resets the uncertainty against the newly acknowledged file.
+_Avoid_: Content conflict, unsaved, external writer identity
+
+**Missing file state**:
+The read-only condition in which an Editing Document's associated Markdown body file no longer exists. Loomark preserves the Editing Document and Metadata without automatic expiration, withholds automatic recreation and ordinary editing, and requires explicit user resolution or deletion.
+_Avoid_: Deleted document, Content conflict, recovery-blocked
+
+**Remove from Loomark**:
+The explicitly confirmed removal of Metadata and File association while leaving the Markdown body file unchanged. Reopening the file creates a new Editing Document and causal history baseline.
+_Avoid_: Delete file, close, unlink
+
+**Move Markdown File to Trash**:
+The explicitly confirmed move of the Markdown body file to the operating system trash while preserving the Editing Document and Metadata in Missing file state.
+_Avoid_: Remove from Loomark, permanent delete, close
+
+**Delete Editing History Permanently**:
+The single explicitly confirmed irreversible deletion, available only in Missing file state, of Metadata, Resolution drafts, Publication ledger entries, and Prepared resolution records. Loomark automatically makes every view read-only, revokes all Writing instances, closes their views, and deletes atomically; if safe revocation cannot complete, no deletion occurs and no force or recovery-file path is offered. Recovery Markdown files remain ordinary files and require separate deletion.
+_Avoid_: Remove from Loomark, Move Markdown File to Trash, automatic expiration, force delete
+
+**Deletion marker**:
+A content-free, short-lived application record containing only an opaque document key and Deletion epoch. It rejects stale writes and resumes interrupted deletion without retaining Markdown content, causal history, conflict variants, title, or path; Loomark removes it after every relevant Writing instance is revoked.
+_Avoid_: Metadata archive, recovery record, permanent tombstone
+
+**Content conflict**:
+The condition in which Loomark content and an Observed external variant both diverge from the same File baseline, or External concurrency uncertainty prevents proving that the external writer observed the Loomark variant. Every observed variant remains recoverable until deliberate resolution; none may be discarded by silent overwrite.
+_Avoid_: External file change, CRDT conflict, last-write-wins
+
+**Conflict state**:
+The read-only editing condition for an unresolved Content conflict. The Markdown body file retains the external variant, durable Metadata retains the Loomark variant, and Loomark withholds ordinary editing and file writes until resolution.
+_Avoid_: Error state, merge failure, recovery-blocked
+
+**Conflict resolution**:
+A deliberate exact choice of the external or Loomark variant, or the application of a reviewed Resolution draft, as the next Markdown body file content. `Use External` and `Use Loomark` produce exactly the named variant; resolution is recorded as a Resolution transaction in the same Editing Document.
+_Avoid_: Retry, automatic merge, last-write-wins, archive restore
+
+**Resolution transaction**:
+The application-owned durable record that binds both pre-resolution variants and the chosen result to exact main-history before/after versions and authoritative mutation evidence. Its main mutation is a normal causal edit rather than embedded application metadata; the record makes an applied Conflict resolution undoable through normal history, including after reopen.
+_Avoid_: EGW operation payload, Autosave, transient undo, conflict marker
+
+**Prepared resolution record**:
+The durable pre-publication record that preserves the Publication token, both conflict variants, sealed candidate, and expected file fingerprint before a destructive Conflict resolution can replace the Markdown body file. Preparation neither mutates main history nor establishes Saved status or an Applied workspace; it supplies evidence for crash recovery and finalization.
+_Avoid_: Resolution transaction, Metadata durability, Applied, Autosave
+
+**Prepared resolution recovery**:
+The reopen classification that compares a Prepared resolution record, a Publication ledger entry bound to durable main history, and the current Markdown body file. Without durable commit evidence, matching candidate content may reconstruct the Resolution transaction; with ledger evidence, main mutation is never retried; unexpected file content becomes an Observed external variant and requires revalidation or a new Content conflict.
+_Avoid_: Blind retry, archive restore, file overwrite
+
+**Resolution draft**:
+A durable EGW-backed candidate created by `Keep Both` and collaboratively editable by multiple Writing instances. Its causal history is separate from the Editing Document, is preserved in Metadata, and resumes after reopen; it does not change the Editing Document or Markdown body file until explicit application, while the file retains the external variant and Metadata failure falls back to a Recovery Markdown file.
+_Avoid_: Editing Document branch, Applied document, Autosave target, local-only draft
+
+**Resolution workspace**:
+The application-owned lifecycle envelope that links one Content conflict to its separate Resolution draft history and coordinates `Drafting`, `Deferred`, `Sealing`, `CommittedPendingFile`, `Applied`, and `Discarded` states. EGW owns draft convergence; Loomark owns workspace identity, persistence, participation, and Apply Resolution policy. `Discarded` requires explicit confirmation, deletes only the draft history, and returns to the unresolved Conflict state.
+_Avoid_: Editing Document, EGW branch, collaboration room
+
+**Deferred resolution**:
+The resumable state entered by `Resolve Later`. The Resolution draft remains durable and the Markdown body file retains the external variant until a Writing instance chooses `Continue Resolution`.
+_Avoid_: Shelved, Abandoned, Closed, Saved
+
+**Committed pending file**:
+The read-only recovery state in which a Resolution transaction and its Publication ledger entry are durable but the sealed candidate has not received exact Self-write acknowledgment from the Markdown body file. Main mutation is never retried; Loomark permits only completion of file persistence, review of newly observed content, Choose New Location, or close for later recovery.
+_Avoid_: Rejected, Applied, Autosave pending, retryable commit
+
+**Applied resolution**:
+The finalized state in which the Resolution transaction and Publication ledger entry are durable, the Markdown body file has exact Self-write acknowledgment for the chosen content, and Metadata records completion. Normal Editing Document work may resume.
+_Avoid_: Main commit only, Saved status, Committed pending file
+
+**Resolution baseline**:
+The external variant acknowledged when a Resolution draft is created or last revalidated. It identifies what external content the draft was reviewed against and remains distinct from the Editing Document's File baseline.
+_Avoid_: File baseline, Causal seal, draft source
+
+**Revalidation required**:
+The orthogonal condition entered when the current Markdown body file diverges from the Resolution baseline. Loomark preserves the prior and latest external variants without changing the Resolution draft, and prohibits sealing until a Writing instance completes Review Latest External.
+_Avoid_: Content conflict, automatic merge, Deferred resolution
+
+**Review Latest External**:
+The explicit comparison of the Resolution baseline, latest external variant, and current Resolution draft. Selected changes enter the draft as normal EGW operations; `Mark Reviewed` advances the Resolution baseline only when the current file still matches the reviewed fingerprint, including when no change was selected, and warns when applying the draft would replace latest external content.
+_Avoid_: Automatic merge, External admission, Use Latest External
+
+**Revalidation outdated**:
+The result when `Mark Reviewed` finds that the Markdown body file changed after review began. The Resolution baseline does not advance, selected draft operations remain preserved, and Review Latest External restarts against the newest variant.
+_Avoid_: Rejected edit, Content conflict, discarded review
+
+**Recovery Markdown file**:
+A human-readable content-only `.md` fallback containing the Loomark variant when normal file and Metadata durability cannot preserve it. It never claims to preserve Editing Document or draft identity, operation IDs, writer identities, causal frontier, collaborative undo, or Publication state. Loomark creates it without replacement under a unique name beside the Markdown body file, falls back to a user-chosen location when that directory is unwritable, and withholds close until recovery succeeds or the user explicitly discards the changes.
+_Avoid_: Metadata, archive, causal recovery, backup, Autosave target
+
+**Close with content recovery**:
+The explicit last-resort release of a Draining lease after Coordinator replay fails and a Recovery Markdown file safely preserves the accepted portable text. It never establishes Saved status and warns that causal history and collaborative undo were not preserved.
+_Avoid_: Unmount success, File durability, causal handoff
+
+**Resume Resolution from Recovery**:
+The explicit creation of a new Resolution draft identity and causal history baseline from Recovery Markdown file content when the original Editing Document and Content conflict Metadata remain readable. If that Metadata is unavailable, the file can only enter through Import Markdown as a new Editing Document.
+_Avoid_: Reopen draft, history restore, Join Existing Editing Document
+
+**Review Recovered Content**:
+The explicit comparison of normal-editing Recovery Markdown content with a readable existing Editing Document. Applying reviewed differences creates a new causal edit under a fresh Writing instance while preserving Editing Document identity; it never claims to recover the lost operations, and the recovery file remains until the user deletes it. If Metadata is unavailable, only Import Markdown is possible.
+_Avoid_: Causal recovery, External admission, automatic restore
 
 **Document archive**:
-An application-owned recovery value containing a Loomark document's logical identity, portable Markdown, and opaque causal history.
+An application-owned recovery value containing an Editing Document's identity, portable Markdown, and opaque causal history. In file-backed editing it is Metadata and does not override a divergent Markdown body file.
 _Avoid_: Snapshot, session snapshot, save file
 
 **Active document**:
-The sole Loomark document selected for the current standalone application while document catalogs and document switching remain unavailable.
+The sole Editing Document selected for the current standalone application while document catalogs and document switching remain unavailable.
 _Avoid_: Current file, active session, recent document
 
 **Baseline archive**:
-The first complete archive that establishes a new active document's logical identity before its first history-changing commit.
+The first complete archive that establishes a new active Editing Document's identity before its first history-changing commit.
 _Avoid_: Empty snapshot, default file
 
 **Local archive repository**:
-The single-device authority that retains the latest complete document archive for the standalone application's active document.
+The application-managed Metadata repository that retains the latest complete document archive for the standalone application's active document. It is the content Authority only when no Markdown body file is present.
 _Avoid_: Session store, backup, replica
 
 **Local restore policy**:
@@ -32,6 +268,50 @@ _Avoid_: Network limit, archive format limit
 Confirmation that one complete archive replacement finished successfully in the local archive repository. It describes one repository operation, not the current product durability state.
 _Avoid_: Saved status, durable-local state
 
+**File durability**:
+The condition in which the accepted content is represented by a completed write to its Markdown body file.
+_Avoid_: Metadata durability, repository acknowledgment, applied
+
+**Metadata durability**:
+The condition in which the Editing Document's accepted identity and causal history are represented in acknowledged Metadata.
+_Avoid_: File durability, Saved status, backed up
+
+**Atomic Metadata transaction**:
+The storage capability that durably applies all Metadata belonging to one logical transition or leaves the prior state unchanged. Causal history, Publication ledger entry, Resolution receipt, and workspace state must never become independently visible; without this capability Loomark does not claim Metadata durability, permit destructive resolution, or provide Archive-backed persistence.
+_Avoid_: Field write, best-effort persistence, Safe file replacement
+
+**Metadata-unavailable state**:
+The file-backed condition in which a valid Markdown body file exists but its associated Metadata is corrupt, unreadable, or from an unsupported newer version. Loomark preserves and distinguishes the failed Metadata, leaves the file unchanged, and requires explicit confirmation before opening the content under a new Editing Document identity.
+_Avoid_: Recovery-blocked, silent import, Content conflict
+
+**Applied locally**:
+The status after one Mounted Markdown runtime accepts a commit and can show its result. It carries authoritative mutation evidence for that replica but implies neither Aggregate acknowledgment nor durability.
+_Avoid_: Aggregated, Saved status, optimistic preview
+
+**Aggregate acknowledgment**:
+Confirmation that the Aggregate Markdown runtime causally applied the accepted window history. It permits the Persistence Coordinator to schedule persistence but implies neither File durability nor Metadata durability.
+_Avoid_: Commit receipt, Repository acknowledgment, Saved status
+
+**Saving status**:
+The user-facing status after Aggregate acknowledgment while required Autosave or Metadata work remains incomplete. Aggregate synchronization never waits for the Autosave debounce.
+_Avoid_: Applied locally, Saved status, replicated
+
+**Saved status**:
+The user-facing confirmation of File durability. File durability keeps this status active when Metadata durability fails; Loomark separately warns that editing history was not preserved.
+_Avoid_: Metadata durability, repository acknowledgment, fully saved
+
+**Autosave**:
+The automatic persistence triggered by an accepted causal change. A source-changing commit establishes File durability before Metadata durability; a source-equal history change updates Metadata without rewriting an unchanged Markdown body file.
+_Avoid_: Repository acknowledgment, periodic backup, history no-op
+
+**Self-write acknowledgment**:
+Recognition that an observed file change exactly matches one expected Autosave generation for the same File association and File encoding profile. It advances the File baseline; any mismatch is handled as an External file change rather than hidden by timing-based watcher suppression.
+_Avoid_: External admission, watcher timeout, ignored file event
+
+**External change observation**:
+The reread and fingerprint comparison that establishes an Observed external variant. A watcher reduces detection latency but never supplies correctness; observation is mandatory on focus or resume and immediately before Autosave, Causal seal, and `Mark Reviewed`, and a mismatch stops the pending write or seal.
+_Avoid_: Watcher event, polling guarantee, cached stat
+
 **History-changing commit**:
 An accepted document commit that advances causal history, whether or not its resulting Markdown source differs from the prior source.
 _Avoid_: Text change, source change
@@ -41,11 +321,11 @@ An accepted document commit that leaves causal history unchanged.
 _Avoid_: Unchanged text
 
 **Applied document**:
-The current accepted in-memory document state, which may be newer than the last locally durable archive.
+The current accepted in-memory document state, which may be newer than its Markdown body file or Metadata.
 _Avoid_: Saved document, durable document
 
 **Local durability**:
-The condition in which the current accepted document version is represented by an acknowledged archive in the local archive repository.
+For the standalone application when no Markdown body file is present, the condition in which the current accepted document version is represented by an acknowledged archive in the local archive repository.
 _Avoid_: Applied, replicated, backed up
 
 **Recovery-blocked**:
@@ -53,12 +333,68 @@ The condition in which an existing archive cannot be safely reopened and remains
 _Avoid_: Empty document, recovered, reset
 
 **Writing instance**:
-One active lifetime that writes operations under its own replica identity. Reopening a document starts a new writing instance while retaining the logical document identity.
-_Avoid_: Document identity, user identity, browser identity
+One active host lifetime that writes operations under its own replica identity. Multiple writing instances may edit the same Editing Document concurrently; a surviving host retains its identity across Coordinator replacement, while full reopen starts a fresh writing instance and retains the Editing Document identity.
+_Avoid_: Editing Document identity, user identity, browser identity, window
+
+## Framework — Markdown causal editing
+
+Framework vocabulary for the Canopy layer contained by a Loomark Editing Document. These terms describe causal Markdown runtime mechanics without application identity, file ownership, persistence policy, or product conflict state.
+
+**Markdown causal state**:
+The Canopy-owned opaque history, causal version, sentinel-free portable source, and reconstruction capability from which replica runtimes are mounted. It owns history admission and export but no Editing Document identity, File association, Metadata storage, Saved status, Resolution workspace, or Publication ledger.
+_Avoid_: Editing Document, archive, parser state, file buffer
+
+**Mounted Markdown runtime**:
+The Canopy-owned live EGW and parser runtime for one Writing instance lease. It accepts Markdown commits and returns outcomes, receipts, snapshots, and history evidence without deciding application persistence or conflict policy.
+_Avoid_: Editing Document, Persistence Coordinator, mounted file
+
+**Markdown commit outcome**:
+The Canopy result algebra for one commit: rejected without mutation, committed with authoritative receipt evidence, or committed with receipt evidence, a later issue, and an Accepted causal handoff. Both committed variants prohibit retry and remain distinct from persistence status; compatibility façades may translate committed-with-issue into their legacy error shape.
+_Avoid_: Result error, Saved status, Publication outcome
+
+**Accepted causal handoff**:
+The opaque replay-safe ownership evidence returned with committed-with-issue so a caller can admit the exact accepted history to the Aggregate Markdown runtime, reconstruct accepted Markdown causal state, and discard the terminal mounted runtime without reading parser or projection internals. At-least-once delivery is safe because operation identity and causal versions make admission idempotent; it exposes neither a read snapshot nor mutable internal collections.
+_Avoid_: Snapshot, commit retry token, parser recovery, mutable history
+
+**Accepted handoff admission**:
+The Aggregate outcome for an Accepted causal handoff: advanced, already present, pending dependencies, or rejected evidence. Only an advanced causal version schedules persistence; already-present evidence acknowledges replay without duplicating Autosave.
+_Avoid_: Commit retry, duplicate save, parser reconstruction
+
+**Aggregate Markdown runtime**:
+The headless Canopy replica owned by a Persistence Coordinator while leases or persistence work remain. It receives every window and application operation, materializes the causally complete portable source used for Autosave, and is never a user Writing instance; after last unmount and completed persistence, its history returns to Markdown causal state and the runtime may be discarded.
+_Avoid_: Leader window, Editing Document, Authority, permanent runtime
+
+## Framework — staged publication
+
+Framework vocabulary for the EGW-versioned companion that owns causal sealing and publication of a Resolution draft. Distinct from the Editing Document domain, Markdown causal editing, and projection editing: these describe how a sealed candidate moves from draft convergence to applied transaction, not how documents persist or how trees keep identity.
+
+**Staged publication**:
+The lifecycle that moves a Resolution draft from collaborative editing through Causal seal to application of one sealed candidate. It separates draft convergence, which may continue independently, from one Resolution transaction in the Editing Document's main history; it does not make persistence, network, and Metadata one atomic transaction.
+_Avoid_: Save, commit, deploy, two-phase commit
+
+**Causal seal**:
+The operation that fixes a sealed frontier on a separate draft EGW history after required participant flush acknowledgments or an explicit `Apply Current Draft` choice. Checkout of the sealed version remains constant while later draft operations advance the live head into a Recovery head; they do not enter the sealed candidate. It is not a branch, merge, or snapshot.
+_Avoid_: Branch point, checkpoint, tag, freeze
+
+**Publication token**:
+The stable application identity of one intent to publish one sealed candidate. It lets Loomark detect duplicate main-history application and correlate recovery across the Markdown body file and Metadata, but does not make those stores atomic; a committed outcome bound to the token never authorizes retry.
+_Avoid_: Version tag, lock, session key, cross-store transaction
+
+**Publication ledger**:
+The application-owned Metadata index that binds a Publication token to durable main-history before/after versions, its Resolution receipt, and Publication outcome. A matching ledger entry is the durable evidence that main mutation committed; the ledger is not part of EGW operations or the Markdown body file.
+_Avoid_: EGW history, File baseline, Prepared resolution record, transaction log
+
+**Publication outcome**:
+The result of applying a sealed candidate: rejected without main-history mutation, committed with authoritative mutation evidence, or committed with both mutation evidence and a later issue. Both committed forms prohibit retry.
+_Avoid_: Error channel, save result, retry signal
+
+**Recovery head**:
+The live EGW draft version after it advances beyond a Causal seal. It identifies late operations that remain recoverable but are excluded from the sealed candidate and the applied Resolution transaction.
+_Avoid_: Document head, autosave, recovery file, main history
 
 ## Framework — projection editing
 
-Framework vocabulary for the projection engine that backs the application terms above. Distinct from the Loomark document domain: these describe how the editing session's tree keeps identity across reparses, not how documents persist.
+Framework vocabulary for the projection engine that backs the application terms above. Distinct from the Editing Document domain: these describe how the editing session's tree keeps identity across reparses, not how documents persist.
 
 **Reconciliation**:
 The identity-preserving match between the previous projection tree and the newly reparsed tree: it decides, for each node in the new tree, whether it is the same node as one in the old tree (carrying its NodeId) or a fresh node. It is not text diffing and not CRDT merge.

--- a/docs/README.md
+++ b/docs/README.md
@@ -188,6 +188,13 @@ behavior** — check the code before relying on any specific detail.
   — deepens the `lang/runtime` SPI to structured errors, patch traces, identity
   hints, language-owned extras, and edit-port moves; partially supersedes the
   Lambda edit bridge boundary.
+- [EGW staged publication responsibility boundary](decisions/2026-08-09-egw-staged-publication-responsibility-boundary.md)
+  — keeps EGW core unchanged while an EGW-versioned companion owns causal
+  sealing and publication outcomes; Loomark retains persistence and product
+  resolution policy.
+- [Markdown file-backed authority and external admission](decisions/2026-08-09-markdown-file-backed-authority-and-external-admission.md)
+  — separates File and Causal Authority, Archive-backed and File-backed
+  persistence, and bounded External admission for associated Markdown files.
 
 ## Historical / Archive
 

--- a/docs/decisions/2026-08-09-egw-staged-publication-responsibility-boundary.md
+++ b/docs/decisions/2026-08-09-egw-staged-publication-responsibility-boundary.md
@@ -26,7 +26,7 @@ This ADR specializes that boundary for Resolution draft publication. A Resolutio
 
 Implementation evidence:
 
-- EGW text façade: `TextState::version`, `TextState::checkout` (read-only `TextView`), `TextState::sync`, `SyncSession::apply`, `SyncSession::export_since`, `SyncReport::pending_operations`. These are current source-verified APIs, not promised new package API.
+- EGW text and sync façades support fixed-version read-only materialization while the live head advances, and sync reports that classify pending operations. See [`deps/event-graph-walker/text/pkg.generated.mbti`](../../deps/event-graph-walker/text/pkg.generated.mbti) and [`deps/event-graph-walker/sync/pkg.generated.mbti`](../../deps/event-graph-walker/sync/pkg.generated.mbti) for current source-verified interfaces, not promised new package API.
 - [EGW collaboration responsibility boundary](2026-07-21-egw-collaboration-responsibility-boundary.md)
 - [Local-first document ownership](../design/local-first-document-ownership.md)
 
@@ -46,7 +46,7 @@ EGW core remains unchanged: no writable branch/fork and no tentative Resolution 
 
 ## State and outcome invariants
 
-**Seal uses a separate draft EGW history.** For text, existing source-verified APIs are `TextState::version`, `TextState::checkout` (read-only `TextView`), `TextState::sync`, `SyncSession::apply`/`export_since`, `SyncReport::pending_operations`. Sealed checkout remains fixed while later draft operations advance the live head; those operations remain recoverable outside the applied candidate.
+**Seal uses a separate draft EGW history.** The current text and sync façades support fixed-version read-only materialization while the live head advances, and sync reports that classify pending operations. Sealed checkout remains fixed while later draft operations advance the live head; those operations remain recoverable outside the applied candidate.
 
 **Seal coordination does not wait forever or discard late work.** The collaboration runtime freezes connected participants and gathers flush acknowledgments. When a participant does not respond, Loomark offers `Wait`, `Apply Current Draft`, and `Cancel`; choosing `Apply Current Draft` seals the known frontier, and operations arriving later advance a Recovery head without changing the sealed checkout.
 
@@ -56,16 +56,18 @@ EGW core remains unchanged: no writable branch/fork and no tentative Resolution 
 
 **Destructive resolution is prepared before file replacement.** Normal Autosave remains file-first. Before a Conflict resolution can replace the external variant in the Markdown body file, Loomark durably records the Publication token, both variants, sealed candidate, and expected file fingerprint. Preparation does not mutate main history or establish Saved status. After main mutation commits, Loomark persists the resulting history and Publication ledger entry as `CommittedPendingFile`, atomically replaces the file, then finalizes the workspace as `Applied`. This resolution-specific sequence preserves enough evidence to classify and resume a partial publication after crash without changing ordinary Autosave ordering.
 
-**Crash recovery classifies durable evidence rather than guessing execution.** On reopen, Loomark compares the prepared token with durable main history and compares the current file with the prepared external and candidate variants:
+**Crash recovery classifies durable evidence rather than guessing execution.** On reopen, Loomark compares the prepared token with durable main history and compares the current file with the prepared external and candidate variants. Because neither EGW operations nor the file carry the Publication token, an absent ledger entry cannot by itself classify main mutation as rejected:
 
 | Publication ledger entry bound to durable main history | Current file | Recovery |
 |---|---|---|
-| Absent | Prepared external variant | Restore the prepared state and offer resume or cancel |
-| Absent | Sealed candidate | Reconstruct the Resolution transaction under the same token, then finalize Metadata |
-| Absent | Other observed content | Preserve it and require revalidation |
+| Absent | Prepared external variant | Preserve the prepared state and report indeterminate publication; reconcile durable and replicated main-history evidence without retrying or canceling the main mutation |
+| Absent | Sealed candidate | Preserve the prepared state and candidate, report indeterminate publication, and require durable idempotency evidence before any main-history action |
+| Absent | Other observed content | Preserve every variant, keep publication indeterminate, and require revalidation without retrying main mutation |
 | Present | Sealed candidate | Finalize Metadata and mark the workspace applied |
 | Present | Prepared external variant | Report a committed persistence issue; do not retry main mutation |
 | Present | Other observed content | Enter a new Content conflict; do not retry main mutation |
+
+File-content equality alone never authorizes reconstruction or retry of main mutation. Without durable idempotency evidence, the prepared state remains read-only and Loomark offers only reconciliation, later recovery, or content-only recovery.
 
 `CommittedPendingFile` is read-only. Loomark may complete file persistence, review newly observed content, choose a new location, or close for later recovery, but it may not accept ordinary edits or retry the Resolution transaction. The workspace becomes `Applied` only after exact self-write acknowledgment and Metadata finalization.
 
@@ -108,7 +110,7 @@ Rejected because the container façade has no text-equivalent historical materia
 - An application-owned Publication ledger binds the Publication token and outcome/receipt to durable main history for duplicate detection and partial-recovery correlation; it does not make main mutation, file, and Metadata atomic.
 - Sealed checkout remains fixed while later draft operations advance the live head; those operations remain recoverable outside the applied candidate.
 - Current container façade must not be claimed to have text-equivalent historical materialization until a second adapter validates the seam.
-- EGW core APIs (`TextState::version`, `TextState::checkout`, `TextState::sync`, `SyncSession::apply`/`export_since`, `SyncReport::pending_operations`) are current source-verified implementation evidence, not promised new package API.
+- Current text and sync façade capabilities are source-verified implementation evidence for fixed-version read-only materialization while live head advances and pending-operation classification; they are not promised new package API. See [`deps/event-graph-walker/text/pkg.generated.mbti`](../../deps/event-graph-walker/text/pkg.generated.mbti) and [`deps/event-graph-walker/sync/pkg.generated.mbti`](../../deps/event-graph-walker/sync/pkg.generated.mbti) for the current interfaces.
 
 ## Non-goals
 

--- a/docs/decisions/2026-08-09-egw-staged-publication-responsibility-boundary.md
+++ b/docs/decisions/2026-08-09-egw-staged-publication-responsibility-boundary.md
@@ -1,0 +1,119 @@
+# EGW staged publication responsibility boundary
+
+**Date:** 2026-08-09
+
+**Status:** Accepted target architecture; implementation not started
+
+**Related:**
+
+- [EGW collaboration responsibility boundary](2026-07-21-egw-collaboration-responsibility-boundary.md)
+- [Markdown file-backed authority and external admission](2026-08-09-markdown-file-backed-authority-and-external-admission.md)
+- [Library API boundary](2026-06-11-library-api-boundary.md)
+
+**Reader:** Maintainers designing or reviewing causal sealing, publication outcomes, or Resolution draft application across EGW, Loomark, and the collaboration runtime.
+
+**Decision:** Introduce an EGW-versioned staged-publication companion that owns causal sealing, a sealed frontier/version, classification of head advancement after seal, and committed/rejected/committed-with-issue publication outcomes with no-retry-after-commit semantics. The companion owns no peers/windows, transports, timeouts, persistence, file I/O, or product resolution policy.
+
+**Keep until:** Permanently. ADRs are durable and are superseded rather than deleted.
+
+**Disposition:** Supersede this record if implementation evidence from both text and container drivers shows that the staged-publication boundary cannot remain independent of the adjacent layers.
+
+## Context
+
+The existing EGW collaboration responsibility boundary separates collaboration into five layers: EGW core, an EGW-versioned peer-sync companion, a reusable payload-opaque collaboration runtime, infrastructure providers, and application policy. That boundary owns transport, session management, and CRDT synchronization.
+
+This ADR specializes that boundary for Resolution draft publication. A Resolution draft is a separate EGW-backed candidate with its own causal history, collaboratively editable by multiple Writing instances. When a draft reaches a convergence point, it must be sealed and applied to the main Editing Document without merging draft history directly into main history, and without allowing retry after a committed outcome.
+
+Implementation evidence:
+
+- EGW text façade: `TextState::version`, `TextState::checkout` (read-only `TextView`), `TextState::sync`, `SyncSession::apply`, `SyncSession::export_since`, `SyncReport::pending_operations`. These are current source-verified APIs, not promised new package API.
+- [EGW collaboration responsibility boundary](2026-07-21-egw-collaboration-responsibility-boundary.md)
+- [Local-first document ownership](../design/local-first-document-ownership.md)
+
+These sources demonstrate that EGW can produce a fixed-version read-only view while the live head continues to advance, and that sync reports can classify pending operations. They do not prove that a staged-publication companion can remain independent of the peer-sync or runtime layers.
+
+## Responsibility split
+
+| Reason to change | Owning layer |
+|---|---|
+| CRDT operations, causal rules, façade versions, sync-message formats, or document-local pending replay change | EGW core (unchanged) |
+| Causal sealing, sealed frontier/version, head-advancement classification after seal, or publication outcome semantics change | EGW staged-publication companion |
+| Participant sets, freeze/flush acknowledgments, timeouts, coordinator succession, or transport change | Payload-opaque collaboration runtime |
+| Network, hosting, room routing, access control, reconnect backoff, or storage-provider implementation changes | Infrastructure provider |
+| Conflict variants, Resolution workspace lifecycle, seed/UI, Metadata, Publication ledger, File Authority, Use External/Use Loomark/Keep Both behavior, application of one Resolution transaction to main Editing Document, file-first Autosave, recovery, or undo change | Loomark |
+
+EGW core remains unchanged: no writable branch/fork and no tentative Resolution draft operations in the main Editing Document history. A separate EGW-backed Resolution draft has its own causal history and can be collaboratively edited by multiple Writing instances.
+
+## State and outcome invariants
+
+**Seal uses a separate draft EGW history.** For text, existing source-verified APIs are `TextState::version`, `TextState::checkout` (read-only `TextView`), `TextState::sync`, `SyncSession::apply`/`export_since`, `SyncReport::pending_operations`. Sealed checkout remains fixed while later draft operations advance the live head; those operations remain recoverable outside the applied candidate.
+
+**Seal coordination does not wait forever or discard late work.** The collaboration runtime freezes connected participants and gathers flush acknowledgments. When a participant does not respond, Loomark offers `Wait`, `Apply Current Draft`, and `Cancel`; choosing `Apply Current Draft` seals the known frontier, and operations arriving later advance a Recovery head without changing the sealed checkout.
+
+**Draft history is never merged directly into main Editing Document history.** Application materializes the sealed candidate and commits one Resolution transaction. The main Editing Document's causal history does not absorb draft operations.
+
+**EGW cannot alone guarantee exactly-once across main mutation, Markdown body file, and Metadata.** Loomark assigns a stable Publication token to one sealed candidate and supplies it opaquely to the companion. Application-owned Metadata carries a Publication ledger that binds the token to durable main-history before/after versions, its Resolution receipt, and outcome; EGW operations and the Markdown body file do not carry the token. The ledger lets Loomark detect duplicate main-history application and correlate partial recovery, but does not make the stores atomic; a committed or committed-with-issue outcome never authorizes retry.
+
+**Destructive resolution is prepared before file replacement.** Normal Autosave remains file-first. Before a Conflict resolution can replace the external variant in the Markdown body file, Loomark durably records the Publication token, both variants, sealed candidate, and expected file fingerprint. Preparation does not mutate main history or establish Saved status. After main mutation commits, Loomark persists the resulting history and Publication ledger entry as `CommittedPendingFile`, atomically replaces the file, then finalizes the workspace as `Applied`. This resolution-specific sequence preserves enough evidence to classify and resume a partial publication after crash without changing ordinary Autosave ordering.
+
+**Crash recovery classifies durable evidence rather than guessing execution.** On reopen, Loomark compares the prepared token with durable main history and compares the current file with the prepared external and candidate variants:
+
+| Publication ledger entry bound to durable main history | Current file | Recovery |
+|---|---|---|
+| Absent | Prepared external variant | Restore the prepared state and offer resume or cancel |
+| Absent | Sealed candidate | Reconstruct the Resolution transaction under the same token, then finalize Metadata |
+| Absent | Other observed content | Preserve it and require revalidation |
+| Present | Sealed candidate | Finalize Metadata and mark the workspace applied |
+| Present | Prepared external variant | Report a committed persistence issue; do not retry main mutation |
+| Present | Other observed content | Enter a new Content conflict; do not retry main mutation |
+
+`CommittedPendingFile` is read-only. Loomark may complete file persistence, review newly observed content, choose a new location, or close for later recovery, but it may not accept ordinary edits or retry the Resolution transaction. The workspace becomes `Applied` only after exact self-write acknowledgment and Metadata finalization.
+
+**Plain-file conflict preservation is scoped to observed variants.** Immediately before replacement, Loomark rereads the file and compares it with the expected fingerprint; a mismatch stops publication and requires revalidation. Exact self-write acknowledgment classifies the result after replacement. A portable plain-file workflow cannot guarantee preservation of an intermediate external write that another uncooperative process replaces before Loomark can observe it, and the product must not imply otherwise.
+
+**Incubate with Loomark/text evidence.** Do not claim stable generic support until a second real adapter/consumer validates the seam. Current container façade must not be claimed to have text-equivalent historical materialization.
+
+## Relationship to existing ADR
+
+This ADR specializes the EGW collaboration responsibility boundary. It does not supersede any existing ADR. The peer-sync companion, collaboration runtime, infrastructure providers, and application policy layers retain their ownership as defined in the 2026-07-21 ADR. This ADR adds a sibling EGW-versioned companion responsibility beside peer-sync, rather than a new universal layer, and clarifies that Resolution draft publication is application policy (Loomark) that consults the companion for seal and outcome semantics.
+
+## Rejected alternatives
+
+### Writable branch or fork in EGW core
+
+Rejected because it would couple EGW core to Resolution draft semantics and require EGW to understand main Editing Document history. The separate draft history keeps EGW core unchanged and allows the companion to own seal semantics independently.
+
+### Tentative Resolution draft operations in main Editing Document history
+
+Rejected because it would make main history aware of draft convergence and require rollback or conditional commit. The separate draft history and one-shot application keep main history deterministic.
+
+### EGW-owned exactly-once guarantee across main mutation, file, and Metadata
+
+Rejected because EGW owns CRDT synchronization, not file I/O, Metadata persistence, or application-level transaction semantics. An application-assigned Publication token carried opaquely by the companion supports duplicate detection and recovery correlation without coupling EGW to persistence.
+
+### Merge draft history into main history at application
+
+Rejected because it would require main history to understand draft causal structure and would make undo/recovery ambiguous. Materializing the sealed candidate as one Resolution transaction keeps main history linear and undoable.
+
+### Claim stable generic support before second adapter validates
+
+Rejected because the container façade has no text-equivalent historical materialization evidence. Incubating with Loomark/text evidence prevents premature API commitment.
+
+## Consequences
+
+- EGW core remains free of Resolution draft semantics and main-history awareness.
+- The staged-publication companion is a deterministic core that accepts seal events and returns outcome and next-state commands. It does not own peers, transports, timeouts, persistence, or product policy.
+- Loomark owns application of one Resolution transaction to main Editing Document, including file-first Autosave, recovery, and undo.
+- The collaboration runtime remains payload-opaque; it does not interpret seal or publication semantics.
+- An application-owned Publication ledger binds the Publication token and outcome/receipt to durable main history for duplicate detection and partial-recovery correlation; it does not make main mutation, file, and Metadata atomic.
+- Sealed checkout remains fixed while later draft operations advance the live head; those operations remain recoverable outside the applied candidate.
+- Current container façade must not be claimed to have text-equivalent historical materialization until a second adapter validates the seam.
+- EGW core APIs (`TextState::version`, `TextState::checkout`, `TextState::sync`, `SyncSession::apply`/`export_since`, `SyncReport::pending_operations`) are current source-verified implementation evidence, not promised new package API.
+
+## Non-goals
+
+- Implementing or moving code in this documentation change.
+- Changing EGW core to own Resolution draft semantics or main-history awareness.
+- Defining the peer-sync companion's protocol or the collaboration runtime's envelope format.
+- Specifying Loomark's Resolution workspace lifecycle, conflict resolution UX, or Autosave policy.
+- Claiming generic support for container or non-text façades before a second adapter validates the seam.

--- a/docs/decisions/2026-08-09-markdown-file-backed-authority-and-external-admission.md
+++ b/docs/decisions/2026-08-09-markdown-file-backed-authority-and-external-admission.md
@@ -70,7 +70,7 @@ External admission is the deterministic bounded multi-span conversion of an admi
 
 **Coordinator writer.** External admission uses the stable synthetic Coordinator writer of the Editing Document's Aggregate Markdown runtime. The same writer may generate other application operations, whose category and provenance are recorded in application Metadata. It persists across reopen and never represents an external person, editor, or tool.
 
-**Atomic transaction.** External admission is an optimistic atomic transaction against its expected causal version and File baseline. A match applies every inferred edit exactly once under the Coordinator writer and records one application-level undo group. A mismatch applies none, preserves the Observed external variant, and enters Content conflict without re-diffing against the newer Loomark source.
+**Atomic transaction.** Before mutation, External admission validates its expected causal version, File baseline, and Observed external variant fingerprint. A match applies every inferred edit exactly once as one optimistic atomic transaction under the Coordinator writer and records one application-level undo group. A mismatch applies none, preserves every Observed external variant, and enters Content conflict without re-diffing against the newer Loomark source.
 
 ### What it is not
 
@@ -120,7 +120,7 @@ Rejected because External admission must remain deterministic and bounded under 
 - External admission preserves Editing Document identity for associated external file changes. It does not create a new Editing Document.
 - External admission is deterministic and bounded. It validates UTF-16 boundaries, uses a resource budget, and requires exact replay. Exceeding the budget falls back to one contiguous replacement, which must also satisfy receiver admission limits before any mutation. If no inferred batch fits, apply nothing, preserve the Observed external variant, and enter Content conflict.
 - Coordinator writer plus application records preserve synthetic provenance without treating writer identity as an operation category.
-- External admission is an optimistic atomic transaction. A mismatch applies none and enters Content conflict without re-diffing against the newer Loomark source.
+- External admission preflights its expected causal version, File baseline, and Observed external variant fingerprint before one optimistic atomic history transaction. A mismatch applies none, preserves all retained variants, and enters Content conflict without re-diffing against the newer Loomark source.
 - External concurrency uncertainty prevents silent overwrite after a Loomark source change. An external write in this condition enters Content conflict.
 - A rename or move of an associated file preserves Editing Document identity via File association.
 - An unassociated `.md` follows Import Markdown. Synchronized Metadata is required for Join Existing Editing Document.

--- a/docs/decisions/2026-08-09-markdown-file-backed-authority-and-external-admission.md
+++ b/docs/decisions/2026-08-09-markdown-file-backed-authority-and-external-admission.md
@@ -1,0 +1,135 @@
+# Markdown file-backed authority and external admission
+
+**Date:** 2026-08-09
+
+**Status:** Accepted target architecture; implementation not started
+
+**Related:**
+
+- [EGW staged publication responsibility boundary](2026-08-09-egw-staged-publication-responsibility-boundary.md)
+- [EGW collaboration responsibility boundary](2026-07-21-egw-collaboration-responsibility-boundary.md)
+- [Local-first document ownership](../design/local-first-document-ownership.md)
+
+**Reader:** Maintainers designing or reviewing Markdown persistence, external editor admission, or File Authority behavior in Loomark.
+
+**Decision:** Split persistence into Archive-backed and File-backed capabilities. With a continuing File association, the Markdown body file is File Authority for portable content; accepted operation history remains Causal Authority for causal order and identity. Archive-backed exports are unassociated portable artifacts, and reading one creates a new Editing Document identity and causal history baseline through Import Markdown unless synchronized Metadata supports Join Existing Editing Document. Associated external changes preserve Editing Document identity through External admission.
+
+**Keep until:** Permanently. ADRs are durable and are superseded rather than deleted.
+
+**Disposition:** Supersede this record if implementation evidence shows that External admission cannot remain deterministic and bounded, or if File Authority and Causal Authority cannot remain separate scopes.
+
+## Context
+
+The local-first document ownership design establishes that text alone does not preserve identity or causal history, and that persisting the operation history is the rule. It distinguishes four authorities (Causal, Current state, Portable artifact, Derived caches) and states that a `.md` changed by an outside tool re-enters as an explicit import, never as a merge between two truths.
+
+This ADR refines that design by distinguishing two persistence modes and introducing External admission as a narrowly scoped exception to the "edits arrive as edits" rule for file-backed editing with external tools.
+
+Implementation evidence:
+
+- [Local-first document ownership](../design/local-first-document-ownership.md)
+- [EGW staged publication responsibility boundary](2026-08-09-egw-staged-publication-responsibility-boundary.md)
+- [EGW collaboration responsibility boundary](2026-07-21-egw-collaboration-responsibility-boundary.md)
+
+These sources establish the need to preserve Editing Document identity and causal history across writing instances and the separate staged-publication path for Resolution candidates. File association continuity and External admission are decisions introduced by this ADR; the cited evidence does not yet prove that External admission can remain deterministic and bounded.
+
+## Partial supersession
+
+This ADR partially supersedes two statements in the local-first document ownership design:
+
+1. Universal Import Markdown treatment for every outside-modified `.md`. In File-backed persistence, an associated external change preserves Editing Document identity through External admission. An unassociated `.md` still follows Import Markdown.
+
+2. Universal prohibition on snapshot inference. External admission is a narrowly scoped external-boundary exception for File-backed persistence only. The rule remains absolute for all Loomark-originated input paths.
+
+This ADR does not supersede any other part of the local-first design. Causal-history durability, source-equal history persistence, the archive envelope, writer identity, restore limits, and parser-losslessness remain unchanged.
+
+## Persistence modes
+
+### Archive-backed persistence
+
+No Markdown body file is associated with the Editing Document. The application-owned archive retains durable content and Metadata preserves the Causal Authority. Exported Markdown is an unassociated portable artifact. Opening it follows Import Markdown: a new Editing Document and a new causal history baseline, unless explicit synchronized Metadata supports Join Existing Editing Document.
+
+### File-backed persistence
+
+A continuing File association links the Editing Document to a Markdown body file. The associated body file is File Authority for portable content at open, save, and external-change admission. Accepted operation history remains Causal Authority for causal order, Editing Document identity, and writer identity; File Authority does not determine either.
+
+Safe file replacement is required for writable File-backed persistence. Without it, Loomark limits the association to read-only access and offers Archive-backed editing, Export Markdown, or Choose New Location.
+
+## External admission
+
+### What it is
+
+External admission is the deterministic bounded multi-span conversion of an admitted external file's final text, relative to the File baseline, into inferred causal edits that preserve unchanged spans and produce the exact external source. It preserves Editing Document identity but never claims to recover the external editor's original operations or intent.
+
+### Requirements
+
+**UTF-16 validation.** External admission validates sentinel-free UTF-16 boundaries before inference. Invalid boundaries reject admission and enter Content conflict.
+
+**Resource budget.** External admission uses a resource budget. Exceeding the budget falls back to one contiguous replacement. The budget is receiver policy, not a property of the format.
+
+**Exact replay.** External admission requires exact replay verification: applying the inferred edits to the File baseline must produce the exact admitted external source. Mismatch rejects admission and enters Content conflict.
+
+**Coordinator writer.** External admission uses the stable synthetic Coordinator writer of the Editing Document's Aggregate Markdown runtime. The same writer may generate other application operations, whose category and provenance are recorded in application Metadata. It persists across reopen and never represents an external person, editor, or tool.
+
+**Atomic transaction.** External admission is an optimistic atomic transaction against its expected causal version and File baseline. A match applies every inferred edit exactly once under the Coordinator writer and records one application-level undo group. A mismatch applies none, preserves the Observed external variant, and enters Content conflict without re-diffing against the newer Loomark source.
+
+### What it is not
+
+External admission is not Import Markdown. Import creates a new Editing Document; External admission preserves the existing one.
+
+External admission is not operation reconstruction. It infers bounded multi-span edits from a final text, not the external editor's actual operations or intent.
+
+External admission is not a relaxation of "edits arrive as edits" for Loomark input paths. The rule remains absolute for user actions within Loomark. Snapshot inference is a narrowly scoped external-boundary exception only.
+
+## External concurrency uncertainty
+
+After a Loomark source change in an active Editing Document lifetime, a plain external file write cannot prove which prior content its writer observed. External concurrency uncertainty sends such a write to Content conflict rather than silently replacing the Loomark variant. Close and reopen resets the uncertainty against the newly acknowledged file.
+
+Generic plain files cannot reveal writer IDs or causal parents. External concurrency uncertainty and Observed-variant preservation prevent silent overwrite.
+
+## File association and identity
+
+External file relocation updates the File association after a rename or move without changing the Editing Document's identity or causal history.
+
+An unassociated `.md` — whether copied, exported, or never associated — follows Import Markdown. Opening a cloned Markdown body file without synchronized Metadata creates a new Editing Document even when another device edits equivalent content.
+
+## Rejected alternatives
+
+### Universal `.md` authority
+
+Rejected because it would conflate File Authority for portable content with Causal Authority for causal history and identity. A `.md` cannot reconstruct causal history; only Metadata preserves it.
+
+### Automatic rebase on mismatch
+
+Rejected because External admission is an optimistic atomic transaction. A mismatch against the expected causal version or File baseline must apply none and enter Content conflict without re-diffing against the newer Loomark source. Automatic rebase would silently apply partial changes and lose the Observed external variant.
+
+### External admission for Loomark input paths
+
+Rejected because it would relax the "edits arrive as edits" rule for user actions within Loomark. The rule must remain absolute for Loomark-originated paths; snapshot inference is a narrowly scoped external-boundary exception only.
+
+### Operation reconstruction
+
+Rejected because External admission cannot recover the external editor's actual operations or intent. It infers bounded multi-span edits from a final text relative to a File baseline. Claiming operation reconstruction would overstate what is possible and misrepresent the synthetic writer's provenance.
+
+### Claim stable support before External admission is deterministic and bounded
+
+Rejected because External admission must remain deterministic and bounded under resource limits. Incubating with File-backed persistence evidence prevents premature commitment.
+
+## Consequences
+
+- File Authority and Causal Authority are separate scopes. File Authority settles portable content at file-backed open, save, and external-change admission. Causal Authority settles causal order, Editing Document identity, and writer identity.
+- External admission preserves Editing Document identity for associated external file changes. It does not create a new Editing Document.
+- External admission is deterministic and bounded. It validates UTF-16 boundaries, uses a resource budget, and requires exact replay. Exceeding the budget falls back to one contiguous replacement.
+- Coordinator writer plus application records preserve synthetic provenance without treating writer identity as an operation category.
+- External admission is an optimistic atomic transaction. A mismatch applies none and enters Content conflict without re-diffing against the newer Loomark source.
+- External concurrency uncertainty prevents silent overwrite after a Loomark source change. An external write in this condition enters Content conflict.
+- A rename or move of an associated file preserves Editing Document identity via File association.
+- An unassociated `.md` follows Import Markdown. Synchronized Metadata is required for Join Existing Editing Document.
+- The local-first design's causal-history durability, source-equal history persistence, archive envelope, writer identity, restore limits, and parser-losslessness remain unchanged.
+
+## Non-goals
+
+- Implementing or moving code in this documentation change.
+- Changing EGW core or the collaboration runtime.
+- Defining the archive envelope format or Metadata persistence.
+- Specifying Loomark's Autosave policy, conflict resolution UX, or Resolution workspace lifecycle.
+- Claiming stable External admission support before it is deterministic and bounded under resource limits.

--- a/docs/decisions/2026-08-09-markdown-file-backed-authority-and-external-admission.md
+++ b/docs/decisions/2026-08-09-markdown-file-backed-authority-and-external-admission.md
@@ -64,7 +64,7 @@ External admission is the deterministic bounded multi-span conversion of an admi
 
 **UTF-16 validation.** External admission validates sentinel-free UTF-16 boundaries before inference. Invalid boundaries reject admission and enter Content conflict.
 
-**Resource budget.** External admission uses a resource budget. Exceeding the budget falls back to one contiguous replacement. The budget is receiver policy, not a property of the format.
+**Resource budget.** External admission uses a resource budget. Exceeding the budget falls back to one contiguous replacement, which must also satisfy receiver admission limits before any mutation. If no inferred batch — including the contiguous-replacement fallback — fits within receiver admission limits, apply nothing, preserve the Observed external variant, and enter Content conflict. The budget is receiver policy, not a property of the format.
 
 **Exact replay.** External admission requires exact replay verification: applying the inferred edits to the File baseline must produce the exact admitted external source. Mismatch rejects admission and enters Content conflict.
 
@@ -118,7 +118,7 @@ Rejected because External admission must remain deterministic and bounded under 
 
 - File Authority and Causal Authority are separate scopes. File Authority settles portable content at file-backed open, save, and external-change admission. Causal Authority settles causal order, Editing Document identity, and writer identity.
 - External admission preserves Editing Document identity for associated external file changes. It does not create a new Editing Document.
-- External admission is deterministic and bounded. It validates UTF-16 boundaries, uses a resource budget, and requires exact replay. Exceeding the budget falls back to one contiguous replacement.
+- External admission is deterministic and bounded. It validates UTF-16 boundaries, uses a resource budget, and requires exact replay. Exceeding the budget falls back to one contiguous replacement, which must also satisfy receiver admission limits before any mutation. If no inferred batch fits, apply nothing, preserve the Observed external variant, and enter Content conflict.
 - Coordinator writer plus application records preserve synthetic provenance without treating writer identity as an operation category.
 - External admission is an optimistic atomic transaction. A mismatch applies none and enters Content conflict without re-diffing against the newer Loomark source.
 - External concurrency uncertainty prevents silent overwrite after a Loomark source change. An external write in this condition enters Content conflict.

--- a/docs/design/local-first-document-ownership.md
+++ b/docs/design/local-first-document-ownership.md
@@ -44,15 +44,33 @@ Confusing these is the failure this design prevents.
 | Portable artifact | what survives this software's disappearance |
 | Derived caches | syntax tree, semantic IR, projection, view patches |
 
-The causal authority is the operation graph. Current state is materialized from
-it. The portable artifact is a plain `.md`. Derived caches are reconstructible
-and never authoritative — losing them costs time, never information.
+The Causal Authority is the operation graph. Current state is materialized
+from it. Derived caches are reconstructible and never authoritative — losing
+them costs time, never information.
 
-The portable artifact is deliberately redundant. It is the guarantee that
-remains when the history cannot be read at all, and it is why an archive is
-never reduced to "just the operations". It is a materialized view, not a second
-writable authority: a `.md` changed by an outside tool re-enters as an explicit
-import, never as a merge between two truths.
+Portable content has two persistence modes, neither a single universal
+authority:
+
+| Mode | What survives | What settles portable content |
+| --- | --- | --- |
+| Archive-backed | Opaque history payload, portable text, application Metadata | Exported `.md` is an unassociated portable artifact; no File Authority exists |
+| File-backed | Continuing File association to a Markdown body file | The Markdown body file is File Authority for portable content; accepted operation history remains Causal Authority for causal order and identity |
+
+There is no global authority. File Authority and Causal Authority each settle
+their own scope.
+
+In Archive-backed persistence, the portable artifact is deliberately redundant.
+It is the guarantee that remains when the history cannot be read at all, and it
+is why an archive is never reduced to "just the operations". Opening an
+unassociated `.md` — including a copy of an exported file — follows Import
+Markdown: a new Editing Document and a new causal history baseline, unless
+synchronized Metadata supports Join Existing Editing Document.
+
+In File-backed persistence, a continuing File association makes the Markdown
+body file the File Authority for portable content. External admission preserves
+Editing Document identity when associated content changes. A rename or move
+preserves identity by updating the association. Import Markdown remains the
+path for an unassociated `.md`, whether copied, exported, or never associated.
 
 ## Session state is not an archive
 
@@ -177,6 +195,16 @@ input path has durably recorded a history of whole-document replacements in
 place of what the user actually did, and no later feature can recover a
 granularity that was never captured.
 
+Snapshot inference is a narrowly scoped external-boundary exception for
+File-backed persistence only. External admission deterministically infers
+bounded multi-span edits from an admitted external file's final text relative
+to the File baseline, validates sentinel-free UTF-16 boundaries, uses a
+resource budget with one-contiguous-replacement fallback, and requires exact
+replay. It uses the stable synthetic Coordinator writer for application-originated operations; application records distinguish External admission provenance, and it never claims
+to recover the external editor's original operations or intent. This exception
+does not relax the requirement for any Loomark-originated input path: user
+actions within Loomark always arrive as edits.
+
 **Persistence triggers on history, not on text.** An operation that leaves the
 text unchanged still advanced the document. Anything that decides whether to
 save by comparing text will eventually skip a save that mattered.
@@ -213,13 +241,17 @@ Interim behavior should be honest rather than clever: after merging, re-derive
 the structure and, when an expected structural outcome does not hold, surface
 it for review instead of silently repairing it.
 
-Parser coverage belongs to a different axis than any of this. Because the text
-is the authority and no layer writes back to it, constructs the parser does not
-understand are held losslessly and simply cannot be structurally edited.
-Coverage limits what can be manipulated, not what can be kept — and the product
-contract should say so plainly: everything is preserved, structure editing
-applies to what was recognized, unrecognized regions are never rewritten
-without an explicit user action, and saving never reformats.
+Parser coverage belongs to a different axis than any of this. The parser and
+projection never silently reformat or rewrite text on Loomark-originated
+paths; constructs the parser does not understand are held losslessly and simply
+cannot be structurally edited. File-backed persistence may write accepted
+content to a Markdown body file, and the application may deliberately persist
+changes, but these are application writes of accepted content — not parser or
+projection writeback. Coverage limits what can be manipulated, not what can be
+kept — and the product contract should say so plainly: everything is preserved,
+structure editing applies to what was recognized, unrecognized regions are
+never rewritten without an explicit user action, and the parser and projection
+never silently reformat.
 
 ## Verification
 
@@ -262,3 +294,6 @@ being invalidated by it.
 - [Stable Document Entity Graph](stable-document-entity-graph.md) — stable
   editing-entity identity above projection
 - [Design Concerns](design-concerns.md) — open problems
+- [Markdown file-backed authority and external
+  admission](../decisions/2026-08-09-markdown-file-backed-authority-and-external-admission.md)
+  — File Authority, External admission, and the persistence-mode split

--- a/docs/design/local-first-document-ownership.md
+++ b/docs/design/local-first-document-ownership.md
@@ -197,13 +197,18 @@ granularity that was never captured.
 
 Snapshot inference is a narrowly scoped external-boundary exception for
 File-backed persistence only. External admission deterministically infers
-bounded multi-span edits from an admitted external file's final text relative
-to the File baseline, validates sentinel-free UTF-16 boundaries, uses a
-resource budget with one-contiguous-replacement fallback, and requires exact
-replay. It uses the stable synthetic Coordinator writer for application-originated operations; application records distinguish External admission provenance, and it never claims
-to recover the external editor's original operations or intent. This exception
-does not relax the requirement for any Loomark-originated input path: user
-actions within Loomark always arrive as edits.
+bounded multi-span edits from an admitted file's final text relative to the
+File baseline, validates sentinel-free UTF-16 boundaries, uses a resource
+budget with one-contiguous-replacement fallback, and requires exact replay.
+The selected inferred batch — including the contiguous-replacement fallback —
+is preflighted against receiver admission limits before any mutation. If no
+inferred batch fits, apply nothing, preserve the Observed external variant,
+and enter Content conflict. It uses the stable synthetic Coordinator writer
+for application-originated operations; application records distinguish
+admission provenance, and it never claims to recover the source editor's
+original operations or intent. This exception does not relax the requirement
+for any Loomark-originated input path: user actions within Loomark always
+arrive as edits.
 
 **Persistence triggers on history, not on text.** An operation that leaves the
 text unchanged still advanced the document. Anything that decides whether to


### PR DESCRIPTION
## Summary

- Define the Loomark-owned Editing Document, Canopy-owned Markdown causal state, mount/lease lifecycle, and persistence statuses in the canonical glossary.
- Split Archive-backed and File-backed persistence, with scoped File Authority and Causal Authority plus bounded, provenance-aware External admission for associated Markdown body files.
- Record and index the EGW staged-publication and Markdown file-backed authority decisions, including conflict resolution, crash recovery, publication outcomes, and content-only fallback recovery.

## UI and review evidence

N/A — documentation-only architecture and domain-model changes; no rendered UI changed.

## Reuse check

N/A — pure documentation change; no functions, methods, helpers, or types were added.

## Validation scope

Boundary matrix / first failing regression:

No executable behavior changed. The documentation consistency boundary covered Archive-backed versus File-backed persistence, File versus Causal Authority, Import versus External admission, Coordinator writer versus Writing instances, normal Autosave versus prepared destructive resolution, committed-with-issue retry prohibition, content-only recovery, and EGW/application responsibility placement.

Target packages:

`--no-target "documentation-only Markdown persistence domain, ADR discoverability, and admission preflight clarification"`

Additional conditional gates:

- `./scripts/check-documentation-lifecycle.sh`
- `./scripts/check-agent-doc-links.sh`
- Slopless: zero findings for both new ADRs; remaining findings are canonical-term repetition in `CONTEXT.md` and pre-existing prose outside the edited sections of the local-first design.
- Independent semantic review: PASS after resolving persistence-mode, bounded-admission, architecture-doc, and no-retry recovery findings.

## PR-ready evidence

Validated HEAD: `8d171bf52fcccce0c96603b9767e24394938022d`

Validated base: `origin/main@abd34cb03d4f9156868508c36c83f4000f3649dd`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh \
  --no-target "documentation-only Markdown persistence domain, ADR discoverability, and admission preflight clarification"
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for the exact HEAD and base above.
- [x] The base was fetched again and `--verify-evidence` passed immediately before this PR was opened.
- [x] The committed `.mbti` diff against the validated base was reviewed; no `.mbti` files changed.
- [x] No submodule pointer changed.
- [x] Validation was rerun after the final commit and base synchronization.
- [x] Independent review findings were resolved before the final validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the glossary with clearer terminology for document editing, persistence, leases, durability, conflicts, recovery, and resolution.
  * Documented how Archive-backed and File-backed documents handle authority, external Markdown changes, imports, deletions, relocation, and conflicts.
  * Added guidance for staged publication, including draft sealing, recovery outcomes, validation, and committed or rejected results.
  * Clarified local-first document ownership, synchronization, supported persistence modes, and added the new decision records to the documentation index.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


