### PR TITLE
perf(loomark): make startup corpus benchmark reproducible

### DIFF
--- a/apps/loomark/examples/vanilla/README.md
+++ b/apps/loomark/examples/vanilla/README.md
@@ -35,18 +35,40 @@ tests before deleting this adapter and harness.
 
 `npm run bench:startup` runs `bench-startup.mjs`, which boots the standalone
 static output (the same Warren production surface that `standalone.spec.ts`
-exercises) behind a local static server and measures how reload time grows as
-the archive accumulates history. The final Markdown document stays constant
-across every scenario; only the number of history-changing cycles increases
-(`[0, 2, 10, 20]`). Each scenario reports:
+exercises) behind a local static server. It measures reload-to-restored-editor
+time with repeated samples and reports nearest-rank p50/p95 values.
 
-- archive byte size
-- history byte size and character count
-- reload-root-visible timing (page reload until `#loomark-root` is visible)
+Without configuration it uses a small synthetic document and history-changing
+cycles `[0, 2, 10, 20]`. To measure a Markdown corpus, pass a file or directory
+(the directory is searched recursively):
 
-Output is printed as a `console.table` summary followed by one JSON line per
-scenario. The benchmark is a local development tool — it does not define a CI
-budget or a production performance guarantee.
+```bash
+LOOMARK_STARTUP_CORPUS=/path/to/markdown npm run bench:startup
+```
+
+That mode uses the corpus for document size and generates controlled history.
+The first generated edit is a full-document replacement, so this is a stress
+corpus rather than a claim about a user's operation granularity. For real
+persisted histories, pass exported active-archive JSON files instead:
+
+```bash
+LOOMARK_STARTUP_ARCHIVES=/path/to/archive-json npm run bench:startup
+```
+
+Archive fixtures must be complete v1 active-archive envelopes, including
+`schema_version`, `document_id`, `portable_markdown`, `history`, and empty
+`extensions`. Archive mode is the preferred input for deciding a replay
+threshold; Markdown mode is useful for separating document size from generated
+history. `LOOMARK_STARTUP_SAMPLES` controls reload samples (default `20`), and
+`LOOMARK_STARTUP_CYCLES` controls generated cycles (default `0,2,10,20`). Paths
+are emitted as opaque `document-N` labels by default; set
+`LOOMARK_STARTUP_INCLUDE_PATHS=1` when local path labels are useful.
+
+Each result reports archive, Markdown, and history sizes, the individual
+reload samples, and p50/p95 startup timings. Output is printed as a
+`console.table` summary followed by one JSON line per scenario. The benchmark
+is a local development tool — it does not define a CI budget or a production
+performance guarantee.
 
 ## Driver seam
 

--- a/apps/loomark/examples/vanilla/README.md
+++ b/apps/loomark/examples/vanilla/README.md
@@ -65,10 +65,11 @@ are emitted as opaque `document-N` labels by default; set
 `LOOMARK_STARTUP_INCLUDE_PATHS=1` when local path labels are useful.
 
 Each result reports archive, Markdown, and history sizes, the individual
-reload samples, and p50/p95 startup timings. Output is printed as a
-`console.table` summary followed by one JSON line per scenario. The benchmark
-is a local development tool — it does not define a CI budget or a production
-performance guarantee.
+reload samples, and p50/p95 startup timings. The first navigation in each
+scenario is a warm-up, so these are warm-context reload measurements rather
+than cold first-load timings. Output is printed as a `console.table` summary
+followed by one JSON line per scenario. The benchmark is a local development
+tool — it does not define a CI budget or a production performance guarantee.
 
 ## Driver seam
 

