### PR TITLE
refactor(loomark): centralize semantic Raw input state

### DIFF
--- a/apps/loomark/internal/rabbita/raw_input_frontier.mbt
+++ b/apps/loomark/internal/rabbita/raw_input_frontier.mbt
@@ -1,11 +1,14 @@
 ///|
-/// The native Raw frontier that can be ahead of the committed document.
+/// The unified semantic Raw input frontier.
 ///
-/// This is the functional core of the browser-input race: DOM snapshots move
-/// from an active delivery into a deferred snapshot, then back to pending at
-/// the newly accepted document frontier. Scheduler commands and DOM effects
-/// remain in RawInputCoordinator as the imperative shell.
-priv struct RawInputFrontierState {
+/// The transition matrix and shell boundary are documented in
+/// `docs/plans/2026-08-10-loomark-raw-input-state-reducer.md`. This state owns
+/// browser-visible Raw snapshots and their ordering. It does not own DOM,
+/// scheduling, clocks, telemetry, or editor effects.
+priv struct RawInputState {
+  pending : PendingRawInput?
+  composition : PendingRawInput?
+  deferred_composition_finished : Bool
   deferred_before_input : DeferredRawInputCapture?
   deferred : DeferredRawInput?
   deferred_composition : DeferredRawInput?
@@ -19,8 +22,11 @@ priv struct RawInputDelivery {
 }
 
 ///|
-fn RawInputFrontierState::initial() -> RawInputFrontierState {
+fn RawInputState::initial() -> RawInputState {
   {
+    pending: None,
+    composition: None,
+    deferred_composition_finished: false,
     deferred_before_input: None,
     deferred: None,
     deferred_composition: None,
@@ -29,7 +35,17 @@ fn RawInputFrontierState::initial() -> RawInputFrontierState {
 }
 
 ///|
-priv enum RawInputFrontierEvent {
+/// A reducer decision contains only data for the imperative shell to execute.
+/// The shell allocates the token before dispatching `BeginPendingDelivery`;
+/// the reducer decides whether that pending input can become active.
+priv enum RawInputDecision {
+  Noop
+  StoredPending
+  Deliver(Int, PendingRawInput)
+}
+
+///|
+priv enum RawInputEvent {
   CaptureDeferredBeforeInput(DeferredRawInputCapture)
   StoreDeferred(DeferredRawInput)
   BeginDeferredComposition(DeferredRawInput)
@@ -37,6 +53,13 @@ priv enum RawInputFrontierEvent {
   ClearDeferredCapture
   ClearDeferred
   ClearDeferredComposition
+  StorePending(PendingRawInput)
+  BeginPendingDelivery(Int)
+  BeginComposition(PendingRawInput)
+  UpdateComposition(PendingRawInput)
+  ClearComposition
+  MarkDeferredCompositionFinished
+  ClearDeferredCompositionFinished
   BeginDelivery(RawInputDelivery)
   FinishDelivery(Int)
   DiscardDelivery(Int)
@@ -44,79 +67,164 @@ priv enum RawInputFrontierEvent {
 }
 
 ///|
-/// Pure transition function for the browser-visible Raw frontier.
-fn reduce_raw_input_frontier(
-  state : RawInputFrontierState,
-  event : RawInputFrontierEvent,
-) -> RawInputFrontierState {
+/// Pure transition function for semantic browser-visible Raw state.
+fn reduce_raw_input(
+  state : RawInputState,
+  event : RawInputEvent,
+) -> (RawInputState, RawInputDecision) {
   match event {
-    RawInputFrontierEvent::CaptureDeferredBeforeInput(capture) =>
+    RawInputEvent::CaptureDeferredBeforeInput(capture) =>
       if (state.in_flight is Some(_) || state.deferred is Some(_)) &&
         state.deferred_composition is None {
-        { ..state, deferred_before_input: Some(capture) }
+        (
+          { ..state, deferred_before_input: Some(capture) },
+          RawInputDecision::Noop,
+        )
       } else {
-        state
+        (state, RawInputDecision::Noop)
       }
-    RawInputFrontierEvent::StoreDeferred(deferred) =>
+    RawInputEvent::StoreDeferred(deferred) =>
       if state.in_flight is Some(_) &&
         state.deferred_before_input is Some(_) &&
         state.deferred_composition is None {
-        { ..state, deferred_before_input: None, deferred: Some(deferred) }
+        (
+          { ..state, deferred_before_input: None, deferred: Some(deferred) },
+          RawInputDecision::Noop,
+        )
       } else {
-        state
+        (state, RawInputDecision::Noop)
       }
-    RawInputFrontierEvent::BeginDeferredComposition(composition) =>
+    RawInputEvent::BeginDeferredComposition(composition) =>
       if state.in_flight is Some(_) && state.deferred_composition is None {
-        {
-          ..state,
-          deferred: None,
-          deferred_before_input: None,
-          deferred_composition: Some(composition),
-        }
-      } else {
-        state
-      }
-    RawInputFrontierEvent::UpdateDeferredComposition(composition) =>
-      if state.deferred_composition is Some(_) {
-        { ..state, deferred_composition: Some(composition) }
-      } else {
-        state
-      }
-    RawInputFrontierEvent::ClearDeferredCapture =>
-      { ..state, deferred_before_input: None }
-    RawInputFrontierEvent::ClearDeferred =>
-      { ..state, deferred_before_input: None, deferred: None }
-    RawInputFrontierEvent::ClearDeferredComposition =>
-      { ..state, deferred_composition: None }
-    RawInputFrontierEvent::BeginDelivery(delivery) =>
-      if state.in_flight is None {
-        { ..state, in_flight: Some(delivery) }
-      } else {
-        state
-      }
-    RawInputFrontierEvent::FinishDelivery(token) =>
-      match state.in_flight {
-        Some(delivery) if delivery.token == token =>
-          { ..state, in_flight: None }
-        _ => state
-      }
-    RawInputFrontierEvent::DiscardDelivery(token) =>
-      match state.in_flight {
-        Some(delivery) if delivery.token == token =>
+        (
           {
-            deferred_before_input: None,
+            ..state,
+            deferred_composition_finished: false,
             deferred: None,
-            deferred_composition: None,
-            in_flight: None,
+            deferred_before_input: None,
+            deferred_composition: Some(composition),
+          },
+          RawInputDecision::Noop,
+        )
+      } else {
+        (state, RawInputDecision::Noop)
+      }
+    RawInputEvent::UpdateDeferredComposition(composition) =>
+      if state.deferred_composition is Some(_) {
+        (
+          { ..state, deferred_composition: Some(composition) },
+          RawInputDecision::Noop,
+        )
+      } else {
+        (state, RawInputDecision::Noop)
+      }
+    RawInputEvent::ClearDeferredCapture =>
+      ({ ..state, deferred_before_input: None }, RawInputDecision::Noop)
+    RawInputEvent::ClearDeferred =>
+      (
+        { ..state, deferred_before_input: None, deferred: None },
+        RawInputDecision::Noop,
+      )
+    RawInputEvent::ClearDeferredComposition =>
+      ({ ..state, deferred_composition: None }, RawInputDecision::Noop)
+    RawInputEvent::StorePending(input) =>
+      if state.composition is None &&
+        state.deferred_before_input is None &&
+        state.deferred is None &&
+        state.deferred_composition is None {
+        ({ ..state, pending: Some(input) }, RawInputDecision::StoredPending)
+      } else {
+        (state, RawInputDecision::Noop)
+      }
+    RawInputEvent::BeginPendingDelivery(token) =>
+      match state.pending {
+        Some(input) if state.in_flight is None &&
+          state.composition is None &&
+          state.deferred_before_input is None &&
+          state.deferred is None &&
+          state.deferred_composition is None => {
+          let (next, _) = reduce_raw_input(
+            { ..state, pending: None },
+            RawInputEvent::BeginDelivery({ token, source: input.source }),
+          )
+          match next.in_flight {
+            Some(delivery) if delivery.token == token =>
+              (next, RawInputDecision::Deliver(token, input))
+            _ => (state, RawInputDecision::Noop)
           }
-        _ => state
+        }
+        _ => (state, RawInputDecision::Noop)
       }
-    RawInputFrontierEvent::Cancel =>
-      {
-        deferred_before_input: None,
-        deferred: None,
-        deferred_composition: None,
-        in_flight: None,
+    RawInputEvent::BeginComposition(input) =>
+      if state.in_flight is None &&
+        state.deferred_before_input is None &&
+        state.deferred is None &&
+        state.deferred_composition is None {
+        (
+          {
+            ..state,
+            pending: None,
+            composition: Some(input),
+            deferred_composition_finished: false,
+          },
+          RawInputDecision::Noop,
+        )
+      } else {
+        (state, RawInputDecision::Noop)
       }
+    RawInputEvent::UpdateComposition(input) =>
+      if state.composition is Some(_) {
+        ({ ..state, composition: Some(input) }, RawInputDecision::Noop)
+      } else {
+        (state, RawInputDecision::Noop)
+      }
+    RawInputEvent::ClearComposition =>
+      ({ ..state, composition: None }, RawInputDecision::Noop)
+    RawInputEvent::MarkDeferredCompositionFinished =>
+      if state.deferred_composition is Some(_) {
+        (
+          { ..state, deferred_composition_finished: true },
+          RawInputDecision::Noop,
+        )
+      } else {
+        (state, RawInputDecision::Noop)
+      }
+    RawInputEvent::ClearDeferredCompositionFinished =>
+      (
+        { ..state, deferred_composition_finished: false },
+        RawInputDecision::Noop,
+      )
+    RawInputEvent::BeginDelivery(delivery) =>
+      if state.in_flight is None &&
+        state.pending is None &&
+        state.composition is None &&
+        state.deferred_before_input is None &&
+        state.deferred is None &&
+        state.deferred_composition is None {
+        ({ ..state, in_flight: Some(delivery) }, RawInputDecision::Noop)
+      } else {
+        (state, RawInputDecision::Noop)
+      }
+    RawInputEvent::FinishDelivery(token) =>
+      match state.in_flight {
+        Some(delivery) if delivery.token == token => {
+          let next = { ..state, in_flight: None }
+          let next = if next.deferred_composition is None &&
+            next.pending is None {
+            { ..next, deferred_composition_finished: false }
+          } else {
+            next
+          }
+          (next, RawInputDecision::Noop)
+        }
+        _ => (state, RawInputDecision::Noop)
+      }
+    RawInputEvent::DiscardDelivery(token) =>
+      match state.in_flight {
+        Some(delivery) if delivery.token == token =>
+          (RawInputState::initial(), RawInputDecision::Noop)
+        _ => (state, RawInputDecision::Noop)
+      }
+    RawInputEvent::Cancel => (RawInputState::initial(), RawInputDecision::Noop)
   }
 }

--- a/apps/loomark/internal/rabbita/raw_input_frontier.mbt
+++ b/apps/loomark/internal/rabbita/raw_input_frontier.mbt
@@ -208,7 +208,7 @@ fn reduce_raw_input(
     RawInputEvent::FinishDelivery(token) =>
       match state.in_flight {
         Some(delivery) if delivery.token == token => {
-          let next = { ..state, in_flight: None }
+          let next = { ..state, in_flight: None, deferred_before_input: None }
           let next = if next.deferred_composition is None &&
             next.pending is None {
             { ..next, deferred_composition_finished: false }

--- a/apps/loomark/internal/rabbita/raw_input_frontier_wbtest.mbt
+++ b/apps/loomark/internal/rabbita/raw_input_frontier_wbtest.mbt
@@ -1,13 +1,22 @@
 ///|
+fn reduce_raw_input_state(
+  state : RawInputState,
+  event : RawInputEvent,
+) -> RawInputState {
+  let (next, _) = reduce_raw_input(state, event)
+  next
+}
+
+///|
 test "Raw frontier reducer keeps deferred input ahead of the active delivery" {
-  let state = RawInputFrontierState::initial()
-  let active = reduce_raw_input_frontier(
+  let state = RawInputState::initial()
+  let active = reduce_raw_input_state(
     state,
-    RawInputFrontierEvent::BeginDelivery({ token: 4, source: "startX" }),
+    RawInputEvent::BeginDelivery({ token: 4, source: "startX" }),
   )
-  let captured = reduce_raw_input_frontier(
+  let captured = reduce_raw_input_state(
     active,
-    RawInputFrontierEvent::CaptureDeferredBeforeInput({
+    RawInputEvent::CaptureDeferredBeforeInput({
       base_source: "startX",
       input_type: "insertText",
       selection: @dom_boundary.TextSelection(6, 6, @dom_boundary.NoDirection),
@@ -29,9 +38,9 @@ test "Raw frontier reducer keeps deferred input ahead of the active delivery" {
     ),
     input_count: 1,
   }
-  let next = reduce_raw_input_frontier(
+  let next = reduce_raw_input_state(
     captured,
-    RawInputFrontierEvent::StoreDeferred(deferred),
+    RawInputEvent::StoreDeferred(deferred),
   )
   guard next.in_flight is Some(delivery) else {
     fail("storing deferred input must retain the active delivery")
@@ -46,13 +55,13 @@ test "Raw frontier reducer keeps deferred input ahead of the active delivery" {
 
 ///|
 test "Raw frontier reducer keeps composition behind the active delivery" {
-  let active = reduce_raw_input_frontier(
-    RawInputFrontierState::initial(),
-    RawInputFrontierEvent::BeginDelivery({ token: 4, source: "startX" }),
+  let active = reduce_raw_input_state(
+    RawInputState::initial(),
+    RawInputEvent::BeginDelivery({ token: 4, source: "startX" }),
   )
-  let composition = reduce_raw_input_frontier(
+  let composition = reduce_raw_input_state(
     active,
-    RawInputFrontierEvent::BeginDeferredComposition({
+    RawInputEvent::BeginDeferredComposition({
       base_source: "startX",
       input_type: "insertCompositionText",
       before_input_selection: @dom_boundary.TextSelection(
@@ -73,9 +82,9 @@ test "Raw frontier reducer keeps composition behind the active delivery" {
     fail("active composition must be retained behind the delivery")
   }
   assert_eq(input.source, "startX")
-  let updated = reduce_raw_input_frontier(
+  let updated = reduce_raw_input_state(
     composition,
-    RawInputFrontierEvent::UpdateDeferredComposition({
+    RawInputEvent::UpdateDeferredComposition({
       ..input,
       source: "startX漢",
       post_input_selection: @dom_boundary.TextSelection(
@@ -96,10 +105,10 @@ test "Raw frontier reducer keeps composition behind the active delivery" {
 
 ///|
 test "Raw frontier reducer rejects capture without an active delivery" {
-  let state = RawInputFrontierState::initial()
-  let next = reduce_raw_input_frontier(
+  let state = RawInputState::initial()
+  let next = reduce_raw_input_state(
     state,
-    RawInputFrontierEvent::CaptureDeferredBeforeInput({
+    RawInputEvent::CaptureDeferredBeforeInput({
       base_source: "start",
       input_type: "insertText",
       selection: @dom_boundary.TextSelection(5, 5, @dom_boundary.NoDirection),
@@ -111,13 +120,13 @@ test "Raw frontier reducer rejects capture without an active delivery" {
 
 ///|
 test "Raw frontier reducer does not overwrite an active delivery" {
-  let state = reduce_raw_input_frontier(
-    RawInputFrontierState::initial(),
-    RawInputFrontierEvent::BeginDelivery({ token: 4, source: "startX" }),
+  let state = reduce_raw_input_state(
+    RawInputState::initial(),
+    RawInputEvent::BeginDelivery({ token: 4, source: "startX" }),
   )
-  let next = reduce_raw_input_frontier(
+  let next = reduce_raw_input_state(
     state,
-    RawInputFrontierEvent::BeginDelivery({ token: 5, source: "startY" }),
+    RawInputEvent::BeginDelivery({ token: 5, source: "startY" }),
   )
   guard next.in_flight is Some(delivery) else {
     fail("active delivery must remain present")
@@ -128,40 +137,37 @@ test "Raw frontier reducer does not overwrite an active delivery" {
 
 ///|
 test "Raw frontier reducer finishes only the matching delivery" {
-  let state = reduce_raw_input_frontier(
-    RawInputFrontierState::initial(),
-    RawInputFrontierEvent::BeginDelivery({ token: 4, source: "startX" }),
+  let state = reduce_raw_input_state(
+    RawInputState::initial(),
+    RawInputEvent::BeginDelivery({ token: 4, source: "startX" }),
   )
-  let unchanged = reduce_raw_input_frontier(
+  let unchanged = reduce_raw_input_state(
     state,
-    RawInputFrontierEvent::FinishDelivery(3),
+    RawInputEvent::FinishDelivery(3),
   )
   assert_true(unchanged.in_flight is Some(_))
-  let finished = reduce_raw_input_frontier(
+  let finished = reduce_raw_input_state(
     unchanged,
-    RawInputFrontierEvent::FinishDelivery(4),
+    RawInputEvent::FinishDelivery(4),
   )
   assert_true(finished.in_flight is None)
 }
 
 ///|
 test "Raw frontier reducer cancellation clears deferred and active state" {
-  let state = reduce_raw_input_frontier(
-    RawInputFrontierState::initial(),
-    RawInputFrontierEvent::BeginDelivery({ token: 4, source: "startX" }),
+  let state = reduce_raw_input_state(
+    RawInputState::initial(),
+    RawInputEvent::BeginDelivery({ token: 4, source: "startX" }),
   )
-  let captured = reduce_raw_input_frontier(
+  let captured = reduce_raw_input_state(
     state,
-    RawInputFrontierEvent::CaptureDeferredBeforeInput({
+    RawInputEvent::CaptureDeferredBeforeInput({
       base_source: "startX",
       input_type: "insertText",
       selection: @dom_boundary.TextSelection(6, 6, @dom_boundary.NoDirection),
     }),
   )
-  let canceled = reduce_raw_input_frontier(
-    captured,
-    RawInputFrontierEvent::Cancel,
-  )
+  let canceled = reduce_raw_input_state(captured, RawInputEvent::Cancel)
   assert_true(canceled.in_flight is None)
   assert_true(canceled.deferred is None)
   assert_true(canceled.deferred_before_input is None)

--- a/apps/loomark/internal/rabbita/raw_input_state_wbtest.mbt
+++ b/apps/loomark/internal/rabbita/raw_input_state_wbtest.mbt
@@ -190,6 +190,35 @@ test "Raw state reducer keeps pending input through deferred composition no-op" 
 }
 
 ///|
+test "Raw state reducer clears deferred capture when delivery finishes" {
+  let (active, _) = reduce_raw_input(
+    RawInputState::initial(),
+    RawInputEvent::BeginDelivery({ token: 3, source: "start" }),
+  )
+  let (captured, _) = reduce_raw_input(
+    active,
+    RawInputEvent::CaptureDeferredBeforeInput({
+      base_source: "start",
+      input_type: "insertText",
+      selection: @dom_boundary.TextSelection(5, 5, @dom_boundary.NoDirection),
+    }),
+  )
+  assert_true(captured.deferred_before_input is Some(_))
+  let (finished, _) = reduce_raw_input(
+    captured,
+    RawInputEvent::FinishDelivery(3),
+  )
+  assert_true(finished.in_flight is None)
+  assert_true(finished.deferred_before_input is None)
+  let (stored, decision) = reduce_raw_input(
+    finished,
+    RawInputEvent::StorePending(raw_state_test_input("startX")),
+  )
+  assert_true(decision is RawInputDecision::StoredPending)
+  assert_true(stored.pending is Some(_))
+}
+
+///|
 test "Raw state reducer clears completion marker after follow-up delivery" {
   let (active, _) = reduce_raw_input(
     RawInputState::initial(),

--- a/apps/loomark/internal/rabbita/raw_input_state_wbtest.mbt
+++ b/apps/loomark/internal/rabbita/raw_input_state_wbtest.mbt
@@ -1,0 +1,537 @@
+///|
+fn raw_state_test_input(source : String) -> PendingRawInput {
+  let context = RawSelectionTestContext::RawSelectionTestContext(
+    "raw-state-reducer-test", "start",
+  )
+  {
+    before_input: RawBeforeInputCandidate::RawBeforeInputCandidate(
+      selection=context.selection(5, 5),
+      input_type="insertText",
+      is_composing=false,
+    ),
+    source,
+    post_input_selection: @dom_boundary.TextSelection(
+      5,
+      5,
+      @dom_boundary.NoDirection,
+    ),
+    input_count: 1,
+  }
+}
+
+///|
+test "Raw state reducer delivers pending input atomically" {
+  let input = raw_state_test_input("startX")
+  let (stored, _) = reduce_raw_input(
+    RawInputState::initial(),
+    RawInputEvent::StorePending(input),
+  )
+  let (active, decision) = reduce_raw_input(
+    stored,
+    RawInputEvent::BeginPendingDelivery(7),
+  )
+  guard decision is RawInputDecision::Deliver(token, delivered) else {
+    fail("pending delivery must produce an explicit delivery decision")
+  }
+  assert_eq(token, 7)
+  assert_eq(delivered.source, "startX")
+  assert_true(active.pending is None)
+  guard active.in_flight is Some(delivery) else {
+    fail("pending delivery must become the active frontier")
+  }
+  assert_eq(delivery.token, 7)
+  assert_eq(delivery.source, "startX")
+}
+
+///|
+test "Raw state reducer keeps pending input behind an active frontier" {
+  let active = {
+    let (state, _) = reduce_raw_input(
+      RawInputState::initial(),
+      RawInputEvent::BeginDelivery({ token: 3, source: "start" }),
+    )
+    state
+  }
+  let (next, decision) = reduce_raw_input(
+    active,
+    RawInputEvent::StorePending(raw_state_test_input("startX")),
+  )
+  guard next.pending is Some(input) else {
+    fail("pending input must wait behind the active frontier")
+  }
+  assert_eq(input.source, "startX")
+  assert_true(next.in_flight is Some(_))
+  assert_true(decision is RawInputDecision::StoredPending)
+}
+
+///|
+test "Raw state reducer retains pending input when deferred composition starts" {
+  let (active, _) = reduce_raw_input(
+    RawInputState::initial(),
+    RawInputEvent::BeginDelivery({ token: 3, source: "start" }),
+  )
+  let (with_pending, _) = reduce_raw_input(
+    active,
+    RawInputEvent::StorePending(raw_state_test_input("startX")),
+  )
+  let (next, _) = reduce_raw_input(
+    with_pending,
+    RawInputEvent::BeginDeferredComposition({
+      base_source: "start",
+      input_type: "insertCompositionText",
+      before_input_selection: @dom_boundary.TextSelection(
+        5,
+        5,
+        @dom_boundary.NoDirection,
+      ),
+      source: "start",
+      post_input_selection: @dom_boundary.TextSelection(
+        5,
+        5,
+        @dom_boundary.NoDirection,
+      ),
+      input_count: 0,
+    }),
+  )
+  guard next.pending is Some(pending) else {
+    fail("deferred composition must not discard a pending ordinary input")
+  }
+  assert_eq(pending.source, "startX")
+  assert_true(next.deferred_composition is Some(_))
+}
+
+///|
+test "Raw state reducer retains pending input when ordinary input is deferred" {
+  let (active, _) = reduce_raw_input(
+    RawInputState::initial(),
+    RawInputEvent::BeginDelivery({ token: 3, source: "start" }),
+  )
+  let (with_pending, _) = reduce_raw_input(
+    active,
+    RawInputEvent::StorePending(raw_state_test_input("startX")),
+  )
+  let (captured, _) = reduce_raw_input(
+    with_pending,
+    RawInputEvent::CaptureDeferredBeforeInput({
+      base_source: "start",
+      input_type: "insertText",
+      selection: @dom_boundary.TextSelection(5, 5, @dom_boundary.NoDirection),
+    }),
+  )
+  let (next, _) = reduce_raw_input(
+    captured,
+    RawInputEvent::StoreDeferred({
+      base_source: "start",
+      input_type: "insertText",
+      before_input_selection: @dom_boundary.TextSelection(
+        5,
+        5,
+        @dom_boundary.NoDirection,
+      ),
+      source: "startXY",
+      post_input_selection: @dom_boundary.TextSelection(
+        7,
+        7,
+        @dom_boundary.NoDirection,
+      ),
+      input_count: 1,
+    }),
+  )
+  assert_true(next.pending is Some(_))
+  assert_true(next.deferred is Some(_))
+}
+
+///|
+test "Raw state reducer keeps pending input through deferred composition no-op" {
+  let (active, _) = reduce_raw_input(
+    RawInputState::initial(),
+    RawInputEvent::BeginDelivery({ token: 3, source: "start" }),
+  )
+  let (with_pending, _) = reduce_raw_input(
+    active,
+    RawInputEvent::StorePending(raw_state_test_input("startX")),
+  )
+  let (deferred, _) = reduce_raw_input(
+    with_pending,
+    RawInputEvent::BeginDeferredComposition({
+      base_source: "start",
+      input_type: "insertCompositionText",
+      before_input_selection: @dom_boundary.TextSelection(
+        5,
+        5,
+        @dom_boundary.NoDirection,
+      ),
+      source: "start",
+      post_input_selection: @dom_boundary.TextSelection(
+        5,
+        5,
+        @dom_boundary.NoDirection,
+      ),
+      input_count: 0,
+    }),
+  )
+  let (finished, _) = reduce_raw_input(
+    deferred,
+    RawInputEvent::MarkDeferredCompositionFinished,
+  )
+  let (cleared_composition, _) = reduce_raw_input(
+    finished,
+    RawInputEvent::ClearDeferredComposition,
+  )
+  let (next, _) = reduce_raw_input(
+    cleared_composition,
+    RawInputEvent::ClearDeferredCompositionFinished,
+  )
+  guard next.pending is Some(pending) else {
+    fail("a deferred composition no-op must retain ordinary pending input")
+  }
+  assert_eq(pending.source, "startX")
+  assert_false(next.deferred_composition_finished)
+}
+
+///|
+test "Raw state reducer clears completion marker after follow-up delivery" {
+  let (active, _) = reduce_raw_input(
+    RawInputState::initial(),
+    RawInputEvent::BeginDelivery({ token: 3, source: "start" }),
+  )
+  let (deferred, _) = reduce_raw_input(
+    active,
+    RawInputEvent::BeginDeferredComposition({
+      base_source: "start",
+      input_type: "insertCompositionText",
+      before_input_selection: @dom_boundary.TextSelection(
+        5,
+        5,
+        @dom_boundary.NoDirection,
+      ),
+      source: "start漢",
+      post_input_selection: @dom_boundary.TextSelection(
+        6,
+        6,
+        @dom_boundary.NoDirection,
+      ),
+      input_count: 1,
+    }),
+  )
+  let (finished, _) = reduce_raw_input(
+    deferred,
+    RawInputEvent::MarkDeferredCompositionFinished,
+  )
+  let (after_original, _) = reduce_raw_input(
+    finished,
+    RawInputEvent::FinishDelivery(3),
+  )
+  assert_true(after_original.deferred_composition_finished)
+  let (cleared, _) = reduce_raw_input(
+    after_original,
+    RawInputEvent::ClearDeferredComposition,
+  )
+  let (stored, decision) = reduce_raw_input(
+    cleared,
+    RawInputEvent::StorePending(raw_state_test_input("start漢")),
+  )
+  assert_true(decision is RawInputDecision::StoredPending)
+  let (follow_up, delivery_decision) = reduce_raw_input(
+    stored,
+    RawInputEvent::BeginPendingDelivery(4),
+  )
+  assert_true(delivery_decision is RawInputDecision::Deliver(_, _))
+  let (done, _) = reduce_raw_input(follow_up, RawInputEvent::FinishDelivery(4))
+  assert_false(done.deferred_composition_finished)
+}
+
+///|
+test "Raw state reducer discards only the matching active delivery" {
+  let (active, _) = reduce_raw_input(
+    RawInputState::initial(),
+    RawInputEvent::BeginDelivery({ token: 3, source: "start" }),
+  )
+  let (with_pending, _) = reduce_raw_input(
+    active,
+    RawInputEvent::StorePending(raw_state_test_input("startX")),
+  )
+  let (unchanged, _) = reduce_raw_input(
+    with_pending,
+    RawInputEvent::DiscardDelivery(2),
+  )
+  assert_true(unchanged.in_flight is Some(_))
+  assert_true(unchanged.pending is Some(_))
+  let (discarded, _) = reduce_raw_input(
+    unchanged,
+    RawInputEvent::DiscardDelivery(3),
+  )
+  assert_true(discarded.in_flight is None)
+  assert_true(discarded.pending is None)
+}
+
+///|
+test "Raw state reducer rejects pending input during live composition" {
+  let (composing, _) = reduce_raw_input(
+    RawInputState::initial(),
+    RawInputEvent::BeginComposition(raw_state_test_input("start")),
+  )
+  let (next, decision) = reduce_raw_input(
+    composing,
+    RawInputEvent::StorePending(raw_state_test_input("startX")),
+  )
+  assert_true(next.pending is None)
+  assert_true(next.composition is Some(_))
+  assert_true(decision is RawInputDecision::Noop)
+}
+
+///|
+test "Raw state reducer promotes pending input into composition" {
+  let pending = raw_state_test_input("startX")
+  let (stored, _) = reduce_raw_input(
+    RawInputState::initial(),
+    RawInputEvent::StorePending(pending),
+  )
+  let composition_input = raw_state_test_input("startX")
+  let (composing, _) = reduce_raw_input(
+    stored,
+    RawInputEvent::BeginComposition(composition_input),
+  )
+  assert_true(composing.pending is None)
+  guard composing.composition is Some(input) else {
+    fail("composition must own the promoted input")
+  }
+  assert_eq(input.source, "startX")
+  let (updated, _) = reduce_raw_input(
+    composing,
+    RawInputEvent::UpdateComposition({ ..input, source: "start漢" }),
+  )
+  guard updated.composition is Some(latest) else {
+    fail("composition update must retain the live composition")
+  }
+  assert_eq(latest.source, "start漢")
+}
+
+///|
+test "Raw state reducer rejects composition start behind every deferred frontier" {
+  let input = raw_state_test_input("start漢")
+  let (active, _) = reduce_raw_input(
+    RawInputState::initial(),
+    RawInputEvent::BeginDelivery({ token: 5, source: "start" }),
+  )
+  let (active_unchanged, active_decision) = reduce_raw_input(
+    active,
+    RawInputEvent::BeginComposition(input),
+  )
+  assert_true(active_unchanged.in_flight is Some(_))
+  assert_true(active_unchanged.composition is None)
+  assert_true(active_decision is RawInputDecision::Noop)
+
+  let (captured, _) = reduce_raw_input(
+    active,
+    RawInputEvent::CaptureDeferredBeforeInput({
+      base_source: "start",
+      input_type: "insertText",
+      selection: @dom_boundary.TextSelection(5, 5, @dom_boundary.NoDirection),
+    }),
+  )
+  let (captured_unchanged, captured_decision) = reduce_raw_input(
+    captured,
+    RawInputEvent::BeginComposition(input),
+  )
+  assert_true(captured_unchanged.deferred_before_input is Some(_))
+  assert_true(captured_unchanged.composition is None)
+  assert_true(captured_decision is RawInputDecision::Noop)
+
+  let (deferred, _) = reduce_raw_input(
+    captured,
+    RawInputEvent::StoreDeferred({
+      base_source: "start",
+      input_type: "insertText",
+      before_input_selection: @dom_boundary.TextSelection(
+        5,
+        5,
+        @dom_boundary.NoDirection,
+      ),
+      source: "startX",
+      post_input_selection: @dom_boundary.TextSelection(
+        6,
+        6,
+        @dom_boundary.NoDirection,
+      ),
+      input_count: 1,
+    }),
+  )
+  let (deferred_unchanged, deferred_decision) = reduce_raw_input(
+    deferred,
+    RawInputEvent::BeginComposition(input),
+  )
+  assert_true(deferred_unchanged.deferred is Some(_))
+  assert_true(deferred_unchanged.composition is None)
+  assert_true(deferred_decision is RawInputDecision::Noop)
+
+  let (deferred_composition, _) = reduce_raw_input(
+    active,
+    RawInputEvent::BeginDeferredComposition({
+      base_source: "start",
+      input_type: "insertCompositionText",
+      before_input_selection: @dom_boundary.TextSelection(
+        5,
+        5,
+        @dom_boundary.NoDirection,
+      ),
+      source: "start漢",
+      post_input_selection: @dom_boundary.TextSelection(
+        6,
+        6,
+        @dom_boundary.NoDirection,
+      ),
+      input_count: 1,
+    }),
+  )
+  let (deferred_composition_unchanged, deferred_composition_decision) = reduce_raw_input(
+    deferred_composition,
+    RawInputEvent::BeginComposition(input),
+  )
+  assert_true(deferred_composition_unchanged.deferred_composition is Some(_))
+  assert_true(deferred_composition_unchanged.composition is None)
+  assert_true(deferred_composition_decision is RawInputDecision::Noop)
+}
+
+///|
+test "Raw state reducer tracks deferred composition completion" {
+  let (active, _) = reduce_raw_input(
+    RawInputState::initial(),
+    RawInputEvent::BeginDelivery({ token: 4, source: "start" }),
+  )
+  let (deferred, _) = reduce_raw_input(
+    active,
+    RawInputEvent::BeginDeferredComposition({
+      base_source: "start",
+      input_type: "insertCompositionText",
+      before_input_selection: @dom_boundary.TextSelection(
+        5,
+        5,
+        @dom_boundary.NoDirection,
+      ),
+      source: "start",
+      post_input_selection: @dom_boundary.TextSelection(
+        5,
+        5,
+        @dom_boundary.NoDirection,
+      ),
+      input_count: 0,
+    }),
+  )
+  let (finished, _) = reduce_raw_input(
+    deferred,
+    RawInputEvent::MarkDeferredCompositionFinished,
+  )
+  assert_true(finished.deferred_composition_finished)
+  let (cleared, _) = reduce_raw_input(
+    finished,
+    RawInputEvent::ClearDeferredCompositionFinished,
+  )
+  assert_false(cleared.deferred_composition_finished)
+}
+
+///|
+test "Raw state reducer keeps the completion marker on duplicate deferred begin" {
+  let (active, _) = reduce_raw_input(
+    RawInputState::initial(),
+    RawInputEvent::BeginDelivery({ token: 4, source: "start" }),
+  )
+  let (deferred, _) = reduce_raw_input(
+    active,
+    RawInputEvent::BeginDeferredComposition({
+      base_source: "start",
+      input_type: "insertCompositionText",
+      before_input_selection: @dom_boundary.TextSelection(
+        5,
+        5,
+        @dom_boundary.NoDirection,
+      ),
+      source: "start漢",
+      post_input_selection: @dom_boundary.TextSelection(
+        6,
+        6,
+        @dom_boundary.NoDirection,
+      ),
+      input_count: 1,
+    }),
+  )
+  let (finished, _) = reduce_raw_input(
+    deferred,
+    RawInputEvent::MarkDeferredCompositionFinished,
+  )
+  let (unchanged, decision) = reduce_raw_input(
+    finished,
+    RawInputEvent::BeginDeferredComposition({
+      base_source: "start",
+      input_type: "insertCompositionText",
+      before_input_selection: @dom_boundary.TextSelection(
+        5,
+        5,
+        @dom_boundary.NoDirection,
+      ),
+      source: "start別",
+      post_input_selection: @dom_boundary.TextSelection(
+        6,
+        6,
+        @dom_boundary.NoDirection,
+      ),
+      input_count: 1,
+    }),
+  )
+  assert_true(unchanged.deferred_composition_finished)
+  assert_true(unchanged.deferred_composition is Some(_))
+  assert_true(decision is RawInputDecision::Noop)
+}
+
+///|
+test "Raw state reducer ignores mismatched delivery completion" {
+  let (active, _) = reduce_raw_input(
+    RawInputState::initial(),
+    RawInputEvent::BeginDelivery({ token: 4, source: "start" }),
+  )
+  let (unchanged, decision) = reduce_raw_input(
+    active,
+    RawInputEvent::FinishDelivery(5),
+  )
+  assert_true(unchanged.in_flight is Some(_))
+  assert_true(decision is RawInputDecision::Noop)
+}
+
+///|
+test "Raw state reducer cancellation clears every semantic frontier" {
+  let (active, _) = reduce_raw_input(
+    RawInputState::initial(),
+    RawInputEvent::BeginDelivery({ token: 4, source: "start" }),
+  )
+  let (deferred, _) = reduce_raw_input(
+    active,
+    RawInputEvent::BeginDeferredComposition({
+      base_source: "start",
+      input_type: "insertCompositionText",
+      before_input_selection: @dom_boundary.TextSelection(
+        5,
+        5,
+        @dom_boundary.NoDirection,
+      ),
+      source: "start漢",
+      post_input_selection: @dom_boundary.TextSelection(
+        6,
+        6,
+        @dom_boundary.NoDirection,
+      ),
+      input_count: 1,
+    }),
+  )
+  let (finished, _) = reduce_raw_input(
+    deferred,
+    RawInputEvent::MarkDeferredCompositionFinished,
+  )
+  let (canceled, _) = reduce_raw_input(finished, RawInputEvent::Cancel)
+  assert_true(canceled.pending is None)
+  assert_true(canceled.composition is None)
+  assert_true(canceled.deferred_before_input is None)
+  assert_true(canceled.deferred is None)
+  assert_true(canceled.deferred_composition is None)
+  assert_true(canceled.in_flight is None)
+  assert_false(canceled.deferred_composition_finished)
+}

--- a/apps/loomark/internal/rabbita/text_control_repair.mbt
+++ b/apps/loomark/internal/rabbita/text_control_repair.mbt
@@ -61,17 +61,14 @@ priv struct PendingRawInput {
 /// Coalesce native textarea events into one delayed, tokenized Raw transaction.
 /// Custom-driver RawInput events bypass this coordinator and remain token-less.
 priv struct RawInputCoordinator {
-  frontier : @ref.Ref[RawInputFrontierState]
+  frontier : @ref.Ref[RawInputState]
   unmatched_before_input : @ref.Ref[RawBeforeInputCandidate?]
-  pending : @ref.Ref[PendingRawInput?]
   scheduled : @ref.Ref[Bool]
   schedule_generation : @ref.Ref[Int]
   capture_generation : @ref.Ref[Int]
   next_token : @ref.Ref[Int]
   suppress_unmatched_repair : @ref.Ref[Bool]
-  composition : @ref.Ref[PendingRawInput?]
   composition_final_source : @ref.Ref[String?]
-  deferred_composition_finished : @ref.Ref[Bool]
   render_barrier_armed : @ref.Ref[Bool]
   render_barrier_waiting : @ref.Ref[Bool]
   render_barrier_token : @ref.Ref[Int?]
@@ -85,17 +82,14 @@ fn RawInputCoordinator::RawInputCoordinator(
   telemetry : RawInputTelemetry?,
 ) -> RawInputCoordinator {
   {
-    frontier: @ref.Ref(RawInputFrontierState::initial()),
+    frontier: @ref.Ref(RawInputState::initial()),
     unmatched_before_input: @ref.Ref(None),
-    pending: @ref.Ref(None),
     scheduled: @ref.Ref(false),
     schedule_generation: @ref.Ref(0),
     capture_generation: @ref.Ref(0),
     next_token: @ref.Ref(0),
     suppress_unmatched_repair: @ref.Ref(false),
-    composition: @ref.Ref(None),
     composition_final_source: @ref.Ref(None),
-    deferred_composition_finished: @ref.Ref(false),
     render_barrier_armed: @ref.Ref(false),
     render_barrier_waiting: @ref.Ref(false),
     render_barrier_token: @ref.Ref(None),
@@ -106,11 +100,21 @@ fn RawInputCoordinator::RawInputCoordinator(
 }
 
 ///|
+fn RawInputCoordinator::reduce_frontier_with_decision(
+  self : RawInputCoordinator,
+  event : RawInputEvent,
+) -> RawInputDecision {
+  let (state, decision) = reduce_raw_input(self.frontier.val, event)
+  self.frontier.val = state
+  decision
+}
+
+///|
 fn RawInputCoordinator::reduce_frontier(
   self : RawInputCoordinator,
-  event : RawInputFrontierEvent,
+  event : RawInputEvent,
 ) -> Unit {
-  self.frontier.val = reduce_raw_input_frontier(self.frontier.val, event)
+  ignore(self.reduce_frontier_with_decision(event))
 }
 
 ///|
@@ -269,10 +273,10 @@ fn RawInputCoordinator::display_source(
   self : RawInputCoordinator,
   committed_source : String,
 ) -> String {
-  match self.composition.val {
+  match self.frontier.val.composition {
     Some(input) => input.source
     None =>
-      match self.pending.val {
+      match self.frontier.val.pending {
         Some(pending) => pending.source
         None =>
           match self.frontier.val.deferred_composition {
@@ -301,8 +305,13 @@ fn RawInputCoordinator::begin_composition(
   source : String,
   selection : @dom_boundary.TextSelection,
 ) -> Bool {
-  guard !self.has_active_delivery() else { return false }
-  let input = match self.pending.val {
+  guard !self.has_active_delivery() &&
+    self.frontier.val.deferred_before_input is None &&
+    self.frontier.val.deferred is None &&
+    self.frontier.val.deferred_composition is None else {
+    return false
+  }
+  let input = match self.frontier.val.pending {
     Some(pending) if pending.before_input.selection.document_id ==
       before_input.selection.document_id &&
       pending.before_input.selection.version == before_input.selection.version =>
@@ -319,9 +328,8 @@ fn RawInputCoordinator::begin_composition(
   self.capture_generation.val += 1
   self.scheduled.val = false
   self.unmatched_before_input.val = None
-  self.pending.val = None
   self.suppress_unmatched_repair.val = false
-  self.composition.val = Some(input)
+  self.reduce_frontier(RawInputEvent::BeginComposition(input))
   self.composition_final_source.val = None
   true
 }
@@ -337,7 +345,6 @@ fn RawInputCoordinator::begin_native_composition(
 ) -> Bool {
   if self.has_active_delivery() {
     let frontier = self.frontier.val
-    self.deferred_composition_finished.val = false
     let (base_source, frontier_source, before_input_selection) = match
       frontier.deferred {
       Some(deferred) =>
@@ -349,7 +356,7 @@ fn RawInputCoordinator::begin_native_composition(
         }
     }
     self.reduce_frontier(
-      RawInputFrontierEvent::BeginDeferredComposition({
+      RawInputEvent::BeginDeferredComposition({
         base_source,
         input_type: "insertCompositionText",
         before_input_selection,
@@ -360,7 +367,7 @@ fn RawInputCoordinator::begin_native_composition(
     )
     return true
   }
-  let before_input = match self.pending.val {
+  let before_input = match self.frontier.val.pending {
     Some(pending) if pending.before_input.selection.document_id ==
       model.document_id &&
       pending.before_input.selection.version == model.document_version =>
@@ -385,21 +392,23 @@ fn RawInputCoordinator::update_composition(
   source : String,
   selection : @dom_boundary.TextSelection,
 ) -> Bool {
-  match self.composition.val {
+  match self.frontier.val.composition {
     Some(input) => {
-      self.composition.val = Some({
-        ..input,
-        source: raw_textarea_value(source),
-        post_input_selection: selection,
-        input_count: input.input_count + 1,
-      })
+      self.reduce_frontier(
+        RawInputEvent::UpdateComposition({
+          ..input,
+          source: raw_textarea_value(source),
+          post_input_selection: selection,
+          input_count: input.input_count + 1,
+        }),
+      )
       true
     }
     None =>
       match self.frontier.val.deferred_composition {
         Some(input) => {
           self.reduce_frontier(
-            RawInputFrontierEvent::UpdateDeferredComposition({
+            RawInputEvent::UpdateDeferredComposition({
               ..input,
               source: raw_textarea_value(source),
               post_input_selection: selection,
@@ -425,19 +434,19 @@ fn RawInputCoordinator::finish_composition(
   match self.frontier.val.deferred_composition {
     Some(input) => {
       if input.source == raw_textarea_value(input.base_source) {
-        self.reduce_frontier(RawInputFrontierEvent::ClearDeferredComposition)
-        self.deferred_composition_finished.val = false
+        self.reduce_frontier(RawInputEvent::ClearDeferredComposition)
+        self.reduce_frontier(RawInputEvent::ClearDeferredCompositionFinished)
       } else {
-        self.deferred_composition_finished.val = true
+        self.reduce_frontier(RawInputEvent::MarkDeferredCompositionFinished)
       }
       return @rabbita_runtime.none
     }
     None => ()
   }
-  guard self.composition.val is Some(input) else {
+  guard self.frontier.val.composition is Some(input) else {
     return @rabbita_runtime.none
   }
-  self.composition.val = None
+  self.reduce_frontier(RawInputEvent::ClearComposition)
   if input.source == raw_textarea_value(accepted_source) {
     match self.telemetry {
       Some(telemetry) => telemetry.pending_input_received_at.val = None
@@ -445,7 +454,7 @@ fn RawInputCoordinator::finish_composition(
     }
     return @rabbita_runtime.none
   }
-  self.pending.val = Some(input)
+  self.reduce_frontier(RawInputEvent::StorePending(input))
   self.composition_final_source.val = Some(input.source)
   let expiry_command = self.capture_before_input(input.before_input)
   match self.take_pending_delivery() {
@@ -524,7 +533,7 @@ fn RawInputCoordinator::capture_deferred_before_input(
     Some(selection) => selection
     None => {
       self.capture_generation.val += 1
-      self.reduce_frontier(RawInputFrontierEvent::ClearDeferredCapture)
+      self.reduce_frontier(RawInputEvent::ClearDeferredCapture)
       return @rabbita_runtime.none
     }
   }
@@ -538,7 +547,7 @@ fn RawInputCoordinator::capture_deferred_before_input(
   }
   self.capture_generation.val += 1
   self.reduce_frontier(
-    RawInputFrontierEvent::CaptureDeferredBeforeInput({
+    RawInputEvent::CaptureDeferredBeforeInput({
       base_source,
       input_type: raw_input_event_type(event),
       selection,
@@ -555,7 +564,7 @@ fn RawInputCoordinator::capture_native_before_input(
   event : @dom.InputEvent,
 ) -> @cmd.Cmd {
   if raw_input_event_is_composing(event) {
-    if self.composition.val is None &&
+    if self.frontier.val.composition is None &&
       self.frontier.val.deferred_composition is None &&
       !self.has_active_delivery() {
       self.cancel_pending()
@@ -569,7 +578,7 @@ fn RawInputCoordinator::capture_native_before_input(
     self.frontier.val.deferred is Some(_) {
     return self.capture_deferred_before_input(model, event)
   }
-  match self.pending.val {
+  match self.frontier.val.pending {
     Some(pending) => return self.capture_before_input(pending.before_input)
     None => ()
   }
@@ -627,51 +636,61 @@ fn RawInputCoordinator::take_pending_delivery(
   self : RawInputCoordinator,
 ) -> (Int, RawNativeInputCandidate)? {
   guard self.frontier.val.in_flight is None else { return None }
-  guard self.pending.val is Some(pending) else { return None }
-  self.pending.val = None
+  guard self.frontier.val.pending is Some(_) else { return None }
   let token = self.next_token.val
-  self.next_token.val = token + 1
-  let source = pending.source
-  self.reduce_frontier(RawInputFrontierEvent::BeginDelivery({ token, source }))
-  match self.telemetry {
-    Some(telemetry) => {
-      let now = raw_input_now_ms()
-      let input_received_at = match telemetry.pending_input_received_at.val {
-        Some(at) => at
-        None => now
+  match
+    self.reduce_frontier_with_decision(
+      RawInputEvent::BeginPendingDelivery(token),
+    ) {
+    RawInputDecision::Deliver(delivery_token, pending) => {
+      self.next_token.val = token + 1
+      match self.telemetry {
+        Some(telemetry) => {
+          let now = raw_input_now_ms()
+          let input_received_at = match
+            telemetry.pending_input_received_at.val {
+            Some(at) => at
+            None => now
+          }
+          telemetry.pending_input_received_at.val = None
+          telemetry.phase.val = Some({
+            token: delivery_token,
+            input_count: pending.input_count,
+            input_received_at,
+            debounce_fired_at: now,
+            reducer_started_at: None,
+            reducer_finished_at: None,
+            editor_started_at: None,
+            editor_finished_at: None,
+            preview_started_at: None,
+            preview_finished_at: None,
+            publish_started_at: None,
+            publish_finished_at: None,
+            rendered_at: None,
+          })
+        }
+        None => ()
       }
-      telemetry.pending_input_received_at.val = None
-      telemetry.phase.val = Some({
-        token,
-        input_count: pending.input_count,
-        input_received_at,
-        debounce_fired_at: now,
-        reducer_started_at: None,
-        reducer_finished_at: None,
-        editor_started_at: None,
-        editor_finished_at: None,
-        preview_started_at: None,
-        preview_finished_at: None,
-        publish_started_at: None,
-        publish_finished_at: None,
-        rendered_at: None,
-      })
+      Some(
+        (
+          delivery_token,
+          RawNativeInputCandidate::authorized(
+            before_input=pending.before_input,
+            source=pending.source,
+            post_input_selection=pending.post_input_selection,
+          ),
+        ),
+      )
     }
-    None => ()
+    RawInputDecision::Noop | RawInputDecision::StoredPending => None
   }
-  Some(
-    (
-      token,
-      RawNativeInputCandidate::authorized(
-        before_input=pending.before_input,
-        source~,
-        post_input_selection=pending.post_input_selection,
-      ),
-    ),
-  )
 }
 
 ///|
+/// A debounce callback may race an active delivery. Preserve the existing
+/// shell policy: a blocked pending callback cancels the pending transaction;
+/// browser input that must survive the race is captured through the deferred
+/// frontier and rebased after render.
 fn RawInputCoordinator::flush(
   self : RawInputCoordinator,
   scheduler : &@cmd.Scheduler,
@@ -696,7 +715,7 @@ fn RawInputCoordinator::has_captured_before_input(
 fn RawInputCoordinator::suppress_composing_input_repair(
   self : RawInputCoordinator,
 ) -> Unit {
-  if self.composition.val is None &&
+  if self.frontier.val.composition is None &&
     self.frontier.val.deferred_composition is None {
     if !self.has_active_delivery() {
       self.cancel_pending()
@@ -743,7 +762,7 @@ fn RawInputCoordinator::defer_native_input(
   self.unmatched_before_input.val = None
   let source = raw_textarea_value(source)
   self.reduce_frontier(
-    RawInputFrontierEvent::StoreDeferred({
+    RawInputEvent::StoreDeferred({
       base_source,
       input_type,
       before_input_selection,
@@ -789,7 +808,7 @@ fn RawInputCoordinator::enqueue(
     self.cancel_pending()
     return @rabbita_runtime.none
   }
-  let pending = match self.pending.val {
+  let pending = match self.frontier.val.pending {
     Some(pending) if pending.before_input.selection.document_id !=
       before_input.selection.document_id ||
       pending.before_input.selection.version != before_input.selection.version => {
@@ -812,8 +831,12 @@ fn RawInputCoordinator::enqueue(
       { before_input, source, post_input_selection, input_count: 1 }
     }
   }
-  self.pending.val = Some(pending)
-  self.schedule(emit)
+  match
+    self.reduce_frontier_with_decision(RawInputEvent::StorePending(pending)) {
+    RawInputDecision::StoredPending => self.schedule(emit)
+    RawInputDecision::Noop | RawInputDecision::Deliver(_, _) =>
+      @rabbita_runtime.none
+  }
 }
 
 ///|
@@ -827,7 +850,7 @@ fn RawInputCoordinator::enqueue_deferred(
     Some(deferred) => deferred
     None => return @rabbita_runtime.none
   }
-  self.reduce_frontier(RawInputFrontierEvent::ClearDeferred)
+  self.reduce_frontier(RawInputEvent::ClearDeferred)
   guard raw_textarea_value(model.document.source()) ==
     raw_textarea_value(deferred.base_source) else {
     return @rabbita_runtime.none
@@ -843,9 +866,14 @@ fn RawInputCoordinator::enqueue_deferred(
     deferred.post_input_selection,
     emit,
   )
-  match self.pending.val {
+  match self.frontier.val.pending {
     Some(pending) =>
-      self.pending.val = Some({ ..pending, input_count: deferred.input_count })
+      self.reduce_frontier(
+        RawInputEvent::StorePending({
+          ..pending,
+          input_count: deferred.input_count,
+        }),
+      )
     None => ()
   }
   command
@@ -860,31 +888,33 @@ fn RawInputCoordinator::enqueue_deferred_composition(
   let deferred = match self.frontier.val.deferred_composition {
     Some(deferred) => deferred
     None => {
-      self.deferred_composition_finished.val = false
+      self.reduce_frontier(RawInputEvent::ClearDeferredCompositionFinished)
       return @rabbita_runtime.none
     }
   }
-  self.reduce_frontier(RawInputFrontierEvent::ClearDeferredComposition)
+  self.reduce_frontier(RawInputEvent::ClearDeferredComposition)
   guard raw_textarea_value(model.document.source()) ==
     raw_textarea_value(deferred.base_source) else {
-    self.deferred_composition_finished.val = false
+    self.reduce_frontier(RawInputEvent::ClearDeferredCompositionFinished)
     return @rabbita_runtime.none
   }
   let before_input = match rebase_deferred_raw_input(model, deferred) {
     Some(before_input) => before_input
     None => {
-      self.deferred_composition_finished.val = false
+      self.reduce_frontier(RawInputEvent::ClearDeferredCompositionFinished)
       return @rabbita_runtime.none
     }
   }
   self.capture_generation.val += 1
   self.unmatched_before_input.val = None
-  self.pending.val = Some({
-    before_input,
-    source: deferred.source,
-    post_input_selection: deferred.post_input_selection,
-    input_count: deferred.input_count,
-  })
+  self.reduce_frontier(
+    RawInputEvent::StorePending({
+      before_input,
+      source: deferred.source,
+      post_input_selection: deferred.post_input_selection,
+      input_count: deferred.input_count,
+    }),
+  )
   match self.take_pending_delivery() {
     Some((token, candidate)) =>
       emit(Editing(RawNativeInput(token~, candidate~)))
@@ -898,7 +928,7 @@ fn RawInputCoordinator::finalize_deferred_composition(
   model : DriverModel,
   emit : @cmd.Emit[DriverEvent],
 ) -> @cmd.Cmd {
-  guard self.deferred_composition_finished.val else {
+  guard self.frontier.val.deferred_composition_finished else {
     return @rabbita_runtime.none
   }
   guard !self.has_active_delivery() else { return @rabbita_runtime.none }
@@ -907,9 +937,9 @@ fn RawInputCoordinator::finalize_deferred_composition(
 
 ///|
 fn RawInputCoordinator::discard_deferred(self : RawInputCoordinator) -> Unit {
-  self.reduce_frontier(RawInputFrontierEvent::ClearDeferred)
-  self.reduce_frontier(RawInputFrontierEvent::ClearDeferredComposition)
-  self.deferred_composition_finished.val = false
+  self.reduce_frontier(RawInputEvent::ClearDeferred)
+  self.reduce_frontier(RawInputEvent::ClearDeferredComposition)
+  self.reduce_frontier(RawInputEvent::ClearDeferredCompositionFinished)
 }
 
 ///|
@@ -974,12 +1004,12 @@ fn RawInputCoordinator::complete_after_render(
   let has_deferred = self.frontier.val.deferred is Some(_)
   let has_deferred_composition = self.frontier.val.deferred_composition
     is Some(_) &&
-    self.deferred_composition_finished.val
-  self.reduce_frontier(RawInputFrontierEvent::ClearDeferredCapture)
+    self.frontier.val.deferred_composition_finished
+  self.reduce_frontier(RawInputEvent::ClearDeferredCapture)
   match latest_model.val {
     Some(model) => {
       publish(model, Some(self), None)
-      self.reduce_frontier(RawInputFrontierEvent::FinishDelivery(token))
+      self.reduce_frontier(RawInputEvent::FinishDelivery(token))
       if has_deferred_composition {
         scheduler.add(self.enqueue_deferred_composition(model, emit))
       } else if has_deferred {
@@ -988,12 +1018,9 @@ fn RawInputCoordinator::complete_after_render(
     }
     None => {
       self.discard_deferred()
-      self.reduce_frontier(RawInputFrontierEvent::ClearDeferredComposition)
-      self.reduce_frontier(RawInputFrontierEvent::FinishDelivery(token))
+      self.reduce_frontier(RawInputEvent::ClearDeferredComposition)
+      self.reduce_frontier(RawInputEvent::FinishDelivery(token))
     }
-  }
-  if !has_deferred_composition && self.pending.val is None {
-    self.deferred_composition_finished.val = false
   }
 }
 
@@ -1035,8 +1062,7 @@ fn RawInputCoordinator::discard(
   token : Int,
 ) -> Unit {
   if self.is_active(token) {
-    self.reduce_frontier(RawInputFrontierEvent::DiscardDelivery(token))
-    self.deferred_composition_finished.val = false
+    self.reduce_frontier(RawInputEvent::DiscardDelivery(token))
     self.render_barrier_armed.val = false
     self.render_barrier_waiting.val = false
     self.render_barrier_token.val = None
@@ -1057,7 +1083,6 @@ fn RawInputCoordinator::cancel_pending(self : RawInputCoordinator) -> Unit {
   self.capture_generation.val += 1
   self.scheduled.val = false
   self.unmatched_before_input.val = None
-  self.pending.val = None
   match self.telemetry {
     Some(telemetry) => {
       telemetry.pending_input_received_at.val = None
@@ -1065,11 +1090,9 @@ fn RawInputCoordinator::cancel_pending(self : RawInputCoordinator) -> Unit {
     }
     None => ()
   }
-  self.reduce_frontier(RawInputFrontierEvent::Cancel)
+  self.reduce_frontier(RawInputEvent::Cancel)
   self.suppress_unmatched_repair.val = false
-  self.composition.val = None
   self.composition_final_source.val = None
-  self.deferred_composition_finished.val = false
   self.render_barrier_armed.val = false
   self.render_barrier_waiting.val = false
   self.render_barrier_token.val = None
@@ -1095,7 +1118,7 @@ fn RawInputCoordinator::has_deferred_composition(
 fn RawInputCoordinator::cancel_pending_for_navigation(
   self : RawInputCoordinator,
 ) -> Unit {
-  if self.deferred_composition_finished.val ||
+  if self.frontier.val.deferred_composition_finished ||
     (self.has_active_delivery() && self.has_deferred_composition()) {
     return
   }
@@ -1109,8 +1132,8 @@ fn RawInputCoordinator::native_selection_frontier_is_current(
   self : RawInputCoordinator,
   committed_source : String,
 ) -> Bool {
-  self.pending.val is None &&
-  self.composition.val is None &&
+  self.frontier.val.pending is None &&
+  self.frontier.val.composition is None &&
   self.frontier.val.deferred_before_input is None &&
   self.frontier.val.deferred is None &&
   self.frontier.val.deferred_composition is None &&

--- a/apps/loomark/internal/rabbita/text_control_repair_wbtest.mbt
+++ b/apps/loomark/internal/rabbita/text_control_repair_wbtest.mbt
@@ -104,8 +104,92 @@ test "Raw composition keeps intermediate DOM state out of pending input" {
   )
 
   assert_eq(coordinator.display_source("start"), "startか")
-  assert_true(coordinator.pending.val is None)
+  assert_true(coordinator.frontier.val.pending is None)
   assert_true(test_in_flight_token(coordinator) is None)
+}
+
+///|
+test "Raw coordinator does not schedule a pending store during live composition" {
+  let context = RawSelectionTestContext::RawSelectionTestContext(
+    "raw-composition-pending-rejection", "start",
+  )
+  let coordinator = RawInputCoordinator::RawInputCoordinator(None)
+  let emit : @cmd.Emit[DriverEvent] = @cmd.Emit(_ => @rabbita_runtime.none)
+  assert_true(
+    coordinator.begin_composition(
+      RawBeforeInputCandidate::RawBeforeInputCandidate(
+        selection=context.selection(5, 5),
+        input_type="insertCompositionText",
+        is_composing=false,
+      ),
+      "start",
+      @dom_boundary.TextSelection(5, 5, @dom_boundary.NoDirection),
+    ),
+  )
+  ignore(
+    coordinator.capture_before_input(
+      RawBeforeInputCandidate::RawBeforeInputCandidate(
+        selection=context.selection(5, 5),
+        input_type="insertText",
+        is_composing=false,
+      ),
+    ),
+  )
+  ignore(
+    coordinator.enqueue(
+      "startX",
+      @dom_boundary.TextSelection(6, 6, @dom_boundary.NoDirection),
+      emit,
+    ),
+  )
+  assert_true(coordinator.frontier.val.pending is None)
+  assert_true(coordinator.frontier.val.composition is Some(_))
+  assert_false(coordinator.scheduled.val)
+}
+
+///|
+test "Raw coordinator rejects composition start behind active delivery without generation changes" {
+  let context = RawSelectionTestContext::RawSelectionTestContext(
+    "raw-composition-active-rejection", "start",
+  )
+  let coordinator = RawInputCoordinator::RawInputCoordinator(None)
+  let emit : @cmd.Emit[DriverEvent] = @cmd.Emit(_ => @rabbita_runtime.none)
+  ignore(
+    coordinator.capture_before_input(
+      RawBeforeInputCandidate::RawBeforeInputCandidate(
+        selection=context.selection(5, 5),
+        input_type="insertText",
+        is_composing=false,
+      ),
+    ),
+  )
+  ignore(
+    coordinator.enqueue(
+      "startX",
+      @dom_boundary.TextSelection(6, 6, @dom_boundary.NoDirection),
+      emit,
+    ),
+  )
+  guard coordinator.take_pending_delivery() is Some((0, _)) else {
+    fail("the test input must become active")
+  }
+  let schedule_generation = coordinator.schedule_generation.val
+  let capture_generation = coordinator.capture_generation.val
+  assert_false(
+    coordinator.begin_composition(
+      RawBeforeInputCandidate::RawBeforeInputCandidate(
+        selection=context.selection(5, 5),
+        input_type="insertCompositionText",
+        is_composing=false,
+      ),
+      "startX",
+      @dom_boundary.TextSelection(6, 6, @dom_boundary.NoDirection),
+    ),
+  )
+  assert_eq(coordinator.schedule_generation.val, schedule_generation)
+  assert_eq(coordinator.capture_generation.val, capture_generation)
+  assert_true(coordinator.frontier.val.in_flight is Some(_))
+  assert_true(coordinator.frontier.val.composition is None)
 }
 
 ///|
@@ -135,8 +219,8 @@ test "Raw composition end releases one immediate final transaction" {
 
   ignore(coordinator.finish_composition("start", emit))
 
-  assert_true(coordinator.composition.val is None)
-  assert_true(coordinator.pending.val is None)
+  assert_true(coordinator.frontier.val.composition is None)
+  assert_true(coordinator.frontier.val.pending is None)
   assert_eq(test_in_flight_token(coordinator), Some(0))
   assert_eq(test_in_flight_source(coordinator), Some("start漢字"))
 }
@@ -168,8 +252,8 @@ test "Canceled Raw composition never becomes an editor transaction" {
 
   ignore(coordinator.finish_composition("start", emit))
 
-  assert_true(coordinator.composition.val is None)
-  assert_true(coordinator.pending.val is None)
+  assert_true(coordinator.frontier.val.composition is None)
+  assert_true(coordinator.frontier.val.pending is None)
   assert_true(test_in_flight_token(coordinator) is None)
   assert_true(coordinator.unmatched_before_input.val is None)
 }
@@ -209,7 +293,7 @@ test "Raw composition ignores one same-value final input while delivery is activ
     ),
   )
 
-  assert_true(coordinator.pending.val is None)
+  assert_true(coordinator.frontier.val.pending is None)
   assert_eq(test_in_flight_token(coordinator), Some(0))
   assert_eq(test_in_flight_source(coordinator), Some("start漢字"))
 }
@@ -241,6 +325,7 @@ test "Raw input keeps latest same-value text after a different pending value" {
   guard coordinator.take_pending_delivery() is Some((0, _)) else {
     fail("first value must become active")
   }
+  assert_true(coordinator.frontier.val.in_flight is Some(_))
   ignore(capture())
   ignore(
     coordinator.enqueue(
@@ -258,7 +343,7 @@ test "Raw input keeps latest same-value text after a different pending value" {
     ),
   )
 
-  guard coordinator.pending.val is Some(pending) else {
+  guard coordinator.frontier.val.pending is Some(pending) else {
     fail("latest value must remain pending")
   }
   assert_eq(pending.source, "A")
@@ -301,7 +386,7 @@ test "Raw composition releases promoted input without a composition input" {
 
   ignore(coordinator.finish_composition("abcdef", emit))
 
-  assert_true(coordinator.composition.val is None)
+  assert_true(coordinator.frontier.val.composition is None)
   assert_eq(test_in_flight_source(coordinator), Some("abxyef"))
   assert_eq(test_in_flight_token(coordinator), Some(0))
 }
@@ -340,7 +425,7 @@ test "Raw composition keeps a pending ordinary input as its transaction base" {
       @dom_boundary.TextSelection(4, 4, @dom_boundary.NoDirection),
     ),
   )
-  guard coordinator.composition.val is Some(started) else {
+  guard coordinator.frontier.val.composition is Some(started) else {
     fail("composition must promote the pending ordinary input")
   }
   assert_eq(started.source, "abxyef")
@@ -351,21 +436,21 @@ test "Raw composition keeps a pending ordinary input as its transaction base" {
     ),
   )
 
-  guard coordinator.composition.val is Some(input) else {
+  guard coordinator.frontier.val.composition is Some(input) else {
     fail("composition must retain one complete final transaction")
   }
   assert_eq(input.before_input.selection.selection.anchor(), 4)
   assert_eq(input.before_input.selection.selection.head(), 2)
   assert_eq(input.source, "abxy漢ef")
   assert_eq(input.post_input_selection.start(), 5)
-  assert_true(coordinator.pending.val is None)
+  assert_true(coordinator.frontier.val.pending is None)
 }
 
 ///|
 test "Raw coordinator does not guess an unpaired in-flight input" {
   let coordinator = RawInputCoordinator::RawInputCoordinator(None)
   coordinator.reduce_frontier(
-    RawInputFrontierEvent::BeginDelivery({ token: 1, source: "startX" }),
+    RawInputEvent::BeginDelivery({ token: 1, source: "startX" }),
   )
   let deferred = coordinator.defer_native_input(
     "startXY",
@@ -379,7 +464,7 @@ test "Raw coordinator does not guess an unpaired in-flight input" {
 test "Raw coordinator keeps an active delivery for unpaired input" {
   let coordinator = RawInputCoordinator::RawInputCoordinator(None)
   coordinator.reduce_frontier(
-    RawInputFrontierEvent::BeginDelivery({ token: 1, source: "startX" }),
+    RawInputEvent::BeginDelivery({ token: 1, source: "startX" }),
   )
   let emit : @cmd.Emit[DriverEvent] = @cmd.Emit(_ => @rabbita_runtime.none)
   ignore(
@@ -397,10 +482,10 @@ test "Raw coordinator keeps an active delivery for unpaired input" {
 test "Raw coordinator keeps the first deferred selection and latest native value" {
   let coordinator = RawInputCoordinator::RawInputCoordinator(None)
   coordinator.reduce_frontier(
-    RawInputFrontierEvent::BeginDelivery({ token: 1, source: "xx" }),
+    RawInputEvent::BeginDelivery({ token: 1, source: "xx" }),
   )
   coordinator.reduce_frontier(
-    RawInputFrontierEvent::CaptureDeferredBeforeInput({
+    RawInputEvent::CaptureDeferredBeforeInput({
       base_source: "xx",
       input_type: "insertText",
       selection: @dom_boundary.TextSelection(1, 1, @dom_boundary.NoDirection),
@@ -413,7 +498,7 @@ test "Raw coordinator keeps the first deferred selection and latest native value
     ),
   )
   coordinator.reduce_frontier(
-    RawInputFrontierEvent::CaptureDeferredBeforeInput({
+    RawInputEvent::CaptureDeferredBeforeInput({
       base_source: "xx",
       input_type: "insertFromPaste",
       selection: @dom_boundary.TextSelection(2, 2, @dom_boundary.NoDirection),
@@ -444,10 +529,10 @@ test "deferred Raw composition keeps the first ordinary input selection" {
   )
   let coordinator = RawInputCoordinator::RawInputCoordinator(None)
   coordinator.reduce_frontier(
-    RawInputFrontierEvent::BeginDelivery({ token: 1, source: "xx" }),
+    RawInputEvent::BeginDelivery({ token: 1, source: "xx" }),
   )
   coordinator.reduce_frontier(
-    RawInputFrontierEvent::CaptureDeferredBeforeInput({
+    RawInputEvent::CaptureDeferredBeforeInput({
       base_source: "xx",
       input_type: "insertText",
       selection: @dom_boundary.TextSelection(1, 1, @dom_boundary.NoDirection),
@@ -503,17 +588,17 @@ test "Raw coordinator clears a canceled deferred capture before rebase" {
   )
   let coordinator = RawInputCoordinator::RawInputCoordinator(None)
   coordinator.reduce_frontier(
-    RawInputFrontierEvent::BeginDelivery({ token: 1, source: "startX" }),
+    RawInputEvent::BeginDelivery({ token: 1, source: "startX" }),
   )
   coordinator.reduce_frontier(
-    RawInputFrontierEvent::CaptureDeferredBeforeInput({
+    RawInputEvent::CaptureDeferredBeforeInput({
       base_source: "startX",
       input_type: "insertText",
       selection: @dom_boundary.TextSelection(6, 6, @dom_boundary.NoDirection),
     }),
   )
   coordinator.reduce_frontier(
-    RawInputFrontierEvent::StoreDeferred({
+    RawInputEvent::StoreDeferred({
       base_source: "startX",
       input_type: "insertText",
       before_input_selection: @dom_boundary.TextSelection(
@@ -533,7 +618,7 @@ test "Raw coordinator clears a canceled deferred capture before rebase" {
   let emit : @cmd.Emit[DriverEvent] = @cmd.Emit(_ => @rabbita_runtime.none)
   ignore(coordinator.enqueue_deferred(context.model, emit))
   assert_true(coordinator.frontier.val.deferred_before_input is None)
-  guard coordinator.pending.val is Some(pending) else {
+  guard coordinator.frontier.val.pending is Some(pending) else {
     fail("deferred input must become pending after rebase")
   }
   assert_eq(pending.source, "startXY")
@@ -578,7 +663,7 @@ test "Raw coordinator keeps the first backward base and latest collapsed caret" 
       emit,
     ),
   )
-  guard coordinator.pending.val is Some(pending) else {
+  guard coordinator.frontier.val.pending is Some(pending) else {
     fail("first capture must remain the batch base")
   }
   assert_eq(pending.before_input.selection.selection.anchor(), 4)
@@ -627,7 +712,7 @@ test "Raw coordinator discards a batch on version or document mismatch" {
       emit,
     ),
   )
-  assert_true(coordinator.pending.val is None)
+  assert_true(coordinator.frontier.val.pending is None)
 
   ignore(coordinator.capture_before_input(capture(context.selection(1, 1))))
   ignore(
@@ -648,7 +733,7 @@ test "Raw coordinator discards a batch on version or document mismatch" {
       emit,
     ),
   )
-  assert_true(coordinator.pending.val is None)
+  assert_true(coordinator.frontier.val.pending is None)
 }
 
 ///|
@@ -681,7 +766,7 @@ test "Raw coordinator input without capture discards a pending batch" {
       emit,
     ),
   )
-  assert_true(coordinator.pending.val is None)
+  assert_true(coordinator.frontier.val.pending is None)
 }
 
 ///|
@@ -708,7 +793,7 @@ test "Raw coordinator discards a composition-intermediate capture" {
     ),
   )
   assert_true(coordinator.unmatched_before_input.val is None)
-  assert_true(coordinator.pending.val is None)
+  assert_true(coordinator.frontier.val.pending is None)
 }
 
 ///|
@@ -738,8 +823,8 @@ test "Raw input cancellation clears live composition" {
 
   coordinator.cancel_pending()
 
-  assert_true(coordinator.composition.val is None)
-  assert_true(coordinator.pending.val is None)
+  assert_true(coordinator.frontier.val.composition is None)
+  assert_true(coordinator.frontier.val.pending is None)
   assert_true(test_in_flight_token(coordinator) is None)
   assert_eq(coordinator.display_source("start"), "start")
 }
@@ -779,7 +864,7 @@ test "Raw coordinator capture expiry clears only an unmatched capture" {
   let generation = coordinator.capture_generation.val
   coordinator.expire_before_input(generation)
   assert_true(coordinator.unmatched_before_input.val is None)
-  guard coordinator.pending.val is Some(pending) else {
+  guard coordinator.frontier.val.pending is Some(pending) else {
     fail("capture expiry must preserve the pending batch")
   }
   assert_eq(pending.source, "aXbc")
@@ -819,13 +904,13 @@ test "Raw coordinator cancel clears all state and invalidates capture expiry" {
     ),
   )
   let expiry_generation = coordinator.capture_generation.val
-  coordinator.reduce_frontier(
-    RawInputFrontierEvent::BeginDelivery({ token: 7, source: "in-flight" }),
-  )
+  guard coordinator.take_pending_delivery() is Some((0, _)) else {
+    fail("pending input must become active before cancellation")
+  }
   coordinator.cancel_pending()
   coordinator.expire_before_input(expiry_generation)
   assert_true(coordinator.unmatched_before_input.val is None)
-  assert_true(coordinator.pending.val is None)
+  assert_true(coordinator.frontier.val.pending is None)
   assert_true(test_in_flight_token(coordinator) is None)
   assert_true(test_in_flight_source(coordinator) is None)
   assert_false(coordinator.scheduled.val)

--- a/docs/plans/2026-08-10-loomark-raw-input-state-reducer.md
+++ b/docs/plans/2026-08-10-loomark-raw-input-state-reducer.md
@@ -25,7 +25,7 @@ state or cause a shell effect.
 | --- | --- | --- | --- |
 | `BeginDelivery(delivery)` | no active delivery, pending, live composition, capture, ordinary deferred input, or deferred composition | set `in_flight` | `Noop` |
 | `BeginPendingDelivery(token)` | pending exists; no active delivery, composition, or deferred frontier | move pending to `in_flight` and clear pending | `Deliver(token, input)` |
-| `FinishDelivery(token)` | active token matches | clear `in_flight`; also clear a completion marker when no deferred composition or pending follow-up remains | `Noop` |
+| `FinishDelivery(token)` | active token matches | clear `in_flight` and its deferred capture; also clear a completion marker when no deferred composition or pending follow-up remains | `Noop` |
 | `DiscardDelivery(token)` | active token matches | clear active, pending, composition, all deferred state, and completion marker | `Noop` |
 | `CaptureDeferredBeforeInput(capture)` | active delivery or deferred ordinary input; no deferred composition | set `deferred_before_input` | `Noop` |
 | `StoreDeferred(input)` | active delivery + capture; no deferred composition | clear capture and set deferred ordinary input; retain any pending batch waiting behind the active delivery | `Noop` |

--- a/docs/plans/2026-08-10-loomark-raw-input-state-reducer.md
+++ b/docs/plans/2026-08-10-loomark-raw-input-state-reducer.md
@@ -18,8 +18,7 @@ rebase/normalization, commits editor changes, and executes reducer decisions.
 
 ## State transition table
 
-`—` means the event is a deterministic no-op. A guard failure must not mutate
-state or cause a shell effect.
+A guard failure must not mutate state or cause a shell effect.
 
 | Event | Guard | State change | Decision |
 | --- | --- | --- | --- |
@@ -35,7 +34,7 @@ state or cause a shell effect.
 | `ClearDeferred` | always | clear capture and ordinary deferred input | `Noop` |
 | `ClearDeferredComposition` | always | clear deferred composition only | `Noop` |
 | `StorePending(input)` | no live composition or deferred frontier | replace pending input (it may wait behind an active delivery) | `StoredPending` |
-| `BeginComposition(input)` | no active delivery or deferred frontier | clear pending; set live composition | `Noop` |
+| `BeginComposition(input)` | no active delivery or deferred frontier | clear pending and completion marker; set live composition | `Noop` |
 | `UpdateComposition(input)` | live composition exists | replace live composition | `Noop` |
 | `ClearComposition` | always | clear live composition | `Noop` |
 | `MarkDeferredCompositionFinished` | deferred composition exists | set completion marker | `Noop` |
@@ -61,7 +60,8 @@ finish or discard an active delivery.
 - `composition` is not combined with an active delivery or deferred frontier.
 - The completion marker is meaningful only for a deferred composition or the
   follow-up delivery created from one; it is cleared by cancellation,
-  discard, failed rebase, and completion of that follow-up delivery.
+  discard, failed rebase, completion of that follow-up delivery, and the start
+  of a new live or deferred composition.
 - `BeginDeferredComposition` clears the ordinary deferred snapshot and its
   capture while retaining an already pending ordinary input. This preserves
   the #1222 IME-over-ordinary-input ordering and net-no-op behavior.

--- a/docs/plans/2026-08-10-loomark-raw-input-state-reducer.md
+++ b/docs/plans/2026-08-10-loomark-raw-input-state-reducer.md
@@ -1,0 +1,104 @@
+# Loomark Raw input state reducer
+
+Issue: #1223
+
+## Boundary
+
+`RawInputState` is the single owner of semantic Raw input state. The pure
+transition boundary is:
+
+```text
+RawInputState + RawInputEvent -> (RawInputState, RawInputDecision)
+```
+
+The reducer never reads the DOM, editor, scheduler, clock, telemetry, or
+provider state. `RawInputCoordinator` remains the imperative shell that
+captures browser values, allocates tokens, schedules commands, performs
+rebase/normalization, commits editor changes, and executes reducer decisions.
+
+## State transition table
+
+`—` means the event is a deterministic no-op. A guard failure must not mutate
+state or cause a shell effect.
+
+| Event | Guard | State change | Decision |
+| --- | --- | --- | --- |
+| `BeginDelivery(delivery)` | no active delivery, pending, live composition, capture, ordinary deferred input, or deferred composition | set `in_flight` | `Noop` |
+| `BeginPendingDelivery(token)` | pending exists; no active delivery, composition, or deferred frontier | move pending to `in_flight` and clear pending | `Deliver(token, input)` |
+| `FinishDelivery(token)` | active token matches | clear `in_flight`; also clear a completion marker when no deferred composition or pending follow-up remains | `Noop` |
+| `DiscardDelivery(token)` | active token matches | clear active, pending, composition, all deferred state, and completion marker | `Noop` |
+| `CaptureDeferredBeforeInput(capture)` | active delivery or deferred ordinary input; no deferred composition | set `deferred_before_input` | `Noop` |
+| `StoreDeferred(input)` | active delivery + capture; no deferred composition | clear capture and set deferred ordinary input; retain any pending batch waiting behind the active delivery | `Noop` |
+| `BeginDeferredComposition(input)` | active delivery; no deferred composition | clear ordinary deferred/capture and completion marker; set deferred composition; retain an already pending ordinary input until the composition result replaces it | `Noop` |
+| `UpdateDeferredComposition(input)` | deferred composition exists | replace deferred composition | `Noop` |
+| `ClearDeferredCapture` | always | clear capture only | `Noop` |
+| `ClearDeferred` | always | clear capture and ordinary deferred input | `Noop` |
+| `ClearDeferredComposition` | always | clear deferred composition only | `Noop` |
+| `StorePending(input)` | no live composition or deferred frontier | replace pending input (it may wait behind an active delivery) | `StoredPending` |
+| `BeginComposition(input)` | no active delivery or deferred frontier | clear pending; set live composition | `Noop` |
+| `UpdateComposition(input)` | live composition exists | replace live composition | `Noop` |
+| `ClearComposition` | always | clear live composition | `Noop` |
+| `MarkDeferredCompositionFinished` | deferred composition exists | set completion marker | `Noop` |
+| `ClearDeferredCompositionFinished` | always | clear completion marker | `Noop` |
+| `Cancel` | always | clear every semantic field | `Noop` |
+
+The reducer may reject an event by returning the original state and
+`Noop`. A successful pending store returns `StoredPending`; a successful
+pending delivery returns `Deliver(token, input)`. In particular, an unpaired
+`input` cannot create pending or deferred state, and an unmatched token cannot
+finish or discard an active delivery.
+
+## Invariants
+
+- There is at most one `in_flight` delivery.
+- `deferred` and `deferred_composition` are mutually exclusive.
+- `deferred_before_input` is meaningful only with an active delivery or an
+  existing ordinary deferred input.
+- `pending` may wait behind one active delivery and may temporarily coexist
+  with an ordinary deferred snapshot or deferred composition. A deferred
+  composition result may replace it; cancellation/discard clears both.
+- `pending` is not combined with a live composition.
+- `composition` is not combined with an active delivery or deferred frontier.
+- The completion marker is meaningful only for a deferred composition or the
+  follow-up delivery created from one; it is cleared by cancellation,
+  discard, failed rebase, and completion of that follow-up delivery.
+- `BeginDeferredComposition` clears the ordinary deferred snapshot and its
+  capture while retaining an already pending ordinary input. This preserves
+  the #1222 IME-over-ordinary-input ordering and net-no-op behavior.
+- A token mismatch is a no-op. Document/version/editor authorization remains
+  in the shell and in Raw candidate normalization; the reducer does not infer
+  an edit from an unpaired `input`.
+
+## Migration order
+
+1. Add pure transition tests for the table and make the reducer boundary
+   explicit without changing coordinator behavior.
+2. Move `pending` into `RawInputState`; keep scheduling and token allocation in
+   the shell.
+3. Move live `composition` into `RawInputState`; keep DOM composition event
+   capture and editor delivery in the shell.
+4. Move `deferred_composition_finished` into `RawInputState`; keep the
+   after-render follow-up command in the shell.
+5. Run targeted MoonBit checks/tests after every stage, inspect generated
+   interfaces, then run Loomark browser validation.
+
+## Existing shell scheduling and display policy
+
+The migration does not change the existing imperative scheduling policy. A
+pending batch whose debounce callback fires while delivery is blocked is
+invalidated by `flush`/`cancel_pending`; deferred captures use the frontier
+rebase path instead. This is intentionally shell-owned scheduling, not a
+reducer transition.
+
+`display_source` also retains the current precedence used by the textarea:
+`composition`, `pending`, `deferred_composition`, `deferred`, `in_flight`, then
+the committed source. The reducer migration moves these values under one
+owner without changing that browser-visible ordering.
+
+## Shell-owned state
+
+`unmatched_before_input`, `composition_final_source`, suppression flags,
+schedule/capture generations, timer handles, render-barrier handles,
+telemetry, DOM selections/values, editor commits, and command execution remain
+imperative-shell state. These values authorize or schedule effects; they are
+not the semantic Raw frontier being reduced here.


### PR DESCRIPTION
## Summary

- Centralize `pending`, live `composition`, deferred composition, completion-marker, and in-flight Raw input semantics in a pure reducer.
- Keep DOM capture, scheduling, token allocation, telemetry, normalization, and editor commits in the imperative shell.
- Add the transition matrix, invariant documentation, pure reducer coverage, and the delivery-capture regression fix.

Closes #1223

## UI and review evidence

N/A — this change preserves the existing Raw/IME behavior and does not introduce a visual design change.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `RawInputCoordinator` shell methods (`reduce_frontier`, scheduling, commit/repair paths) | `apps/loomark/internal/rabbita/text_control_repair.mbt` | Yes | The reducer returns decisions while existing shell effects remain in the coordinator. |
| `Option` and variant pattern matching | MoonBit core/language | Yes | Fixed reducer slots and event/decision handling are represented declaratively. |
| `Map` / `Set` | MoonBit core | No | The state has fixed named slots; no keyed collection is involved. |
| `String` / `StringView` / `Bytes` / `Buffer` / `Array` / `Iter` | MoonBit core | No new use | Existing source and selection payloads are passed through; this change adds no collection or text transformation helper. |

New helpers/types added:

- `RawInputState`, `RawInputEvent`, `RawInputDecision`, and `reduce_raw_input` are private and form the explicit pure state/event/decision boundary. No existing API represents the combined Raw frontier semantics.

## Validation scope

Boundary matrix / first failing regression:

- pending ordinary input behind an active delivery
- live and deferred IME composition, including completion-marker follow-up delivery
- deferred capture, ordinary deferred input, cancellation, discard, and token mismatch
- rejection of unpaired or stale events without state mutation
- first failing regression: `BeginDelivery → CaptureDeferredBeforeInput → FinishDelivery` left a capture behind; the new test verifies capture removal and that subsequent pending input is accepted

Target packages:

- `apps/loomark/internal/rabbita`

Additional conditional gates:

- Dev Host Playwright E2E: 120/120
- Standalone Playwright E2E: 13/13
- `moon fmt && moon info`; no generated `.mbti` drift

## PR-ready evidence

Validated HEAD: `2e99982595bd01350b3ca0fadec9b25d82df263f`

Validated base: `origin/main@2b42a25917c9a70dafbd9eb47d62709df028465d`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh \
  --target apps/loomark/internal/rabbita
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for the exact HEAD and base above.
- [x] The base was fetched again and `--verify-evidence` passed immediately before this PR was opened.
- [x] The committed `.mbti` diff against the validated base was reviewed for unintended API or trait-bound changes.
- [x] No submodule pointer changed in this PR.
- [x] Validation was rerun after the final documentation commit and rebase.
- [x] Independent review findings were resolved before the final validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved raw text input handling across active, pending, and deferred composition states.
  * Added more reliable delivery safeguards to prevent conflicting or mismatched input events.
  * Improved cancellation, completion, capture rejection, and cleanup behavior.
  * Preserved deferred input and composition data appropriately during transitions.

* **Tests**
  * Expanded coverage for composition, delivery, cancellation, expiry, deferred input, and state cleanup.

* **Documentation**
  * Added a design plan describing raw input state transitions and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
