### PR TITLE
test(editor): persist applied-edit regression coverage

### DIFF
--- a/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
+++ b/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
@@ -34,9 +34,24 @@ type Host = {
   mountResult: string
 }
 
-async function mountPage(context: BrowserContext, source: string): Promise<Omit<Host, "context">> {
+type AppliedEditSample = {
+  spans: Record<string, number>
+  inputToRenderMs: number
+  commitMs: number
+}
+
+async function mountPage(
+  context: BrowserContext,
+  source: string,
+  profileTextEdit = false,
+): Promise<Omit<Host, "context">> {
   const page = await context.newPage()
   await page.goto(pageUrl)
+  if (profileTextEdit) {
+    await page.evaluate(() => {
+      ;(globalThis as any).__canopy_bridge = { perfCurrent: null }
+    })
+  }
   const mountResult = await page.evaluate(
     ({ moduleUrl, source }) =>
       import(moduleUrl).then(module => module.mount_dev_host("app", source)),
@@ -112,6 +127,66 @@ async function dispatchRawNativeEdits(input: Locator, edits: RawNativeEdit[]): P
       textarea.dispatchEvent(new InputEvent("input", init))
     }
   }, edits)
+}
+
+function markdownPerfBlocks(count: number): string {
+  return Array.from(
+    { length: count },
+    (_, index) => `## Heading ${index}\n\nParagraph ${index} with **bold** and [link](https://example.com/${index}).`,
+  ).join("\n\n")
+}
+
+async function measureRawAppliedEdit(
+  page: Page,
+  input: Locator,
+  before: string,
+  start: number,
+  inserted: string,
+): Promise<AppliedEditSample> {
+  const expected = `${before.slice(0, start)}${inserted}${before.slice(start)}`
+  await page.evaluate(() => {
+    const bridge = (globalThis as any).__canopy_bridge
+    if (!bridge) throw new Error("performance bridge is not installed")
+    bridge.perfCurrent = { spans: {}, profileTextEdit: true }
+  })
+  await dispatchRawNativeEdits(input, [{
+    value: expected,
+    beforeStart: start,
+    beforeEnd: start,
+    afterStart: start + inserted.length,
+    afterEnd: start + inserted.length,
+    inputType: "insertText",
+    data: inserted,
+  }])
+  await expect.poll(async () => (await snapshot(page)).source).toBe(expected)
+  await expect.poll(async () => {
+    const phase = (await snapshot(page)).raw_input_phase
+    if (!phase || typeof phase !== "object") return false
+    const fields = phase as Record<string, unknown>
+    return typeof fields.input_to_render_ms === "number" &&
+      typeof fields.commit_ms === "number"
+  }).toBe(true)
+  const after = await snapshot(page)
+  const rawPhase = after.raw_input_phase
+  if (!rawPhase || typeof rawPhase !== "object") {
+    throw new Error("raw input phase was not recorded")
+  }
+  const phase = rawPhase as Record<string, unknown>
+  const inputToRenderMs = phase.input_to_render_ms
+  const commitMs = phase.commit_ms
+  if (typeof inputToRenderMs !== "number" || typeof commitMs !== "number") {
+    throw new Error("raw input phase is missing commit/render timing")
+  }
+  const spans = await page.evaluate(() => {
+    const bridge = (globalThis as any).__canopy_bridge
+    const recorded = { ...(bridge?.perfCurrent?.spans ?? {}) }
+    if (bridge) bridge.perfCurrent = null
+    return recorded as Record<string, number>
+  })
+  if (typeof spans.localTextChange !== "number") {
+    throw new Error("localTextChange phase was not recorded")
+  }
+  return { spans, inputToRenderMs, commitMs }
 }
 
 async function armRawRenderBarrier(page: Page): Promise<void> {
@@ -425,6 +500,72 @@ test("Raw input exposes phase timings through the dev-host snapshot", async ({ b
     }).toBe(true)
   } finally {
     await host.context.close()
+  }
+})
+
+test("Raw input preserves applied-edit fast path and fallback boundaries", async ({ browser }) => {
+  test.setTimeout(60_000)
+  const context = await browser.newContext()
+  const prefix = markdownPerfBlocks(125)
+  const source = `${prefix}\n\nx\n\n${prefix}`
+  const position = prefix.length + 2
+  const mounted = await mountPage(context, source, true)
+  try {
+    const input = mounted.page.locator("#loomark-input")
+    const accepted: AppliedEditSample[] = []
+    const fallback: AppliedEditSample[] = []
+    for (let index = 0; index < 12; index += 1) {
+      const run = async (inserted: string): Promise<AppliedEditSample> => {
+        await requestSource(mounted.page, source)
+        await expect.poll(async () => (await snapshot(mounted.page)).source).toBe(source)
+        return measureRawAppliedEdit(mounted.page, input, source, position, inserted)
+      }
+      if (index % 2 === 0) {
+        accepted.push(await run("y"))
+        fallback.push(await run("x"))
+      } else {
+        fallback.push(await run("x"))
+        accepted.push(await run("y"))
+      }
+    }
+
+    const percentile = (
+      samples: AppliedEditSample[],
+      select: (sample: AppliedEditSample) => number,
+      quantile: number,
+    ): number => {
+      const values = samples.map(select).sort((a, b) => a - b)
+      const index = Math.min(values.length - 1, Math.max(0, Math.ceil(values.length * quantile) - 1))
+      return Number(values[index].toFixed(2))
+    }
+    const summarize = (samples: AppliedEditSample[]) => ({
+      fallbackSpanCount: samples.filter(sample =>
+        typeof sample.spans.resolveAppliedEditDiff === "number").length,
+      inputToRenderP50Ms: percentile(samples, sample => sample.inputToRenderMs, 0.5),
+      inputToRenderP95Ms: percentile(samples, sample => sample.inputToRenderMs, 0.95),
+      commitP50Ms: percentile(samples, sample => sample.commitMs, 0.5),
+      localTextChangeP50Ms: percentile(
+        samples,
+        sample => sample.spans.localTextChange ?? 0,
+        0.5,
+      ),
+      resolveAppliedEditDiffP50Ms: percentile(
+        samples,
+        sample => sample.spans.resolveAppliedEditDiff ?? 0,
+        0.5,
+      ),
+    })
+    const summary = {
+      sourceChars: source.length,
+      samples: accepted.length,
+      accepted: summarize(accepted),
+      fallback: summarize(fallback),
+    }
+    console.log(`[applied-edit-adoption] ${JSON.stringify(summary)}`)
+    expect(summary.accepted.fallbackSpanCount).toBe(0)
+    expect(summary.fallback.fallbackSpanCount).toBe(12)
+  } finally {
+    await context.close()
   }
 })
 

