### PR TITLE
perf(loomark): reuse grapheme boundaries per validation

### DIFF
--- a/modules/canopy/editor/markdown/editor.mbt
+++ b/modules/canopy/editor/markdown/editor.mbt
@@ -420,12 +420,13 @@ pub fn MarkdownDocumentUtf16Selection::MarkdownDocumentUtf16Selection(
       source_length~,
     )
   }
-  guard @moji.is_grapheme_boundary(source, anchor) else {
+  let boundaries = @moji.grapheme_boundaries(source)
+  guard boundaries.binary_search(anchor) is Ok(_) else {
     raise MarkdownDocumentUtf16SelectionError::MidGraphemeBoundary(
       offset=anchor,
     )
   }
-  guard @moji.is_grapheme_boundary(source, head) else {
+  guard boundaries.binary_search(head) is Ok(_) else {
     raise MarkdownDocumentUtf16SelectionError::MidGraphemeBoundary(offset=head)
   }
   { anchor, head }

--- a/modules/canopy/editor/sync_editor_text.mbt
+++ b/modules/canopy/editor/sync_editor_text.mbt
@@ -285,9 +285,13 @@ fn[T : Eq] SyncEditor::apply_text_edit_with_policy(
       if start < 0 ||
         deleted_len < 0 ||
         start > text_len ||
-        start + deleted_len > text_len ||
-        !@moji.is_grapheme_boundary(old_source, start) ||
-        !@moji.is_grapheme_boundary(old_source, start + deleted_len) {
+        start + deleted_len > text_len {
+        editor_perf_end("applyEditPolicy")
+        return false
+      }
+      let boundaries = @moji.grapheme_boundaries(old_source)
+      if boundaries.binary_search(start) is Err(_) ||
+        boundaries.binary_search(start + deleted_len) is Err(_) {
         editor_perf_end("applyEditPolicy")
         return false
       }


### PR DESCRIPTION
## Summary

- Generate the grapheme-boundary array once per Loomark Raw selection/exact-edit validation.
- Reuse the sorted boundaries with `Array::binary_search` for both endpoints while preserving snapshot revalidation and the existing commit path.
- Keep the change limited to the editor and markdown editor packages; no public API, cache, or submodule changes.

## UI and review evidence

N/A — this is an internal editor validation/performance change. Browser behavior and latency were checked with the Loomark vanilla dev host and standalone E2E suites.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `@moji.grapheme_boundaries` | `deps/loom/moji` | Yes | Canonical grapheme segmentation and sorted UTF-16 boundary generation. |
| `Array::binary_search` | MoonBit core `Array` | Yes | Exact membership lookup over the sorted boundary array without adding a helper or cache. |
| `String`/`StringView` slicing APIs | MoonBit core | Checked, not needed | The existing validation only needs boundary membership; no new slicing is introduced. |
| `Option`/`Result` | MoonBit core and existing editor API | Checked, existing API retained | Existing success/error semantics are unchanged. |

New helpers added: none.

## Validation scope

Boundary matrix covered by existing tests and E2E:

- LF, CRLF, CR, and EOF terminators
- emoji, ZWJ, regional-indicator, and combining-mark graphemes
- valid boundaries and mid-grapheme rejection, including endpoint validation
- selection construction and exact edit validation
- composition/IME, same-character insertion, stale snapshots, external document changes, and failure/no-op paths

Target packages:

- `modules/canopy/editor`
- `modules/canopy/editor/markdown`

Additional conditional gates:

- Markdown JS: 78/78 passed
- Editor JS: 237/237 passed
- Rabbita JS: 112/112 passed
- Moji JS: 3934/3934 passed
- Loomark dev-host E2E: 57/57 passed
- Loomark standalone E2E: 13/13 passed
- `scripts/build-js.sh` passed
- The full native editor test attempt still encounters the pre-existing parse/`JsWebSocket` issues; markdown native tests pass and the PR-ready baseline reports zero non-vendored failures.

Browser performance probe (fresh context/mount, 5 warmups + 50 measured edits, nearest-rank percentiles, 50 ms debounce included):

| | p50 | p95 |
|---|---:|---:|
| baseline | 166.3 ms | 177.2 ms |
| optimized | 134.7 ms | 142.7 ms |

The current probe fixture is 20,169 UTF-16 units; the historical note says approximately 19,415. Baseline and optimized runs used the same current fixture. The probe uses a synthetic DOM input seam and is not a claim about total native keyboard, paste, or IME latency.

## PR-ready evidence

Validated HEAD: `167410b0e8a2ec98b20f924058f200d32f4e5b63`

Validated base: `origin/main@fea86792408e5a681477a676608c893836c5a930`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh \
  --target modules/canopy/editor \
  --target modules/canopy/editor/markdown
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for the exact HEAD and base above.
- [x] The base was fetched again and `--verify-evidence` passed immediately before opening this PR.
- [x] The committed `.mbti` diff against the validated base was reviewed; there is no `.mbti` diff.
- [x] No submodule commit was changed.
- [x] Validation was rerun after the final commit.
- [x] Independent MoonBit review found no critical or warning findings; its optional suggestion was not required for this minimal change.
