### PR TITLE
docs(loomark): define concurrent projection execution

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -405,12 +405,16 @@ One contiguous lifetime of projection state initialized from a coherent committe
 _Avoid_: Writing instance, document version, browser generation
 
 **Projection stamp**:
-The provenance that binds projection work and its artifacts to one Projection generation, one ordered work position, the exact source revision used for derivation, and the originating causal document version. Artifact display requires current source provenance; applying an edit intent additionally requires the exact causal version.
+The provenance that binds projection work and its artifacts to one Projection generation, one adapter-lifetime ordered position, the exact source revision used for derivation, and the originating causal document version. The sequence does not reset when generation changes. Artifact display requires current source provenance; applying an edit intent additionally requires the exact causal version.
 _Avoid_: Cache key, timestamp, render version
 
+**Group work**:
+One independently terminal derivation for one demanded consistency group. One projection request may issue Block, Preview, and diagnostics group work with different outcomes; a presentation may correlate several adopted group work items.
+_Avoid_: Authority event, projection request, frame
+
 **Artifact Bundle**:
-An immutable set of demanded projection artifacts derived from one Projection stamp and adopted together when those artifacts can be observed together. An absent undemanded artifact is not an independently current representation.
-_Avoid_: Application state, parser snapshot, independent view cache
+The immutable atomic payload of one group work item, derived from one Projection stamp and adopted as one demand-defined consistency group. Unrelated groups do not share an adoption barrier, and an absent undemanded artifact is not an independently current representation.
+_Avoid_: Application state, parser snapshot, all-lane snapshot, independent view cache
 
 **Reconciliation**:
 The identity-preserving match between the previous projection tree and the newly reparsed tree: it decides, for each node in the new tree, whether it is the same node as one in the old tree (carrying its NodeId) or a fresh node. It is not text diffing and not CRDT merge.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -396,6 +396,22 @@ _Avoid_: Document head, autosave, recovery file, main history
 
 Framework vocabulary for the projection engine that backs the application terms above. Distinct from the Editing Document domain: these describe how the editing session's tree keeps identity across reparses, not how documents persist.
 
+**Projection execution**:
+The derivation of replaceable Block, semantic, diagnostic, and presentation artifacts from immutable committed input. Every group uses Markdown source; the Block interactive group also uses selection/focus state captured at the same Projection stamp. Projection execution may complete after its requesting mutation and cannot mutate authority state.
+_Avoid_: Authority commit, parser callback, render pass
+
+**Projection generation**:
+One contiguous lifetime of projection state initialized from a coherent committed source. Recovery, replacement, or a source-continuity gap starts a new generation, after which results from every earlier generation are obsolete.
+_Avoid_: Writing instance, document version, browser generation
+
+**Projection stamp**:
+The provenance that binds projection work and its artifacts to one Projection generation, one ordered work position, the exact source revision used for derivation, and the originating causal document version. Artifact display requires current source provenance; applying an edit intent additionally requires the exact causal version.
+_Avoid_: Cache key, timestamp, render version
+
+**Artifact Bundle**:
+An immutable set of demanded projection artifacts derived from one Projection stamp and adopted together when those artifacts can be observed together. An absent undemanded artifact is not an independently current representation.
+_Avoid_: Application state, parser snapshot, independent view cache
+
 **Reconciliation**:
 The identity-preserving match between the previous projection tree and the newly reparsed tree: it decides, for each node in the new tree, whether it is the same node as one in the old tree (carrying its NodeId) or a fresh node. It is not text diffing and not CRDT merge.
 _Avoid_: Merge, diff, CRDT merge

