### PR TITLE
perf(loomark): avoid duplicate archive history replay

### DIFF
--- a/apps/loomark/archive/archive.mbt
+++ b/apps/loomark/archive/archive.mbt
@@ -65,6 +65,33 @@ pub struct LoomarkDocumentArchive {
 }
 
 ///|
+/// A structurally decoded archive whose history has not been admitted.
+pub struct DecodedLoomarkDocumentArchive {
+  priv document_id : LoomarkDocumentId
+  priv portable_markdown : String
+  priv history : @markdown.MarkdownDocumentHistory
+}
+
+///|
+pub fn DecodedLoomarkDocumentArchive::document_id(
+  self : Self,
+) -> LoomarkDocumentId {
+  self.document_id
+}
+
+///|
+pub fn DecodedLoomarkDocumentArchive::portable_markdown(self : Self) -> String {
+  self.portable_markdown
+}
+
+///|
+pub fn DecodedLoomarkDocumentArchive::history(
+  self : Self,
+) -> @markdown.MarkdownDocumentHistory {
+  self.history
+}
+
+///|
 pub fn LoomarkDocumentArchive::document_id(self : Self) -> LoomarkDocumentId {
   self.document_id
 }
@@ -127,18 +154,15 @@ pub fn LoomarkDocumentArchive::to_json_string(self : Self) -> String {
 }
 
 ///|
-/// Decode and validate a v1 archive with a caller-owned fresh validation ID
-/// and explicit archive open limits.
+/// Decode the structural v1 archive envelope without admitting its history.
 ///
 /// Field uniqueness follows core JSON's semantic-object `Map` behavior: a
 /// duplicate member overwrites the earlier value. Canonical Loomark encoding
 /// emits each field once, and strict validation below is over that semantic
 /// object rather than lexical JSON member occurrences.