--- a/modules/canopy/editor/sync_editor_test.mbt
+++ b/modules/canopy/editor/sync_editor_test.mbt
@@ -483,3 +483,92 @@ test "SyncEditor: local insertion adjusts a peer cursor after the edit" {
     ),
   )
 }
+
+///|
+test "SyncEditor: concurrent middle inserts converge with parser state" {
+  let alice = try! @probe.new_test_editor("alice")
+  let bob = try! @probe.new_test_editor("bob")
+  alice.set_text("abcd")
+  try! bob.apply_sync(try! alice.export_all())
+
+  alice.move_cursor(4)
+  bob.move_cursor(4)
+  alice.set_local_presence("Alice", "#ff0000")
+  bob.set_local_presence("Bob", "#00ff00")
+  alice.apply_ephemeral(bob.encode_ephemeral_all())
+  bob.apply_ephemeral(alice.encode_ephemeral_all())
+  alice.move_cursor(2)
+  bob.move_cursor(2)
+
+  try! alice.insert_and_record("A", 1000)
+  try! bob.insert_and_record("B", 1001)
+  try! alice.apply_sync(try! bob.export_all())
+  try! bob.apply_sync(try! alice.export_all())
+
+  inspect(alice.get_text(), content="abBAcd")
+  inspect(bob.get_text(), content="abBAcd")
+  inspect(
+    @probe.get_test_ast(alice) == @probe.get_test_ast(bob),
+    content="true",
+  )
+  inspect(
+    alice.get_peer_cursors().get("bob").unwrap().adjusted_cursor,
+    content="6",
+  )
+  inspect(
+    bob.get_peer_cursors().get("alice").unwrap().adjusted_cursor,
+    content="6",
+  )
+}
+
+///|
+test "SyncEditor: undo and redo converge across a remote interleaving" {
+  let alice = try! @probe.new_test_editor("alice", capture_timeout_ms=500)
+  let bob = try! @probe.new_test_editor("bob", capture_timeout_ms=500)
+  alice.set_text("abcd")
+  try! bob.apply_sync(try! alice.export_all())
+
+  alice.move_cursor(2)
+  try! alice.insert_and_record("A", 1000)
+  try! bob.apply_sync(try! alice.export_all())
+  inspect(bob.get_text(), content="abAcd")
+
+  bob.move_cursor(2)
+  try! bob.insert_and_record("B", 2000)
+  inspect(bob.get_text(), content="abBAcd")
+  try! alice.apply_sync(try! bob.export_all())
+  inspect(alice.get_text(), content="abBAcd")
+
+  let undo_message = alice.undo_and_export()
+  inspect(alice.get_text(), content="abBcd")
+  inspect(
+    @probe.get_test_ast(alice),
+    content=(
+      #|Branch("", [Leaf("abBcd")])
+    ),
+  )
+  match undo_message {
+    Some(message) => try! bob.apply_sync(message)
+    None => fail("undo should produce sync operations")
+  }
+  inspect(bob.get_text(), content="abBcd")
+  inspect(
+    @probe.get_test_ast(bob),
+    content=(
+      #|Branch("", [Leaf("abBcd")])
+    ),
+  )
+
+  let redo_message = alice.redo_and_export()
+  inspect(alice.get_text(), content="abBAcd")
+  match redo_message {
+    Some(message) => try! bob.apply_sync(message)
+    None => fail("redo should produce sync operations")
+  }
+  inspect(bob.get_text(), content="abBAcd")
+  inspect(alice.get_text() == bob.get_text(), content="true")
+  inspect(
+    @probe.get_test_ast(alice) == @probe.get_test_ast(bob),
+    content="true",
+  )
+}