--- a/docs/README.md
+++ b/docs/README.md
@@ -108,6 +108,10 @@ Only needed if you are modifying Canopy itself.
   [plans/TEMPLATE.md](plans/TEMPLATE.md) when adding a new one).
 - [Advisory plans](plans/advisory/) — dependency-ordered specifications for
   [issue #1125](https://github.com/dowdiness/canopy/issues/1125).
+- [Loomark concurrent projection execution](plans/2026-08-12-loomark-concurrent-projection-execution.md)
+  — active evidence-gated implementation plan for
+  [issue #1244](https://github.com/dowdiness/canopy/issues/1244), governed by
+  the [asynchronous source-stamped projection decision](decisions/2026-08-12-loomark-concurrent-projection-execution.md).
 - [Legacy TODO snapshot](archive/TODO-snapshot-2026-08-03.md) — historical
   candidates being triaged in
   [issue #1124](https://github.com/dowdiness/canopy/issues/1124), not active

--- a/docs/decisions/2026-08-04-markdown-semantic-preview-ownership.md
+++ b/docs/decisions/2026-08-04-markdown-semantic-preview-ownership.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-08-04
 
-**Status:** Accepted for the private single-mount Loomark host.
+**Status:** Accepted current implementation; superseded when #1244 completes.
 
 **Related:**
 
@@ -10,6 +10,7 @@
 - [Loom Markdown semantic attachment boundary](../../deps/loom/docs/decisions/2026-08-04-markdown-semantic-attachment-boundary.md)
 - [Issue #1145](https://github.com/dowdiness/canopy/issues/1145)
 - [Lifecycle follow-up #1159](https://github.com/dowdiness/canopy/issues/1159)
+- [Concurrent projection execution target](2026-08-12-loomark-concurrent-projection-execution.md)
 
 **Decision:** The Markdown editor offers an explicit, opt-in construction path
 that returns its existing editing facade together with one semantic observer
@@ -17,8 +18,8 @@ over the same parser. Ordinary construction remains observer-free. The private
 Loomark host retains both resources for its existing page/process lifetime and
 installs owning semantic documents only at accepted Preview transition points.
 
-**Keep until:** A reusable Browser Session with explicit teardown supersedes
-the private single-mount host.
+**Keep until:** The concurrent projection execution target completes #1244 and
+removes the main-thread editor/semantic-observer co-location described here.
 
 ## Context
 

--- a/docs/decisions/2026-08-12-loomark-concurrent-projection-execution.md
+++ b/docs/decisions/2026-08-12-loomark-concurrent-projection-execution.md
@@ -121,10 +121,12 @@ the portable source payload and may remain unchanged when authority advances
 without changing source. The document version fences authority mutations
 against stale evidence.
 
-No currentness decision relies on source revision alone. A source-equal causal
-advance may retain an existing display artifact because its semantic input did
-not change, while advancing projection sequence and causal document version.
-It never authorizes an intent calculated against the older causal frontier.
+Currentness requires the complete stamp rather than source revision alone. When
+a source-equal causal advance preserves semantic input, current adoption may
+reuse its artifact payload and publishes or wraps that payload with the new
+projection sequence and causal document version. Only the newly stamped
+artifact is current. An intent calculated against the older causal frontier
+remains unauthorized.
 
 ### 5. Publish demand-defined consistency groups
 

--- a/docs/decisions/2026-08-12-loomark-concurrent-projection-execution.md
+++ b/docs/decisions/2026-08-12-loomark-concurrent-projection-execution.md
@@ -1,0 +1,253 @@
+# Loomark projection execution is asynchronous and source-stamped
+
+**Date:** 2026-08-12
+
+**Status:** Accepted target architecture; implementation is not complete.
+
+**Issue:** [#1244](https://github.com/dowdiness/canopy/issues/1244)
+
+**Dependency:** [#1241 — canonical TextEvent admission correctness](https://github.com/dowdiness/canopy/issues/1241)
+
+**Implementation plan:** [Loomark concurrent projection execution](../plans/2026-08-12-loomark-concurrent-projection-execution.md)
+
+**Related:**
+
+- [Causal Authority residency](2026-08-12-causal-authority-residency.md)
+- [Indexed projection lifecycle](2026-07-22-indexed-projection-lifecycle.md)
+- [EGW collaboration responsibility boundary](2026-07-21-egw-collaboration-responsibility-boundary.md)
+- [Markdown semantic Preview ownership](2026-08-04-markdown-semantic-preview-ownership.md)
+- [Markdown semantic attachment boundary](../../deps/loom/docs/decisions/2026-08-04-markdown-semantic-attachment-boundary.md)
+- [Markdown projection attachment boundary](../../deps/loom/docs/decisions/2026-08-03-markdown-projection-attachment-boundary.md)
+
+## Context
+
+Loomark currently advances causal authority, synchronizes the parser, reconciles
+the editable Block projection, reads MarkdownIR for Preview, prepares persistence,
+adopts the next application model, and presents the browser view on one
+synchronous edit path. The path is coherent, but its interface forces every
+future parser, semantic, persistence, and presentation cost into the authority
+commit's main-thread task.
+
+The existing keyed MarkdownIR attachment proves reuse inside one live parser,
+but it does not provide an execution seam. Its `incr` runtime, scopes, watches,
+and parser state are process-local mutable state. They cannot be serialized or
+shared across a browser Worker. The current Warren release build also emits one
+JavaScript entry. A production Worker therefore requires both a persistent
+projection session created inside the Worker and a proven multi-entry build.
+
+The earlier Markdown semantic Preview ownership decision describes the current
+single-mount implementation: one main-thread editor owns both editable
+projection and an opt-in semantic observer. This decision supersedes that
+co-location and same-turn read policy only when #1244 completes. It preserves
+the earlier renderer, security, demand, and single-current-source decisions.
+The production target still has one projection parser; it resides in the
+Worker after the main-thread authority path relinquishes parser ownership. The
+Gate 0 dual-parser differential harness is test evidence and is removed before
+production cutover.
+
+The 16 ms objective applies to measured main-thread responsiveness. It does not
+require every derived projection to be presented in the same turn as its
+causal mutation. Causal authority and derived projection have different
+correctness obligations: every accepted mutation must retain authoritative
+receipt/history evidence, while an intermediate projection that was never
+presented may be superseded by a newer committed source.
+
+## Decision
+
+### 1. Separate authority mutation from projection execution and materialization
+
+The authority linearization path ends after causal admission, the resulting
+document version and source identity are known, a small receipt/effect value is
+available, and required persistence work is scheduled. It does not materialize
+or copy the full Markdown source, export history, prepare an archive, encode
+JSON, transfer Worker input, synchronize a parser, reconcile Block structure,
+lower MarkdownIR, compute diagnostics, materialize Preview, or mutate the DOM.
+
+Full source or history materialization required by a Seed or persistence begins
+after the authority result is available. If the current implementation cannot
+provide an immutable source handle without a full scan or copy, it records the
+need for later materialization rather than extending the authority critical
+path.
+
+This separation does not weaken commit semantics. A committed outcome remains
+committed even if later source materialization, projection, persistence, or
+presentation work fails. Those failures are recorded against the accepted
+authority event and never become permission to retry the mutation.
+
+### 2. Keep one application-lifetime Projection Adapter
+
+One Loomark Projection Adapter owns projection demand, scheduling, result
+adoption, and the lifecycle of its executor. It is created with the mounted
+application and disposed with that application. Editor-session recovery or
+replacement starts a new projection generation inside the same adapter rather
+than creating an unrelated application currentness domain.
+
+Loom continues to own parsing and Markdown semantic lowering. Canopy continues
+to own projection construction, source maps, editable roles, and identity.
+Loomark owns the mounted adapter, production execution policy, artifact demand,
+and browser adoption. Live Loom or `incr` values never cross this seam.
+
+### 3. Make projection placement conditional on evidence
+
+The projection protocol supports both an in-process executor and a dedicated
+browser Worker executor. Each executor owns one long-lived projection session
+with its parser, `incr` runtime, semantic attachment, projection memos, and
+collection lifecycle. Live parser or reactive values never cross an executor
+seam; only explicit portable input and output values do.
+
+The in-process executor defines and tests the protocol before Worker semantics
+are implemented. A dedicated Worker is the preferred production placement
+because it can isolate interactive main-thread work, but it becomes the
+production decision only after the feasibility, correctness, latency, queue,
+failure, and memory gates pass. The promotion record must state the measured
+trade-off against the in-process executor. Production never silently switches
+placement at runtime; an unavailable executor enters an explicit failure state.
+
+### 4. Stamp every work item and immutable artifact
+
+A projection stamp contains:
+
+- projection generation;
+- projection sequence within that generation;
+- exact source revision used for derivation; and
+- originating causal document version.
+
+Generation names one projection-session incarnation, so replacing the session
+invalidates its results. Sequence orders adapter observations and deliveries
+within that session and is never reused. Source revision identifies changes to
+the portable source payload and may remain unchanged when authority advances
+without changing source. The document version fences authority mutations
+against stale evidence.
+
+No currentness decision relies on source revision alone. A source-equal causal
+advance may retain an existing display artifact because its semantic input did
+not change, while advancing projection sequence and causal document version.
+It never authorizes an intent calculated against the older causal frontier.
+
+### 5. Publish demand-defined consistency groups
+
+One projection work item may derive several immutable Artifact Bundles, each for
+one demand-defined consistency group. Members of one group are adopted
+transactionally at one stamp; unrelated groups do not form a global barrier.
+
+The interactive Block group contains Block structure, selection/focus mapping,
+and resolver evidence required by Block intent. Preview and diagnostics are
+separate groups. Diagnostics never delay Block adoption; hidden Preview is not
+computed or included; Block-only mode never waits for Preview; Raw remains an
+authority-owned surface and never waits for a projection group.
+
+When Block and Preview are simultaneously visible, each group exposes its own
+stamp. Temporary lag is permitted only when the presentation makes that
+currentness observable and no intent uses stale evidence. A later product
+decision may require same-source presentation and accept the resulting
+head-of-line blocking, but this ADR does not require it.
+
+### 6. Bound pending projection work, not only queue slots
+
+The scheduler retains at most one active work item and one latest pending work
+description. A newer committed source may replace pending work that has not
+begun and has never been presented. Active work may finish, but an obsolete
+result is rejected before application adoption.
+
+The pending description is bounded by encoded bytes, retained source/effect
+bytes, and Advance count as well as slot count. It may retain a bounded
+contiguous Advance chain from the executor's acknowledged source. If continuity
+cannot be retained within those bounds, the adapter replaces the chain with one
+latest Seed request. Seed source materialization occurs outside the authority
+critical path.
+
+These limits are explicit Projection Adapter configuration. Tests override them;
+production records fixed selected values, which may be tightened without
+changing the protocol or artifact interface.
+
+Causal operations, receipts, history, and persistence are never coalesced.
+Promotion requires evidence that ordinary typing does not degenerate into a
+Seed per edit, burst work catches up, and obsolete tails become collectible.
+
+### 7. Make Block-mode lag explicit
+
+Block intent resolves only from the latest immutable Block artifact and carries
+its source revision and causal document-version fence. While a newer bundle is
+pending, Loomark exposes a typed pending state and does not silently apply an
+intent to stale structure. Raw native input remains available. Browser evidence
+must measure Worker response separately from main-thread task duration.
+
+### 8. Require staged gates before executor promotion
+
+Before authority and projection are decoupled, staged evidence must prove:
+
+1. Warren can emit and serve page and Worker entries in direct and release
+   builds without defining projection semantics.
+2. A normalized projection protocol, pure adapter reducer, and in-process
+   executor preserve the current observable projection contract.
+3. A real Worker running the same protocol has differential parity after
+   normalization, survives failure/restart, bounds Advance/Seed work and
+   retained bytes under burst load, and records transport, interactive latency,
+   presentation, and heap evidence.
+
+Differential comparison covers observable source, Block structure and ranges,
+semantic roles, MarkdownIR, diagnostics, Preview payload, and resolver evidence.
+It normalizes or excludes Worker-local object identity, reactive-runtime
+identity, timestamps, test-specific generation/sequence values, and incidental
+map iteration order.
+
+Dedicated-Worker promotion requires a recorded comparison against the
+in-process executor. It may prefer main-thread isolation despite higher
+end-to-end latency, but that trade-off must be explicit. If any stage fails,
+implementation stops with evidence. Loomark does not ship a hidden synchronous
+fallback under an asynchronous interface.
+
+## Consequences
+
+- The authority commit interface becomes deeper: callers receive one settled
+  mutation result without coordinating parser, semantic, and presentation
+  details.
+- A causal mutation may produce zero projection artifacts, and one projection
+  work item may produce several artifacts.
+- Intermediate committed sources may have no projection artifact if they were
+  superseded before presentation. Their authority receipts and history remain
+  complete.
+- Projection presentation may become eventually current rather than same-turn.
+  Currentness is explicit and testable through group stamps rather than call
+  order.
+- Worker packaging is proven infrastructure; Worker placement and protocol
+  serialization become production architecture only after promotion.
+- A promoted Worker owns a second live source representation plus
+  parser/projection state. Memory, disposal, Seed frequency, pending bytes, and
+  cutover retention require browser evidence.
+- Block mode gains explicit feedback and pending/failure conditions. It never
+  edits stale structure without an exact authority fence.
+- Loom and Canopy retain their existing ownership: Loom defines parsing and
+  semantics, Canopy defines projection, and Loomark defines execution policy and
+  presentation. The execution seam changes only where that work runs.
+
+## Rejected alternatives
+
+### Keep all projection same-turn
+
+This preserves current call order but leaves parser and semantic cost on the
+authority task and cannot establish the requested main-thread isolation.
+
+### Reparse from source in a fresh Worker for every edit
+
+This avoids persistent Worker state but discards the incrementality and
+collection contracts already established by Loom. It is retained only as the
+Seed recovery path, not the steady-state design.
+
+### Transfer live parser or reactive values across the Worker seam
+
+Browser structured clone cannot preserve the process-local runtime identity,
+closures, watches, scopes, or collection ownership required by Loom and `incr`.
+
+### Publish every demanded lane through one global barrier
+
+A global barrier gives simple same-source presentation but lets slow Preview or
+diagnostic work delay interactive Block adoption. Demand-defined consistency
+groups preserve atomicity where consumers share an invariant without restoring
+head-of-line blocking between unrelated lanes.
+
+### Fall back silently to same-turn projection
+
+A silent fallback would make production responsiveness depend on an unobserved
+runtime branch and invalidate the architecture's performance claim. Feasibility
+failure stops executor promotion.

--- a/docs/decisions/2026-08-12-loomark-concurrent-projection-execution.md
+++ b/docs/decisions/2026-08-12-loomark-concurrent-projection-execution.md
@@ -6,7 +6,7 @@
 
 **Issue:** [#1244](https://github.com/dowdiness/canopy/issues/1244)
 
-**Dependency:** [#1241 — canonical TextEvent admission correctness](https://github.com/dowdiness/canopy/issues/1241)
+**Conditional integration dependency:** [#1241 — canonical TextEvent admission correctness](https://github.com/dowdiness/canopy/issues/1241)
 
 **Implementation plan:** [Loomark concurrent projection execution](../plans/2026-08-12-loomark-concurrent-projection-execution.md)
 
@@ -40,10 +40,11 @@ single-mount implementation: one main-thread editor owns both editable
 projection and an opt-in semantic observer. This decision supersedes that
 co-location and same-turn read policy only when #1244 completes. It preserves
 the earlier renderer, security, demand, and single-current-source decisions.
-The production target still has one projection parser; it resides in the
-Worker after the main-thread authority path relinquishes parser ownership. The
-Gate 0 dual-parser differential harness is test evidence and is removed before
-production cutover.
+The production target has one projection parser inside the selected executor
+after the main-thread authority path relinquishes parser ownership. A browser
+Worker is the preferred candidate, not an accepted production placement before
+promotion evidence. The Gate 0 dual-parser differential harness is test evidence
+and is removed before production cutover.
 
 The 16 ms objective applies to measured main-thread responsiveness. It does not
 require every derived projection to be presented in the same turn as its
@@ -103,18 +104,19 @@ failure, and memory gates pass. The promotion record must state the measured
 trade-off against the in-process executor. Production never silently switches
 placement at runtime; an unavailable executor enters an explicit failure state.
 
-### 4. Stamp every work item and immutable artifact
+### 4. Stamp every projection request, group work item, and immutable artifact
 
 A projection stamp contains:
 
 - projection generation;
-- projection sequence within that generation;
+- adapter-lifetime projection sequence;
 - exact source revision used for derivation; and
 - originating causal document version.
 
 Generation names one projection-session incarnation, so replacing the session
 invalidates its results. Sequence orders adapter observations and deliveries
-within that session and is never reused. Source revision identifies changes to
+across generations and never resets, wraps, or reuses a value during the
+adapter lifetime. Source revision identifies changes to
 the portable source payload and may remain unchanged when authority advances
 without changing source. The document version fences authority mutations
 against stale evidence.
@@ -126,9 +128,13 @@ It never authorizes an intent calculated against the older causal frontier.
 
 ### 5. Publish demand-defined consistency groups
 
-One projection work item may derive several immutable Artifact Bundles, each for
-one demand-defined consistency group. Members of one group are adopted
-transactionally at one stamp; unrelated groups do not form a global barrier.
+One projection request may issue separate group work items. `NoDemand` is a
+request disposition and issues no group work. Each issued group work item
+derives one immutable Artifact Bundle for one demand-defined consistency group
+and ends independently as presented, adopted without presentation, rejected,
+superseded, invalidated, failed, or disposed. Materialization alone is not a
+terminal outcome. Members of one group are adopted transactionally at one stamp;
+unrelated groups do not form a global barrier.
 
 The interactive Block group contains Block structure, selection/focus mapping,
 and resolver evidence required by Block intent. Preview and diagnostics are
@@ -144,10 +150,10 @@ head-of-line blocking, but this ADR does not require it.
 
 ### 6. Bound pending projection work, not only queue slots
 
-The scheduler retains at most one active work item and one latest pending work
-description. A newer committed source may replace pending work that has not
-begun and has never been presented. Active work may finish, but an obsolete
-result is rejected before application adoption.
+Pending projection work is bounded; authority history is never bounded or
+coalesced by the projection scheduler. A newer committed source may replace
+projection work that has not begun and has never been presented. Active work may
+finish, but an obsolete result is rejected before application adoption.
 
 The pending description is bounded by encoded bytes, retained source/effect
 bytes, and Advance count as well as slot count. It may retain a bounded
@@ -156,9 +162,9 @@ cannot be retained within those bounds, the adapter replaces the chain with one
 latest Seed request. Seed source materialization occurs outside the authority
 critical path.
 
-These limits are explicit Projection Adapter configuration. Tests override them;
-production records fixed selected values, which may be tightened without
-changing the protocol or artifact interface.
+Exact slot counts, selected limits, and configuration mechanisms are
+implementation policy recorded by the plan and promotion evidence; changing
+them does not change the protocol or artifact interface.
 
 Causal operations, receipts, history, and persistence are never coalesced.
 Promotion requires evidence that ordinary typing does not degenerate into a
@@ -170,7 +176,8 @@ Block intent resolves only from the latest immutable Block artifact and carries
 its source revision and causal document-version fence. While a newer bundle is
 pending, Loomark exposes a typed pending state and does not silently apply an
 intent to stale structure. Raw native input remains available. Browser evidence
-must measure Worker response separately from main-thread task duration.
+must measure selected-executor response separately from main-thread task duration
+and compare the Worker candidate when Gate 0C runs.
 
 ### 8. Require staged gates before executor promotion
 

--- a/docs/decisions/2026-08-12-loomark-concurrent-projection-execution.md
+++ b/docs/decisions/2026-08-12-loomark-concurrent-projection-execution.md
@@ -209,8 +209,9 @@ fallback under an asynchronous interface.
 - The authority commit interface becomes deeper: callers receive one settled
   mutation result without coordinating parser, semantic, and presentation
   details.
-- A causal mutation may produce zero projection artifacts, and one projection
-  work item may produce several artifacts.
+- A causal mutation may produce zero projection artifacts. One projection
+  request may issue zero or more group work items, each producing one Artifact
+  Bundle.
 - Intermediate committed sources may have no projection artifact if they were
   superseded before presentation. Their authority receipts and history remain
   complete.

--- a/docs/plans/2026-08-12-loomark-concurrent-projection-execution.md
+++ b/docs/plans/2026-08-12-loomark-concurrent-projection-execution.md
@@ -85,11 +85,11 @@ therefore starts with an evidence gate and stops if that gate fails.
 | Path | Current owner and evidence | Required change |
 |---|---|---|
 | Raw input | `application.mbt` routes `RawInput`; `raw_selection_transaction.mbt` normalizes it; `document_transaction.mbt` commits it. | Authority commit returns before projection; native input remains responsive while a bundle is pending. |
-| ReplaceSource | `ApplicationEvent::RequestCanonicalSource` reaches the same shared commit shell. | Treat as an authority replacement followed by a new projection generation Seed. |
+| ReplaceSource | `ApplicationEvent::RequestCanonicalSource` reaches the same shared commit shell and commits `MarkdownEditRequest::ReplaceSource` through the current editor. | Treat it as one authority mutation, not authority/session replacement. Publish `SourceUnchanged` when the accepted mutation preserves source; otherwise publish a replayable Advance when its source transition is available without adding full-source work to A0/A1. If neither portable result is safely available, invalidate the projection generation and recover from a coherent Seed. |
 | Block structural edit | `BlockInput` resolves against current Block/source-map state before `commit_edit_request`. | Resolve only against a stamped immutable Block artifact; apply only under the exact causal-version fence. |
 | Undo/redo | `SyncEditor` currently owns `UndoManager`, text authority, parser, and projection in one struct. | Extract authority and projection responsibilities without changing existing public `SyncEditor` behavior during the refactor commit. |
 | Remote admission | Production Loomark does not yet have a proven canonical admission route. | Consume #1241's contract if it exists; otherwise relocate only the existing accepted transition without redefining canonical admission. |
-| Source-equal causal advance | `commit_classification.mbt` advances document version while retaining source revision. | Carry the current artifact by source revision, but invalidate intent fences bound to the older causal version. |
+| Source-equal causal advance | `commit_classification.mbt` advances document version while retaining source revision. | Reuse the existing payload when valid, but publish or wrap it with the new projection stamp; the old stamped artifact does not become current. Invalidate intent fences bound to the older causal version. |
 | Post-commit archive failure | `document_transaction.mbt` classifies the accepted receipt before persistence scheduling/failure. | Preserve the accepted authority event and record persistence failure independently of projection status. |
 | Parser failure recovery | `recovery_shell.mbt` and `application.mbt` replace the editor/session after parser failure. | Increment projection generation, dispose the failed session, reject its results, and Seed the replacement. |
 | Archive reopen | `editor_session.mbt` reconstructs a fresh editor and semantic attachment from complete local history. | Create authority first, then Seed one new projection generation inside the selected executor from the recovered committed source. |
@@ -208,8 +208,10 @@ revision, and causal document version:
 
 Source revision alone never establishes currentness. A source-equal causal
 advance may keep source revision unchanged while advancing sequence and causal
-version. Display artifacts may be carried forward, but an edit intent fenced to
-the older causal version is rejected before authority mutation.
+version. It may reuse an existing artifact payload, but current adoption
+publishes or wraps that payload with the new projection stamp; the old stamped
+artifact does not become current. An edit intent fenced to the older causal
+version is rejected before authority mutation.
 
 Generation and sequence never wrap or reuse a value within one application
 mount. Disposal closes routing before executor termination. Counter exhaustion
@@ -491,12 +493,16 @@ and generated interfaces.
 1. authority commit returns A0/A1 before projection or Seed materialization;
 2. projection/source-materialization failure cannot alter accepted history;
 3. Raw, exact/structural edit, undo/redo, remote admission, and source
-   replacement are classified once as replayable `Advance` or
-   `SourceUnchanged`;
+   replacement are classified once as replayable `Advance`,
+   `SourceUnchanged`, or generation invalidation followed by coherent `Seed`;
+   source replacement may use the Seed branch only when its accepted replay
+   effect is not safely and cheaply available without adding full-source work to
+   A0/A1;
 4. recovery, archive reopen, and session replacement invalidate the old
    generation and issue coherent Seed recovery rather than masquerading as
    `SourceTransition`;
-5. source-equal advance changes authority version without semantic source work;
+5. source-equal advance changes authority version, reuses only the payload, and
+   publishes or wraps it with the new projection stamp;
 6. Seed capture executes after the authority result; and
 7. the existing public `SyncEditor` facade preserves behavior and signatures.
 
@@ -600,8 +606,12 @@ assertions.
       JSON/transfer, parser, projection, semantic, Preview, or DOM work.
 - [ ] Every projection-relevant authority event is classified exactly once as
       replayable Advance/SourceUnchanged or generation invalidation followed by
-      coherent Seed recovery. Lifecycle replacement does not masquerade as
-      SourceTransition.
+      coherent Seed recovery. ReplaceSource uses Seed only when its accepted
+      replay effect is unavailable without unsafe or full-source A0/A1 work;
+      lifecycle replacement does not masquerade as SourceTransition.
+- [ ] A source-equal advance may reuse an artifact payload, but current adoption
+      publishes or wraps it with the new projection stamp; the old stamped
+      artifact never becomes current.
 - [ ] Existing `SyncEditor` callers retain behavior and public interface unless
       an explicitly reviewed interface change is recorded.
 

--- a/docs/plans/2026-08-12-loomark-concurrent-projection-execution.md
+++ b/docs/plans/2026-08-12-loomark-concurrent-projection-execution.md
@@ -6,7 +6,7 @@
 
 **Decision:** [Loomark projection execution is asynchronous and source-stamped](../decisions/2026-08-12-loomark-concurrent-projection-execution.md)
 
-**Required predecessor:** [#1241 — canonical TextEvent admission correctness](https://github.com/dowdiness/canopy/issues/1241). Gate A must prove the canonical event model before this plan changes a production authority path.
+**Conditional integration dependency:** [#1241 — canonical TextEvent admission correctness](https://github.com/dowdiness/canopy/issues/1241). #1244 does not redefine canonical TextEvent admission. If #1241's production contract exists, #1244 consumes it; otherwise #1244 may relocate only the existing accepted authority transition, with characterization evidence preserving current authority semantics.
 
 **Related decisions:**
 
@@ -26,11 +26,12 @@ parser cost leaks into the authority task.
 
 The desired deep module has one small authority interface: admit one operation
 and return settled mutation evidence. Projection execution sits behind a second
-seam: submit one immutable committed input and eventually receive one stamped
-Artifact Bundle. This separation improves locality because authority failures,
-projection failures, and presentation failures each have one owner. It improves
-leverage because Preview, Block, diagnostics, and later derived artifacts reuse
-one execution and currentness contract.
+seam: submit one immutable committed input and eventually receive zero or more
+stamped Artifact Bundles, one per demanded consistency group. This separation
+improves locality because authority failures, projection failures, and
+presentation failures each have one owner. It improves leverage because
+Preview, Block, diagnostics, and later derived artifacts reuse one execution and
+currentness contract.
 
 The deletion test justifies both modules. Deleting the authority/projection seam
 would move generation, sequencing, stale-result rejection, and demand
@@ -50,11 +51,14 @@ therefore starts with an evidence gate and stops if that gate fails.
    ordering authoritative and independent from later derived work.
 2. Remove parser, CST, Block reconciliation, MarkdownIR, diagnostics, and
    Preview materialization from the production main-thread authority task.
-3. Keep one long-lived incremental projection session inside a browser Worker.
-4. Give every work item and artifact explicit generation, order, source, and
-   causal provenance.
+3. Keep one long-lived incremental projection session inside the selected
+   executor. A browser Worker is a preferred candidate, not an accepted
+   production placement before promotion evidence.
+4. Give every group work item and artifact explicit generation, order, source,
+   and causal provenance.
 5. Bound queued projection work while preserving the latest committed source.
-6. Adopt every simultaneously visible projection lane atomically.
+6. Adopt each demand-defined consistency group atomically. Visible groups may
+   advance independently under stamped currentness rules.
 7. Preserve Block edit correctness through exact source and authority fences;
    expose pending state rather than using stale structure.
 8. Measure authority, Worker, protocol, adoption, DOM, scheduling, and memory
@@ -84,13 +88,13 @@ therefore starts with an evidence gate and stops if that gate fails.
 | ReplaceSource | `ApplicationEvent::RequestCanonicalSource` reaches the same shared commit shell. | Treat as an authority replacement followed by a new projection generation Seed. |
 | Block structural edit | `BlockInput` resolves against current Block/source-map state before `commit_edit_request`. | Resolve only against a stamped immutable Block artifact; apply only under the exact causal-version fence. |
 | Undo/redo | `SyncEditor` currently owns `UndoManager`, text authority, parser, and projection in one struct. | Extract authority and projection responsibilities without changing existing public `SyncEditor` behavior during the refactor commit. |
-| Remote admission | Production Loomark does not yet have a proven canonical admission route. | Do not cut over until #1241 lands; route its accepted operation through the same authority-event publication seam. |
+| Remote admission | Production Loomark does not yet have a proven canonical admission route. | Consume #1241's contract if it exists; otherwise relocate only the existing accepted transition without redefining canonical admission. |
 | Source-equal causal advance | `commit_classification.mbt` advances document version while retaining source revision. | Carry the current artifact by source revision, but invalidate intent fences bound to the older causal version. |
 | Post-commit archive failure | `document_transaction.mbt` classifies the accepted receipt before persistence scheduling/failure. | Preserve the accepted authority event and record persistence failure independently of projection status. |
 | Parser failure recovery | `recovery_shell.mbt` and `application.mbt` replace the editor/session after parser failure. | Increment projection generation, dispose the failed session, reject its results, and Seed the replacement. |
-| Archive reopen | `editor_session.mbt` reconstructs a fresh editor and semantic attachment from complete local history. | Create authority first, then Seed one new Worker projection generation from the recovered committed source. |
+| Archive reopen | `editor_session.mbt` reconstructs a fresh editor and semantic attachment from complete local history. | Create authority first, then Seed one new projection generation inside the selected executor from the recovered committed source. |
 | Session replacement | `application.mbt` swaps the current `EditorSession` and disposes the old attachment. | Keep one application-lifetime Projection Adapter; replacement changes its generation and executor session. |
-| Demand-only change | `preview_read_model.mbt` may read Preview when mode/split demand changes without a commit. | Request an Artifact Bundle for the current source stamp without inventing an authority event. |
+| Demand-only change | `preview_read_model.mbt` may read Preview when mode/split demand changes without a commit. | Issue group work for the current source stamp without inventing an authority event. |
 
 Before changing code, refresh every row against the current branch and record
 exact file:line evidence in the implementation PR. #1241 may change remote
@@ -122,17 +126,19 @@ parser/projection work.
 
 Refactor generic `SyncEditor` into composed internal authority and projection
 responsibilities while preserving its public facade. Do not duplicate mutation
-logic. Before extraction, characterize every text-changing path and prove that
-the authority side can publish a small accepted SourceTransition. If Seed needs
-full source and no immutable handle exists, record `SeedCaptureRequired`, return
-the authority result, and materialize source afterward.
+logic. Before extraction, classify each projection-relevant authority event
+exactly once as either a replayable `Advance`/`SourceUnchanged`, or a generation
+invalidation followed by coherent `Seed` recovery. Lifecycle replacement events
+do not masquerade as `SourceTransition`. If Seed needs full source and no
+immutable handle exists, record `SeedCaptureRequired`, return the authority
+result, and materialize source afterward.
 
 Trace the authority boundary as:
 
-- **A0** — causal mutation is irreversibly classified;
+- **A0** — causal mutation or lifecycle replacement is irreversibly classified;
 - **A1** — small receipt/effect, document version, and source identity are
   available; and
-- **B** — deferred SourceTransition or Seed input is materialized.
+- **B** — deferred Advance or Seed input is materialized.
 
 Property tests and trace fields must make it structurally impossible for A0/A1
 to perform full-source export, history encoding, archive preparation, JSON
@@ -191,11 +197,12 @@ incidental map iteration order.
 
 ### Projection stamp
 
-A stamp contains generation, projection sequence, source revision, and causal
-document version:
+A stamp contains generation, adapter-lifetime projection sequence, source
+revision, and causal document version:
 
 - generation identifies the Projection Session incarnation;
-- projection sequence orders adapter observation and delivery;
+- projection sequence orders adapter observations and deliveries across
+  generations and never resets when generation changes;
 - source revision identifies portable source payload changes and cache reuse;
 - causal document version validates authority staleness.
 
@@ -206,8 +213,9 @@ the older causal version is rejected before authority mutation.
 
 Generation and sequence never wrap or reuse a value within one application
 mount. Disposal closes routing before executor termination. Counter exhaustion
-and delayed callbacks fail closed. Equal normalized stamps identify equal
-observable payloads.
+and delayed callbacks fail closed. The determinism key is the consistency group,
+normalized stamp, and relevant non-authority policy inputs; equality of that key
+implies equivalent normalized observable payload.
 
 ### Demand-defined consistency groups
 
@@ -279,23 +287,32 @@ permanent pending state.
 ## A–F trace contract
 
 Instrumentation is private, opt-in, bounded, and allocation-free when disabled.
-One authority event may reference zero or more artifact work items; one work item
-may produce several consistency-group artifacts.
+One authority event may reference zero or more projection requests. Each request
+issues zero or one group work item per demanded consistency group. Authority
+event ID, group work ID, and presentation ID are distinct axes; one presentation
+may correlate several adopted group work items in the same frame.
 
 | Phase | Linearization point | Required fields |
 |---|---|---|
-| A0 — authority mutation | Commit is irreversibly classified. | event id, operation kind, accepted/rejected, before/after document version, duration |
+| A0 — authority mutation | Commit or lifecycle replacement is irreversibly classified. | event id, operation kind, accepted/rejected, before/after document version, duration |
 | A1 — authority evidence | Small receipt/effect and source identity are available without full export. | event id, source revision/identity, evidence bytes, duration, forbidden-full-export control |
-| B — deferred source materialization | SourceTransition or Seed input is available after A1. | event id, work id, input kind, bytes/copies, duration |
-| C — projection execution | Executor Seed/Advance begins and ends against one acknowledged base. | work id, placement, generation, sequence, base/result revision, queue wait, stage durations, terminal status |
-| D — artifact publication | One consistency-group envelope is complete. | work id, group, encoded bytes, encode/clone/decode durations, terminal status |
-| E — application adoption | Reducer accepts or rejects one whole group. | work id, group, stamp, currentness decision, duration, rejection reason |
-| F — presentation | Adopted work becomes observable after reconciliation/paint. | work id, group, presentation id, contiguous main-thread slice, input-to-paint critical path, dropped-frame/Long Task evidence |
+| B — deferred source materialization | Advance or Seed input is available after A1. | event id, projection request id, input kind, bytes/copies, duration |
+| C — projection execution | Executor Seed/Advance begins and ends against one acknowledged base. | projection request id, placement, generation, sequence, base/result revision, queue wait, stage durations, request disposition |
+| D — artifact publication | One consistency-group envelope is complete. | projection request id, group work id, group, encoded bytes, encode/clone/decode durations, materialized-at |
+| E — application adoption | Reducer accepts or rejects one whole group. | group work id, group, stamp, currentness decision, duration, rejection reason, adoption outcome |
+| F — presentation | Adopted group work becomes observable or is explicitly retired without presentation. | group work id, group, presentation id when presented, presentation outcome, contiguous main-thread slice, input-to-paint critical path, dropped-frame/Long Task evidence |
 
-Every issued work id receives exactly one terminal status:
-`Materialized`, `Superseded`, `SupersededAfterExecution`,
-`GenerationInvalidated`, `RejectedAtAdoption`, `Failed`, or `Disposed`.
-Missing B–F phases require a recorded reason.
+`NoDemand` is a projection-request disposition and never creates a group work
+id. Materialization at D is progress, not a terminal group outcome. Every issued
+group work id eventually receives exactly one final outcome:
+`Presented`, `AdoptedNotPresented`, `RejectedAtAdoption`,
+`SupersededBeforeExecution`, `SupersededAfterExecution`,
+`GenerationInvalidated`, `Failed`, or `Disposed`. `AdoptedNotPresented` requires
+an explicit reason such as demand removal or disposal; it is not inferred from a
+missing F record. A projection request records its own disposition without
+collapsing independent group outcomes. Missing B–F phases require a recorded
+reason at the applicable request or group-work axis.
+
 ## Test-first execution plan
 
 Use one Canopy issue and implementation PR. Keep characterization, Warren
@@ -318,8 +335,11 @@ host, and private trace modules.
 4. demand-only Preview produces C–F without A0/A1;
 5. source-equal causal advance changes causal version without changing source
    revision and invalidates an old intent fence;
-6. recovery/session replacement gives old work a terminal invalidation;
-7. every work has one terminal status and every missing phase has a reason; and
+6. recovery/session replacement invalidates the generation, gives each old group
+   work item a final outcome, and issues coherent Seed recovery;
+7. `NoDemand` issues no group work, D materialization is non-terminal, every
+   issued group work item has one final outcome, request dispositions do not
+   collapse group outcomes, and every missing phase has a reason; and
 8. trace-disabled control creates no record or formatted String.
 
 Each later commit calibrates the phases it introduces with a known-positive
@@ -370,8 +390,9 @@ property/differential tests.
 **Red reducer tests:**
 
 1. generation invalidates old active, pending, result, and callback paths;
-2. sequence is monotonic, unique, non-wrapping, and source revision never acts
-   as the sole currentness check;
+2. adapter-lifetime sequence is monotonic, unique, non-wrapping, and does not
+   reset across generation replacement; source revision never acts as the sole
+   currentness check;
 3. source-equal causal advance keeps source revision, advances sequence/version,
    carries display artifacts, and rejects old Block intent;
 4. pending Advance count/bytes/source-effect bytes remain within configured
@@ -381,8 +402,11 @@ property/differential tests.
 7. Block, Preview, and diagnostics consistency groups adopt independently and
    atomically within their group;
 8. hidden Preview and diagnostics never block the Block group;
-9. every work and group receives one terminal result;
-10. disposal, timeout, decode failure, and counter-limit cases fail closed.
+9. each demanded group work item independently ends as presented,
+   adopted-not-presented, rejected, superseded, invalidated, failed, or disposed;
+10. `NoDemand` creates no group work and materialization is non-terminal;
+11. presentation IDs may correlate several adopted group work items; and
+12. disposal, timeout, decode failure, and counter-limit cases fail closed.
 
 **Red oracle tests:**
 
@@ -391,7 +415,8 @@ property/differential tests.
    MarkdownIR, diagnostics, Preview, and resolver evidence;
 3. runtime identity, timestamps, generation/sequence fixtures, and map ordering
    are normalized rather than compared;
-4. equal normalized stamps imply equal observable payloads; and
+4. equal group, normalized stamp, and relevant non-authority policy inputs imply
+   equivalent normalized observable payload; and
 5. Block feedback/pending/failure states are typed and non-destructive.
 
 **Gate 0B:** the in-process executor establishes the protocol contract and
@@ -466,16 +491,21 @@ and generated interfaces.
 1. authority commit returns A0/A1 before projection or Seed materialization;
 2. projection/source-materialization failure cannot alter accepted history;
 3. Raw, exact/structural edit, undo/redo, remote admission, and source
-   replacement publish one canonical small SourceTransition;
-4. source-equal advance changes authority version without semantic source work;
-5. Seed capture executes after the authority result; and
-6. the existing public `SyncEditor` facade preserves behavior and signatures.
+   replacement are classified once as replayable `Advance` or
+   `SourceUnchanged`;
+4. recovery, archive reopen, and session replacement invalidate the old
+   generation and issue coherent Seed recovery rather than masquerading as
+   `SourceTransition`;
+5. source-equal advance changes authority version without semantic source work;
+6. Seed capture executes after the authority result; and
+7. the existing public `SyncEditor` facade preserves behavior and signatures.
 
 Extract internal authority and projection modules without duplicating mutation
-logic. Keep the old synchronous production path active. Use #1241's canonical
-event representation only if its production contract exists when this commit
-starts; otherwise #1244 relocates the existing authority transition independently
-and does not wait for or redefine #1241's test-only admission evidence.
+logic. Keep the old synchronous production path active. Consume #1241's
+canonical event representation if its production contract exists when this
+commit starts; otherwise relocate only the existing accepted authority
+transition, preserve current semantics with characterization evidence, and do
+not redefine #1241's admission contract.
 
 ### Commit 6 — integrate the application-lifetime Adapter behind a comparison flag
 
@@ -530,6 +560,7 @@ Only after promotion gates pass:
 3. keep normalized differential and reducer/property tests;
 4. update Loomark build/development and performance evidence; and
 5. update this plan, the ADR, #1244, and the prior Preview ownership ADR.
+
 ## Validation commands
 
 Run from the Canopy repository root unless a command names a submodule:
@@ -549,24 +580,28 @@ rtk ./scripts/check-agent-doc-links.sh
 
 Run the paired Warren package tests in `deps/rabbita` before advancing its
 gitlink. Use `moon ide` diagnostics during every MoonBit edit. Inspect generated
-`.mbti` diffs after each Canopy interface change. Run the release browser
-benchmark separately and retain its raw output as evidence rather than making
-machine-specific latency thresholds CI assertions.
+`.mbti` diffs after each Canopy interface change. The commit that introduces the
+release browser benchmark harness must add its exact release invocation and raw
+output location to this section. Run that benchmark separately and retain its
+raw output as evidence rather than making machine-specific latency thresholds CI
+assertions.
 
 ## Acceptance criteria
 
 ### Authority and correctness
 
-- [ ] Before production authority changes, either #1241 provides a production
-      canonical TextEvent contract or #1244 records and tests its independent
-      relocation of the existing authority transition.
+- [ ] #1244 does not redefine canonical TextEvent admission. It consumes #1241's
+      production contract when available; otherwise it relocates only the
+      existing accepted authority transition and proves unchanged semantics with
+      characterization evidence.
 - [ ] Every accepted operation retains exact causal receipt/history evidence
       even when projection, persistence, or presentation later fails.
 - [ ] Authority A0/A1 calls no full source/history export, archive preparation,
       JSON/transfer, parser, projection, semantic, Preview, or DOM work.
-- [ ] Raw, ReplaceSource, Block, undo, redo, remote admission, source-equal,
-      archive failure/reopen, parser recovery, and session replacement publish
-      one canonical small SourceTransition through the authority seam.
+- [ ] Every projection-relevant authority event is classified exactly once as
+      replayable Advance/SourceUnchanged or generation invalidation followed by
+      coherent Seed recovery. Lifecycle replacement does not masquerade as
+      SourceTransition.
 - [ ] Existing `SyncEditor` callers retain behavior and public interface unless
       an explicitly reviewed interface change is recorded.
 
@@ -590,14 +625,22 @@ machine-specific latency thresholds CI assertions.
 
 ### Currentness and lifecycle
 
-- [ ] Generation, sequence, source revision, and causal document version retain
-      their distinct meanings on every work item and consistency-group artifact.
+- [ ] Generation, adapter-lifetime sequence, source revision, and causal document
+      version retain their distinct meanings on every projection request and
+      consistency-group artifact.
+- [ ] Sequence never resets across generation replacement, wraps, or reuses a
+      value within one application mount.
 - [ ] No currentness check relies on source revision alone.
 - [ ] Stale generation, sequence, source, causal version, disposed callback, and
       counter-wrap cases all fail closed.
-- [ ] Every issued work id has exactly one terminal status.
+- [ ] `NoDemand` is request disposition and creates no group work;
+      materialization is non-terminal; every issued group work id has exactly one
+      final outcome distinguishing presented, adopted-not-presented, rejected,
+      superseded, invalidated, failed, and disposed work.
 - [ ] Block, Preview, and diagnostics adopt independently and atomically within
       their own consistency group; Preview/diagnostics never delay Block.
+- [ ] Equal group, normalized stamp, and relevant non-authority policy inputs
+      imply equivalent normalized observable payload.
 - [ ] Source-equal causal advance may retain display artifacts but cannot apply
       an intent fenced to the older causal version.
 - [ ] Recovery, archive reopen, session replacement, executor failure, and

--- a/docs/plans/2026-08-12-loomark-concurrent-projection-execution.md
+++ b/docs/plans/2026-08-12-loomark-concurrent-projection-execution.md
@@ -1,0 +1,688 @@
+# Loomark concurrent projection execution — implementation plan
+
+**Status:** Active plan; no implementation has landed.
+
+**Canonical issue:** [#1244 — Loomark: move Markdown projection off the authority commit path](https://github.com/dowdiness/canopy/issues/1244)
+
+**Decision:** [Loomark projection execution is asynchronous and source-stamped](../decisions/2026-08-12-loomark-concurrent-projection-execution.md)
+
+**Required predecessor:** [#1241 — canonical TextEvent admission correctness](https://github.com/dowdiness/canopy/issues/1241). Gate A must prove the canonical event model before this plan changes a production authority path.
+
+**Related decisions:**
+
+- [Causal Authority residency](../decisions/2026-08-12-causal-authority-residency.md)
+- [Indexed projection lifecycle](../decisions/2026-07-22-indexed-projection-lifecycle.md)
+- [Markdown semantic Preview ownership](../decisions/2026-08-04-markdown-semantic-preview-ownership.md)
+- [Markdown semantic attachment boundary](../../deps/loom/docs/decisions/2026-08-04-markdown-semantic-attachment-boundary.md)
+- [Markdown projection attachment boundary](../../deps/loom/docs/decisions/2026-08-03-markdown-projection-attachment-boundary.md)
+
+## Why
+
+Loomark's current commit path is coherent but shallow. One caller coordinates
+causal mutation, parser synchronization, Block reconciliation, semantic Preview
+read, persistence preparation, model adoption, and browser presentation. Its
+interface nearly describes its implementation, so every new derived view or
+parser cost leaks into the authority task.
+
+The desired deep module has one small authority interface: admit one operation
+and return settled mutation evidence. Projection execution sits behind a second
+seam: submit one immutable committed input and eventually receive one stamped
+Artifact Bundle. This separation improves locality because authority failures,
+projection failures, and presentation failures each have one owner. It improves
+leverage because Preview, Block, diagnostics, and later derived artifacts reuse
+one execution and currentness contract.
+
+The deletion test justifies both modules. Deleting the authority/projection seam
+would move generation, sequencing, stale-result rejection, and demand
+coherence back into every edit caller. Deleting the Projection Adapter would
+force application update, recovery, and presentation paths to coordinate the
+Worker protocol independently. Both deletions disperse rather than concentrate
+complexity.
+
+Current evidence does not yet prove the Worker architecture. The existing
+`MarkdownSemanticAttachment` owns process-local reactive state, Warren emits one
+JavaScript entry, and browser protocol/allocation costs are unknown. This plan
+therefore starts with an evidence gate and stops if that gate fails.
+
+## Goals
+
+1. Keep accepted causal mutation, receipt/history evidence, and persistence
+   ordering authoritative and independent from later derived work.
+2. Remove parser, CST, Block reconciliation, MarkdownIR, diagnostics, and
+   Preview materialization from the production main-thread authority task.
+3. Keep one long-lived incremental projection session inside a browser Worker.
+4. Give every work item and artifact explicit generation, order, source, and
+   causal provenance.
+5. Bound queued projection work while preserving the latest committed source.
+6. Adopt every simultaneously visible projection lane atomically.
+7. Preserve Block edit correctness through exact source and authority fences;
+   expose pending state rather than using stale structure.
+8. Measure authority, Worker, protocol, adoption, DOM, scheduling, and memory
+   costs in a production release build at 2k, 10k, and 50k lines.
+9. Leave no production synchronous projection fallback after cutover.
+
+## Non-goals
+
+- Replacing EGW causal history, `TextState`, or the accepted Causal Authority
+  residency decision.
+- Making persistence, projection, and presentation one transaction.
+- Requiring every intermediate committed source to produce an artifact.
+- Moving live Loom parsers, `incr` runtimes, scopes, watches, memos, closures, or
+  Canopy projection nodes across the Worker seam.
+- Shipping a public cache-management or Worker-management interface.
+- Guaranteeing cold open, network load, or a 50k-line full projection within one
+  16 ms frame.
+- Optimizing protocol encoding before its measured cost is isolated.
+- Changing CommonMark behavior, Block identity policy, source-map semantics, or
+  Preview security policy.
+
+## Existing responsibility map
+
+| Path | Current owner and evidence | Required change |
+|---|---|---|
+| Raw input | `application.mbt` routes `RawInput`; `raw_selection_transaction.mbt` normalizes it; `document_transaction.mbt` commits it. | Authority commit returns before projection; native input remains responsive while a bundle is pending. |
+| ReplaceSource | `ApplicationEvent::RequestCanonicalSource` reaches the same shared commit shell. | Treat as an authority replacement followed by a new projection generation Seed. |
+| Block structural edit | `BlockInput` resolves against current Block/source-map state before `commit_edit_request`. | Resolve only against a stamped immutable Block artifact; apply only under the exact causal-version fence. |
+| Undo/redo | `SyncEditor` currently owns `UndoManager`, text authority, parser, and projection in one struct. | Extract authority and projection responsibilities without changing existing public `SyncEditor` behavior during the refactor commit. |
+| Remote admission | Production Loomark does not yet have a proven canonical admission route. | Do not cut over until #1241 lands; route its accepted operation through the same authority-event publication seam. |
+| Source-equal causal advance | `commit_classification.mbt` advances document version while retaining source revision. | Carry the current artifact by source revision, but invalidate intent fences bound to the older causal version. |
+| Post-commit archive failure | `document_transaction.mbt` classifies the accepted receipt before persistence scheduling/failure. | Preserve the accepted authority event and record persistence failure independently of projection status. |
+| Parser failure recovery | `recovery_shell.mbt` and `application.mbt` replace the editor/session after parser failure. | Increment projection generation, dispose the failed session, reject its results, and Seed the replacement. |
+| Archive reopen | `editor_session.mbt` reconstructs a fresh editor and semantic attachment from complete local history. | Create authority first, then Seed one new Worker projection generation from the recovered committed source. |
+| Session replacement | `application.mbt` swaps the current `EditorSession` and disposes the old attachment. | Keep one application-lifetime Projection Adapter; replacement changes its generation and executor session. |
+| Demand-only change | `preview_read_model.mbt` may read Preview when mode/split demand changes without a commit. | Request an Artifact Bundle for the current source stamp without inventing an authority event. |
+
+Before changing code, refresh every row against the current branch and record
+exact file:line evidence in the implementation PR. #1241 may change remote
+admission and receipt surfaces.
+
+## Target architecture
+
+```mermaid
+flowchart LR
+  Input[Raw / Block / remote operation] --> A[Authority module]
+  A -->|small receipt + version/source identity| PA[Projection Adapter]
+  A --> Persist[Persistence scheduling]
+  PA -->|SourceTransition / Seed request / Demand| EX[Projection Executor interface]
+  EX --> IW[In-process executor]
+  EX --> WW[Candidate Worker executor]
+  EX --> PS[Executor-owned Projection Session]
+  PS -->|portable stamped consistency groups| PA
+  PA --> Adopt[Per-group atomic adoption]
+  Adopt --> Present[Browser presentation]
+```
+
+### Authority module
+
+The authority module owns causal admission, document version, source identity,
+undo/history semantics, small receipt/effect evidence, and persistence
+scheduling. Its linearization path does not materialize or copy full source,
+export history, prepare archives, encode JSON, transfer executor input, or run
+parser/projection work.
+
+Refactor generic `SyncEditor` into composed internal authority and projection
+responsibilities while preserving its public facade. Do not duplicate mutation
+logic. Before extraction, characterize every text-changing path and prove that
+the authority side can publish a small accepted SourceTransition. If Seed needs
+full source and no immutable handle exists, record `SeedCaptureRequired`, return
+the authority result, and materialize source afterward.
+
+Trace the authority boundary as:
+
+- **A0** — causal mutation is irreversibly classified;
+- **A1** — small receipt/effect, document version, and source identity are
+  available; and
+- **B** — deferred SourceTransition or Seed input is materialized.
+
+Property tests and trace fields must make it structurally impossible for A0/A1
+to perform full-source export, history encoding, archive preparation, JSON
+generation, or Worker transfer.
+
+### Projection Adapter
+
+One private application-lifetime module owns generation, projection sequence,
+authority document version, source revision, executor acknowledgement, demand,
+active work, bounded pending work, adopted consistency groups, failure state,
+callback routing, disposal, and trace correlation.
+
+Application edit, recovery, demand, split, and mount paths call this deep module
+instead of coordinating parsers or executor callbacks. The pure reducer models
+messages and commands as data; executor effects remain in a thin shell.
+
+### Projection Executor interface and placement
+
+Define one normalized protocol before implementing Worker projection semantics.
+It has two adapters:
+
+1. **In-process executor** — the first implementation and correctness oracle.
+   It establishes Projection Session behavior, reducer laws, portable inputs,
+   consistency-group outputs, failures, and normalized comparison.
+2. **Worker executor** — a later adapter for the same protocol. It owns Worker
+   transport, callback routing, restart, termination, and error conversion.
+
+Each adapter creates and owns a long-lived Projection Session containing its
+parser, reactive runtime, Block projection, source maps, identity policy,
+semantic attachment, diagnostics, and artifact materializers. Live parser,
+scope, watch, memo, closure, or runtime values never cross the executor seam.
+
+Dedicated Worker placement is conditional. It is promoted only after comparison
+with the in-process executor proves correctness and records interactive latency,
+main-thread isolation, queue pressure, transport cost, failure behavior, and
+memory. Production selects one recorded placement; it never silently falls back
+at runtime.
+
+### Portable protocol and normalized differential contract
+
+Seed constructs a fresh Projection Session. Advance is legal only when its base
+matches the executor's acknowledged source. Demand may request a consistency
+group for the current source without an authority event.
+
+Start with explicit typed JSON, without relying on generated JavaScript object
+layout. Measure encode, clone, decode, materialization, payload bytes, retained
+bytes, and peak live copies. Redesign the wire before production integration if
+serialization dominates interactive work or duplicates the document
+unacceptably.
+
+Differential comparison includes observable source, Block hierarchy/keys and
+ranges, source maps, semantic roles, MarkdownIR, diagnostics, Preview payload,
+and selection/resolver evidence. Normalize or exclude Worker-local object and
+reactive identities, generation/sequence test values, timestamps, and
+incidental map iteration order.
+
+### Projection stamp
+
+A stamp contains generation, projection sequence, source revision, and causal
+document version:
+
+- generation identifies the Projection Session incarnation;
+- projection sequence orders adapter observation and delivery;
+- source revision identifies portable source payload changes and cache reuse;
+- causal document version validates authority staleness.
+
+Source revision alone never establishes currentness. A source-equal causal
+advance may keep source revision unchanged while advancing sequence and causal
+version. Display artifacts may be carried forward, but an edit intent fenced to
+the older causal version is rejected before authority mutation.
+
+Generation and sequence never wrap or reuse a value within one application
+mount. Disposal closes routing before executor termination. Counter exhaustion
+and delayed callbacks fail closed. Equal normalized stamps identify equal
+observable payloads.
+
+### Demand-defined consistency groups
+
+Artifact Bundles are immutable, portable, and atomic within one consistency
+group, not across every visible lane:
+
+- **Block interactive group** — Block hierarchy, editable kinds, ranges, source
+  maps/roles, selection/focus mapping, and BlockIntent resolver evidence;
+- **Preview group** — MarkdownIR-derived Preview payload and security decisions;
+- **Diagnostics group** — diagnostics for one source provenance.
+
+Diagnostics never delay Block adoption. Hidden Preview is absent. Block-only
+mode never waits for Preview. Raw is authority-owned and waits for no projection
+group. Split Block+Preview may temporarily show different stamped revisions if
+the UI exposes that lag and stale evidence cannot authorize an edit. Requiring
+same-source split presentation is a separate measured product trade-off.
+
+### Bounded scheduling and Seed pressure
+
+The scheduler retains one active work item and one pending description, but slot
+count is not its memory bound. The pending description also has explicit limits
+for Advance count, encoded bytes, and retained source/effect bytes.
+
+A bounded contiguous Advance chain may be retained from the executor's
+acknowledged source. When continuity cannot fit, replace it with one latest Seed
+request and materialize that Seed outside A0/A1. Replacing unstarted pending work
+records `Superseded`; obsolete active output records
+`SupersededAfterExecution` and is rejected before artifact decoding where
+possible. Authority operations, receipts, history, and persistence are never
+coalesced.
+
+Promotion requires all of these structural conditions:
+
+- normal continuous typing does not become one Seed per edit;
+- pending payload cannot grow without bound;
+- only continuity loss or a configured bound triggers Seed;
+- burst work converges to the latest source;
+- Seed generation never delays authority commit; and
+- superseded Advance/source tails become collectible.
+
+Measure pending Advance count, pending encoded bytes, retained source/effect
+bytes, Seed count and bytes per generation/second, Advance-to-Seed ratio,
+pre-start supersession rate, and retained tail after catch-up.
+
+### Block interaction and executor failure
+
+Block intent resolves from the latest Block group and carries exact source and
+causal-version fences. Between an accepted commit and a current group, the model
+exposes typed feedback/pending state; it never applies stale structure. Raw
+remains usable unless an explicit authority failure occurs.
+
+Measure separately:
+
+- Block intent to next-paint feedback;
+- Block intent to authority commit;
+- authority commit to current Block group; and
+- interactive intent queue wait.
+
+Preview and diagnostics use separate convergence measures. Values such as 4 ms,
+8 ms, 16.7 ms, and 50 ms are provisional browser-trace calibration points, not
+ADR invariants.
+
+Executor failure states cover startup failure, decode failure, termination
+during active work, timeout/no response, restart with a fresh generation, old
+result rejection, and disposal. Authority state survives. Raw either remains
+usable or becomes explicitly unavailable; Block/Preview never remain in a fake
+permanent pending state.
+
+## A–F trace contract
+
+Instrumentation is private, opt-in, bounded, and allocation-free when disabled.
+One authority event may reference zero or more artifact work items; one work item
+may produce several consistency-group artifacts.
+
+| Phase | Linearization point | Required fields |
+|---|---|---|
+| A0 — authority mutation | Commit is irreversibly classified. | event id, operation kind, accepted/rejected, before/after document version, duration |
+| A1 — authority evidence | Small receipt/effect and source identity are available without full export. | event id, source revision/identity, evidence bytes, duration, forbidden-full-export control |
+| B — deferred source materialization | SourceTransition or Seed input is available after A1. | event id, work id, input kind, bytes/copies, duration |
+| C — projection execution | Executor Seed/Advance begins and ends against one acknowledged base. | work id, placement, generation, sequence, base/result revision, queue wait, stage durations, terminal status |
+| D — artifact publication | One consistency-group envelope is complete. | work id, group, encoded bytes, encode/clone/decode durations, terminal status |
+| E — application adoption | Reducer accepts or rejects one whole group. | work id, group, stamp, currentness decision, duration, rejection reason |
+| F — presentation | Adopted work becomes observable after reconciliation/paint. | work id, group, presentation id, contiguous main-thread slice, input-to-paint critical path, dropped-frame/Long Task evidence |
+
+Every issued work id receives exactly one terminal status:
+`Materialized`, `Superseded`, `SupersededAfterExecution`,
+`GenerationInvalidated`, `RejectedAtAdoption`, `Failed`, or `Disposed`.
+Missing B–F phases require a recorded reason.
+## Test-first execution plan
+
+Use one Canopy issue and implementation PR. Keep characterization, Warren
+capability, protocol/reducer, Worker evidence, responsibility refactor,
+production integration, and promotion/cleanup in separate commits. A paired
+Rabbita PR is permitted only for Warren multi-entry support.
+
+### Commit 1 — characterize responsibility and A0–F behavior
+
+**Files:** existing Loomark reducer/transaction/lifecycle tests, disposable dev
+host, and private trace modules.
+
+**Red tests first:**
+
+1. accepted mutation plus later history/export failure records A0/A1 and never
+   authorizes retry;
+2. A0/A1 expose only small evidence and invoke no full source/history export,
+   archive preparation, JSON generation, or Worker transfer;
+3. deferred Seed/source materialization records B after A1;
+4. demand-only Preview produces C–F without A0/A1;
+5. source-equal causal advance changes causal version without changing source
+   revision and invalidates an old intent fence;
+6. recovery/session replacement gives old work a terminal invalidation;
+7. every work has one terminal status and every missing phase has a reason; and
+8. trace-disabled control creates no record or formatted String.
+
+Each later commit calibrates the phases it introduces with a known-positive
+event that must emit that phase and a trace-disabled paired run. Commit 2
+calibrates Worker capability transport, Commit 3 calibrates B–E in-process,
+Commit 4 calibrates Worker C–E and failure omissions, and Commit 6 calibrates F
+through browser paint. A clean trace is accepted only after its matching control
+fires.
+
+Implement bounded fixed-width tracing around current synchronous behavior
+without changing execution. Refresh the responsibility map with exact
+file:line evidence, including Raw, ReplaceSource, Block, undo/redo, remote
+admission, source-equal advance, post-commit failure, recovery, reopen, session
+replacement, and demand-only paths.
+
+**Gate:** current behavior is unchanged; A0/A1 full-export detector is calibrated
+with a known-positive control; trace-enabled/disabled paired runs identify
+instrumentation overhead.
+
+### Commit 2 — prove Warren multi-entry capability only
+
+**Files:** paired `deps/rabbita/warren/` PR, Loomark page entry, inert private
+Worker entry, build scripts, and direct/release assertions.
+
+**Red tests first:**
+
+1. Warren emits exactly one page entry and one named auxiliary Worker entry;
+2. direct mode serves both;
+3. release output references the Worker asset correctly under static hosting;
+4. standalone startup proves page↔Worker request/response and termination; and
+5. existing one-entry Warren applications retain output and CLI behavior.
+
+The Worker returns a fixed typed capability response. It does not construct a
+parser or define projection payloads. Do not let Warren constraints determine
+the projection domain contract.
+
+**Gate 0A:** page and inert Worker entries build and run in direct/release modes.
+Record Rabbita commit SHA, Canopy-tested SHA, build matrix, merge order,
+partial-merge behavior, and rollback condition. Failure stops Worker work but
+does not invalidate the executor seam.
+
+### Commit 3 — define the protocol, pure reducer, and in-process executor
+
+**Files:** private Projection Adapter/reducer modules, normalized portable
+protocol, in-process Projection Session/executor, application status types, and
+property/differential tests.
+
+**Red reducer tests:**
+
+1. generation invalidates old active, pending, result, and callback paths;
+2. sequence is monotonic, unique, non-wrapping, and source revision never acts
+   as the sole currentness check;
+3. source-equal causal advance keeps source revision, advances sequence/version,
+   carries display artifacts, and rejects old Block intent;
+4. pending Advance count/bytes/source-effect bytes remain within configured
+   bounds under arbitrary message/result interleavings;
+5. continuity uses Advance; a gap or exceeded bound issues one latest Seed;
+6. Seed capture is a post-A1 command;
+7. Block, Preview, and diagnostics consistency groups adopt independently and
+   atomically within their group;
+8. hidden Preview and diagnostics never block the Block group;
+9. every work and group receives one terminal result;
+10. disposal, timeout, decode failure, and counter-limit cases fail closed.
+
+**Red oracle tests:**
+
+1. Seed and contiguous Advance preserve current main-thread observable behavior;
+2. normalized comparison covers source, Block structure/ranges/maps/roles,
+   MarkdownIR, diagnostics, Preview, and resolver evidence;
+3. runtime identity, timestamps, generation/sequence fixtures, and map ordering
+   are normalized rather than compared;
+4. equal normalized stamps imply equal observable payloads; and
+5. Block feedback/pending/failure states are typed and non-destructive.
+
+**Gate 0B:** the in-process executor establishes the protocol contract and
+passes reducer/property/differential tests before Worker projection semantics
+exist.
+
+### Commit 4 — implement real Worker executor and Gate 0C
+
+**Files:** Worker Projection Session entry, typed JSON codec, Worker executor,
+standalone/dev-host browser harness, and protocol/queue/heap instrumentation.
+
+The Worker implements the exact Gate 0B protocol. It creates parser, `incr`
+runtime, Block projection, source maps, semantic attachment, diagnostics, and
+materializers internally. No live runtime value crosses the seam.
+
+**Red tests first:**
+
+1. normalized Worker output equals the in-process executor for the complete
+   differential corpus;
+2. startup failure, decode failure, active-work termination, timeout/no response,
+   and restart produce typed terminal states;
+3. restart creates a fresh generation and delayed old output is rejected;
+4. authority state survives Worker failure and Raw is usable or explicitly
+   unavailable;
+5. Block/Preview cannot remain in permanent fake pending state;
+6. queue payload limits hold when the Worker is paused for 100–500 ms;
+7. Seed processing concurrent with new advances converges to latest source; and
+8. superseded sources/Advance tails become collectible after catch-up/cutover.
+
+**Stress scenarios:**
+
+- 10 Hz typing for 30 seconds;
+- 30 Hz typing for 5 seconds;
+- 10 ms interval short bursts;
+- paste equivalent to 100–1000 edits;
+- IME composition and composition commit;
+- Worker pauses of 100, 250, and 500 ms;
+- new advances during Seed; and
+- bursts immediately before and after session cutover.
+
+**Metrics and structural rejection conditions:**
+
+- pending Advance count, encoded bytes, retained source/effect bytes;
+- Seed count/bytes per generation and second;
+- Advance-to-Seed ratio and pre-start supersession rate;
+- queue wait and retained tail after catch-up;
+- encode/clone/decode/materialization time and peak live copies;
+- Worker/in-process Block intent feedback, authority commit, and current-group
+  latency p50/p95/p99;
+- main-thread contiguous slice, input-to-paint critical path, dropped frames,
+  and Long Tasks; and
+- startup/restart/cutover heap retention with a positive retention control.
+
+Reject promotion if ordinary typing degenerates to per-edit Seed, pending work
+or retained memory is unbounded, Raw authority work scales with document length,
+the main thread produces a 50 ms Long Task, Seed capture delays authority
+commit, or the Worker cannot recover explicitly. Numerical 4/8/16.7/50 ms
+budgets are calibrated from these traces rather than predeclared as invariants.
+
+**Gate 0C:** exact normalized parity, bounded queue/heap, explicit failure
+recovery, production-shaped browser operation, and a recorded Worker versus
+in-process trade-off. Gate 0C recommends placement; it does not silently promote
+the Worker.
+
+### Commit 5 — split `SyncEditor` authority and projection responsibilities
+
+**Files:** generic SyncEditor internals, Markdown facade/runtime, targeted tests,
+and generated interfaces.
+
+**Red tests first:**
+
+1. authority commit returns A0/A1 before projection or Seed materialization;
+2. projection/source-materialization failure cannot alter accepted history;
+3. Raw, exact/structural edit, undo/redo, remote admission, and source
+   replacement publish one canonical small SourceTransition;
+4. source-equal advance changes authority version without semantic source work;
+5. Seed capture executes after the authority result; and
+6. the existing public `SyncEditor` facade preserves behavior and signatures.
+
+Extract internal authority and projection modules without duplicating mutation
+logic. Keep the old synchronous production path active. Use #1241's canonical
+event representation only if its production contract exists when this commit
+starts; otherwise #1244 relocates the existing authority transition independently
+and does not wait for or redefine #1241's test-only admission evidence.
+
+### Commit 6 — integrate the application-lifetime Adapter behind a comparison flag
+
+**Files:** Projection Adapter shell, chosen executor placement, Loomark
+application/transaction/demand/lifecycle paths, consistency-group views, and
+browser tests.
+
+**Red tests first:**
+
+1. authority receipt and Raw feedback precede any projection result;
+2. Block feedback reaches the next paint target independently from convergence;
+3. Block group never waits for Preview or diagnostics;
+4. split-view group stamps expose temporary lag honestly;
+5. stale source/version, old generation, delayed callback, and disposed results
+   never authorize an edit or reach presentation;
+6. recovery/reopen/replacement/failure starts a fresh generation;
+7. executor failure preserves authority and exits pending explicitly; and
+8. feature-gated in-process and Worker runs preserve normalized behavior.
+
+Replace direct attachment reads with adapter demand only behind a private
+comparison flag. Move semantic attachment ownership into the chosen executor
+session. Retain the old synchronous path for comparative browser evidence; do
+not expose runtime fallback.
+
+### Commit 7 — promotion decision, production cutover, and cleanup
+
+Run 2k/10k/50k release-browser scenarios for cold Seed, local edits at
+start/middle/end, sustained typing, back-to-back Block intent, demand-only
+Preview, split edit, source-equal advance, failure/restart, cutover bursts, and
+100 cutovers with forced GC.
+
+Report separately:
+
+- Raw input→visual echo and authority commit;
+- Block intent→feedback, intent→authority commit, authority commit→current Block;
+- latest authority event→current Preview/diagnostics;
+- maximum contiguous main-thread slice and cumulative input→paint critical path;
+- queue wait, dropped frames, Long Tasks;
+- stage/transport durations, payload/copy counts; and
+- retained executor/parser/source/artifact memory.
+
+Compare in-process, Worker, and current synchronous baselines with
+counterbalanced run order. The promotion record chooses production placement
+and states whether it prioritizes absolute Block latency or main-thread
+isolation. A dedicated Worker is not approved merely because it functions.
+
+Only after promotion gates pass:
+
+1. remove the private comparison flag and unchosen production placement;
+2. delete direct semantic-attachment reads, synchronous projection fields and
+   callbacks, shadow production hooks, and compatibility routes;
+3. keep normalized differential and reducer/property tests;
+4. update Loomark build/development and performance evidence; and
+5. update this plan, the ADR, #1244, and the prior Preview ownership ADR.
+## Validation commands
+
+Run from the Canopy repository root unless a command names a submodule:
+
+```bash
+rtk moon check
+rtk moon test apps/loomark/internal/rabbita
+rtk moon test modules/canopy/editor
+rtk moon test modules/canopy/editor/markdown
+rtk moon test
+rtk moon fmt --check
+rtk ./scripts/test-loomark-dev-host-e2e.sh
+rtk ./scripts/test-loomark-standalone-e2e.sh
+rtk ./scripts/check-documentation-lifecycle.sh
+rtk ./scripts/check-agent-doc-links.sh
+```
+
+Run the paired Warren package tests in `deps/rabbita` before advancing its
+gitlink. Use `moon ide` diagnostics during every MoonBit edit. Inspect generated
+`.mbti` diffs after each Canopy interface change. Run the release browser
+benchmark separately and retain its raw output as evidence rather than making
+machine-specific latency thresholds CI assertions.
+
+## Acceptance criteria
+
+### Authority and correctness
+
+- [ ] Before production authority changes, either #1241 provides a production
+      canonical TextEvent contract or #1244 records and tests its independent
+      relocation of the existing authority transition.
+- [ ] Every accepted operation retains exact causal receipt/history evidence
+      even when projection, persistence, or presentation later fails.
+- [ ] Authority A0/A1 calls no full source/history export, archive preparation,
+      JSON/transfer, parser, projection, semantic, Preview, or DOM work.
+- [ ] Raw, ReplaceSource, Block, undo, redo, remote admission, source-equal,
+      archive failure/reopen, parser recovery, and session replacement publish
+      one canonical small SourceTransition through the authority seam.
+- [ ] Existing `SyncEditor` callers retain behavior and public interface unless
+      an explicitly reviewed interface change is recorded.
+
+### Executor and projection
+
+- [ ] Warren direct and release builds emit and serve one page entry and one
+      inert Worker entry before projection semantics are added.
+- [ ] The normalized protocol and in-process executor pass before the Worker
+      implements projection semantics.
+- [ ] Each executor creates and retains its parser, `incr` runtime, semantic
+      attachment, projection memos, and collection state inside its own
+      Projection Session.
+- [ ] Normalized differential Seed+Advance replay has zero observable
+      differences across the complete corpus.
+- [ ] Production selects only the placement approved by the promotion record and
+      never silently changes placement at runtime.
+- [ ] Pending slot, Advance count, encoded bytes, and retained source/effect
+      bytes remain bounded.
+- [ ] Normal continuous typing does not degenerate to per-edit Seed; a
+      continuity gap or configured bound produces one latest Seed.
+
+### Currentness and lifecycle
+
+- [ ] Generation, sequence, source revision, and causal document version retain
+      their distinct meanings on every work item and consistency-group artifact.
+- [ ] No currentness check relies on source revision alone.
+- [ ] Stale generation, sequence, source, causal version, disposed callback, and
+      counter-wrap cases all fail closed.
+- [ ] Every issued work id has exactly one terminal status.
+- [ ] Block, Preview, and diagnostics adopt independently and atomically within
+      their own consistency group; Preview/diagnostics never delay Block.
+- [ ] Source-equal causal advance may retain display artifacts but cannot apply
+      an intent fenced to the older causal version.
+- [ ] Recovery, archive reopen, session replacement, executor failure, and
+      remount dispose old projection state and reject every late result.
+
+### Product behavior
+
+- [ ] Raw native input remains usable while projection work is blocked.
+- [ ] Block mode exposes a typed, non-destructive pending state and never applies
+      stale structural intent.
+- [ ] Block identity, selection, focus, source maps, diagnostics, Preview output,
+      recovery rendering, escaping, and dangerous-URL rejection preserve their
+      existing observable contracts.
+- [ ] Demand-only Preview/split changes materialize the current source without
+      inventing an authority event.
+- [ ] Existing archive/persistence ordering remains independent of artifact
+      arrival.
+
+### Performance and memory evidence
+
+- [ ] A0–F trace has calibrated known-positive and trace-disabled controls.
+- [ ] 2k/10k/50k release-browser scenarios record raw paired data and all named
+      phase, queue, payload/copy, and consistency-group metrics.
+- [ ] Reports include maximum contiguous main-thread slice, cumulative
+      input-to-paint critical path, dropped frames, Long Tasks, and separate
+      Block feedback/authority/current-group latency.
+- [ ] Continuous and burst typing retain bounded work/memory, avoid per-edit
+      Seed, and catch up to latest source after Worker pauses and cutovers.
+- [ ] Forced-GC cutover tests, calibrated with a positive retention control,
+      show no old executor/session/parser/source/artifact reachable from the
+      current adapter.
+- [ ] No speedup, locality, allocation, or memory claim relies only on a Moon
+      microbenchmark or an uncalibrated clean browser result.
+
+### Cleanup and documentation
+
+- [ ] Direct application semantic-attachment reads and obsolete synchronous
+      projection fields/callbacks are removed.
+- [ ] Shadow production hooks and compatibility routes are removed; the
+      differential oracle corpus remains as test evidence.
+- [ ] Generated interfaces contain only the intended public changes.
+- [ ] Loomark build/development documentation names the selected production
+      placement and any page/Worker assets it requires.
+- [ ] Performance history links raw evidence, environment, compared placements,
+      promotion rationale, and commit SHAs.
+- [ ] This plan's status and the ADR status are updated only after every checked
+      criterion has concrete evidence.
+
+## Risks and stop conditions
+
+1. **Worker cannot host the current reactive parser or loses the measured
+   placement comparison.** Stop Worker promotion; retain the executor seam and
+   evaluate the in-process placement explicitly rather than emulating
+   concurrency or adding runtime fallback.
+2. **Warren multi-entry support requires a generic interface that harms other
+   apps.** Re-run the deletion test and design the build seam twice before
+   changing Warren's public CLI.
+3. **Seed storms erase incrementality.** Stop production cutover if the bounded
+   queue cannot catch up after the typing burst or if Seed/Advance evidence shows
+   no steady-state reuse.
+4. **Portable artifacts duplicate the whole document several times.** Measure
+   payload ownership and redesign the artifact before application integration;
+   do not hide copies behind helper modules.
+5. **Block pending behavior breaks editing expectations.** The pending contract
+   is part of Gate 0 browser validation. Do not weaken source/version fences to
+   make the UI appear responsive.
+6. **Authority still materializes full source or history in A0/A1.** Stop and
+   move materialization behind B; naming the cost "source publication" does not
+   satisfy the invariant.
+7. **DOM reconciliation remains the dominant long task.** Record the result and
+   address the presentation module in the same issue when it violates the
+   calibrated promotion gate; do not claim success from Worker isolation alone.
+8. **A case falls outside the state machine.** Stop implementation and amend the
+   decision/plan before adding an ad-hoc branch.
+
+## Completion record
+
+When implementation completes:
+
+1. mark this plan `Status: Complete` only after every applicable acceptance box
+   is checked with evidence;
+2. add the implementation PR, paired Warren PR, final SHAs, benchmark artifact,
+   and CI links here;
+3. update the ADR from "implementation is not complete" to `Accepted` and record
+   any measured qualification;
+4. move this plan to `docs/archive/` only if active guidance no longer needs it;
+5. update `docs/README.md` for any move; and
+6. close #1244 with the exact evidence links.

--- a/docs/plans/2026-08-12-loomark-concurrent-projection-execution.md
+++ b/docs/plans/2026-08-12-loomark-concurrent-projection-execution.md
@@ -85,7 +85,7 @@ therefore starts with an evidence gate and stops if that gate fails.
 | Path | Current owner and evidence | Required change |
 |---|---|---|
 | Raw input | `application.mbt` routes `RawInput`; `raw_selection_transaction.mbt` normalizes it; `document_transaction.mbt` commits it. | Authority commit returns before projection; native input remains responsive while a bundle is pending. |
-| ReplaceSource | `ApplicationEvent::RequestCanonicalSource` reaches the same shared commit shell and commits `MarkdownEditRequest::ReplaceSource` through the current editor. | Treat it as one authority mutation, not authority/session replacement. Publish `SourceUnchanged` when the accepted mutation preserves source; otherwise publish a replayable Advance when its source transition is available without adding full-source work to A0/A1. If neither portable result is safely available, invalidate the projection generation and recover from a coherent Seed. |
+| ReplaceSource | `ApplicationEvent::RequestCanonicalSource` reaches the same shared commit shell and commits `MarkdownEditRequest::ReplaceSource` through the current editor. | Treat it as one authority mutation, not authority/session replacement. Publish `SourceUnchanged` when the accepted mutation preserves source; otherwise publish a replayable Advance when its source transition is available without adding full-source work to A0/A1.<br>If neither portable result is safely available, invalidate the projection generation and recover from a coherent Seed. |
 | Block structural edit | `BlockInput` resolves against current Block/source-map state before `commit_edit_request`. | Resolve only against a stamped immutable Block artifact; apply only under the exact causal-version fence. |
 | Undo/redo | `SyncEditor` currently owns `UndoManager`, text authority, parser, and projection in one struct. | Extract authority and projection responsibilities without changing existing public `SyncEditor` behavior during the refactor commit. |
 | Remote admission | Production Loomark does not yet have a proven canonical admission route. | Consume #1241's contract if it exists; otherwise relocate only the existing accepted transition without redefining canonical admission. |
@@ -396,7 +396,8 @@ property/differential tests.
    reset across generation replacement; source revision never acts as the sole
    currentness check;
 3. source-equal causal advance keeps source revision, advances sequence/version,
-   carries display artifacts, and rejects old Block intent;
+   reuses display payloads only by publishing or wrapping them under the new
+   projection stamp, and rejects old Block intent;
 4. pending Advance count/bytes/source-effect bytes remain within configured
    bounds under arbitrary message/result interleavings;
 5. continuity uses Advance; a gap or exceeded bound issues one latest Seed;
@@ -651,8 +652,9 @@ assertions.
       their own consistency group; Preview/diagnostics never delay Block.
 - [ ] Equal group, normalized stamp, and relevant non-authority policy inputs
       imply equivalent normalized observable payload.
-- [ ] Source-equal causal advance may retain display artifacts but cannot apply
-      an intent fenced to the older causal version.
+- [ ] Source-equal causal advance may reuse artifact payloads under a new
+      projection stamp but cannot apply an intent fenced to the older causal
+      version.
 - [ ] Recovery, archive reopen, session replacement, executor failure, and
       remount dispose old projection state and reject every late result.
 


### PR DESCRIPTION
## Summary
- record the asynchronous source-stamped projection decision
- define the evidence-gated implementation plan for #1244
- add projection execution vocabulary and Preview ownership supersession links

## Validation
- ./scripts/check-documentation-lifecycle.sh
- ./scripts/check-agent-doc-links.sh
- relative Markdown link check
- independent opencode-go/qwen3.7-plus review: PASS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added glossary definitions for projection execution, generations, stamps, and immutable artifact bundles.
  - Documented the accepted architecture for asynchronous, source-stamped projection execution.
  - Added an active implementation plan covering scheduling, consistency, failure handling, validation, observability, and rollout criteria.
  - Updated the documentation index and related decision records with links, architectural context, and current implementation status.
  - Clarified how projection results remain consistent, traceable, and safely adopted as the implementation evolves.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->