-pub fn LoomarkDocumentArchive::from_json_string(
+pub fn LoomarkDocumentArchive::decode_json_string(
   json : String,
-  validation_agent_id~ : String,
-  open_limits~ : @markdown.MarkdownArchiveOpenLimits,
-) -> LoomarkDocumentArchive raise {
+) -> DecodedLoomarkDocumentArchive raise {
   let value = @json.parse(json) catch {
     _ =>
       raise LoomarkArchiveDecodeError::MalformedEnvelope(detail="invalid JSON")
@@ -189,11 +213,32 @@ pub fn LoomarkDocumentArchive::from_json_string(
         detail="history codec rejected payload",
       )
   }
+  { document_id, portable_markdown, history }
+}
+
+///|
+/// Decode and validate a v1 archive with a caller-owned fresh validation ID
+/// and explicit archive open limits.
+pub fn LoomarkDocumentArchive::from_json_string(
+  json : String,
+  validation_agent_id~ : String,
+  open_limits~ : @markdown.MarkdownArchiveOpenLimits,
+) -> LoomarkDocumentArchive raise {
+  let decoded = LoomarkDocumentArchive::decode_json_string(json)
   if validation_agent_id.is_empty() {
     raise LoomarkArchiveDecodeError::InvalidValidationAgentId
   }
-  validate_decoded(portable_markdown, history, validation_agent_id, open_limits)
-  { document_id, portable_markdown, history }
+  validate_decoded(
+    decoded.portable_markdown,
+    decoded.history,
+    validation_agent_id,
+    open_limits,
+  )
+  {
+    document_id: decoded.document_id,
+    portable_markdown: decoded.portable_markdown,
+    history: decoded.history,
+  }
 }
 
 ///|

--- a/apps/loomark/archive/archive_wbtest.mbt
+++ b/apps/loomark/archive/archive_wbtest.mbt
@@ -43,6 +43,26 @@ test "archive capture and round-trip tracer" {
 }
 
 ///|
+test "archive structural decode leaves history admission to the repository" {
+  let editor = try! @markdown.MarkdownEditor(
+    agent_id="archive-decode-only-source",
+    source="hello",
+  )
+  let document_id = try! LoomarkDocumentId::from_string("doc-decode-only")
+  let archive = try! LoomarkDocumentArchive::capture(document_id~, editor~)
+  let decoded = try! LoomarkDocumentArchive::decode_json_string(
+    archive
+    .to_json_string()
+    .replace(
+      old="\"portable_markdown\":\"hello\"",
+      new="\"portable_markdown\":\"other\"",
+    ),
+  )
+  assert_eq(decoded.portable_markdown(), "other")
+  assert_true(decoded.history() == archive.history())
+}
+
+///|
 test "archive decode error matrix" {
   let editor = try! @markdown.MarkdownEditor(
     agent_id="archive-errors-source",

--- a/apps/loomark/archive/pkg.generated.mbti
+++ b/apps/loomark/archive/pkg.generated.mbti
@@ -33,10 +33,18 @@ pub(all) suberror LoomarkDocumentIdError {
 }
 
 // Types and methods
+pub struct DecodedLoomarkDocumentArchive {
+  // private fields
+}
+pub fn DecodedLoomarkDocumentArchive::document_id(Self) -> LoomarkDocumentId
+pub fn DecodedLoomarkDocumentArchive::history(Self) -> @markdown.MarkdownDocumentHistory
+pub fn DecodedLoomarkDocumentArchive::portable_markdown(Self) -> String
+
 pub struct LoomarkDocumentArchive {
   // private fields
 }
 pub fn LoomarkDocumentArchive::capture(document_id~ : LoomarkDocumentId, editor~ : @markdown.MarkdownEditor) -> Self raise
+pub fn LoomarkDocumentArchive::decode_json_string(String) -> DecodedLoomarkDocumentArchive raise
 pub fn LoomarkDocumentArchive::document_id(Self) -> LoomarkDocumentId
 pub fn LoomarkDocumentArchive::from_json_string(String, validation_agent_id~ : String, open_limits~ : @markdown.MarkdownArchiveOpenLimits) -> Self raise
 pub fn LoomarkDocumentArchive::history(Self) -> @markdown.MarkdownDocumentHistory

--- a/apps/loomark/examples/vanilla/README.md
+++ b/apps/loomark/examples/vanilla/README.md
@@ -31,6 +31,23 @@ The one mount-ownership site in the private adapter is the migration point that
 disposal, repeated-unmount, fatal-cleanup, reentrancy, remount, and host-reuse
 tests before deleting this adapter and harness.
 
+## Startup benchmark
+
+`npm run bench:startup` runs `bench-startup.mjs`, which boots the standalone
+static output (the same Warren production surface that `standalone.spec.ts`
+exercises) behind a local static server and measures how reload time grows as
+the archive accumulates history. The final Markdown document stays constant
+across every scenario; only the number of history-changing cycles increases
+(`[0, 2, 10, 20]`). Each scenario reports:
+
+- archive byte size
+- history byte size and character count
+- reload-root-visible timing (page reload until `#loomark-root` is visible)
+
+Output is printed as a `console.table` summary followed by one JSON line per
+scenario. The benchmark is a local development tool — it does not define a CI
+budget or a production performance guarantee.
+
 ## Driver seam
 
 The generated JavaScript for `internal/dev_host` is private test infrastructure.

--- a/apps/loomark/examples/vanilla/bench-startup.mjs
+++ b/apps/loomark/examples/vanilla/bench-startup.mjs
@@ -1,0 +1,156 @@
+import { spawn } from "node:child_process"
+import { once } from "node:events"
+import { fileURLToPath } from "node:url"
+import { chromium } from "./node_modules/playwright/index.mjs"
+
+const port = Number.parseInt(process.env.LOOMARK_STANDALONE_PORT ?? "4317", 10)
+const serverPath = fileURLToPath(new URL("./serve-standalone-dist.mjs", import.meta.url))
+const server = spawn(process.execPath, [serverPath], {
+  env: { ...process.env, LOOMARK_STANDALONE_PORT: String(port) },
+  stdio: ["ignore", "pipe", "inherit"],
+})
+
+const serverReady = new Promise((resolve, reject) => {
+  const timeout = setTimeout(
+    () => reject(new Error("standalone static server did not become ready")),
+    5_000,
+  )
+  server.stdout.setEncoding("utf8")
+  server.stdout.on("data", chunk => {
+    process.stdout.write(chunk)
+    if (chunk.includes(`http://127.0.0.1:${port}`)) {
+      clearTimeout(timeout)
+      resolve()
+    }
+  })
+  server.once("error", error => {
+    clearTimeout(timeout)
+    reject(error)
+  })
+  server.once("close", code => {
+    clearTimeout(timeout)
+    reject(new Error(`standalone static server exited before readiness (${code ?? "signal"})`))
+  })
+})
+
+async function stopServer() {
+  if (server.exitCode !== null) return
+  server.kill("SIGTERM")
+  await Promise.race([
+    once(server, "close"),
+    new Promise(resolve => setTimeout(resolve, 1_000)),
+  ])
+  if (server.exitCode === null) server.kill("SIGKILL")
+}
+
+async function replaceRawValue(page, value) {
+  const previousHistoryBytes = await page.evaluate(() => {
+    const raw = localStorage.getItem("loomark.active-document-archive") ?? ""
+    const archive = JSON.parse(raw)
+    return new TextEncoder().encode(archive.history ?? "").length
+  })
+  await page.locator("#loomark-input").evaluate((element, nextValue) => {
+    const textarea = element
+    const currentLength = textarea.value.length
+    textarea.setSelectionRange(0, currentLength, "forward")
+    textarea.dispatchEvent(new InputEvent("beforeinput", {
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+      data: nextValue,
+      inputType: "insertText",
+    }))
+    textarea.value = nextValue
+    textarea.setSelectionRange(nextValue.length, nextValue.length)
+    textarea.dispatchEvent(new InputEvent("input", {
+      bubbles: true,
+      composed: true,
+      data: nextValue,
+      inputType: "insertText",
+    }))
+  }, value)
+  await page.waitForTimeout(100)
+  await page.waitForFunction(({ expected, minimumHistoryBytes }) => {
+    const raw = localStorage.getItem("loomark.active-document-archive")
+    if (raw === null) return false
+    const archive = JSON.parse(raw)
+    return archive.portable_markdown === expected &&
+      new TextEncoder().encode(archive.history ?? "").length > minimumHistoryBytes
+  }, { expected: value, minimumHistoryBytes: previousHistoryBytes })
+}
+
+async function archiveStats(page) {
+  return page.evaluate(() => {
+    const raw = localStorage.getItem("loomark.active-document-archive") ?? ""
+    const archive = JSON.parse(raw)
+    const encoder = new TextEncoder()
+    return {
+      archiveBytes: encoder.encode(raw).length,
+      markdownBytes: encoder.encode(archive.portable_markdown ?? "").length,
+      historyBytes: encoder.encode(archive.history ?? "").length,
+      historyChars: (archive.history ?? "").length,
+    }
+  })
+}
+
+async function runScenario(browser, cycles) {
+  const context = await browser.newContext()
+  const page = await context.newPage()
+  const finalValue = "# Startup benchmark\n\nSame final document\n"
+
+  await page.goto(`http://127.0.0.1:${port}/`, { waitUntil: "commit" })
+  await page.locator("#loomark-root").waitFor({ state: "visible" })
+  await replaceRawValue(page, finalValue)
+
+  for (let index = 0; index < cycles; index += 1) {
+    await replaceRawValue(page, `${finalValue}intermediate revision ${index}\n`)
+    await replaceRawValue(page, finalValue)
+  }
+
+  const archive = await archiveStats(page)
+  const reloadStartedAt = performance.now()
+  await page.reload({ waitUntil: "commit" })
+  await page.locator("#loomark-root").waitFor({ state: "visible" })
+  const restoredValue = await page.locator("#loomark-input").inputValue()
+  if (restoredValue !== finalValue) {
+    throw new Error("startup benchmark did not restore the final document")
+  }
+  const reloadRootVisibleMs = performance.now() - reloadStartedAt
+  const navigation = await page.evaluate(() => {
+    const entry = performance.getEntriesByType("navigation")[0]
+    const script = performance
+      .getEntriesByType("resource")
+      .find(resource => resource.name.endsWith("/index.js"))
+    return {
+      appReadyMs: performance.now(),
+      domContentLoadedMs: entry?.domContentLoadedEventEnd ?? null,
+      indexJsTransferBytes: script?.transferSize ?? null,
+      indexJsDecodedBytes: script?.decodedBodySize ?? null,
+    }
+  })
+  const restored = await archiveStats(page)
+  await context.close()
+  return {
+    cycles,
+    historyChangingOperations: 1 + cycles * 2,
+    ...archive,
+    reloadRootVisibleMs: Number(reloadRootVisibleMs.toFixed(1)),
+    ...navigation,
+    restoredArchiveBytes: restored.archiveBytes,
+    restoredDocument: restoredValue.length,
+  }
+}
+
+try {
+  await serverReady
+  const browser = await chromium.launch({ headless: true })
+  const results = []
+  for (const cycles of [0, 2, 10, 20]) {
+    results.push(await runScenario(browser, cycles))
+  }
+  await browser.close()
+  console.table(results)
+  for (const result of results) console.log(JSON.stringify(result))
+} finally {
+  await stopServer()
+}

--- a/apps/loomark/examples/vanilla/package.json
+++ b/apps/loomark/examples/vanilla/package.json
@@ -6,7 +6,8 @@
     "typecheck:dev-host": "tsc --noEmit -p tsconfig.dev-host.json",
     "typecheck:standalone": "tsc --noEmit -p tsconfig.standalone.json",
     "test:dev-host": "playwright test --config=playwright.dev-host.config.ts",
-    "test:standalone": "node ./run-standalone-tests.mjs"
+    "test:standalone": "node ./run-standalone-tests.mjs",
+    "bench:startup": "node ./bench-startup.mjs"
   },
   "devDependencies": {
     "@playwright/test": "1.61.1",

--- a/apps/loomark/internal/rabbita/standalone_bootstrap.mbt
+++ b/apps/loomark/internal/rabbita/standalone_bootstrap.mbt
@@ -108,23 +108,12 @@ fn mount_new_standalone_document(
 }
 
 ///|
-/// Continue a validated local document with a fresh writing instance.
+/// Mount the already validated local document with its fresh writing instance.
 fn mount_reopened_standalone_document(
   host_id : String,
-  archive : @archive.LoomarkDocumentArchive,
+  reopened : @repository.ReopenedLocalArchive,
+  replica_id : String,
 ) -> Unit raise {
-  let policy = @repository.LocalRestorePolicy::trusted()
-  let replica_id = @archive_storage.fresh_id("loomark-standalone-writer-")
-  let reopened = @repository.reopen_local_archive(
-    archive,
-    agent_id=replica_id,
-    policy~,
-  ) catch {
-    _ => {
-      recovery_application(RecoveryCategory::CorruptArchive).mount(host_id)
-      return
-    }
-  }
   mount_standalone_editor(
     host_id,
     reopened.editor(),
@@ -157,17 +146,15 @@ fn finish_standalone_bootstrap(
       recovery_application(RecoveryCategory::StorageReadFailed).mount(host_id)
     @archive_storage.LocalArchiveStorageRead::Loaded(encoded) => {
       let policy = @repository.LocalRestorePolicy::trusted()
-      let validation_agent_id = @archive_storage.fresh_id(
-        "loomark-standalone-validator-",
-      )
+      let replica_id = @archive_storage.fresh_id("loomark-standalone-writer-")
       match
         @repository.classify_local_archive_record(
           Some(encoded),
-          validation_agent_id~,
+          agent_id=replica_id,
           policy~,
         ) {
-        @repository.LocalArchiveLoad::Valid(archive) =>
-          mount_reopened_standalone_document(host_id, archive)
+        @repository.LocalArchiveLoad::Valid(reopened) =>
+          mount_reopened_standalone_document(host_id, reopened, replica_id)
         @repository.LocalArchiveLoad::Rejected(failure) =>
           recovery_application(recovery_category(failure)).mount(host_id)
         @repository.LocalArchiveLoad::Missing =>

--- a/apps/loomark/repository/pkg.generated.mbti
+++ b/apps/loomark/repository/pkg.generated.mbti
@@ -7,11 +7,13 @@ import {
 }
 
 // Values
-pub fn classify_local_archive_record(String?, validation_agent_id~ : String, policy~ : LocalRestorePolicy) -> LocalArchiveLoad raise
+pub fn classify_local_archive_record(String?, agent_id~ : String, policy~ : LocalRestorePolicy) -> LocalArchiveLoad raise
 
 pub fn history_trigger(@dowdiness/canopy/editor/markdown.MarkdownCommitReceipt) -> LocalArchivePersistenceDecision
 
 pub fn prepare_local_archive(document_id~ : @archive.LoomarkDocumentId, editor~ : @dowdiness/canopy/editor/markdown.MarkdownEditor) -> PreparedLocalArchive raise
+
+pub fn reopen_decoded_local_archive(@archive.DecodedLoomarkDocumentArchive, agent_id~ : String, policy~ : LocalRestorePolicy) -> ReopenedLocalArchive raise
 
 pub fn reopen_local_archive(@archive.LoomarkDocumentArchive, agent_id~ : String, policy~ : LocalRestorePolicy) -> ReopenedLocalArchive raise
 
@@ -25,7 +27,7 @@ pub(all) suberror LocalArchivePreparationError {
 // Types and methods
 pub(all) enum LocalArchiveLoad {
   Missing
-  Valid(@archive.LoomarkDocumentArchive)
+  Valid(ReopenedLocalArchive)
   Rejected(LocalArchiveLoadFailure)
 }
 

--- a/apps/loomark/repository/repository.mbt
+++ b/apps/loomark/repository/repository.mbt
@@ -58,7 +58,7 @@ pub(all) enum LocalArchiveLoadFailure {
 /// Classification of the raw active-slot record.
 pub(all) enum LocalArchiveLoad {
   Missing
-  Valid(@archive.LoomarkDocumentArchive)
+  Valid(ReopenedLocalArchive)
   Rejected(LocalArchiveLoadFailure)
 }
 
@@ -99,46 +99,62 @@ fn map_decode_failure(
 }
 
 ///|
-/// Decode one raw local record, keeping missing storage distinct from failure.
+/// Turn one archive-boundary failure into a rejected local record.
+fn reject_decode_failure(
+  error : @archive.LoomarkArchiveDecodeError,
+) -> LocalArchiveLoad {
+  LocalArchiveLoad::Rejected(map_decode_failure(error))
+}
+
+///|
+/// Decode and reopen one raw local record, keeping missing storage distinct.
 pub fn classify_local_archive_record(
   raw_record : String?,
-  validation_agent_id~ : String,
+  agent_id~ : String,
   policy~ : LocalRestorePolicy,
 ) -> LocalArchiveLoad raise {
   match raw_record {
     None => LocalArchiveLoad::Missing
     Some(encoded) => {
-      let archive = @archive.LoomarkDocumentArchive::from_json_string(
-        encoded,
-        validation_agent_id~,
-        open_limits=policy.open_limits,
-      ) catch {
+      let decoded = @archive.LoomarkDocumentArchive::decode_json_string(encoded) catch {
         Failure::Failure(_) as failure => raise failure
         @archive.LoomarkArchiveDecodeError::UnsupportedNewerVersion(..) as error =>
-          return LocalArchiveLoad::Rejected(map_decode_failure(error))
+          return reject_decode_failure(error)
         @archive.LoomarkArchiveDecodeError::MalformedEnvelope(..) as error =>
-          return LocalArchiveLoad::Rejected(map_decode_failure(error))
+          return reject_decode_failure(error)
         @archive.LoomarkArchiveDecodeError::EmptyDocumentId as error =>
-          return LocalArchiveLoad::Rejected(map_decode_failure(error))
+          return reject_decode_failure(error)
         @archive.LoomarkArchiveDecodeError::CorruptHistory(..) as error =>
-          return LocalArchiveLoad::Rejected(map_decode_failure(error))
-        @archive.LoomarkArchiveDecodeError::PortableTextHistoryMismatch as error =>
-          return LocalArchiveLoad::Rejected(map_decode_failure(error))
-        @archive.LoomarkArchiveDecodeError::InvalidValidationAgentId as error =>
-          return LocalArchiveLoad::Rejected(map_decode_failure(error))
-        @archive.LoomarkArchiveDecodeError::WriterCreationFailed(..) as error =>
-          return LocalArchiveLoad::Rejected(map_decode_failure(error))
-        @archive.LoomarkArchiveDecodeError::LimitExceeded(..) as error =>
-          return LocalArchiveLoad::Rejected(map_decode_failure(error))
-        @archive.LoomarkArchiveDecodeError::HistoryAdmissionFailed(..) as error =>
-          return LocalArchiveLoad::Rejected(map_decode_failure(error))
-        @archive.LoomarkArchiveDecodeError::HistoryExportFailed(..) as error =>
-          return LocalArchiveLoad::Rejected(map_decode_failure(error))
-        @archive.LoomarkArchiveDecodeError::IncompleteHistory as error =>
-          return LocalArchiveLoad::Rejected(map_decode_failure(error))
+          return reject_decode_failure(error)
         error => raise error
       }
-      LocalArchiveLoad::Valid(archive)
+      let reopened = reopen_decoded_local_archive(decoded, agent_id~, policy~) catch {
+        Failure::Failure(_) as failure => raise failure
+        @archive.LoomarkArchiveDecodeError::UnsupportedNewerVersion(..) as error =>
+          return reject_decode_failure(error)
+        @archive.LoomarkArchiveDecodeError::MalformedEnvelope(..) as error =>
+          return reject_decode_failure(error)
+        @archive.LoomarkArchiveDecodeError::EmptyDocumentId as error =>
+          return reject_decode_failure(error)
+        @archive.LoomarkArchiveDecodeError::CorruptHistory(..) as error =>
+          return reject_decode_failure(error)
+        @archive.LoomarkArchiveDecodeError::PortableTextHistoryMismatch as error =>
+          return reject_decode_failure(error)
+        @archive.LoomarkArchiveDecodeError::InvalidValidationAgentId as error =>
+          return reject_decode_failure(error)
+        @archive.LoomarkArchiveDecodeError::WriterCreationFailed(..) as error =>
+          return reject_decode_failure(error)
+        @archive.LoomarkArchiveDecodeError::LimitExceeded(..) as error =>
+          return reject_decode_failure(error)
+        @archive.LoomarkArchiveDecodeError::HistoryAdmissionFailed(..) as error =>
+          return reject_decode_failure(error)
+        @archive.LoomarkArchiveDecodeError::HistoryExportFailed(..) as error =>
+          return reject_decode_failure(error)
+        @archive.LoomarkArchiveDecodeError::IncompleteHistory as error =>
+          return reject_decode_failure(error)
+        error => raise error
+      }
+      LocalArchiveLoad::Valid(reopened)
     }
   }
 }
@@ -286,18 +302,73 @@ pub struct ReopenedLocalArchive {
 }
 
 ///|
-/// Reopen a validated archive through the semantic Markdown façade.
+/// Map one Markdown archive-open failure into the Loomark archive taxonomy.
+fn map_markdown_archive_error(
+  error : @markdown.MarkdownArchiveError,
+) -> @archive.LoomarkArchiveDecodeError {
+  match error {
+    @markdown.MarkdownArchiveError::InvalidAgentId =>
+      @archive.LoomarkArchiveDecodeError::InvalidValidationAgentId
+    @markdown.MarkdownArchiveError::WriterCreationFailed(detail~) =>
+      @archive.LoomarkArchiveDecodeError::WriterCreationFailed(detail~)
+    @markdown.MarkdownArchiveError::LimitExceeded(dimension~, maximum~, actual~) =>
+      @archive.LoomarkArchiveDecodeError::LimitExceeded(
+        dimension~,
+        maximum~,
+        actual~,
+      )
+    @markdown.MarkdownArchiveError::HistoryAdmissionFailed(detail~) =>
+      @archive.LoomarkArchiveDecodeError::HistoryAdmissionFailed(detail~)
+    @markdown.MarkdownArchiveError::IncompleteHistory =>
+      @archive.LoomarkArchiveDecodeError::IncompleteHistory
+    @markdown.MarkdownArchiveError::ExportFailed(detail~) =>
+      @archive.LoomarkArchiveDecodeError::HistoryExportFailed(detail~)
+  }
+}
+
+///|
+/// Reopen and validate a complete archive through one semantic Markdown façade.
 pub fn reopen_local_archive(
   archive : @archive.LoomarkDocumentArchive,
   agent_id~ : String,
   policy~ : LocalRestorePolicy,
 ) -> ReopenedLocalArchive raise {
-  let (editor, attachment) = @markdown.MarkdownEditor::open_with_semantic_attachment(
+  let reopened = reopen_local_history(
+    archive.history(),
+    document_id=archive.document_id(),
     agent_id~,
-    history=archive.history(),
-    open_limits=policy.open_limits,
+    policy~,
   )
-  { document_id: archive.document_id(), editor, attachment }
+  verify_reopened_portable_markdown(reopened, archive.portable_markdown())
+}
+
+///|
+/// Reopen a structurally decoded archive and admit its history exactly once.
+pub fn reopen_decoded_local_archive(
+  archive : @archive.DecodedLoomarkDocumentArchive,
+  agent_id~ : String,
+  policy~ : LocalRestorePolicy,
+) -> ReopenedLocalArchive raise {
+  let reopened = reopen_local_history(
+    archive.history(),
+    document_id=archive.document_id(),
+    agent_id~,
+    policy~,
+  )
+  verify_reopened_portable_markdown(reopened, archive.portable_markdown())
+}
+
+///|
+/// Dispose a rejected attachment before surfacing the text/history mismatch.
+fn verify_reopened_portable_markdown(
+  reopened : ReopenedLocalArchive,
+  expected : String,
+) -> ReopenedLocalArchive raise {
+  if reopened.editor.portable_markdown() != expected {
+    reopened.attachment.dispose()
+    raise @archive.LoomarkArchiveDecodeError::PortableTextHistoryMismatch
+  }
+  reopened
 }
 
 ///|
@@ -314,7 +385,22 @@ pub fn reopen_local_history(
     agent_id~,
     history~,
     open_limits=policy.open_limits,
-  )
+  ) catch {
+    Failure::Failure(_) as failure => raise failure
+    @markdown.MarkdownArchiveError::InvalidAgentId as error =>
+      raise map_markdown_archive_error(error)
+    @markdown.MarkdownArchiveError::WriterCreationFailed(..) as error =>
+      raise map_markdown_archive_error(error)
+    @markdown.MarkdownArchiveError::LimitExceeded(..) as error =>
+      raise map_markdown_archive_error(error)
+    @markdown.MarkdownArchiveError::HistoryAdmissionFailed(..) as error =>
+      raise map_markdown_archive_error(error)
+    @markdown.MarkdownArchiveError::ExportFailed(..) as error =>
+      raise map_markdown_archive_error(error)
+    @markdown.MarkdownArchiveError::IncompleteHistory as error =>
+      raise map_markdown_archive_error(error)
+    error => raise error
+  }
   { document_id, editor, attachment }
 }
 

--- a/apps/loomark/repository/repository_wbtest.mbt
+++ b/apps/loomark/repository/repository_wbtest.mbt
@@ -31,11 +31,7 @@ fn captured_archive(
 test "repository classifies a missing record and a valid archive" {
   let policy = restore_policy_for_tests()
   match
-    classify_local_archive_record(
-      None,
-      validation_agent_id="repository-missing",
-      policy~,
-    ) {
+    classify_local_archive_record(None, agent_id="repository-missing", policy~) {
     LocalArchiveLoad::Missing => ()
     _ => fail("expected missing record")
   }
@@ -44,14 +40,16 @@ test "repository classifies a missing record and a valid archive" {
   match
     classify_local_archive_record(
       Some(archive.to_json_string()),
-      validation_agent_id="repository-valid-decode",
+      agent_id="repository-valid-writer",
       policy~,
     ) {
-    LocalArchiveLoad::Valid(decoded) => {
-      assert_true(decoded.document_id() == archive.document_id())
-      assert_true(decoded.history() == archive.history())
+    LocalArchiveLoad::Valid(reopened) => {
+      assert_true(reopened.document_id() == archive.document_id())
+      assert_true(reopened.editor().history_since() == archive.history())
+      assert_eq(reopened.editor().portable_markdown(), "hello")
+      reopened.attachment().dispose()
     }
-    _ => fail("expected a valid archive")
+    _ => fail("expected a reopened valid archive")
   }
 }
 
@@ -66,7 +64,7 @@ test "repository maps archive decode categories without parsing messages" {
       Some(
         "{\"schema_version\":\"2\",\"document_id\":\"x\",\"portable_markdown\":\"\",\"history\":\"\",\"extensions\":{}}",
       ),
-      validation_agent_id="repository-newer",
+      agent_id="repository-newer",
       policy~,
     ) {
     LocalArchiveLoad::Rejected(
@@ -78,7 +76,7 @@ test "repository maps archive decode categories without parsing messages" {
   match
     classify_local_archive_record(
       Some("not-json"),
-      validation_agent_id="repository-malformed",
+      agent_id="repository-malformed",
       policy~,
     ) {
     LocalArchiveLoad::Rejected(LocalArchiveLoadFailure::MalformedArchive(_)) =>
@@ -91,17 +89,32 @@ test "repository maps archive decode categories without parsing messages" {
       Some(
         encoded.replace(old="\"history\":\"", new="\"history\":\"not-history"),
       ),
-      validation_agent_id="repository-corrupt",
+      agent_id="repository-corrupt",
       policy~,
     ) {
     LocalArchiveLoad::Rejected(LocalArchiveLoadFailure::CorruptArchive(_)) => ()
     _ => fail("expected corrupt archive")
   }
 
+  let mismatch_encoded = encoded.replace(
+    old="\"portable_markdown\":\"hello\"",
+    new="\"portable_markdown\":\"other\"",
+  )
+  match
+    classify_local_archive_record(
+      Some(mismatch_encoded),
+      agent_id="repository-mismatch",
+      policy~,
+    ) {
+    LocalArchiveLoad::Rejected(LocalArchiveLoadFailure::CorruptArchive(detail~)) =>
+      assert_eq(detail, "portable text does not match canonical history")
+    _ => fail("expected portable text mismatch")
+  }
+
   match
     classify_local_archive_record(
       Some(encoded),
-      validation_agent_id="repository-over-limit",
+      agent_id="repository-over-limit",
       policy=restore_policy_for_tests(max_encoded_bytes=0),
     ) {
     LocalArchiveLoad::Rejected(LocalArchiveLoadFailure::LimitExceeded(_)) => ()
@@ -133,7 +146,7 @@ test "repository maps archive decode categories without parsing messages" {
   match
     classify_local_archive_record(
       Some(incomplete_encoded),
-      validation_agent_id="repository-incomplete",
+      agent_id="repository-incomplete",
       policy=restore_policy_for_tests(max_pending_operations=1),
     ) {
     LocalArchiveLoad::Rejected(LocalArchiveLoadFailure::IncompleteHistory) => ()


### PR DESCRIPTION
## Summary

- Decode the local archive envelope once, reopen/admit its CRDT history once with the fresh writer identity, and mount that same editor/semantic attachment.
- Keep structural decode and validated archive values distinct, preserve portable-text/history mismatch validation, typed recovery categories, incomplete/corrupt/limit handling, and attachment disposal on mismatch.
- Add a standalone startup benchmark that holds final Markdown constant while increasing history-changing operations and reports archive/history sizes and reload timing.

## UI and review evidence

N/A — this changes the standalone restore/mount path and adds diagnostic browser coverage; no visual design or visible-label change is intended.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `LoomarkDocumentArchive::from_json_string` | `apps/loomark/archive/archive.mbt` | Yes | Retained as the compatibility API for callers that need decode plus admission validation. |
| `MarkdownEditor::open_with_semantic_attachment` | `modules/canopy/editor/markdown/editor.mbt` | Yes | The repository uses the existing semantic admission API once and passes the resulting editor/attachment to mount. |
| `MarkdownDocumentHistory::from_json_string` / `history_since` | Markdown editor package | Yes | Existing history codec and capture APIs remain the archive boundary; no Markdown history format is replaced. |
| `Map` / `String` / `Option` / `Result` and typed `raise`/`catch` | MoonBit core and existing project error APIs | Yes | Structural JSON field lookup, optional storage records, and typed failure routing use the existing core shapes; no new collection or serialization loop was added. |

New helpers/types added:

- `DecodedLoomarkDocumentArchive`: a distinct opaque structural-decode value so an archive whose history has not yet been admitted cannot masquerade as a validated `LoomarkDocumentArchive`.
- `reopen_decoded_local_archive`: repository boundary for admitting a decoded envelope exactly once.
- `verify_reopened_portable_markdown`: owns the post-admission portable-text check and disposes the semantic attachment before rejecting a mismatch.
- `reject_decode_failure` and `map_markdown_archive_error`: keep typed archive failures mapped at the repository boundary without parsing error messages.
- `bench-startup.mjs` helpers: benchmark-only browser/storage synchronization and archive-size measurement; they do not affect production behavior.

## Validation scope

Boundary matrix / first failing regression:

- Record state: missing, valid complete archive, malformed envelope, unsupported newer schema, corrupt history, incomplete history, over-limit history, and portable-text/history mismatch.
- Operation path: structural decode → one semantic reopen/admission → mount → reload restoration.
- Ownership: the fresh writer identity is created once; the same reopened editor and semantic attachment are mounted; mismatch disposal remains explicit.
- Browser benchmark: one final Markdown value with 1, 5, 21, and 41 history-changing operations; the restored document is asserted equal to the final value.

Target packages:

- `apps/loomark/archive`
- `apps/loomark/repository`
- `apps/loomark/internal/rabbita`

Additional conditional gates:

- `./scripts/test-loomark-standalone-e2e.sh`: 13/13 passed, including Warren production build and standalone TypeScript typecheck.
- `npm run bench:startup`: passed; latest run reported reload-root-visible timings of 77.9ms, 147.5ms, 346.8ms, and 633.4ms for 1/5/21/41 history-changing operations, with restored-document checks passing. This is diagnostic output, not a CI budget.

## PR-ready evidence

Validated HEAD: `c6f3116f10a2793a50b0013f691aa74f1535a161`

Validated base: `origin/main@db3421bfa2984f80cf51b210d65014b6022612fa`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh \
  --target apps/loomark/archive \
  --target apps/loomark/repository \
  --target apps/loomark/internal/rabbita
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for the exact HEAD and base above.
- [x] The base was fetched again and `--verify-evidence` passed immediately before this PR was opened.
- [x] The committed `.mbti` diff against the validated base was reviewed for unintended API or trait-bound changes.
- [x] No submodule commit was changed by this PR; the existing dirty submodule in the original worktree was not included.
- [x] Validation was rerun after the final commit and generated-interface changes.