--- a/apps/loomark/examples/vanilla/bench-startup.mjs
+++ b/apps/loomark/examples/vanilla/bench-startup.mjs
@@ -346,7 +346,7 @@ async function measureReloads(browser, encoded, finalValue) {
         .getEntriesByType("resource")
         .find(resource => resource.name.endsWith("/index.js"))
       return {
-        reloadRootVisibleMs: performance.now(),
+        reloadRestoredDocumentMs: performance.now(),
         domContentLoadedMs: entry?.domContentLoadedEventEnd ?? null,
         indexJsTransferBytes: script?.transferSize ?? null,
         indexJsDecodedBytes: script?.decodedBodySize ?? null,
@@ -355,15 +355,17 @@ async function measureReloads(browser, encoded, finalValue) {
   }
   await context.close()
 
-  const rootVisible = measurements.map(measurement => measurement.reloadRootVisibleMs)
+  const restoredDocument = measurements.map(
+    measurement => measurement.reloadRestoredDocumentMs,
+  )
   const domContentLoaded = measurements
     .map(measurement => measurement.domContentLoadedMs)
     .filter(value => value !== null)
   const network = measurements.find(measurement => measurement.indexJsDecodedBytes !== null) ?? measurements[0]
   return {
-    reloadRootVisibleSamples: rootVisible.map(value => Number(value.toFixed(1))),
-    reloadRootVisibleP50Ms: percentile(rootVisible, 50),
-    reloadRootVisibleP95Ms: percentile(rootVisible, 95),
+    reloadRestoredDocumentSamples: restoredDocument.map(value => Number(value.toFixed(1))),
+    reloadRestoredDocumentP50Ms: percentile(restoredDocument, 50),
+    reloadRestoredDocumentP95Ms: percentile(restoredDocument, 95),
     domContentLoadedP50Ms: domContentLoaded.length === 0
       ? null
       : percentile(domContentLoaded, 50),
@@ -416,7 +418,7 @@ try {
   }
   await browser.close()
   console.table(results.map(result => {
-    const { reloadRootVisibleSamples, ...summary } = result
+    const { reloadRestoredDocumentSamples, ...summary } = result
     return summary
   }))
   for (const result of results) console.log(JSON.stringify(result))

--- a/apps/loomark/examples/vanilla/bench-startup.mjs
+++ b/apps/loomark/examples/vanilla/bench-startup.mjs
@@ -1,9 +1,27 @@
 import { spawn } from "node:child_process"
 import { once } from "node:events"
+import { readdir, readFile, stat } from "node:fs/promises"
 import { fileURLToPath } from "node:url"
+import { relative, resolve } from "node:path"
 import { chromium } from "./node_modules/playwright/index.mjs"
 
 const port = Number.parseInt(process.env.LOOMARK_STANDALONE_PORT ?? "4317", 10)
+const archiveKey = "loomark.active-document-archive"
+const sampleCount = parsePositiveInteger(
+  process.env.LOOMARK_STARTUP_SAMPLES ?? "20",
+  "LOOMARK_STARTUP_SAMPLES",
+)
+const historyCycles = parseCycles(
+  process.env.LOOMARK_STARTUP_CYCLES ?? "0,2,10,20",
+)
+const markdownCorpusPath = process.env.LOOMARK_STARTUP_CORPUS
+const archiveCorpusPath = process.env.LOOMARK_STARTUP_ARCHIVES
+const includeCorpusPaths = process.env.LOOMARK_STARTUP_INCLUDE_PATHS === "1"
+
+if (markdownCorpusPath !== undefined && archiveCorpusPath !== undefined) {
+  throw new Error("set only one of LOOMARK_STARTUP_CORPUS and LOOMARK_STARTUP_ARCHIVES")
+}
+
 const serverPath = fileURLToPath(new URL("./serve-standalone-dist.mjs", import.meta.url))
 const server = spawn(process.execPath, [serverPath], {
   env: { ...process.env, LOOMARK_STANDALONE_PORT: String(port) },
@@ -33,6 +51,163 @@ const serverReady = new Promise((resolve, reject) => {
   })
 })
 
+function parsePositiveInteger(raw, name) {
+  const value = Number.parseInt(raw, 10)
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error(`${name} must be a positive integer`)
+  }
+  return value
+}
+
+function parseCycles(raw) {
+  const cycles = raw.split(",").map(value => Number.parseInt(value.trim(), 10))
+  if (
+    cycles.length === 0 ||
+    cycles.some(value => !Number.isInteger(value) || value < 0)
+  ) {
+    throw new Error("LOOMARK_STARTUP_CYCLES must be a comma-separated list of non-negative integers")
+  }
+  return cycles
+}
+
+function browserText(source) {
+  // HTML textareas expose LF-normalized values. Keep the source corpus bytes
+  // in the report, but compare the mounted editor using its browser value.
+  return source.replace(/\r\n?/g, "\n")
+}
+
+function percentile(values, percentage) {
+  const sorted = [...values].sort((left, right) => left - right)
+  const rank = Math.max(0, Math.ceil((percentage / 100) * sorted.length) - 1)
+  return Number(sorted[rank].toFixed(1))
+}
+
+async function collectFiles(pathname, include) {
+  const metadata = await stat(pathname)
+  if (metadata.isFile()) return [pathname]
+  if (!metadata.isDirectory()) {
+    throw new Error(`corpus path is neither a file nor a directory: ${pathname}`)
+  }
+
+  const entries = (await readdir(pathname, { withFileTypes: true }))
+    .sort((left, right) => left.name.localeCompare(right.name))
+  const files = []
+  for (const entry of entries) {
+    const child = resolve(pathname, entry.name)
+    if (entry.isDirectory()) {
+      files.push(...await collectFiles(child, include))
+    } else if (entry.isSymbolicLink()) {
+      const target = await stat(child)
+      if (target.isDirectory()) {
+        throw new Error(`corpus does not follow symlinked directories: ${child}`)
+      }
+      if (target.isFile() && include(child)) files.push(child)
+    } else if (entry.isFile() && include(child)) {
+      files.push(child)
+    }
+  }
+  return files
+}
+
+function corpusDocumentName(file, index) {
+  return includeCorpusPaths ? relative(process.cwd(), file) : `document-${index + 1}`
+}
+
+async function loadMarkdownCorpus(pathname) {
+  const root = resolve(pathname)
+  const files = await collectFiles(
+    root,
+    file => /\.(?:md|markdown|mdown)$/i.test(file),
+  )
+  if (files.length === 0) {
+    throw new Error(`Markdown corpus contains no .md, .markdown, or .mdown files: ${root}`)
+  }
+  return {
+    kind: "markdown",
+    documents: await Promise.all(files.map(async (file, index) => {
+      const source = await readFile(file, "utf8")
+      return {
+        name: corpusDocumentName(file, index),
+        source,
+        sourceBytes: Buffer.byteLength(source),
+      }
+    })),
+  }
+}
+
+function archiveStatsFromEncoded(encoded) {
+  const archive = JSON.parse(encoded)
+  const markdown = typeof archive.portable_markdown === "string"
+    ? archive.portable_markdown
+    : ""
+  const history = typeof archive.history === "string" ? archive.history : ""
+  return {
+    archiveBytes: Buffer.byteLength(encoded),
+    markdownBytes: Buffer.byteLength(markdown),
+    historyBytes: Buffer.byteLength(history),
+    historyChars: history.length,
+  }
+}
+
+async function loadArchiveCorpus(pathname) {
+  const root = resolve(pathname)
+  const files = await collectFiles(root, file => file.toLowerCase().endsWith(".json"))
+  if (files.length === 0) {
+    throw new Error(`Archive corpus contains no .json files: ${root}`)
+  }
+  return {
+    kind: "archive",
+    documents: await Promise.all(files.map(async (file, index) => {
+      const encoded = await readFile(file, "utf8")
+      const archive = JSON.parse(encoded)
+      const fields = archive === null || typeof archive !== "object"
+        ? []
+        : Object.keys(archive).sort()
+      const expectedFields = [
+        "document_id",
+        "extensions",
+        "history",
+        "portable_markdown",
+        "schema_version",
+      ]
+      if (
+        JSON.stringify(fields) !== JSON.stringify(expectedFields) ||
+        archive.schema_version !== "1" ||
+        typeof archive.document_id !== "string" ||
+        archive.document_id.length === 0 ||
+        typeof archive.portable_markdown !== "string" ||
+        typeof archive.history !== "string" ||
+        archive.extensions === null ||
+        typeof archive.extensions !== "object" ||
+        Array.isArray(archive.extensions) ||
+        Object.keys(archive.extensions).length !== 0
+      ) {
+        throw new Error(`archive fixture is not a complete v1 envelope: ${file}`)
+      }
+      return {
+        name: corpusDocumentName(file, index),
+        encoded,
+        finalValue: browserText(archive.portable_markdown),
+        sourceBytes: Buffer.byteLength(archive.portable_markdown),
+        stats: archiveStatsFromEncoded(encoded),
+      }
+    })),
+  }
+}
+
+async function loadCorpus() {
+  if (archiveCorpusPath !== undefined) return loadArchiveCorpus(archiveCorpusPath)
+  if (markdownCorpusPath !== undefined) return loadMarkdownCorpus(markdownCorpusPath)
+  return {
+    kind: "markdown",
+    documents: [{
+      name: "synthetic",
+      source: "# Startup benchmark\n\nSame final document\n",
+      sourceBytes: Buffer.byteLength("# Startup benchmark\n\nSame final document\n"),
+    }],
+  }
+}
+
 async function stopServer() {
   if (server.exitCode !== null) return
   server.kill("SIGTERM")
@@ -44,11 +219,11 @@ async function stopServer() {
 }
 
 async function replaceRawValue(page, value) {
-  const previousHistoryBytes = await page.evaluate(() => {
-    const raw = localStorage.getItem("loomark.active-document-archive") ?? ""
+  const previousHistoryBytes = await page.evaluate(key => {
+    const raw = localStorage.getItem(key) ?? ""
     const archive = JSON.parse(raw)
     return new TextEncoder().encode(archive.history ?? "").length
-  })
+  }, archiveKey)
   await page.locator("#loomark-input").evaluate((element, nextValue) => {
     const textarea = element
     const currentLength = textarea.value.length
@@ -70,37 +245,52 @@ async function replaceRawValue(page, value) {
     }))
   }, value)
   await page.waitForTimeout(100)
-  await page.waitForFunction(({ expected, minimumHistoryBytes }) => {
-    const raw = localStorage.getItem("loomark.active-document-archive")
-    if (raw === null) return false
-    const archive = JSON.parse(raw)
-    return archive.portable_markdown === expected &&
-      new TextEncoder().encode(archive.history ?? "").length > minimumHistoryBytes
-  }, { expected: value, minimumHistoryBytes: previousHistoryBytes })
+  try {
+    await page.waitForFunction(({ expected, minimumHistoryBytes, key }) => {
+      const input = document.querySelector("#loomark-input")
+      const raw = localStorage.getItem(key)
+      if (input === null || raw === null) return false
+      const archive = JSON.parse(raw)
+      return input.value === expected &&
+        archive.portable_markdown === expected &&
+        new TextEncoder().encode(archive.history ?? "").length > minimumHistoryBytes
+    }, { expected: value, minimumHistoryBytes: previousHistoryBytes, key: archiveKey })
+  } catch (error) {
+    const observed = await page.evaluate(key => {
+      const input = document.querySelector("#loomark-input")
+      const raw = localStorage.getItem(key)
+      if (raw === null) {
+        return { inputLength: input?.value.length ?? null, archivePresent: false }
+      }
+      const archive = JSON.parse(raw)
+      return {
+        inputLength: input?.value.length ?? null,
+        archivePresent: true,
+        archiveBytes: new TextEncoder().encode(raw).length,
+        markdownLength: (archive.portable_markdown ?? "").length,
+        historyBytes: new TextEncoder().encode(archive.history ?? "").length,
+      }
+    }, archiveKey)
+    throw new Error(
+      `archive did not settle for ${value.length} input characters: ${JSON.stringify(observed)}; ${error.message}`,
+    )
+  }
 }
 
 async function archiveStats(page) {
-  return page.evaluate(() => {
-    const raw = localStorage.getItem("loomark.active-document-archive") ?? ""
-    const archive = JSON.parse(raw)
-    const encoder = new TextEncoder()
-    return {
-      archiveBytes: encoder.encode(raw).length,
-      markdownBytes: encoder.encode(archive.portable_markdown ?? "").length,
-      historyBytes: encoder.encode(archive.history ?? "").length,
-      historyChars: (archive.history ?? "").length,
-    }
-  })
+  const encoded = await page.evaluate(key => localStorage.getItem(key), archiveKey)
+  if (encoded === null) throw new Error("Loomark did not create an active archive")
+  return { encoded, stats: archiveStatsFromEncoded(encoded) }
 }
 
-async function runScenario(browser, cycles) {
+async function buildArchive(browser, document, cycles) {
   const context = await browser.newContext()
   const page = await context.newPage()
-  const finalValue = "# Startup benchmark\n\nSame final document\n"
+  const finalValue = browserText(document.source)
 
   await page.goto(`http://127.0.0.1:${port}/`, { waitUntil: "commit" })
   await page.locator("#loomark-root").waitFor({ state: "visible" })
-  await replaceRawValue(page, finalValue)
+  if (finalValue.length > 0) await replaceRawValue(page, finalValue)
 
   for (let index = 0; index < cycles; index += 1) {
     await replaceRawValue(page, `${finalValue}intermediate revision ${index}\n`)
@@ -108,48 +298,127 @@ async function runScenario(browser, cycles) {
   }
 
   const archive = await archiveStats(page)
-  const reloadStartedAt = performance.now()
-  await page.reload({ waitUntil: "commit" })
-  await page.locator("#loomark-root").waitFor({ state: "visible" })
-  const restoredValue = await page.locator("#loomark-input").inputValue()
-  if (restoredValue !== finalValue) {
-    throw new Error("startup benchmark did not restore the final document")
-  }
-  const reloadRootVisibleMs = performance.now() - reloadStartedAt
-  const navigation = await page.evaluate(() => {
-    const entry = performance.getEntriesByType("navigation")[0]
-    const script = performance
-      .getEntriesByType("resource")
-      .find(resource => resource.name.endsWith("/index.js"))
-    return {
-      appReadyMs: performance.now(),
-      domContentLoadedMs: entry?.domContentLoadedEventEnd ?? null,
-      indexJsTransferBytes: script?.transferSize ?? null,
-      indexJsDecodedBytes: script?.decodedBodySize ?? null,
-    }
-  })
-  const restored = await archiveStats(page)
   await context.close()
   return {
-    cycles,
-    historyChangingOperations: 1 + cycles * 2,
     ...archive,
-    reloadRootVisibleMs: Number(reloadRootVisibleMs.toFixed(1)),
-    ...navigation,
-    restoredArchiveBytes: restored.archiveBytes,
-    restoredDocument: restoredValue.length,
+    finalValue,
+    historyChangingOperations: (finalValue.length === 0 ? 0 : 1) + cycles * 2,
+  }
+}
+
+async function waitForRestoredDocument(page, finalValue) {
+  await page.waitForFunction(() => {
+    return document.querySelector("#loomark-root") !== null ||
+      document.querySelector("#loomark-recovery-root") !== null
+  })
+  const recovery = page.locator("#loomark-recovery-root")
+  if (await recovery.count() > 0) {
+    const category = await recovery.getAttribute("data-loomark-recovery-category")
+    throw new Error(`archive restore entered recovery (${category ?? "unknown"})`)
+  }
+  await page.locator("#loomark-root").waitFor({ state: "visible" })
+  await page.waitForFunction(expected => {
+    return document.querySelector("#loomark-input")?.value === expected
+  }, finalValue)
+}
+
+async function measureReloads(browser, encoded, finalValue) {
+  const context = await browser.newContext()
+  const page = await context.newPage()
+
+  // Seed and admit the fixture before the measured reloads. In particular, do
+  // not rewrite the archive from an init script on every measured navigation.
+  await page.goto(`http://127.0.0.1:${port}/`, { waitUntil: "commit" })
+  await page.locator("#loomark-root").waitFor({ state: "visible" })
+  await page.evaluate(({ key, value }) => {
+    localStorage.setItem(key, value)
+  }, { key: archiveKey, value: encoded })
+  await page.reload({ waitUntil: "commit" })
+  await waitForRestoredDocument(page, finalValue)
+
+  const measurements = []
+  for (let index = 0; index < sampleCount; index += 1) {
+    await page.reload({ waitUntil: "commit" })
+    await waitForRestoredDocument(page, finalValue)
+    measurements.push(await page.evaluate(() => {
+      const entry = performance.getEntriesByType("navigation")[0]
+      const script = performance
+        .getEntriesByType("resource")
+        .find(resource => resource.name.endsWith("/index.js"))
+      return {
+        reloadRootVisibleMs: performance.now(),
+        domContentLoadedMs: entry?.domContentLoadedEventEnd ?? null,
+        indexJsTransferBytes: script?.transferSize ?? null,
+        indexJsDecodedBytes: script?.decodedBodySize ?? null,
+      }
+    }))
+  }
+  await context.close()
+
+  const rootVisible = measurements.map(measurement => measurement.reloadRootVisibleMs)
+  const domContentLoaded = measurements
+    .map(measurement => measurement.domContentLoadedMs)
+    .filter(value => value !== null)
+  const network = measurements.find(measurement => measurement.indexJsDecodedBytes !== null) ?? measurements[0]
+  return {
+    reloadRootVisibleSamples: rootVisible.map(value => Number(value.toFixed(1))),
+    reloadRootVisibleP50Ms: percentile(rootVisible, 50),
+    reloadRootVisibleP95Ms: percentile(rootVisible, 95),
+    domContentLoadedP50Ms: domContentLoaded.length === 0
+      ? null
+      : percentile(domContentLoaded, 50),
+    domContentLoadedP95Ms: domContentLoaded.length === 0
+      ? null
+      : percentile(domContentLoaded, 95),
+    indexJsTransferBytes: network?.indexJsTransferBytes ?? null,
+    indexJsDecodedBytes: network?.indexJsDecodedBytes ?? null,
+  }
+}
+
+async function runScenario(browser, document, cycles, kind) {
+  const prepared = kind === "archive"
+    ? document
+    : await buildArchive(browser, document, cycles)
+  const measurements = await measureReloads(browser, prepared.encoded, prepared.finalValue)
+  return {
+    corpusDocument: document.name,
+    corpusKind: kind,
+    sourceBytes: document.sourceBytes,
+    cycles: kind === "archive" ? null : cycles,
+    historyChangingOperations: kind === "archive"
+      ? null
+      : prepared.historyChangingOperations,
+    ...prepared.stats,
+    ...measurements,
+    restoredDocument: prepared.finalValue.length,
   }
 }
 
 try {
   await serverReady
+  const corpus = await loadCorpus()
+  console.log(
+    `Startup benchmark corpus: ${corpus.kind} (${corpus.documents.length} document${corpus.documents.length === 1 ? "" : "s"}), ` +
+      `${sampleCount} reload samples`,
+  )
   const browser = await chromium.launch({ headless: true })
   const results = []
-  for (const cycles of [0, 2, 10, 20]) {
-    results.push(await runScenario(browser, cycles))
+  if (corpus.kind === "archive") {
+    for (const document of corpus.documents) {
+      results.push(await runScenario(browser, document, null, corpus.kind))
+    }
+  } else {
+    for (const document of corpus.documents) {
+      for (const cycles of historyCycles) {
+        results.push(await runScenario(browser, document, cycles, corpus.kind))
+      }
+    }
   }
   await browser.close()
-  console.table(results)
+  console.table(results.map(result => {
+    const { reloadRootVisibleSamples, ...summary } = result
+    return summary
+  }))
   for (const result of results) console.log(JSON.stringify(result))
 } finally {
   await stopServer()

--- a/docs/performance/2026-08-10-loomark-startup-history-corpus.md
+++ b/docs/performance/2026-08-10-loomark-startup-history-corpus.md
@@ -1,0 +1,224 @@
+# Loomark startup history corpus measurement
+
+> Status: measurement snapshot. This report does not set a CI budget and does
+> not authorize checkpointing or history compaction by itself.
+
+## Baseline and environment
+
+- Baseline: `e53305a7` (`main` after #1237)
+- Node: `v24.14.1`
+- Chromium: `149.0.7827.55`
+- Browser surface: standalone Warren output
+- Measurement seam: local archive injection, page reload, restored editor
+  readiness, and `#loomark-root` visibility
+
+The benchmark waits for the restored input value, not only for the root shell.
+The first navigation warms the browser context; measured samples are subsequent
+reloads in the same context. Percentiles use nearest-rank selection.
+
+## Synthetic history scaling
+
+Command:
+
+```bash
+cd apps/loomark/examples/vanilla
+LOOMARK_STARTUP_SAMPLES=5 npm run bench:startup
+```
+
+The final Markdown value is 41 bytes. Each cycle adds and removes one
+intermediate revision, so `historyChangingOperations` is `1 + cycles * 2`.
+
+| History-changing operations | Archive bytes | History bytes | Reload p50 | Reload p95 |
+|---:|---:|---:|---:|---:|
+| 1 | 16,516 | 14,927 | 74.3 ms | 77.1 ms |
+| 5 | 186,191 | 170,620 | 117.9 ms | 125.8 ms |
+| 21 | 869,123 | 797,624 | 266.0 ms | 289.6 ms |
+| 41 | 1,732,953 | 1,590,884 | 575.3 ms | 598.1 ms |
+
+The synthetic result confirms that the one-time replay improvement does not
+make startup bounded: replay cost continues to grow with the persisted history.
+
+## Engine phase decomposition
+
+Command:
+
+```bash
+cd modules/canopy
+NEW_MOON_MOD=0 moon bench --release --target js \
+  editor/markdown/markdown_editor_startup_benchmark_wbtest.mbt
+```
+
+The fixture contains 100 Markdown blocks and 41 history-changing operations,
+mostly full-source replacements. These are diagnostic stress measurements, not
+user-operation estimates.
+
+| Phase | Mean | σ |
+|---|---:|---:|
+| `MarkdownDocumentHistory` JSON decode | 125.2 ms | 8.4 ms |
+| `MarkdownEditor::open` (construction + CRDT admission + refresh) | 4.42 s | 0.17 s |
+| `open_with_semantic_attachment` | 4.40 s | 0.14 s |
+| semantic attachment from source, no history | 96.9 ms | 1.7 ms |
+
+The result changes the implementation priority: for this stress history,
+CRDT/editor admission dominates startup. Semantic attachment is not the
+primary bottleneck, and deferring only the parser would not approach 16ms.
+The `open` and `open_with_semantic_attachment` means are within benchmark
+noise; the lower second mean is not evidence that semantic attachment is
+faster.
+
+## EGW internal causal-cut prototype
+
+The next EGW step is implemented in the submodule as an internal, non-public
+capture prototype (merged in event-graph-walker#117):
+
+- `internal/oplog/causal_cut_prototype_wbtest.mbt` can build an exact immutable causal cut from
+  an admitted `OpLog` at an explicit capture boundary.
+- `CausalCut` retains stable operation identities, parents, content, origins,
+  a derived Lamport timestamp, and an immutable frontier set.
+- Whitebox coverage includes immutable snapshots, rebuild equivalence,
+  destination-local LV independence, concurrent fresh agents, empty legacy
+  inserts, pending remote drain, and partial remote admission prefixes.
+- The candidate that maintained a duplicate cut after every admission was
+  measured separately and removed after the matched performance gate failed.
+- No `.mbti` drift or public checkpoint/restore API was introduced.
+
+Command:
+
+```bash
+cd deps/event-graph-walker
+NEW_MOON_MOD=0 moon bench --release --target js \
+  internal/oplog/causal_cut_benchmark_wbtest.mbt
+```
+
+JS release measurements for 1,000 operations:
+
+| Operation | Mean |
+|---|---:|
+| causal-cut rebuild | 449.3 µs |
+| causal-cut equality | 160.0 µs |
+| explicit capture from `OpLog` | 546.6 µs |
+| frontier read | 51.2 ns |
+
+The prototype establishes the internal evidence seam, not a fresh-writer
+restore API. It still does not create a new `TextState` from a retained cut
+without replay; that is the next EGW design boundary. The implementation also
+hardens legacy `OpRun` handling so empty and multi-character singleton inserts
+remain lossless during rebuild and JSON round-trip.
+
+## Matched admission performance gate
+
+The same `admission_overhead_benchmark_wbtest.mbt` was run against the clean EGW
+baseline `29f10ec` and the candidate that maintained a duplicate causal-cut
+node map after every admission:
+
+| Path | Baseline | Candidate | Change |
+|---|---:|---:|---:|
+| local, 1,000 ops | 0.666 ms | 2.48 ms | 3.7× |
+| local, 10,000 ops | 8.09 ms | 138.4 ms | 17.1× |
+| remote, 1,000 ops | 2.50 ms | 3.93 ms | 1.6× |
+| remote, 10,000 ops | 30.5 ms | 158.8 ms | 5.2× |
+| reverse/pending drain, 1,000 ops | 5.42 ms | 6.68 ms | 1.2× |
+
+**Verdict: NO-GO for duplicating the full causal node map inside every
+`OpLog` on the typing path.** The cut shape is valid, but the maintenance
+boundary is too expensive for local admission. The next design must reuse the
+existing `OpLog`/causal graph as the runtime store and create immutable cut
+material only at an explicit capture boundary, or share one coordinator-owned
+store instead of maintaining one duplicate map per replica.
+
+## Fresh-writer authority prototype
+
+The next causal-layer boundary is now covered by the test-only prototype:
+
+- `replica_session_prototype_wbtest.mbt` keeps one retained `OpLog` authority
+  and gives each page session only a fresh writer ID plus an observed frontier.
+- Local operations use the session's parents and writer identity, rather than
+  the authority's default writer/frontier.
+- `pull()` returns causal retreat/advance operations; `export_since()` uses the
+  existing frontier-diff path.
+- Coverage includes fresh identities, duplicate delivery, pending dependency
+  drain, concurrent peer branches, and partial admission prefixes.
+
+The prototype passes 5/5 focused tests and introduces no production API or
+`.mbti` change. It deliberately does not restore `TextState` or `FugueTree`;
+the local-operation allocator is test-only until the text materializer and
+cross-package API boundary are designed.
+
+## Text materializer prototype
+
+`internal/document/replica_text_session_wbtest.mbt` now connects the causal
+boundary to an editable `Document`:
+
+- `attach` creates a fresh `Document` writer and replays the retained
+  authority's operations into it once.
+- `publish` and `pull` translate a stored RawVersion frontier into the
+  destination document's local LVs, then reuse the existing causal graph diff
+  and `Document::merge_remote` projection path.
+- Identity and conflict handling use `(agent, seq)` plus full payload
+  validation, not destination-local LV. This is required because independently
+  materialized documents can assign different local versions to concurrent
+  operations.
+- Coverage includes initial materialization, fresh-writer publish, incremental
+  pull, duplicate publish, and concurrent authority/session edits.
+
+The focused materializer tests pass 5/5. JS release measurements are
+312.8µs for a 100-operation attach and 6.28ms for a 1,000-operation attach.
+The attach measurements use one measured iteration and are descriptive only.
+This proves an editable fresh-writer shell, but **not** replay-free startup:
+initial attach still replays all history, and the wrapper remains test-only.
+The next decision is whether a materialized branch/tree can be safely retained
+or cloned without replacing causal history.
+
+## Excluded browser prototype
+
+The throwaway SharedWorker warm-reload probe remains local-only and is
+intentionally excluded from this durable measurement snapshot. Its findings do
+not establish standalone reload durability, causal-history persistence, or the
+fresh-writer production boundary.
+
+## Repository-authored Markdown proxy corpus
+
+This is a proxy corpus, not a user-history corpus. It used four repository
+Markdown documents and generated one full-document replacement from the empty
+baseline. Three reload samples were measured for each document with
+`LOOMARK_STARTUP_CYCLES=0` and `LOOMARK_STARTUP_SAMPLES=3`. With three
+samples, the reported p95 is the sample maximum and is descriptive only.
+
+| Source bytes | Archive bytes | History bytes | Reload p50 | Reload p95 |
+|---:|---:|---:|---:|---:|
+| 2,885 | 1,168,359 | 1,067,072 | 1,461.1 ms | 1,465.3 ms |
+| 5,051 | 2,046,946 | 1,869,919 | 3,536.3 ms | 3,798.1 ms |
+| 5,273 | 2,133,300 | 1,948,665 | 3,781.3 ms | 3,952.2 ms |
+| 8,147 | 3,282,534 | 2,998,689 | 9,200.6 ms | 9,611.5 ms |
+
+The generated full-document replacement is intentionally a stress case. It
+shows that archive size can dominate source size, but it must not be presented
+as a user's normal editing distribution.
+
+A 39,572-character repository document did not produce a settled archive
+within the harness timeout. The DOM input changed, but local storage still
+contained the 233-byte empty baseline (`portable_markdown` length 0, history
+79 bytes). The harness cannot distinguish the exact provider/admission cause
+from this observation; it is evidence that this generated path has a capacity
+or operation-size boundary that must be measured explicitly.
+
+## Interpretation
+
+No replay threshold should be chosen from this proxy corpus. The next
+measurement input must be complete active-archive JSON captured from real
+Editing Documents, because Markdown alone cannot describe causal history or
+operation granularity:
+
+```bash
+cd apps/loomark/examples/vanilla
+LOOMARK_STARTUP_ARCHIVES=/path/to/archive-json \
+LOOMARK_STARTUP_SAMPLES=20 \
+npm run bench:startup
+```
+
+The archive mode reports each archive's portable Markdown size, causal-history
+size, and reload p50/p95 through the same standalone seam. After that run,
+define an explicit user-visible p95 target and select the checkpoint trigger
+from measured causal-history size/replay time. A checkpoint must preserve CRDT
+causal frontier semantics; a Markdown-only snapshot is not an acceptable
+replacement for the archive.

--- a/modules/canopy/editor/markdown/markdown_editor_startup_benchmark_wbtest.mbt
+++ b/modules/canopy/editor/markdown/markdown_editor_startup_benchmark_wbtest.mbt
@@ -1,0 +1,102 @@
+///| Startup restore phase measurements for the Eg-walker-backed Markdown façade.
+///
+/// These benchmarks keep fixture construction outside the timed closure and
+/// separate history JSON decode, CRDT admission, and semantic attachment.
+/// They are diagnostic evidence, not a startup budget or a production cache.
+
+///|
+fn startup_phase_source(block_count : Int) -> String {
+  Array::makei(block_count, index => {
+    let number = index.to_string()
+    "## Heading " +
+    number +
+    "\n\nParagraph " +
+    number +
+    " with **bold** and [link](https://example.com/" +
+    number +
+    ").\n"
+  }).join("\n")
+}
+
+///|
+fn startup_phase_history(cycles : Int) -> MarkdownDocumentHistory {
+  let source = startup_phase_source(100)
+  let editor = try! MarkdownEditor(
+    agent_id="markdown-startup-fixture",
+    source="",
+  )
+  ignore(try! editor.commit(MarkdownEditRequest::ReplaceSource(source)))
+  for index = 0; index < cycles; index = index + 1 {
+    let intermediate = source +
+      "\nIntermediate revision " +
+      index.to_string() +
+      "\n"
+    ignore(try! editor.commit(MarkdownEditRequest::ReplaceSource(intermediate)))
+    ignore(try! editor.commit(MarkdownEditRequest::ReplaceSource(source)))
+  }
+  try! editor.history_since()
+}
+
+///|
+fn startup_phase_limits() -> MarkdownArchiveOpenLimits {
+  try! MarkdownArchiveOpenLimits(
+    max_encoded_bytes=256 * 1024 * 1024,
+    max_decoded_operations=100000,
+    max_pending_operations=100000,
+    max_parents_per_operation=1024,
+  )
+}
+
+///|
+test "perf: startup history JSON decode (41 operations)" (b : @bench.T) {
+  let history = startup_phase_history(20)
+  let encoded = history.to_json_string()
+  b.bench(() => {
+    let decoded = try! MarkdownDocumentHistory::from_json_string(encoded)
+    b.keep(decoded)
+  })
+}
+
+///|
+test "perf: startup CRDT admission (41 operations)" (b : @bench.T) {
+  let history = startup_phase_history(20)
+  b.bench(() => {
+    let editor = try! MarkdownEditor::open(
+      agent_id="markdown-startup-open",
+      history~,
+      open_limits=startup_phase_limits(),
+    )
+    b.keep(editor.portable_markdown())
+  })
+}
+
+///|
+test "perf: startup CRDT admission with semantic attachment (41 operations)" (
+  b : @bench.T,
+) {
+  let history = startup_phase_history(20)
+  b.bench(() => {
+    let (editor, attachment) = try! MarkdownEditor::open_with_semantic_attachment(
+      agent_id="markdown-startup-semantic-open",
+      history~,
+      open_limits=startup_phase_limits(),
+    )
+    let source = editor.portable_markdown()
+    attachment.dispose()
+    b.keep(source)
+  })
+}
+
+///|
+test "perf: startup semantic attachment from source (100 blocks)" (b : @bench.T) {
+  let source = startup_phase_source(100)
+  b.bench(() => {
+    let (editor, attachment) = try! MarkdownEditor::with_semantic_attachment(
+      agent_id="markdown-startup-semantic-source",
+      source~,
+    )
+    let current = editor.portable_markdown()
+    attachment.dispose()
+    b.keep(current)
+  })
+}


### PR DESCRIPTION
## Replacement PR

This is a clean replacement for #1238. It contains the same source changes at `f22c67e7` and intentionally excludes the empty Cloudflare-retrigger commit `b60e3b73`. It is opened as a new PR so the updated Cloudflare Workers Builds configuration is captured for this PR.

## Summary

- Make the Loomark startup corpus benchmark reproducible for synthetic Markdown and complete v1 active-archive JSON fixtures.
- Add phase benchmarks separating history JSON decode, CRDT admission, and semantic attachment.
- Align the measurement snapshot with the merged event-graph-walker causal prototype and label the browser measurements as warm-context reloads.

## UI and review evidence

N/A — this change adds measurement tooling and documentation; it does not change the production UI.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `MarkdownDocumentHistory::from_json_string` | `modules/canopy/editor/markdown` | Yes | Measures the existing archive decode boundary. |
| `MarkdownEditor::open` / `open_with_semantic_attachment` | `modules/canopy/editor/markdown` | Yes | Measures existing restore and semantic-attachment paths without changing production APIs. |
| `MarkdownEditor::with_semantic_attachment` | `modules/canopy/editor/markdown` | Yes | Separates source-only semantic attachment from history admission. |
| `@bench.T::bench` / `keep` | MoonBit core bench | Yes | Keeps fixture construction outside timed closures and prevents dead-code elimination. |
| `Array::makei`, `Array::join`, `String::to_string` | MoonBit core | Yes | Builds the deterministic Markdown fixture declaratively. |
| `Option`/`Result` and existing archive validation | MoonBit/Canopy APIs | Yes | Preserves explicit failure handling at fixture and restore boundaries. |

New helpers added:

- `startup_phase_source` builds a deterministic Markdown stress fixture for the benchmark only.
- `startup_phase_history` constructs history outside the timed closure.
- `startup_phase_limits` supplies explicit archive-open limits for the diagnostic benchmark.

These helpers are benchmark-local and do not duplicate production behavior.

## Validation scope

Boundary matrix / first failing regression:

- synthetic history cycles: 0, 2, 10, and 20
- complete v1 archive JSON corpus validation
- history JSON decode
- CRDT admission with and without semantic attachment
- semantic attachment from source without history
- browser reload to restored document, recovery rejection, and archive-size reporting
- warm-context measurement labels; no absolute latency CI budget is introduced

Target packages:

- `modules/canopy/editor/markdown`

Additional conditional gates:

- `moon check --deny-warn`
- full `moon test`
- dev-host and standalone TypeScript typechecks
- Loomark Standalone E2E: 13/13
- startup benchmark with 3 and 5 samples
- merged submodule `dowdiness/event-graph-walker#117` at `c0da9cec41be0f8f0edbb8b91d0dc3ccddd39d31`

## PR-ready evidence

Validated HEAD: `f22c67e73984e9a98b77ac8cadf5c930c28e6636`

Validated base: `origin/main@e53305a7a7459dace95aef0153a1a505b31e6af4`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh --target modules/canopy/editor/markdown
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for the exact HEAD and base above.
- [x] `--verify-evidence` passed immediately before opening this PR.
- [x] No unintended `.mbti` changes were produced.
- [x] The changed submodule commit is merged and reachable from its remote.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded startup benchmark guidance with Markdown and archive inputs, configurable sampling, corpus labels, and clearer timing metrics.
  * Added a performance report covering startup behavior across representative content sizes and environments, including known limitations and follow-up criteria.

* **Tests**
  * Added startup benchmarks for Markdown history loading, document updates, and semantic processing to improve performance tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->