### PR TITLE
perf(editor): reuse validated applied edit ranges

### DIFF
--- a/modules/canopy/editor/resolve_applied_edit_benchmark_wbtest.mbt
+++ b/modules/canopy/editor/resolve_applied_edit_benchmark_wbtest.mbt
@@ -13,8 +13,8 @@ fn resolve_benchmark_source(block_count : Int) -> String {
 }
 
 ///|
-fn resolve_benchmark_middle_edit(source : String) -> String {
-  let target = "Paragraph 125 with"
+fn resolve_benchmark_middle_edit(source : String, block_count : Int) -> String {
+  let target = "Paragraph " + (block_count / 2).to_string() + " with"
   match source.find(target) {
     Some(position) =>
       source[:position].to_owned() +
@@ -27,7 +27,7 @@ fn resolve_benchmark_middle_edit(source : String) -> String {
 ///|
 test "perf: resolve known ASCII edit fast path (250 blocks)" (b : @bench.T) {
   let old_source = resolve_benchmark_source(250)
-  let new_source = resolve_benchmark_middle_edit(old_source)
+  let new_source = resolve_benchmark_middle_edit(old_source, 250)
   let known_edit = compute_edit(old_source, new_source)
   b.bench(() => {
     let resolved = try! resolve_applied_edit(
@@ -42,7 +42,7 @@ test "perf: resolve known ASCII edit fast path (250 blocks)" (b : @bench.T) {
 ///|
 test "perf: resolve divergent edit fallback (250 blocks)" (b : @bench.T) {
   let old_source = resolve_benchmark_source(250)
-  let new_source = resolve_benchmark_middle_edit(old_source)
+  let new_source = resolve_benchmark_middle_edit(old_source, 250)
   let divergent_source = "Q" + new_source
   let known_edit = compute_edit(old_source, new_source)
   b.bench(() => {

--- a/modules/canopy/editor/resolve_applied_edit_benchmark_wbtest.mbt
+++ b/modules/canopy/editor/resolve_applied_edit_benchmark_wbtest.mbt
@@ -1,0 +1,56 @@
+///|
+fn resolve_benchmark_source(block_count : Int) -> String {
+  Array::makei(block_count, index => {
+    let number = index.to_string()
+    "## Heading " +
+    number +
+    "\n\nParagraph " +
+    number +
+    " with **bold** and [link](https://example.com/" +
+    number +
+    ").\n"
+  }).join("\n")
+}
+
+///|
+fn resolve_benchmark_middle_edit(source : String) -> String {
+  let target = "Paragraph 125 with"
+  match source.find(target) {
+    Some(position) =>
+      source[:position].to_owned() +
+      "Paragraph 125 changed" +
+      source[position + target.length():].to_owned()
+    None => abort("resolve benchmark target not found")
+  }
+}
+
+///|
+test "perf: resolve known ASCII edit fast path (250 blocks)" (b : @bench.T) {
+  let old_source = resolve_benchmark_source(250)
+  let new_source = resolve_benchmark_middle_edit(old_source)
+  let known_edit = compute_edit(old_source, new_source)
+  b.bench(() => {
+    let resolved = try! resolve_applied_edit(
+      old_source,
+      new_source,
+      Some(known_edit),
+    )
+    b.keep(resolved)
+  })
+}
+
+///|
+test "perf: resolve divergent edit fallback (250 blocks)" (b : @bench.T) {
+  let old_source = resolve_benchmark_source(250)
+  let new_source = resolve_benchmark_middle_edit(old_source)
+  let divergent_source = "Q" + new_source
+  let known_edit = compute_edit(old_source, new_source)
+  b.bench(() => {
+    let resolved = try! resolve_applied_edit(
+      old_source,
+      divergent_source,
+      Some(known_edit),
+    )
+    b.keep(resolved)
+  })
+}

--- a/modules/canopy/editor/resolve_applied_edit_integration_wbtest.mbt
+++ b/modules/canopy/editor/resolve_applied_edit_integration_wbtest.mbt
@@ -1,0 +1,236 @@
+// Integration tests for the resolved edit passed to cursor and parser sync.
+// The direct TextState mutations model a CRDT placement that differs from the
+// caller's trusted position hint, while keeping the test deterministic.
+
+///|
+test "apply_local_text_change uses actual CRDT insertion for peer cursors" {
+  let editor = try! @probe.new_test_editor("crdt-insert-integration")
+  editor.set_text("abcd")
+  editor.cursor_view.set_cursor("before", 0, "Before", "#000000")
+  editor.cursor_view.set_cursor("after", 2, "After", "#000000")
+  editor.cursor_view.set_cursor("end", 4, "End", "#000000")
+
+  let old_source = editor.doc.text()
+  let item_start = utf16_offset_to_item_pos(old_source, 0)
+  editor.doc.insert(@text.Pos::at(item_start), "X")
+  let new_source = editor.doc.text()
+  inspect(new_source, content="Xabcd")
+
+  // The caller believed the insertion landed at the end. The resolver must
+  // reject that hint and use the actual CRDT transition at position 0.
+  editor.apply_local_text_change(
+    old_source,
+    new_source,
+    Some(@loom_core.Edit::insert(4, 1)),
+  )
+  inspect(
+    editor.cursor_view.get_cursor("before").unwrap().adjusted_cursor,
+    content="0",
+  )
+  inspect(
+    editor.cursor_view.get_cursor("after").unwrap().adjusted_cursor,
+    content="3",
+  )
+  inspect(
+    editor.cursor_view.get_cursor("end").unwrap().adjusted_cursor,
+    content="5",
+  )
+  inspect(
+    @probe.get_test_ast(editor),
+    content=(
+      #|Branch("", [Leaf("Xabcd")])
+    ),
+  )
+}
+
+///|
+test "apply_local_text_change adjusts cursors inside a displaced replacement" {
+  let editor = try! @probe.new_test_editor("crdt-replace-integration")
+  editor.set_text("abcd")
+  editor.cursor_view.set_cursor("before", 0, "Before", "#000000")
+  editor.cursor_view.set_cursor("inside", 2, "Inside", "#000000")
+  editor.cursor_view.set_cursor("after", 4, "After", "#000000")
+
+  let old_source = editor.doc.text()
+  editor.doc.replace_range(@text.Range::from_ints(1, 3), "X") catch {
+    _ => fail("test CRDT replacement failed")
+  }
+  let new_source = editor.doc.text()
+  inspect(new_source, content="aXd")
+
+  // Actual transition: old range 1..3 becomes one code unit. The supplied
+  // hint is intentionally shifted to exercise the full-diff fallback.
+  editor.apply_local_text_change(
+    old_source,
+    new_source,
+    Some(@loom_core.Edit::new(0, 1, 1)),
+  )
+  inspect(
+    editor.cursor_view.get_cursor("before").unwrap().adjusted_cursor,
+    content="0",
+  )
+  inspect(
+    editor.cursor_view.get_cursor("inside").unwrap().adjusted_cursor,
+    content="2",
+  )
+  inspect(
+    editor.cursor_view.get_cursor("after").unwrap().adjusted_cursor,
+    content="3",
+  )
+  inspect(
+    @probe.get_test_ast(editor),
+    content=(
+      #|Branch("", [Leaf("aXd")])
+    ),
+  )
+}
+
+///|
+test "apply_local_text_change reuses a valid ASCII insertion hint" {
+  let editor = try! @probe.new_test_editor("crdt-fast-path-integration")
+  editor.set_text("abcd")
+  editor.cursor_view.set_cursor("after", 4, "After", "#000000")
+
+  let old_source = editor.doc.text()
+  let item_start = utf16_offset_to_item_pos(old_source, 2)
+  editor.doc.insert(@text.Pos::at(item_start), "X")
+  let new_source = editor.doc.text()
+  inspect(new_source, content="abXcd")
+
+  editor.apply_local_text_change(
+    old_source,
+    new_source,
+    Some(@loom_core.Edit::insert(2, 1)),
+  )
+  inspect(
+    editor.cursor_view.get_cursor("after").unwrap().adjusted_cursor,
+    content="5",
+  )
+  inspect(
+    @probe.get_test_ast(editor),
+    content=(
+      #|Branch("", [Leaf("abXcd")])
+    ),
+  )
+}
+
+///|
+test "apply_local_text_change keeps same-character insertion ambiguity conservative" {
+  let editor = try! @probe.new_test_editor("crdt-same-character-integration")
+  editor.set_text("x")
+  editor.cursor_view.set_cursor("peer", 1, "Peer", "#000000")
+
+  let old_source = editor.doc.text()
+  let item_start = utf16_offset_to_item_pos(old_source, 0)
+  editor.doc.insert(@text.Pos::at(item_start), "x")
+  let new_source = editor.doc.text()
+  inspect(new_source, content="xx")
+
+  // The trusted hint is physically plausible at offset 0, but the canonical
+  // grapheme diff intentionally resolves the repeated-character ambiguity at
+  // offset 1, preserving the existing cursor semantics.
+  editor.apply_local_text_change(
+    old_source,
+    new_source,
+    Some(@loom_core.Edit::insert(0, 1)),
+  )
+  inspect(
+    editor.cursor_view.get_cursor("peer").unwrap().adjusted_cursor,
+    content="1",
+  )
+}
+
+///|
+test "apply_local_text_change uses actual CRDT deletion" {
+  let editor = try! @probe.new_test_editor("crdt-delete-integration")
+  editor.set_text("abcd")
+  editor.cursor_view.set_cursor("before", 0, "Before", "#000000")
+  editor.cursor_view.set_cursor("inside", 2, "Inside", "#000000")
+  editor.cursor_view.set_cursor("after", 4, "After", "#000000")
+
+  let old_source = editor.doc.text()
+  editor.doc.delete_range(@text.Range::from_ints(1, 3)) catch {
+    _ => fail("test CRDT deletion failed")
+  }
+  let new_source = editor.doc.text()
+  inspect(new_source, content="ad")
+
+  editor.apply_local_text_change(
+    old_source,
+    new_source,
+    Some(@loom_core.Edit::delete(0, 1)),
+  )
+  inspect(
+    editor.cursor_view.get_cursor("before").unwrap().adjusted_cursor,
+    content="0",
+  )
+  inspect(
+    editor.cursor_view.get_cursor("inside").unwrap().adjusted_cursor,
+    content="1",
+  )
+  inspect(
+    editor.cursor_view.get_cursor("after").unwrap().adjusted_cursor,
+    content="2",
+  )
+  inspect(
+    @probe.get_test_ast(editor),
+    content=(
+      #|Branch("", [Leaf("ad")])
+    ),
+  )
+}
+
+///|
+test "apply_local_text_change falls back for a combining grapheme" {
+  let editor = try! @probe.new_test_editor("crdt-combining-integration")
+  editor.set_text("e\u{0301}x")
+  editor.cursor_view.set_cursor("after", 3, "After", "#000000")
+
+  let old_source = editor.doc.text()
+  editor.doc.replace_range(@text.Range::from_ints(0, 2), "e") catch {
+    _ => fail("test combining replacement failed")
+  }
+  let new_source = editor.doc.text()
+  inspect(new_source, content="ex")
+
+  // Removing the combining mark alone is not the canonical grapheme edit.
+  editor.apply_local_text_change(
+    old_source,
+    new_source,
+    Some(@loom_core.Edit::new(1, 1, 0)),
+  )
+  inspect(
+    editor.cursor_view.get_cursor("after").unwrap().adjusted_cursor,
+    content="2",
+  )
+  inspect(
+    @probe.get_test_ast(editor),
+    content=(
+      #|Branch("", [Leaf("ex")])
+    ),
+  )
+}
+
+///|
+test "apply_local_text_change falls back for a CRLF transition" {
+  let editor = try! @probe.new_test_editor("crdt-crlf-integration")
+  editor.set_text("a\r\nb")
+  editor.cursor_view.set_cursor("after", 4, "After", "#000000")
+
+  let old_source = editor.doc.text()
+  editor.doc.replace_range(@text.Range::from_ints(1, 3), "\n") catch {
+    _ => fail("test CRLF replacement failed")
+  }
+  let new_source = editor.doc.text()
+  inspect(new_source, content="a\nb")
+
+  editor.apply_local_text_change(
+    old_source,
+    new_source,
+    Some(@loom_core.Edit::new(0, 1, 1)),
+  )
+  inspect(
+    editor.cursor_view.get_cursor("after").unwrap().adjusted_cursor,
+    content="3",
+  )
+}

--- a/modules/canopy/editor/resolve_applied_edit_integration_wbtest.mbt
+++ b/modules/canopy/editor/resolve_applied_edit_integration_wbtest.mbt
@@ -96,12 +96,10 @@ test "apply_local_text_change reuses a valid ASCII insertion hint" {
   editor.doc.insert(@text.Pos::at(item_start), "X")
   let new_source = editor.doc.text()
   inspect(new_source, content="abXcd")
+  let hint = @loom_core.Edit::insert(2, 1)
+  assert_true(known_edit_matches_source_change(old_source, new_source, hint))
 
-  editor.apply_local_text_change(
-    old_source,
-    new_source,
-    Some(@loom_core.Edit::insert(2, 1)),
-  )
+  editor.apply_local_text_change(old_source, new_source, Some(hint))
   inspect(
     editor.cursor_view.get_cursor("after").unwrap().adjusted_cursor,
     content="5",

--- a/modules/canopy/editor/resolve_applied_edit_wbtest.mbt
+++ b/modules/canopy/editor/resolve_applied_edit_wbtest.mbt
@@ -1,0 +1,128 @@
+///|
+/// Compare a resolved edit with the canonical diff for a single matrix row.
+fn assert_resolved_edit_matches(
+  old_source : String,
+  new_source : String,
+  known_start : Int,
+  known_old_len : Int,
+  known_new_len : Int,
+) -> Unit raise Failure {
+  let expected = compute_edit(old_source, new_source)
+  let resolved = try! resolve_applied_edit(
+    old_source,
+    new_source,
+    Some(@loom_core.Edit::new(known_start, known_old_len, known_new_len)),
+  )
+  match resolved {
+    Some(edit) =>
+      if edit.start() != expected.start() ||
+        edit.old_len() != expected.old_len() ||
+        edit.new_len() != expected.new_len() {
+        fail(
+          "resolved edit differs: \{old_source} -> \{new_source}, known=\{known_start}/\{known_old_len}/\{known_new_len}, actual=\{edit.start()}/\{edit.old_len()}/\{edit.new_len()}, expected=\{expected.start()}/\{expected.old_len()}/\{expected.new_len()}",
+        )
+      }
+    None => abort("known edit unexpectedly resolved to None")
+  }
+}
+
+///|
+/// Exhaustively vary the supplied known edit over a small UTF-16 matrix. The
+/// resolver must return the same range as `compute_edit`, even when the hint is
+/// invalid, over-wide, shifted, or ambiguous around repeated characters.
+fn assert_resolve_matrix(
+  old_source : String,
+  new_source : String,
+) -> Unit raise Failure {
+  let old_length = old_source.length()
+  let new_length = new_source.length()
+  for known_start = 0; known_start <= old_length; known_start = known_start + 1 {
+    for known_old_len = 0
+        known_old_len <= old_length
+        known_old_len = known_old_len + 1 {
+      for known_new_len = 0
+          known_new_len <= new_length
+          known_new_len = known_new_len + 1 {
+        assert_resolved_edit_matches(
+          old_source, new_source, known_start, known_old_len, known_new_len,
+        )
+      }
+    }
+  }
+}
+
+///|
+test "resolve_applied_edit preserves the canonical ASCII edit matrix" {
+  let cases = [
+    ("", ""),
+    ("abc", "abc"),
+    ("abc", "xabc"),
+    ("abc", "abcx"),
+    ("abc", "aXbc"),
+    ("abc", "ac"),
+    ("abc", "aXc"),
+    ("x", "xx"),
+    ("xx", "x"),
+    ("abcd", "aXcd"),
+    ("aab", "ab"),
+    ("aba", "aXba"),
+  ]
+  for case in cases {
+    let (old_source, new_source) = case
+    assert_resolve_matrix(old_source, new_source)
+  }
+}
+
+///|
+test "resolve_applied_edit preserves Unicode and line-ending boundaries" {
+  let cases = [
+    ("😀a", "😁a"),
+    ("e\u{0301}x", "ex"),
+    ("👩‍💻x", "👩‍💼x"),
+    ("🇺🇸x", "🇨🇦x"),
+    ("a\r\nb", "a\nb"),
+    ("a\rb", "a\nb"),
+  ]
+  for case in cases {
+    let (old_source, new_source) = case
+    assert_resolve_matrix(old_source, new_source)
+  }
+}
+
+///|
+test "known edit fast path is conservative around boundaries" {
+  let ascii_old = "abc"
+  let ascii_new = "aXc"
+  let ascii_edit = compute_edit(ascii_old, ascii_new)
+  assert_true(
+    known_edit_matches_source_change(ascii_old, ascii_new, ascii_edit),
+  )
+
+  let repeated_old = "x"
+  let repeated_new = "xx"
+  let repeated_edit = compute_edit(repeated_old, repeated_new)
+  assert_false(
+    known_edit_matches_source_change(repeated_old, repeated_new, repeated_edit),
+  )
+
+  let unicode_old = "e\u{0301}x"
+  let unicode_new = "ex"
+  let unicode_edit = compute_edit(unicode_old, unicode_new)
+  assert_false(
+    known_edit_matches_source_change(unicode_old, unicode_new, unicode_edit),
+  )
+
+  let crlf_old = "a\r\nb"
+  let crlf_new = "a\nb"
+  let crlf_edit = compute_edit(crlf_old, crlf_new)
+  assert_false(known_edit_matches_source_change(crlf_old, crlf_new, crlf_edit))
+}
+
+///|
+test "resolve_applied_edit keeps absent hints absent" {
+  let resolved = try! resolve_applied_edit("abc", "aXbc", None)
+  match resolved {
+    None => ()
+    Some(_) => abort("an absent known edit must remain absent")
+  }
+}

--- a/modules/canopy/editor/resolve_applied_edit_wbtest.mbt
+++ b/modules/canopy/editor/resolve_applied_edit_wbtest.mbt
@@ -3,11 +3,11 @@
 fn assert_resolved_edit_matches(
   old_source : String,
   new_source : String,
+  expected : @loom_core.Edit,
   known_start : Int,
   known_old_len : Int,
   known_new_len : Int,
 ) -> Unit raise Failure {
-  let expected = compute_edit(old_source, new_source)
   let resolved = try! resolve_applied_edit(
     old_source,
     new_source,
@@ -22,7 +22,7 @@ fn assert_resolved_edit_matches(
           "resolved edit differs: \{old_source} -> \{new_source}, known=\{known_start}/\{known_old_len}/\{known_new_len}, actual=\{edit.start()}/\{edit.old_len()}/\{edit.new_len()}, expected=\{expected.start()}/\{expected.old_len()}/\{expected.new_len()}",
         )
       }
-    None => abort("known edit unexpectedly resolved to None")
+    None => fail("known edit unexpectedly resolved to None")
   }
 }
 
@@ -36,15 +36,12 @@ fn assert_resolve_matrix(
 ) -> Unit raise Failure {
   let old_length = old_source.length()
   let new_length = new_source.length()
-  for known_start = 0; known_start <= old_length; known_start = known_start + 1 {
-    for known_old_len = 0
-        known_old_len <= old_length
-        known_old_len = known_old_len + 1 {
-      for known_new_len = 0
-          known_new_len <= new_length
-          known_new_len = known_new_len + 1 {
+  let expected = compute_edit(old_source, new_source)
+  for known_start in 0..<=old_length {
+    for known_old_len in 0..<=old_length {
+      for known_new_len in 0..<=new_length {
         assert_resolved_edit_matches(
-          old_source, new_source, known_start, known_old_len, known_new_len,
+          old_source, new_source, expected, known_start, known_old_len, known_new_len,
         )
       }
     }
@@ -116,6 +113,20 @@ test "known edit fast path is conservative around boundaries" {
   let crlf_new = "a\nb"
   let crlf_edit = compute_edit(crlf_old, crlf_new)
   assert_false(known_edit_matches_source_change(crlf_old, crlf_new, crlf_edit))
+
+  let lone_cr_old = "a\rb"
+  let lone_cr_new = "a\rXb"
+  let lone_cr_edit = compute_edit(lone_cr_old, lone_cr_new)
+  assert_true(
+    known_edit_matches_source_change(lone_cr_old, lone_cr_new, lone_cr_edit),
+  )
+
+  let lone_lf_old = "a\nb"
+  let lone_lf_new = "a\nXb"
+  let lone_lf_edit = compute_edit(lone_lf_old, lone_lf_new)
+  assert_true(
+    known_edit_matches_source_change(lone_lf_old, lone_lf_new, lone_lf_edit),
+  )
 }
 
 ///|
@@ -123,6 +134,6 @@ test "resolve_applied_edit keeps absent hints absent" {
   let resolved = try! resolve_applied_edit("abc", "aXbc", None)
   match resolved {
     None => ()
-    Some(_) => abort("an absent known edit must remain absent")
+    Some(_) => fail("an absent known edit must remain absent")
   }
 }

--- a/modules/canopy/editor/sync_editor_parser.mbt
+++ b/modules/canopy/editor/sync_editor_parser.mbt
@@ -92,11 +92,27 @@ fn[T] SyncEditor::adjust_peer_cursors_after_text_change(
 }
 
 ///|
+/// Return true only for ASCII text without a CRLF grapheme. The local state is
+/// limited to the previous code unit so the ASCII and CRLF checks share one
+/// source pass; non-ASCII and CRLF transitions remain on the canonical diff.
+fn is_ascii_without_crlf(text : String) -> Bool {
+  let mut previous_was_cr = false
+  for ch in text {
+    if !ch.is_ascii() || (previous_was_cr && ch == '\n') {
+      return false
+    }
+    previous_was_cr = ch == '\r'
+  }
+  true
+}
+
+///|
 /// A known edit is safe to reuse when it describes the same minimal UTF-16
 /// range as the source transition. Prefix/suffix equality proves the changed
 /// window is in the right place; the edge checks conservatively reject ranges
-/// that could be shrunk or shifted across repeated code units. Uncertain
-/// Unicode cases fall back to the canonical grapheme-aware diff.
+/// that could be shrunk or shifted across repeated code units. Matching edge
+/// characters intentionally reduce the fast-path hit rate and use the
+/// canonical grapheme-aware diff instead of weakening this proof.
 fn known_edit_matches_source_change(
   old_source : String,
   new_source : String,
@@ -114,27 +130,11 @@ fn known_edit_matches_source_change(
     new_len > new_source.length() - start {
     return false
   }
-  if old_source.contains("\r\n") || new_source.contains("\r\n") {
+  if !is_ascii_without_crlf(old_source) || !is_ascii_without_crlf(new_source) {
     return false
-  }
-  for ch in old_source {
-    if !ch.is_ascii() {
-      return false
-    }
-  }
-  for ch in new_source {
-    if !ch.is_ascii() {
-      return false
-    }
   }
   let old_end = start + old_len
   let new_end = start + new_len
-  if @moji.is_trailing_surrogate_at(old_source, start) ||
-    @moji.is_trailing_surrogate_at(old_source, old_end) ||
-    @moji.is_trailing_surrogate_at(new_source, start) ||
-    @moji.is_trailing_surrogate_at(new_source, new_end) {
-    return false
-  }
   if old_len == 0 && new_len == 0 && start != old_source.length() {
     return false
   }

--- a/modules/canopy/editor/sync_editor_parser.mbt
+++ b/modules/canopy/editor/sync_editor_parser.mbt
@@ -92,6 +92,83 @@ fn[T] SyncEditor::adjust_peer_cursors_after_text_change(
 }
 
 ///|
+/// A known edit is safe to reuse when it describes the same minimal UTF-16
+/// range as the source transition. Prefix/suffix equality proves the changed
+/// window is in the right place; the edge checks conservatively reject ranges
+/// that could be shrunk or shifted across repeated code units. Uncertain
+/// Unicode cases fall back to the canonical grapheme-aware diff.
+fn known_edit_matches_source_change(
+  old_source : String,
+  new_source : String,
+  edit : @loom_core.Edit,
+) -> Bool {
+  let start = edit.start()
+  let old_len = edit.old_len()
+  let new_len = edit.new_len()
+  if start < 0 ||
+    old_len < 0 ||
+    new_len < 0 ||
+    start > old_source.length() ||
+    start > new_source.length() ||
+    old_len > old_source.length() - start ||
+    new_len > new_source.length() - start {
+    return false
+  }
+  if old_source.contains("\r\n") || new_source.contains("\r\n") {
+    return false
+  }
+  for ch in old_source {
+    if !ch.is_ascii() {
+      return false
+    }
+  }
+  for ch in new_source {
+    if !ch.is_ascii() {
+      return false
+    }
+  }
+  let old_end = start + old_len
+  let new_end = start + new_len
+  if @moji.is_trailing_surrogate_at(old_source, start) ||
+    @moji.is_trailing_surrogate_at(old_source, old_end) ||
+    @moji.is_trailing_surrogate_at(new_source, start) ||
+    @moji.is_trailing_surrogate_at(new_source, new_end) {
+    return false
+  }
+  if old_len == 0 && new_len == 0 && start != old_source.length() {
+    return false
+  }
+  if old_source[:start] != new_source[:start] ||
+    old_source[old_end:] != new_source[new_end:] {
+    return false
+  }
+  if old_len == 0 {
+    if new_len > 0 &&
+      start < old_source.length() &&
+      new_source.at(start) == old_source.at(start) {
+      return false
+    }
+    if new_len > 0 &&
+      start > 0 &&
+      new_source.at(new_end - 1) == old_source.at(start - 1) {
+      return false
+    }
+  } else if new_len == 0 {
+    if old_end < old_source.length() &&
+      old_source.at(start) == old_source.at(old_end) {
+      return false
+    }
+    if start > 0 && old_source.at(old_end - 1) == old_source.at(start - 1) {
+      return false
+    }
+  } else if old_source.at(start) == new_source.at(start) ||
+    old_source.at(old_end - 1) == new_source.at(new_end - 1) {
+    return false
+  }
+  true
+}
+
+///|
 /// The CRDT may place inserts at different positions than the cursor indicates
 /// (e.g. after set_text, position semantics can diverge). Verify the known edit
 /// against the actual text change so cursor adjustments use the real positions.
@@ -102,18 +179,15 @@ fn resolve_applied_edit(
 ) -> @loom_core.Edit? raise Failure {
   match known_edit {
     None => None
-    Some(edit) => {
-      let actual = editor_perf_measure("resolveAppliedEditDiff", () => {
-        compute_edit(old_source, new_source)
-      })
-      if edit.start() == actual.start() &&
-        edit.old_len() == actual.old_len() &&
-        edit.new_len() == actual.new_len() {
+    Some(edit) =>
+      if known_edit_matches_source_change(old_source, new_source, edit) {
         Some(edit)
       } else {
+        let actual = editor_perf_measure("resolveAppliedEditDiff", () => {
+          compute_edit(old_source, new_source)
+        })
         Some(actual)
       }
-    }
   }
 }
 

--- a/modules/canopy/editor/sync_editor_test.mbt
+++ b/modules/canopy/editor/sync_editor_test.mbt
@@ -429,3 +429,57 @@ test "SyncEditor: undo sync ops can be applied to peer" {
   // Bob should converge with Alice
   inspect(se2.get_text(), content="")
 }
+
+///|
+test "SyncEditor: set_text placement stays coherent through public edits" {
+  let local_editor = try! @probe.new_test_editor("local-user")
+  let remote = try! @probe.new_test_editor("remote-user")
+  local_editor.set_text("abcd")
+  try! remote.apply_sync(try! local_editor.export_all())
+  remote.move_cursor(4)
+  remote.set_local_presence("Bob", "#00ff00")
+  local_editor.apply_ephemeral(remote.encode_ephemeral_all())
+
+  // A bulk set_text creates one CRDT batch. Exercise the public insert_at
+  // path after that initialization and assert the observed placement, cursor
+  // adjustment, parser state, and remote convergence together.
+  local_editor.insert_at(0, "X", 1000)
+  inspect(local_editor.get_text(), content="Xabcd")
+  inspect(
+    local_editor.get_peer_cursors().get("remote-user").unwrap().adjusted_cursor,
+    content="5",
+  )
+  inspect(
+    @probe.get_test_ast(local_editor),
+    content=(
+      #|Branch("", [Leaf("Xabcd")])
+    ),
+  )
+
+  try! remote.apply_sync(try! local_editor.export_all())
+  inspect(remote.get_text(), content="Xabcd")
+}
+
+///|
+test "SyncEditor: local insertion adjusts a peer cursor after the edit" {
+  let local_editor = try! @probe.new_test_editor("local-user")
+  let remote = try! @probe.new_test_editor("remote-user")
+  local_editor.set_text("abcd")
+  try! remote.apply_sync(try! local_editor.export_all())
+  remote.move_cursor(4)
+  remote.set_local_presence("Bob", "#00ff00")
+  local_editor.apply_ephemeral(remote.encode_ephemeral_all())
+
+  local_editor.insert_at(2, "X", 1000)
+  inspect(local_editor.get_text(), content="abXcd")
+  inspect(
+    local_editor.get_peer_cursors().get("remote-user").unwrap().adjusted_cursor,
+    content="5",
+  )
+  inspect(
+    @probe.get_test_ast(local_editor),
+    content=(
+      #|Branch("", [Leaf("abXcd")])
+    ),
+  )
+}


### PR DESCRIPTION
## Summary

- Reuse a trusted `known_edit` when it is provably the minimal ASCII/LF source transition.
- Keep the existing grapheme-aware `compute_edit` fallback for Unicode, CRLF, invalid, shifted, and ambiguous ranges.
- Combine ASCII and CRLF validation into one pass, and add exhaustive resolver plus CRDT/cursor/parser integration coverage.
- Add public `SyncEditor` regression coverage for `set_text` followed by `insert_at`, peer presence, parser state, and remote convergence.

## UI and review evidence

N/A — no UI or visual changes.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `compute_edit` | `modules/canopy/editor/text_diff.mbt:6` | Yes | Canonical correctness fallback when the hint cannot be proven safe. |
| `@loom_core.Edit::new/insert/delete` | Existing Loom core API | Yes | Existing edit representation and constructors; no new type or public API. |
| `String::at`, slicing, `Char::is_ascii` | MoonBit core string/char APIs | Yes | Bounds, local code-unit edge checks, and the combined ASCII/CRLF scan. |

New private helpers:

- `is_ascii_without_crlf` combines two safety checks in one source pass; its local previous-character state is necessary to recognize CRLF.
- `known_edit_matches_source_change` verifies a trusted edit without executing the full grapheme-aware diff; no existing API provides this predicate.

Neither helper changes the public API or `.mbti` surface.

## Validation scope

Boundary matrix / first failing regression:

- ASCII insert/delete/replace/no-op and every bounded known-edit range for small fixtures.
- Repeated-character ambiguity and shifted/over-wide hints.
- Combining marks, non-BMP/ZWJ/regional-indicator Unicode, LF/CRLF/CR.
- Lone CR/LF fast-path acceptance assertions.
- Direct CRDT placement simulations with peer cursors before/inside/after the observed edit and parser AST assertions.
- Public `SyncEditor` path: `set_text` → sync → peer presence → `insert_at` → cursor/parser checks → remote convergence.
- Public middle insertion path with a peer cursor after the edit.

The public `set_text`/`insert_at` scenario currently observes the requested
prepend (`Xabcd`) rather than a placement divergence; the direct integration
cases retain coverage for a supplied hint that differs from the observed CRDT
transition.

Target package:

- `modules/canopy/editor`

Additional gates:

- JS release editor tests: 250 passed.
- Dev Host Playwright E2E: 120 passed.
- Standalone Playwright E2E: 13 passed.
- Ideal editor-response benchmark: 6 passed.
- Isolated JS benchmark, 250 blocks: fast path approximately 0.12 ms; divergent fallback approximately 22–24 ms.
- Exact-HEAD Loomark browser probe: 200 synthetic samples, 0 `resolveAppliedEditDiff` fallback samples.

## PR-ready evidence

Validated HEAD: `d2e6d4e6fbba901b6e34b3de828e7f8171727d4f`

Validated base: `origin/main@e779b3ea3c92af85188e7179096e1d0ae8af5f8f`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh --target modules/canopy/editor
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for the exact HEAD and base above.
- [x] `--verify-evidence` passed immediately before updating this PR.
- [x] `.mbti` was reviewed; no public API drift.
- [x] No submodule pointers were changed.
- [x] Independent current-HEAD review passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved editor synchronization for insertions, replacements, deletions, Unicode text, combining characters, emojis, and different line endings.
  * Corrected cursor positioning and parser updates after local and remote edits.
  * Added safer fallback handling when edit hints do not match the actual document change.
  * Improved convergence between peers after text insertion.

* **Tests**
  * Added comprehensive coverage for edit resolution, cursor adjustment, parser synchronization, and remote updates.
  * Added performance benchmarks for common and fallback edit-processing paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->