### PR DESCRIPTION
## Summary

- Persist real Loomark Raw-input measurement for the `resolve_applied_edit` fast path and fallback path.
- Add deterministic concurrent-edit and remote undo/redo convergence coverage.
- Keep the measurement observational: adoption is asserted, latency is logged without a fixed CI threshold.

## UI and review evidence

N/A — test and editor semantics coverage only; no visual or production UI changes.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `snapshot`, `requestSource`, `dispatchRawNativeEdits` | `apps/loomark/examples/vanilla/tests/dev-host.spec.ts` | Yes | Existing dev-host seams cover source convergence and the native Raw `beforeinput`/`input` boundary. |
| `dev_host_snapshot`, `dev_host_request_source` | `apps/loomark/internal/dev_host/dev_host.mbt` | Yes | Existing private dev-host bridge; no production API added. |
| `SyncEditor::apply_sync`, `insert_and_record`, `undo_and_export`, `redo_and_export` | `modules/canopy/editor/` | Yes | Existing public editor seams exercise CRDT sync and history propagation. |
| `String` slicing and `Array` iteration | MoonBit/TypeScript test runtime | Yes | Used only for the independent measurement corpus and expected source construction; no new low-level production helper. |

New helpers added:

- `markdownPerfBlocks` — creates the fixed Markdown measurement corpus; no existing corpus builder owns this test scenario.
- `measureRawAppliedEdit` — owns the test-only perf bridge lifecycle, native edit dispatch, timing capture, and span capture.
- `AppliedEditSample` — test-only measurement result shape.

## Validation scope

Boundary matrix / first failing regression:

- Real Raw `beforeinput`/`input` middle insertion in a 19,841-character Markdown source.
- Non-repeating ASCII insertion: fast path must produce zero `resolveAppliedEditDiff` fallback spans.
- Same-character insertion: fallback must produce `resolveAppliedEditDiff` for every sample.
- Twelve alternating accepted/fallback pairs; p50/p95 timing is logged but not used as a flaky absolute gate.
- Two peers performing concurrent middle inserts from the same snapshot must converge on text, AST, and peer-cursor state.
- Remote edit followed by local undo/redo must propagate undo and redo sync messages and preserve intermediate parser state.

Target packages:

- `modules/canopy/editor`

Additional conditional gates:

- `./scripts/test-loomark-dev-host-e2e.sh --reporter=line`
- `npm run typecheck:dev-host` (included by the script)

## PR-ready evidence

Validated HEAD: `bec44c1f3c8a793bc6aded2b4def476e9ed11e65`

Validated base: `origin/main@ae153986168bc412920e6afdae770289e6e405bf`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh \
  --target modules/canopy/editor
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for the exact HEAD and base above.
- [x] The base was fetched again and `--verify-evidence` passed immediately before this PR was opened.
- [x] The committed `.mbti` diff against the validated base was reviewed for unintended API or trait-bound changes.
- [x] No submodule commit was changed.
- [x] Validation was rerun after the commit.
- [x] Independent review findings were resolved before final validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Added optional profiling for raw-text page updates.
  * Added performance coverage comparing optimized applied edits with fallback edits, including percentile timing metrics.

* **Tests**
  * Added coverage confirming concurrent insertions converge consistently across editors.
  * Added undo and redo synchronization tests involving remote edits, cursor adjustments, and parser state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->