### PR TITLE
feat(ideal): add interactive Incr spatial canvas

### DIFF
--- a/apps/ideal/main/incr_canvas_state.mbt
+++ b/apps/ideal/main/incr_canvas_state.mbt
@@ -1,0 +1,309 @@
+///|
+const INCR_CANVAS_NODE_WIDTH : Double = 150.0
+
+///|
+const INCR_CANVAS_NODE_HEIGHT : Double = 44.0
+
+///|
+const INCR_CANVAS_GRID_COLUMNS : Int = 4
+
+///|
+const INCR_CANVAS_GRID_X : Double = 190.0
+
+///|
+const INCR_CANVAS_GRID_Y : Double = 90.0
+
+///|
+const INCR_CANVAS_ORIGIN_X : Double = 260.0
+
+///|
+const INCR_CANVAS_ORIGIN_Y : Double = 42.0
+
+///|
+const INCR_CANVAS_MIN_SCALE : Double = 0.25
+
+///|
+const INCR_CANVAS_MAX_SCALE : Double = 4.0
+
+///|
+struct IncrCanvasState {
+  viewport : @spatial.Viewport
+  panning : @spatial.Pan?
+  dragging : @spatial.Drag[@incr.CellId]?
+  positions : Map[@incr.CellId, @spatial.WorldPoint]
+  selected : Array[@incr.CellId]
+  snapshot_key : (Int, Int, Int)
+  active_pointer_id : Int?
+} derive(Eq)
+
+///|
+fn IncrCanvasState::empty() -> IncrCanvasState {
+  let origin = try! @spatial.ScreenPoint::from_xy(
+    x=INCR_CANVAS_ORIGIN_X,
+    y=INCR_CANVAS_ORIGIN_Y,
+  )
+  let scale = try! @spatial.Scale::from_double(value=1.0)
+  {
+    viewport: @spatial.Viewport::from_scale(origin~, scale~),
+    panning: None,
+    dragging: None,
+    positions: Map([]),
+    selected: [],
+    snapshot_key: (-1, -1, -1),
+    active_pointer_id: None,
+  }
+}
+
+///|
+fn incr_canvas_initial_position(index : Int) -> @spatial.WorldPoint {
+  let column = index % INCR_CANVAS_GRID_COLUMNS
+  let row = index / INCR_CANVAS_GRID_COLUMNS
+  try! @spatial.WorldPoint::from_xy(
+    x=column.to_double() * INCR_CANVAS_GRID_X,
+    y=row.to_double() * INCR_CANVAS_GRID_Y,
+  )
+}
+
+///|
+/// Reconcile local layout against the live CellId frontier.
+///
+/// Existing positions are intentionally retained by identity. New cells use a
+/// deterministic grid position, while cells absent from the frontier are
+/// removed from the local layout.
+fn reconcile_incr_positions(
+  nodes : Array[@incr.CellId],
+  existing : Map[@incr.CellId, @spatial.WorldPoint],
+) -> Map[@incr.CellId, @spatial.WorldPoint] {
+  let positions : Map[@incr.CellId, @spatial.WorldPoint] = Map([])
+  for index, id in nodes {
+    let point = existing
+      .get(id)
+      .unwrap_or_else(() => incr_canvas_initial_position(index))
+    positions[id] = point
+  }
+  positions
+}
+
+///|
+fn reconcile_incr_selection(
+  selected : Array[@incr.CellId],
+  nodes : Array[@incr.CellId],
+) -> Array[@incr.CellId] {
+  let live : Set[@incr.CellId] = Set(nodes[:])
+  selected.filter(id => live.contains(id))
+}
+
+///|
+fn reconcile_incr_canvas(
+  state : IncrCanvasState,
+  snapshot : @visualizer.RecomputeSnapshot,
+) -> IncrCanvasState {
+  let nodes = snapshot.nodes.map(node => node.id)
+  {
+    ..state,
+    panning: None,
+    dragging: None,
+    positions: reconcile_incr_positions(nodes, state.positions),
+    selected: reconcile_incr_selection(state.selected, nodes),
+    active_pointer_id: None,
+  }
+}
+
+///|
+fn incr_canvas_world_positions(
+  state : IncrCanvasState,
+) -> Array[@spatial.ItemPosition[@incr.CellId]] {
+  state.selected.filter_map(id => {
+    state.positions
+    .get(id)
+    .map(point => @spatial.ItemPosition::from_id_and_point(id~, point~))
+  })
+}
+
+///|
+fn incr_canvas_screen_point(x : Double, y : Double) -> @spatial.ScreenPoint? {
+  try @spatial.ScreenPoint::from_xy(x~, y~) catch {
+    @spatial.CoordinateError::NonFinite => None
+  } noraise {
+    point => Some(point)
+  }
+}
+
+///|
+fn incr_canvas_node_contains(
+  state : IncrCanvasState,
+  id : @incr.CellId,
+  screen : @spatial.ScreenPoint,
+) -> Bool {
+  match state.positions.get(id) {
+    Some(world) => {
+      let center = state.viewport.world_to_screen(world) catch {
+        @spatial.CoordinateError::NonFinite => return false
+      }
+      (screen.x() - center.x()).abs() <= INCR_CANVAS_NODE_WIDTH / 2.0 &&
+      (screen.y() - center.y()).abs() <= INCR_CANVAS_NODE_HEIGHT / 2.0
+    }
+    None => false
+  }
+}
+
+///|
+fn incr_canvas_hit_test(
+  state : IncrCanvasState,
+  snapshot : @visualizer.RecomputeSnapshot,
+  screen : @spatial.ScreenPoint,
+) -> @incr.CellId? {
+  let nodes = snapshot.nodes.rev()
+  nodes
+  .search_by(node => incr_canvas_node_contains(state, node.id, screen))
+  .map(index => nodes[index].id)
+}
+
+///|
+fn incr_canvas_pointer_admitted(
+  state : IncrCanvasState,
+  pointer_id : Int?,
+) -> Bool {
+  state.active_pointer_id is None && pointer_id is Some(_)
+}
+
+///|
+fn incr_canvas_pointer_down(
+  state : IncrCanvasState,
+  snapshot : @visualizer.RecomputeSnapshot,
+  x : Double,
+  y : Double,
+  pointer_id : Int?,
+) -> IncrCanvasState {
+  guard incr_canvas_pointer_admitted(state, pointer_id) else { return state }
+  let screen = match incr_canvas_screen_point(x, y) {
+    Some(point) => point
+    None => return state
+  }
+  match incr_canvas_hit_test(state, snapshot, screen) {
+    Some(id) => {
+      let selected = if state.selected.contains(id) {
+        state.selected
+      } else {
+        [id]
+      }
+      let positions = { ..state, selected, }
+      let items = incr_canvas_world_positions(positions)
+      guard items.length() > 0 else { return state }
+      let world = state.viewport.screen_to_world(screen) catch {
+        @spatial.CoordinateError::NonFinite => return state
+      }
+      let drag = @spatial.Drag::start(
+        positions=ReadOnlyArray::from_array(items[:]),
+        pointer=world,
+      )
+      {
+        ..positions,
+        panning: None,
+        dragging: Some(drag),
+        active_pointer_id: pointer_id,
+      }
+    }
+    None =>
+      {
+        ..state,
+        selected: [],
+        panning: Some(
+          @spatial.Pan::start(viewport=state.viewport, pointer=screen),
+        ),
+        dragging: None,
+        active_pointer_id: pointer_id,
+      }
+  }
+}
+
+///|
+fn incr_canvas_pointer_move(
+  state : IncrCanvasState,
+  x : Double,
+  y : Double,
+  pointer_id : Int?,
+) -> IncrCanvasState {
+  guard state.active_pointer_id == pointer_id else { return state }
+  let screen = match incr_canvas_screen_point(x, y) {
+    Some(point) => point
+    None => return state
+  }
+  match (state.dragging, state.panning) {
+    (Some(drag), _) => {
+      let world = state.viewport.screen_to_world(screen) catch {
+        @spatial.CoordinateError::NonFinite => return state
+      }
+      let moved = drag.positions_at(world) catch {
+        @spatial.CoordinateError::NonFinite => return state
+      }
+      let positions = state.positions.copy()
+      for item in moved {
+        positions[item.id] = item.point
+      }
+      { ..state, positions, }
+    }
+    (None, Some(pan)) => {
+      let viewport = pan.viewport_at(screen) catch {
+        @spatial.CoordinateError::NonFinite => return state
+      }
+      { ..state, viewport, }
+    }
+    (None, None) => state
+  }
+}
+
+///|
+fn incr_canvas_pointer_up(
+  state : IncrCanvasState,
+  pointer_id : Int?,
+) -> IncrCanvasState {
+  guard state.active_pointer_id == pointer_id else { return state }
+  { ..state, panning: None, dragging: None, active_pointer_id: None }
+}
+
+///|
+fn incr_canvas_capture_lost(state : IncrCanvasState) -> IncrCanvasState {
+  { ..state, panning: None, dragging: None, active_pointer_id: None }
+}
+
+///|
+fn incr_canvas_capture_lost_for_pointer(
+  state : IncrCanvasState,
+  pointer_id : Int?,
+) -> IncrCanvasState {
+  guard state.active_pointer_id == pointer_id else { return state }
+  incr_canvas_capture_lost(state)
+}
+
+///|
+fn incr_canvas_zoom(
+  state : IncrCanvasState,
+  delta : Double,
+  x : Double,
+  y : Double,
+) -> IncrCanvasState {
+  guard !delta.is_nan() && !delta.is_inf() && delta != 0.0 else { return state }
+  let anchor = match incr_canvas_screen_point(x, y) {
+    Some(point) => point
+    None => return state
+  }
+  let current = state.viewport.scale().to_double()
+  let factor = if delta < 0.0 { 1.1 } else { 0.9 }
+  let next = current * factor
+  let bounded = if next < INCR_CANVAS_MIN_SCALE {
+    INCR_CANVAS_MIN_SCALE
+  } else if next > INCR_CANVAS_MAX_SCALE {
+    INCR_CANVAS_MAX_SCALE
+  } else {
+    next
+  }
+  let scale = @spatial.Scale::from_double(value=bounded) catch {
+    @spatial.ScaleError::NonFinite | @spatial.ScaleError::NonPositive =>
+      return state
+  }
+  let viewport = state.viewport.with_scale_around(anchor~, absolute_scale=scale) catch {
+    @spatial.CoordinateError::NonFinite => return state
+  }
+  { ..state, viewport, }
+}

--- a/apps/ideal/main/incr_canvas_state.mbt
+++ b/apps/ideal/main/incr_canvas_state.mbt
@@ -65,21 +65,43 @@ fn incr_canvas_initial_position(index : Int) -> @spatial.WorldPoint {
 }
 
 ///|
+/// Find the first deterministic grid slot not already occupied by a live
+/// node. Starting at the node's frontier index keeps stable layouts compact
+/// while avoiding overlaps after remove/add transitions.
+fn incr_canvas_free_initial_position(
+  index : Int,
+  occupied : Array[@spatial.WorldPoint],
+) -> @spatial.WorldPoint {
+  let mut slot = index
+  while occupied.contains(incr_canvas_initial_position(slot)) {
+    slot += 1
+  }
+  incr_canvas_initial_position(slot)
+}
+
+///|
 /// Reconcile local layout against the live CellId frontier.
 ///
 /// Existing positions are intentionally retained by identity. New cells use a
-/// deterministic grid position, while cells absent from the frontier are
-/// removed from the local layout.
+/// deterministic unoccupied grid position, while cells absent from the
+/// frontier are removed from the local layout.
 fn reconcile_incr_positions(
   nodes : Array[@incr.CellId],
   existing : Map[@incr.CellId, @spatial.WorldPoint],
 ) -> Map[@incr.CellId, @spatial.WorldPoint] {
   let positions : Map[@incr.CellId, @spatial.WorldPoint] = Map([])
+  let occupied : Array[@spatial.WorldPoint] = nodes.filter_map(id => {
+    existing.get(id)
+  })
   for index, id in nodes {
-    let point = existing
-      .get(id)
-      .unwrap_or_else(() => incr_canvas_initial_position(index))
-    positions[id] = point
+    match existing.get(id) {
+      Some(point) => positions[id] = point
+      None => {
+        let point = incr_canvas_free_initial_position(index, occupied)
+        positions[id] = point
+        occupied.push(point)
+      }
+    }
   }
   positions
 }

--- a/apps/ideal/main/incr_canvas_state.mbt
+++ b/apps/ideal/main/incr_canvas_state.mbt
@@ -32,7 +32,7 @@ struct IncrCanvasState {
   dragging : @spatial.Drag[@incr.CellId]?
   positions : Map[@incr.CellId, @spatial.WorldPoint]
   selected : Array[@incr.CellId]
-  snapshot_key : (Int, Int, Int)
+  live_cells : Set[@incr.CellId]
   active_pointer_id : Int?
 } derive(Eq)
 
@@ -49,7 +49,7 @@ fn IncrCanvasState::empty() -> IncrCanvasState {
     dragging: None,
     positions: Map([]),
     selected: [],
-    snapshot_key: (-1, -1, -1),
+    live_cells: Set([]),
     active_pointer_id: None,
   }
 }
@@ -116,6 +116,13 @@ fn reconcile_incr_selection(
 }
 
 ///|
+fn incr_canvas_live_cells(
+  snapshot : @visualizer.RecomputeSnapshot,
+) -> Set[@incr.CellId] {
+  Set(snapshot.nodes.map(node => node.id)[:])
+}
+
+///|
 fn reconcile_incr_canvas(
   state : IncrCanvasState,
   snapshot : @visualizer.RecomputeSnapshot,
@@ -127,8 +134,22 @@ fn reconcile_incr_canvas(
     dragging: None,
     positions: reconcile_incr_positions(nodes, state.positions),
     selected: reconcile_incr_selection(state.selected, nodes),
+    live_cells: incr_canvas_live_cells(snapshot),
     active_pointer_id: None,
   }
+}
+
+///|
+/// Reconcile only when the live snapshot membership changes. Causal editor
+/// revisions are intentionally not consulted: the Incr runtime can add or
+/// remove cells without changing the editor's CRDT snapshot.
+fn sync_incr_canvas_state(
+  state : IncrCanvasState,
+  snapshot : @visualizer.RecomputeSnapshot,
+) -> IncrCanvasState {
+  let live_cells = incr_canvas_live_cells(snapshot)
+  guard !Set::equal(live_cells, state.live_cells) else { return state }
+  reconcile_incr_canvas(state, snapshot)
 }
 
 ///|

--- a/apps/ideal/main/incr_canvas_state.mbt
+++ b/apps/ideal/main/incr_canvas_state.mbt
@@ -26,6 +26,9 @@ const INCR_CANVAS_MIN_SCALE : Double = 0.25
 const INCR_CANVAS_MAX_SCALE : Double = 4.0
 
 ///|
+const INCR_CANVAS_ZOOM_FACTOR : Double = 1.1
+
+///|
 struct IncrCanvasState {
   viewport : @spatial.Viewport
   panning : @spatial.Pan?
@@ -203,6 +206,17 @@ fn incr_canvas_hit_test(
 }
 
 ///|
+fn incr_canvas_pointer_claim_matches(
+  claimed_id : String?,
+  pointer_id : Int?,
+) -> Bool {
+  match (claimed_id, pointer_id) {
+    (Some(claimed), Some(pointer)) => claimed == pointer.to_string()
+    _ => false
+  }
+}
+
+///|
 fn incr_canvas_pointer_admitted(
   state : IncrCanvasState,
   pointer_id : Int?,
@@ -332,7 +346,11 @@ fn incr_canvas_zoom(
     None => return state
   }
   let current = state.viewport.scale().to_double()
-  let factor = if delta < 0.0 { 1.1 } else { 0.9 }
+  let factor = if delta < 0.0 {
+    INCR_CANVAS_ZOOM_FACTOR
+  } else {
+    1.0 / INCR_CANVAS_ZOOM_FACTOR
+  }
   let next = current * factor
   let bounded = if next < INCR_CANVAS_MIN_SCALE {
     INCR_CANVAS_MIN_SCALE

--- a/apps/ideal/main/incr_canvas_update.mbt
+++ b/apps/ideal/main/incr_canvas_update.mbt
@@ -1,0 +1,44 @@
+///|
+fn sync_incr_canvas(model : Model) -> Model {
+  let key = render_cache_key(
+    model.editor.identity(),
+    model.editor.causal_snapshot(),
+  )
+  guard key != model.incr_canvas.snapshot_key else { return model }
+  let snapshot = model.incr_tap.snapshot()
+  let canvas = reconcile_incr_canvas(model.incr_canvas, snapshot)
+  { ..model, incr_canvas: { ..canvas, snapshot_key: key } }
+}
+
+///|
+fn handle_incr_canvas(
+  emit : Emit[Msg],
+  msg : Msg,
+  model : Model,
+) -> (Cmd, Model)? {
+  let _ = emit
+  match msg {
+    IncrCanvas(canvas_msg) => {
+      let current = sync_incr_canvas(model)
+      let state = match canvas_msg {
+        PointerDown(x, y, pointer_id) =>
+          incr_canvas_pointer_down(
+            current.incr_canvas,
+            current.incr_tap.snapshot(),
+            x,
+            y,
+            pointer_id,
+          )
+        PointerMove(x, y, pointer_id) =>
+          incr_canvas_pointer_move(current.incr_canvas, x, y, pointer_id)
+        PointerUp(pointer_id) | PointerCancel(pointer_id) =>
+          incr_canvas_pointer_up(current.incr_canvas, pointer_id)
+        CaptureLost(pointer_id) =>
+          incr_canvas_capture_lost_for_pointer(current.incr_canvas, pointer_id)
+        Wheel(delta, x, y) => incr_canvas_zoom(current.incr_canvas, delta, x, y)
+      }
+      Some((none, { ..current, incr_canvas: state }))
+    }
+    _ => None
+  }
+}

--- a/apps/ideal/main/incr_canvas_update.mbt
+++ b/apps/ideal/main/incr_canvas_update.mbt
@@ -1,13 +1,8 @@
 ///|
 fn sync_incr_canvas(model : Model) -> Model {
-  let key = render_cache_key(
-    model.editor.identity(),
-    model.editor.causal_snapshot(),
-  )
-  guard key != model.incr_canvas.snapshot_key else { return model }
   let snapshot = model.incr_tap.snapshot()
-  let canvas = reconcile_incr_canvas(model.incr_canvas, snapshot)
-  { ..model, incr_canvas: { ..canvas, snapshot_key: key } }
+  let canvas = sync_incr_canvas_state(model.incr_canvas, snapshot)
+  { ..model, incr_canvas: canvas }
 }
 
 ///|

--- a/apps/ideal/main/incr_canvas_wbtest.mbt
+++ b/apps/ideal/main/incr_canvas_wbtest.mbt
@@ -66,6 +66,23 @@ test "incr canvas reconciliation preserves, adds, and removes local layout" {
 }
 
 ///|
+test "incr canvas reconciliation avoids retained-position overlap" {
+  let first = test_cell(1, 1)
+  let second = test_cell(1, 2)
+  let added = test_cell(1, 3)
+  let existing = Map([
+    (first, incr_canvas_initial_position(0)),
+    (second, incr_canvas_initial_position(1)),
+  ])
+  let next = reconcile_incr_positions([second, added], existing)
+  assert_eq(next.get(second), Some(incr_canvas_initial_position(1)))
+  assert_eq(next.get(added), Some(incr_canvas_initial_position(2)))
+  let reverse = reconcile_incr_positions([added, first], existing)
+  assert_eq(reverse.get(first), Some(incr_canvas_initial_position(0)))
+  assert_eq(reverse.get(added), Some(incr_canvas_initial_position(1)))
+}
+
+///|
 test "incr canvas pointer movement rejects non-finite geometry" {
   let id = test_cell(2, 1)
   let point = test_world(10.0, 20.0)

--- a/apps/ideal/main/incr_canvas_wbtest.mbt
+++ b/apps/ideal/main/incr_canvas_wbtest.mbt
@@ -217,6 +217,14 @@ test "incr canvas pointer identity gates gestures and zero wheel is a no-op" {
 }
 
 ///|
+test "incr canvas DOM claim gates pointer messages" {
+  assert_true(incr_canvas_pointer_claim_matches(Some("7"), Some(7)))
+  assert_false(incr_canvas_pointer_claim_matches(Some("7"), Some(8)))
+  assert_false(incr_canvas_pointer_claim_matches(None, Some(7)))
+  assert_false(incr_canvas_pointer_claim_matches(Some("7"), None))
+}
+
+///|
 test "incr canvas pointer admission rejects unknown and secondary pointers" {
   let empty = IncrCanvasState::empty()
   assert_true(incr_canvas_pointer_admitted(empty, Some(1)))
@@ -236,6 +244,11 @@ test "incr canvas zoom preserves the screen anchor and rejects invalid input" {
   let projected = try! changed.viewport.world_to_screen(world_at_anchor)
   incr_canvas_assert_close(projected.x(), anchor.x())
   incr_canvas_assert_close(projected.y(), anchor.y())
+  let returned = incr_canvas_zoom(changed, 1.0, anchor.x(), anchor.y())
+  incr_canvas_assert_close(
+    returned.viewport.scale().to_double(),
+    state.viewport.scale().to_double(),
+  )
   assert_incr_canvas_state_eq(
     incr_canvas_zoom(state, 0.0 / 0.0, 0.0, 0.0),
     state,

--- a/apps/ideal/main/incr_canvas_wbtest.mbt
+++ b/apps/ideal/main/incr_canvas_wbtest.mbt
@@ -1,0 +1,201 @@
+///|
+fn test_cell(runtime_id : Int, id : Int) -> @incr.CellId {
+  @incr.CellId::{ runtime_id: @incr.RuntimeId(runtime_id), id }
+}
+
+///|
+fn test_world(x : Double, y : Double) -> @spatial.WorldPoint {
+  try! @spatial.WorldPoint::from_xy(x~, y~)
+}
+
+///|
+fn test_screen(x : Double, y : Double) -> @spatial.ScreenPoint {
+  try! @spatial.ScreenPoint::from_xy(x~, y~)
+}
+
+///|
+fn incr_canvas_assert_close(actual : Double, expected : Double) -> Unit raise {
+  assert_true(
+    actual.is_close(
+      expected,
+      relative_tolerance=1.0e-10,
+      absolute_tolerance=1.0e-10,
+    ),
+  )
+}
+
+///|
+fn assert_incr_canvas_state_eq(
+  actual : IncrCanvasState,
+  expected : IncrCanvasState,
+) -> Unit raise {
+  assert_true(actual.viewport == expected.viewport)
+  assert_true(actual.panning == expected.panning)
+  assert_true(actual.dragging == expected.dragging)
+  assert_true(actual.positions == expected.positions)
+  assert_true(actual.selected == expected.selected)
+  assert_true(actual.snapshot_key == expected.snapshot_key)
+  assert_true(actual.active_pointer_id == expected.active_pointer_id)
+}
+
+///|
+fn incr_canvas_test_viewport(
+  x : Double,
+  y : Double,
+  scale_value : Double,
+) -> @spatial.Viewport {
+  let origin = test_screen(x, y)
+  let scale = try! @spatial.Scale::from_double(value=scale_value)
+  @spatial.Viewport::from_scale(origin~, scale~)
+}
+
+///|
+test "incr canvas reconciliation preserves, adds, and removes local layout" {
+  let first = test_cell(1, 1)
+  let second = test_cell(1, 2)
+  let removed = test_cell(1, 3)
+  let existing = Map([
+    (first, test_world(42.0, 9.0)),
+    (removed, test_world(99.0, 99.0)),
+  ])
+  let next = reconcile_incr_positions([first, second], existing)
+  assert_eq(next.get(first), Some(test_world(42.0, 9.0)))
+  assert_true(next.get(second) is Some(_))
+  assert_eq(next.get(removed), None)
+  assert_eq(reconcile_incr_positions([first, second], existing), next)
+}
+
+///|
+test "incr canvas pointer movement rejects non-finite geometry" {
+  let id = test_cell(2, 1)
+  let point = test_world(10.0, 20.0)
+  let pointer = test_world(0.0, 0.0)
+  let drag = @spatial.Drag::start(
+    positions=[@spatial.ItemPosition::from_id_and_point(id~, point~)],
+    pointer~,
+  )
+  let state = {
+    ..IncrCanvasState::empty(),
+    positions: Map([(id, point)]),
+    selected: [id],
+    dragging: Some(drag),
+    active_pointer_id: Some(1),
+  }
+  let invalid_nan = incr_canvas_pointer_move(state, 0.0 / 0.0, 0.0, Some(1))
+  let invalid_infinity = incr_canvas_pointer_move(
+    state,
+    1.0 / 0.0,
+    0.0,
+    Some(1),
+  )
+  assert_incr_canvas_state_eq(invalid_nan, state)
+  assert_incr_canvas_state_eq(invalid_infinity, state)
+}
+
+///|
+test "incr canvas drag is independent of intermediate pointer moves" {
+  let id = test_cell(3, 1)
+  let point = test_world(10.0, 20.0)
+  let pointer = test_world(4.0, 8.0)
+  let drag = @spatial.Drag::start(
+    positions=[@spatial.ItemPosition::from_id_and_point(id~, point~)],
+    pointer~,
+  )
+  let state = {
+    ..IncrCanvasState::empty(),
+    viewport: incr_canvas_test_viewport(0.0, 0.0, 1.0),
+    positions: Map([(id, point)]),
+    selected: [id],
+    dragging: Some(drag),
+    active_pointer_id: Some(1),
+  }
+  let direct = incr_canvas_pointer_move(state, 20.0, 30.0, Some(1))
+  let via_middle = incr_canvas_pointer_move(
+    incr_canvas_pointer_move(state, 12.0, 18.0, Some(1)),
+    20.0,
+    30.0,
+    Some(1),
+  )
+  assert_eq(direct.positions, via_middle.positions)
+  assert_eq(direct.positions.get(id), Some(test_world(26.0, 42.0)))
+}
+
+///|
+test "incr canvas pan is independent of intermediate pointer moves" {
+  let start = test_screen(20.0, 30.0)
+  let middle = test_screen(75.0, -10.0)
+  let end = test_screen(160.0, 85.0)
+  let viewport = incr_canvas_test_viewport(400.0, -120.0, 2.0)
+  let state = {
+    ..IncrCanvasState::empty(),
+    viewport,
+    panning: Some(@spatial.Pan::start(viewport~, pointer=start)),
+    active_pointer_id: Some(1),
+  }
+  let direct = incr_canvas_pointer_move(state, end.x(), end.y(), Some(1))
+  let via_middle = incr_canvas_pointer_move(
+    incr_canvas_pointer_move(state, middle.x(), middle.y(), Some(1)),
+    end.x(),
+    end.y(),
+    Some(1),
+  )
+  assert_eq(direct.viewport, via_middle.viewport)
+}
+
+///|
+test "incr canvas pointer identity gates gestures and zero wheel is a no-op" {
+  let viewport = incr_canvas_test_viewport(0.0, 0.0, 1.0)
+  let state = {
+    ..IncrCanvasState::empty(),
+    viewport,
+    active_pointer_id: Some(7),
+  }
+  assert_incr_canvas_state_eq(
+    incr_canvas_pointer_move(state, 20.0, 30.0, Some(8)),
+    state,
+  )
+  assert_incr_canvas_state_eq(incr_canvas_pointer_up(state, Some(8)), state)
+  let released = incr_canvas_pointer_up(state, Some(7))
+  assert_true(released.active_pointer_id is None)
+  let lost = incr_canvas_capture_lost(state)
+  assert_true(lost.active_pointer_id is None)
+  assert_incr_canvas_state_eq(
+    incr_canvas_capture_lost_for_pointer(state, Some(8)),
+    state,
+  )
+  assert_incr_canvas_state_eq(
+    incr_canvas_capture_lost_for_pointer(state, Some(7)),
+    lost,
+  )
+  assert_incr_canvas_state_eq(incr_canvas_zoom(state, 0.0, 10.0, 10.0), state)
+}
+
+///|
+test "incr canvas pointer admission rejects unknown and secondary pointers" {
+  let empty = IncrCanvasState::empty()
+  assert_true(incr_canvas_pointer_admitted(empty, Some(1)))
+  assert_false(incr_canvas_pointer_admitted(empty, None))
+  let active = { ..empty, active_pointer_id: Some(1) }
+  assert_false(incr_canvas_pointer_admitted(active, Some(2)))
+  assert_false(incr_canvas_pointer_admitted(active, Some(1)))
+}
+
+///|
+test "incr canvas zoom preserves the screen anchor and rejects invalid input" {
+  let viewport = incr_canvas_test_viewport(100.0, -20.0, 0.75)
+  let state = { ..IncrCanvasState::empty(), viewport, }
+  let anchor = test_screen(310.0, 145.0)
+  let world_at_anchor = try! viewport.screen_to_world(anchor)
+  let changed = incr_canvas_zoom(state, -1.0, anchor.x(), anchor.y())
+  let projected = try! changed.viewport.world_to_screen(world_at_anchor)
+  incr_canvas_assert_close(projected.x(), anchor.x())
+  incr_canvas_assert_close(projected.y(), anchor.y())
+  assert_incr_canvas_state_eq(
+    incr_canvas_zoom(state, 0.0 / 0.0, 0.0, 0.0),
+    state,
+  )
+  assert_incr_canvas_state_eq(
+    incr_canvas_zoom(state, 1.0, 1.0 / 0.0, 0.0),
+    state,
+  )
+}

--- a/apps/ideal/main/incr_canvas_wbtest.mbt
+++ b/apps/ideal/main/incr_canvas_wbtest.mbt
@@ -34,7 +34,7 @@ fn assert_incr_canvas_state_eq(
   assert_true(actual.dragging == expected.dragging)
   assert_true(actual.positions == expected.positions)
   assert_true(actual.selected == expected.selected)
-  assert_true(actual.snapshot_key == expected.snapshot_key)
+  assert_true(Set::equal(actual.live_cells, expected.live_cells))
   assert_true(actual.active_pointer_id == expected.active_pointer_id)
 }
 
@@ -80,6 +80,35 @@ test "incr canvas reconciliation avoids retained-position overlap" {
   let reverse = reconcile_incr_positions([added, first], existing)
   assert_eq(reverse.get(first), Some(incr_canvas_initial_position(0)))
   assert_eq(reverse.get(added), Some(incr_canvas_initial_position(1)))
+}
+
+///|
+test "incr canvas sync follows live snapshot membership" {
+  let runtime = @incr.Runtime()
+  let source = @incr.Input(runtime, 1, label="source")
+  let first = @incr.Derived(runtime, () => source.get() + 1, label="first")
+  let tap = @visualizer.RecomputeTap::attach(runtime)
+  ignore(first.read_or_abort())
+  let first_state = sync_incr_canvas_state(
+    IncrCanvasState::empty(),
+    tap.snapshot(),
+  )
+  let first_position = first_state.positions.get(first.id())
+
+  // The editor's causal snapshot is unchanged in this test; only the live
+  // RecomputeSnapshot frontier changes.
+  let second = @incr.Derived(runtime, () => source.get() + 2, label="second")
+  ignore(second.read_or_abort())
+  let expanded = sync_incr_canvas_state(first_state, tap.snapshot())
+  assert_true(expanded.live_cells.contains(second.id()))
+  assert_eq(expanded.positions.get(first.id()), first_position)
+  assert_true(expanded.positions.get(second.id()) is Some(_))
+
+  second.dispose()
+  let contracted = sync_incr_canvas_state(expanded, tap.snapshot())
+  assert_eq(contracted.positions.get(second.id()), None)
+  assert_eq(contracted.positions.get(first.id()), first_position)
+  tap.detach()
 }
 
 ///|

--- a/apps/ideal/main/init.mbt
+++ b/apps/ideal/main/init.mbt
@@ -67,6 +67,7 @@ fn init_model() -> Model raise {
     intent_log: [],
     patch_log: [],
     incr_tap,
+    incr_canvas: IncrCanvasState::empty(),
   }
 }
 
@@ -94,6 +95,7 @@ fn root_init(emit : Emit[Msg]) -> (RootState, Cmd) {
   let model = init_model() catch {
     _ => abort("Ideal editor initialization failed")
   }
+  let model = sync_incr_canvas(model)
   (RootState(model, 0), cm_mount_cmd(emit, model))
 }
 
@@ -106,6 +108,7 @@ fn root_update(
   let (cmd, model) = update(emit, msg, state.0) catch {
     _ => (none, { ..state.0, sync_status: Error })
   }
+  let model = sync_incr_canvas(model)
   (RootState(model, next_root_revision(state.1)), cmd)
 }
 

--- a/apps/ideal/main/model.mbt
+++ b/apps/ideal/main/model.mbt
@@ -13,6 +13,7 @@ pub enum BottomTab {
   CrdtState
   Graphviz
   IncrGraph
+  IncrCanvas
 } derive(Eq)
 
 ///|
@@ -156,4 +157,6 @@ pub struct Model {
   // observes memo events across the whole session, not per render. Reads via
   // `snapshot()` for the IncrGraph bottom-panel tab.
   incr_tap : @visualizer.RecomputeTap
+  // Ideal-local interaction state for the direct @spatial Incr canvas.
+  priv incr_canvas : IncrCanvasState
 }

--- a/apps/ideal/main/moon.pkg
+++ b/apps/ideal/main/moon.pkg
@@ -2,6 +2,7 @@ import {
   "moonbit-community/rabbita",
   "moonbit-community/rabbita/html",
   "moonbit-community/rabbita/sub",
+  "moonbit-community/rabbita/dom",
   "moonbit-community/rabbita/js" @js_value,
   "dowdiness/rabbita_codemirror" @cm,
   "dowdiness/rabbita_codemirror/js" @cm_js,
@@ -35,6 +36,8 @@ import {
   "dowdiness/graphviz/lib/layout" @gv_layout,
   "dowdiness/graphviz/lib/svg" @gv_svg,
   "dowdiness/visualizer",
+  "dowdiness/canopy-canvas-graph/spatial",
+  "dowdiness/incr",
   "dowdiness/ideal-editor/main/ui",
 }
 

--- a/apps/ideal/main/msg.mbt
+++ b/apps/ideal/main/msg.mbt
@@ -6,6 +6,16 @@ enum OverlayEvent {
 }
 
 ///|
+enum IncrCanvasMsg {
+  PointerDown(Double, Double, Int?)
+  PointerMove(Double, Double, Int?)
+  PointerUp(Int?)
+  PointerCancel(Int?)
+  CaptureLost(Int?)
+  Wheel(Double, Double, Double)
+}
+
+///|
 #warnings("-unused_constructor-unused_field")
 enum Msg {
   // Mode & layout
@@ -13,6 +23,7 @@ enum Msg {
   TogglePanel(PanelId)
   OutlineResize(@resizable.Msg)
   SelectBottomTab(BottomTab)
+  IncrCanvas(IncrCanvasMsg)
   // From Web Component events (inspector panel dispatch)
   StructuralEditRequested(op~ : String, node_id~ : String)
   // Undo/redo

--- a/apps/ideal/main/pkg.generated.mbti
+++ b/apps/ideal/main/pkg.generated.mbti
@@ -98,12 +98,17 @@ pub enum BottomTab {
   CrdtState
   Graphviz
   IncrGraph
+  IncrCanvas
 } derive(Eq)
 
 pub enum EditorMode {
   Text
   Structure
 } derive(Eq)
+
+type IncrCanvasMsg
+
+type IncrCanvasState derive(Eq)
 
 pub struct Model {
   editor : @editor.SyncEditor[@ast.Term]
@@ -129,6 +134,7 @@ pub struct Model {
   intent_log : Array[String]
   patch_log : Array[PatchEntry]
   incr_tap : @visualizer.RecomputeTap
+  // private fields
 }
 
 type Msg

--- a/apps/ideal/main/update.mbt
+++ b/apps/ideal/main/update.mbt
@@ -24,6 +24,10 @@ fn update(emit : Emit[Msg], msg : Msg, model : Model) -> (Cmd, Model) raise {
     Some(r) => return r
     None => ()
   }
+  match handle_incr_canvas(emit, msg, model) {
+    Some(r) => return r
+    None => ()
+  }
   match handle_structural(emit, msg, model) {
     Some(r) => return r
     None => ()

--- a/apps/ideal/main/view_bottom.mbt
+++ b/apps/ideal/main/view_bottom.mbt
@@ -116,6 +116,7 @@ let bottom_tab_defs : Array[(BottomTab, String)] = [
   (History, "History"),
   (CrdtState, "CRDT State"),
   (Graphviz, "Graphviz"),
+  (IncrCanvas, "Incr Canvas"),
   (IncrGraph, "Incr Graph"),
 ]
 
@@ -167,6 +168,7 @@ fn bottom_tab_slug(tab : BottomTab) -> String {
     CrdtState => "crdt"
     Graphviz => "graphviz"
     IncrGraph => "incr"
+    IncrCanvas => "incr-canvas"
   }
 }
 
@@ -202,6 +204,7 @@ fn bottom_tab_panel_id(tab : BottomTab) -> String {
     History => "canopy-history-container"
     Graphviz => "canopy-graphviz-container"
     IncrGraph => "canopy-incr-container"
+    IncrCanvas => "canopy-incr-canvas-container"
     _ => "canopy-bottom-panel-" + bottom_tab_slug(tab)
   }
 }
@@ -322,6 +325,7 @@ fn view_bottom_content(dispatch : Emit[Msg], model : Model) -> Html raise {
     History => view_history_panel(model)
     Graphviz => view_graphviz_panel(model)
     IncrGraph => view_incr_graph_panel(model)
+    IncrCanvas => view_incr_canvas_panel(dispatch, model)
   }
   @html.fragment([view_bottom_tabs(dispatch, model), content])
 }

--- a/apps/ideal/main/view_bottom_incr_canvas.mbt
+++ b/apps/ideal/main/view_bottom_incr_canvas.mbt
@@ -120,6 +120,9 @@ fn render_incr_canvas_svg(
 }
 
 ///|
+const INCR_CANVAS_ACTIVE_POINTER_ATTRIBUTE : String = "data-incr-active-pointer-id"
+
+///|
 #cfg(target="js")
 extern "js" fn incr_canvas_offset_x(event : @dom.MouseEvent) -> Double = "(event) => event.offsetX"
 
@@ -141,16 +144,32 @@ fn incr_canvas_pointer_id(event : @dom.MouseEvent) -> Int? {
 }
 
 ///|
+fn incr_canvas_pointer_is_claimed(event : @dom.MouseEvent) -> Bool {
+  match (event.to_pointer_event(), event.current_target().to_option()) {
+    (Some(pointer), Some(target)) =>
+      match target.to_element() {
+        Some(element) =>
+          incr_canvas_pointer_claim_matches(
+            element.get_attribute(INCR_CANVAS_ACTIVE_POINTER_ATTRIBUTE),
+            Some(pointer.get_pointer_id()),
+          )
+        None => false
+      }
+    _ => false
+  }
+}
+
+///|
 fn incr_canvas_try_claim_pointer(event : @dom.MouseEvent) -> Bool {
   match (event.to_pointer_event(), event.current_target().to_option()) {
     (Some(pointer), Some(target)) =>
       match target.to_element() {
         Some(element) =>
-          match element.get_attribute("data-incr-active-pointer-id") {
+          match element.get_attribute(INCR_CANVAS_ACTIVE_POINTER_ATTRIBUTE) {
             Some(_) => false
             None => {
               element.set_attribute(
-                "data-incr-active-pointer-id",
+                INCR_CANVAS_ACTIVE_POINTER_ATTRIBUTE,
                 pointer.get_pointer_id().to_string(),
               )
               true
@@ -171,9 +190,9 @@ fn incr_canvas_clear_pointer_claim(
     Some(target) =>
       match target.to_element() {
         Some(element) =>
-          if element.get_attribute("data-incr-active-pointer-id") ==
+          if element.get_attribute(INCR_CANVAS_ACTIVE_POINTER_ATTRIBUTE) ==
             Some(pointer_id.to_string()) {
-            element.remove_attribute("data-incr-active-pointer-id")
+            element.remove_attribute(INCR_CANVAS_ACTIVE_POINTER_ATTRIBUTE)
           }
         None => ()
       }
@@ -249,12 +268,12 @@ fn incr_canvas_release_pointer_capture(event : @dom.MouseEvent) -> Unit {
           match target.to_element() {
             Some(element) => {
               let pointer_id = pointer.get_pointer_id()
-              if element.get_attribute("data-incr-active-pointer-id") ==
+              if element.get_attribute(INCR_CANVAS_ACTIVE_POINTER_ATTRIBUTE) ==
                 Some(pointer_id.to_string()) {
                 if element.has_pointer_capture(pointer_id) {
                   element.release_pointer_capture(pointer_id)
                 }
-                element.remove_attribute("data-incr-active-pointer-id")
+                element.remove_attribute(INCR_CANVAS_ACTIVE_POINTER_ATTRIBUTE)
               }
             }
             None => ()
@@ -285,25 +304,37 @@ fn incr_canvas_pointer_attrs(dispatch : Emit[Msg]) -> @html.Attrs {
     }
   })
   .on_pointermove(event => {
-    dispatch(
-      IncrCanvas(
-        PointerMove(
-          incr_canvas_offset_x(event),
-          incr_canvas_offset_y(event),
-          incr_canvas_pointer_id(event),
+    if incr_canvas_pointer_is_claimed(event) {
+      dispatch(
+        IncrCanvas(
+          PointerMove(
+            incr_canvas_offset_x(event),
+            incr_canvas_offset_y(event),
+            incr_canvas_pointer_id(event),
+          ),
         ),
-      ),
-    )
+      )
+    } else {
+      @rabbita_cmd.none
+    }
   })
   .on_pointerup(event => {
     event.prevent_default()
-    incr_canvas_release_pointer_capture(event)
-    dispatch(IncrCanvas(PointerUp(incr_canvas_pointer_id(event))))
+    if incr_canvas_pointer_is_claimed(event) {
+      incr_canvas_release_pointer_capture(event)
+      dispatch(IncrCanvas(PointerUp(incr_canvas_pointer_id(event))))
+    } else {
+      @rabbita_cmd.none
+    }
   })
   .on_pointercancel(event => {
     event.prevent_default()
-    incr_canvas_release_pointer_capture(event)
-    dispatch(IncrCanvas(PointerCancel(incr_canvas_pointer_id(event))))
+    if incr_canvas_pointer_is_claimed(event) {
+      incr_canvas_release_pointer_capture(event)
+      dispatch(IncrCanvas(PointerCancel(incr_canvas_pointer_id(event))))
+    } else {
+      @rabbita_cmd.none
+    }
   })
   .on_wheel(event => {
     event.prevent_default()

--- a/apps/ideal/main/view_bottom_incr_canvas.mbt
+++ b/apps/ideal/main/view_bottom_incr_canvas.mbt
@@ -87,8 +87,10 @@ fn append_incr_canvas_node(
       let cell_id = @history_render.escape_html_string(
         incr_canvas_cell_id(node.id),
       )
+      let half_width = INCR_CANVAS_NODE_WIDTH / 2.0
+      let half_height = INCR_CANVAS_NODE_HEIGHT / 2.0
       buf.write_string(
-        "<g class=\"incr-canvas-node\" data-cell-id=\"\{cell_id}\" transform=\"translate(\{center.x()} \{center.y()})\"><rect x=\"-75\" y=\"-22\" width=\"150\" height=\"44\" rx=\"6\" fill=\"\{status.fill()}\" stroke=\"\{stroke}\" /><text x=\"0\" y=\"5\" text-anchor=\"middle\">\{label}</text></g>",
+        "<g class=\"incr-canvas-node\" data-cell-id=\"\{cell_id}\" transform=\"translate(\{center.x()} \{center.y()})\"><rect x=\"\{0.0 - half_width}\" y=\"\{0.0 - half_height}\" width=\"\{INCR_CANVAS_NODE_WIDTH}\" height=\"\{INCR_CANVAS_NODE_HEIGHT}\" rx=\"6\" fill=\"\{status.fill()}\" stroke=\"\{stroke}\" /><text x=\"0\" y=\"5\" text-anchor=\"middle\">\{label}</text></g>",
       )
     }
     None => ()

--- a/apps/ideal/main/view_bottom_incr_canvas.mbt
+++ b/apps/ideal/main/view_bottom_incr_canvas.mbt
@@ -1,0 +1,369 @@
+///|
+fn incr_canvas_screen_position(
+  state : IncrCanvasState,
+  id : @incr.CellId,
+) -> @spatial.ScreenPoint? {
+  match state.positions.get(id) {
+    Some(world) =>
+      Some(
+        state.viewport.world_to_screen(world) catch {
+          @spatial.CoordinateError::NonFinite => return None
+        },
+      )
+    None => None
+  }
+}
+
+///|
+fn incr_canvas_cell_id(id : @incr.CellId) -> String {
+  "cell_" + id.runtime_id.to_string() + "_" + id.id.to_string()
+}
+
+///|
+fn incr_canvas_node_label(node : @visualizer.RecomputeSnapshotNode) -> String {
+  match node.label {
+    Some(label) => label
+    None => "cell " + node.id.id.to_string()
+  }
+}
+
+///|
+fn incr_canvas_status(
+  snapshot : @visualizer.RecomputeSnapshot,
+  id : @incr.CellId,
+) -> @visualizer.VisualNodeStatus {
+  match snapshot.events.filter(event => event.cell_id == id).last() {
+    Some(event) =>
+      match event.phase {
+        @visualizer.RecomputePhase::Entering =>
+          @visualizer.VisualNodeStatus::Active
+        @visualizer.RecomputePhase::Completed =>
+          if event.backdated {
+            @visualizer.VisualNodeStatus::Neutral
+          } else {
+            @visualizer.VisualNodeStatus::Changed
+          }
+        @visualizer.RecomputePhase::Aborted =>
+          @visualizer.VisualNodeStatus::Failed
+      }
+    None => @visualizer.VisualNodeStatus::Neutral
+  }
+}
+
+///|
+fn append_incr_canvas_edge(
+  buf : StringBuilder,
+  state : IncrCanvasState,
+  edge : @visualizer.RecomputeSnapshotEdge,
+) -> Unit {
+  match
+    (
+      incr_canvas_screen_position(state, edge.from),
+      incr_canvas_screen_position(state, edge.to),
+    ) {
+    (Some(from), Some(to)) =>
+      buf.write_string(
+        "<line class=\"incr-canvas-edge\" x1=\"\{from.x()}\" y1=\"\{from.y()}\" x2=\"\{to.x()}\" y2=\"\{to.y()}\" />",
+      )
+    _ => ()
+  }
+}
+
+///|
+fn append_incr_canvas_node(
+  buf : StringBuilder,
+  state : IncrCanvasState,
+  snapshot : @visualizer.RecomputeSnapshot,
+  node : @visualizer.RecomputeSnapshotNode,
+) -> Unit {
+  match incr_canvas_screen_position(state, node.id) {
+    Some(center) => {
+      let status = incr_canvas_status(snapshot, node.id)
+      let selected = state.selected.contains(node.id)
+      let stroke = if selected { "#b090e0" } else { status.stroke() }
+      let label = @history_render.escape_html_string(
+        incr_canvas_node_label(node),
+      )
+      let cell_id = @history_render.escape_html_string(
+        incr_canvas_cell_id(node.id),
+      )
+      buf.write_string(
+        "<g class=\"incr-canvas-node\" data-cell-id=\"\{cell_id}\" transform=\"translate(\{center.x()} \{center.y()})\"><rect x=\"-75\" y=\"-22\" width=\"150\" height=\"44\" rx=\"6\" fill=\"\{status.fill()}\" stroke=\"\{stroke}\" /><text x=\"0\" y=\"5\" text-anchor=\"middle\">\{label}</text></g>",
+      )
+    }
+    None => ()
+  }
+}
+
+///|
+/// Render the Ideal-local interactive graph. The SVG is deliberately small
+/// and local: positions belong to `IncrCanvasState`, while nodes and edges are
+/// read directly from the current `RecomputeSnapshot`.
+fn render_incr_canvas_svg(
+  state : IncrCanvasState,
+  snapshot : @visualizer.RecomputeSnapshot,
+) -> String {
+  let buf = StringBuilder::new()
+  buf.write_string(
+    "<svg class=\"incr-canvas-svg\" width=\"100%\" height=\"220\" role=\"img\" aria-label=\"Interactive Incr dependency graph\" style=\"pointer-events:none\">",
+  )
+  for edge in snapshot.edges {
+    append_incr_canvas_edge(buf, state, edge)
+  }
+  for node in snapshot.nodes {
+    append_incr_canvas_node(buf, state, snapshot, node)
+  }
+  buf.write_string("</svg>")
+  buf.to_string()
+}
+
+///|
+#cfg(target="js")
+extern "js" fn incr_canvas_offset_x(event : @dom.MouseEvent) -> Double = "(event) => event.offsetX"
+
+///|
+#cfg(target="js")
+extern "js" fn incr_canvas_offset_y(event : @dom.MouseEvent) -> Double = "(event) => event.offsetY"
+
+///|
+#cfg(target="js")
+extern "js" fn incr_canvas_wheel_offset_x(event : @dom.WheelEvent) -> Double = "(event) => event.offsetX"
+
+///|
+#cfg(target="js")
+extern "js" fn incr_canvas_wheel_offset_y(event : @dom.WheelEvent) -> Double = "(event) => event.offsetY"
+
+///|
+fn incr_canvas_pointer_id(event : @dom.MouseEvent) -> Int? {
+  event.to_pointer_event().map(pointer => pointer.get_pointer_id())
+}
+
+///|
+fn incr_canvas_try_claim_pointer(event : @dom.MouseEvent) -> Bool {
+  match (event.to_pointer_event(), event.current_target().to_option()) {
+    (Some(pointer), Some(target)) =>
+      match target.to_element() {
+        Some(element) =>
+          match element.get_attribute("data-incr-active-pointer-id") {
+            Some(_) => false
+            None => {
+              element.set_attribute(
+                "data-incr-active-pointer-id",
+                pointer.get_pointer_id().to_string(),
+              )
+              true
+            }
+          }
+        None => false
+      }
+    _ => false
+  }
+}
+
+///|
+fn incr_canvas_clear_pointer_claim(
+  event : @dom.Event,
+  pointer_id : Int,
+) -> Unit {
+  match event.current_target().to_option() {
+    Some(target) =>
+      match target.to_element() {
+        Some(element) =>
+          if element.get_attribute("data-incr-active-pointer-id") ==
+            Some(pointer_id.to_string()) {
+            element.remove_attribute("data-incr-active-pointer-id")
+          }
+        None => ()
+      }
+    None => ()
+  }
+}
+
+///|
+fn incr_canvas_handle_lost_pointer_capture(
+  scheduler : &@rabbita_cmd.Scheduler,
+  dispatch : Emit[Msg],
+  event : @dom.Event,
+) -> Unit {
+  match event.to_pointer_event() {
+    Some(pointer) => {
+      let pointer_id = pointer.get_pointer_id()
+      incr_canvas_clear_pointer_claim(event, pointer_id)
+      scheduler.add(dispatch(IncrCanvas(CaptureLost(Some(pointer_id)))))
+    }
+    None => ()
+  }
+}
+
+///|
+fn incr_canvas_capture_listener_cmd(
+  element : @dom.Element,
+  dispatch : Emit[Msg],
+) -> @rabbita_cmd.Cmd {
+  @rabbita_cmd.custom_cmd(scheduler => {
+    element.add_event_listener("lostpointercapture", event => {
+      incr_canvas_handle_lost_pointer_capture(scheduler, dispatch, event)
+    })
+  })
+}
+
+///|
+fn incr_canvas_set_pointer_capture(
+  event : @dom.MouseEvent,
+  dispatch : Emit[Msg],
+) -> @rabbita_cmd.Cmd {
+  match event.to_pointer_event() {
+    Some(pointer) =>
+      match event.current_target().to_option() {
+        Some(target) =>
+          match target.to_element() {
+            Some(element) => {
+              let listener_cmd = if element.get_attribute(
+                  "data-incr-capture-listener",
+                )
+                is None {
+                element.set_attribute("data-incr-capture-listener", "true")
+                incr_canvas_capture_listener_cmd(element, dispatch)
+              } else {
+                @rabbita_cmd.none
+              }
+              element.set_pointer_capture(pointer.get_pointer_id())
+              listener_cmd
+            }
+            None => @rabbita_cmd.none
+          }
+        None => @rabbita_cmd.none
+      }
+    None => @rabbita_cmd.none
+  }
+}
+
+///|
+fn incr_canvas_release_pointer_capture(event : @dom.MouseEvent) -> Unit {
+  match event.to_pointer_event() {
+    Some(pointer) =>
+      match event.current_target().to_option() {
+        Some(target) =>
+          match target.to_element() {
+            Some(element) => {
+              let pointer_id = pointer.get_pointer_id()
+              if element.get_attribute("data-incr-active-pointer-id") ==
+                Some(pointer_id.to_string()) {
+                if element.has_pointer_capture(pointer_id) {
+                  element.release_pointer_capture(pointer_id)
+                }
+                element.remove_attribute("data-incr-active-pointer-id")
+              }
+            }
+            None => ()
+          }
+        None => ()
+      }
+    None => ()
+  }
+}
+
+///|
+fn incr_canvas_pointer_attrs(dispatch : Emit[Msg]) -> @html.Attrs {
+  @html.Attrs::build()
+  .on_pointerdown(event => {
+    event.prevent_default()
+    let x = incr_canvas_offset_x(event)
+    let y = incr_canvas_offset_y(event)
+    let pointer_id = incr_canvas_pointer_id(event)
+    let admitted = incr_canvas_screen_point(x, y) is Some(_) &&
+      pointer_id is Some(_)
+    if admitted && incr_canvas_try_claim_pointer(event) {
+      @rabbita_cmd.batch([
+        incr_canvas_set_pointer_capture(event, dispatch),
+        dispatch(IncrCanvas(PointerDown(x, y, pointer_id))),
+      ])
+    } else {
+      @rabbita_cmd.none
+    }
+  })
+  .on_pointermove(event => {
+    dispatch(
+      IncrCanvas(
+        PointerMove(
+          incr_canvas_offset_x(event),
+          incr_canvas_offset_y(event),
+          incr_canvas_pointer_id(event),
+        ),
+      ),
+    )
+  })
+  .on_pointerup(event => {
+    event.prevent_default()
+    incr_canvas_release_pointer_capture(event)
+    dispatch(IncrCanvas(PointerUp(incr_canvas_pointer_id(event))))
+  })
+  .on_pointercancel(event => {
+    event.prevent_default()
+    incr_canvas_release_pointer_capture(event)
+    dispatch(IncrCanvas(PointerCancel(incr_canvas_pointer_id(event))))
+  })
+  .on_wheel(event => {
+    event.prevent_default()
+    dispatch(
+      IncrCanvas(
+        Wheel(
+          event.get_delta_y(),
+          incr_canvas_wheel_offset_x(event),
+          incr_canvas_wheel_offset_y(event),
+        ),
+      ),
+    )
+  })
+}
+
+///|
+fn incr_canvas_interaction_attrs(
+  dispatch : Emit[Msg],
+  state : IncrCanvasState,
+) -> @html.Attrs {
+  let attrs = incr_canvas_pointer_attrs(dispatch)
+  match state.active_pointer_id {
+    Some(pointer_id) =>
+      attrs.data_set("incr-reducer-pointer-id", pointer_id.to_string())
+    None => attrs
+  }
+}
+
+///|
+#warnings("-alert_xss_vulnerable")
+fn view_incr_canvas_panel(dispatch : Emit[Msg], model : Model) -> Html {
+  let snapshot = model.incr_tap.snapshot()
+  let svg = if model.workspace.bottom_visible {
+    render_incr_canvas_svg(model.incr_canvas, snapshot)
+  } else {
+    ""
+  }
+  // Use a distinct outer tag from the raw-innerHTML SVG panels. Rabbita then
+  // replaces the subtree when switching tabs instead of trying to patch a
+  // stale innerHTML property in place.
+  @html.div(
+    class="bottom-content incr-canvas-content",
+    attrs=bottom_panel_attrs(IncrCanvas),
+    [
+      @html.div(class="incr-canvas-meta", [
+        @html.text(
+          "\{snapshot.nodes.length()} cells — drag nodes, pan the background, scroll to zoom",
+        ),
+      ]),
+      @html.div(class="incr-canvas-stage", [
+        @html.div(
+          class="incr-canvas-interaction",
+          attrs=incr_canvas_interaction_attrs(dispatch, model.incr_canvas),
+          [
+            @html.div(
+              class="incr-canvas-svg-host",
+              attrs=@html.Attrs::build().inner_html(svg),
+              ([] : Array[Html]),
+            ),
+          ],
+        ),
+      ]),
+    ],
+  )
+}

--- a/apps/ideal/moon.mod
+++ b/apps/ideal/moon.mod
@@ -18,6 +18,8 @@ import {
   "dowdiness/lambda@0.1.0",
   "dowdiness/event-graph-walker@0.7.1",
   "dowdiness/visualizer@0.1.0",
+  "dowdiness/canopy-canvas-graph@0.1.0",
+  "dowdiness/incr@0.15.0",
 }
 
 preferred_target = "js"

--- a/apps/ideal/web/e2e/incr-canvas.spec.ts
+++ b/apps/ideal/web/e2e/incr-canvas.spec.ts
@@ -1,0 +1,203 @@
+import { test, expect } from '@playwright/test';
+
+async function waitForEditorReady(page: import('@playwright/test').Page) {
+  await page.goto('/');
+  await expect(page).toHaveTitle('Canopy Editor');
+  await expect(page.getByRole('button', { name: 'Text' })).toBeVisible();
+  await page.waitForFunction(() => {
+    return document.querySelector('#canopy-text-editor .cm-editor') !== null;
+  }, { timeout: 10000 });
+}
+
+test.describe('Bottom panel — interactive Incr Canvas', () => {
+  test('renders CellId-backed nodes and supports local drag', async ({ page }) => {
+    await waitForEditorReady(page);
+    await page.getByRole('button', { name: 'Panels' }).click();
+    await page.getByRole('tab', { name: 'Incr Canvas' }).click();
+
+    const panel = page.locator('#canopy-incr-canvas-container');
+    await expect(panel).toBeVisible();
+    const nodes = panel.locator('.incr-canvas-node');
+    await expect(nodes.first()).toBeVisible({ timeout: 5000 });
+    await expect(nodes).not.toHaveCount(0);
+
+    const node = nodes.first();
+    const before = await node.getAttribute('transform');
+    const box = await node.boundingBox();
+    expect(box).not.toBeNull();
+    if (!box) return;
+
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(box.x + box.width / 2 + 40, box.y + box.height / 2 + 12);
+    await page.mouse.up();
+
+    await expect(node).not.toHaveAttribute('transform', before ?? '');
+  });
+
+  test('claims only the first synchronous pointer gesture', async ({ page }) => {
+    await waitForEditorReady(page);
+    await page.getByRole('button', { name: 'Panels' }).click();
+    await page.getByRole('tab', { name: 'Incr Canvas' }).click();
+
+    const stage = page.locator('.incr-canvas-interaction');
+    await expect(stage).toBeVisible({ timeout: 5000 });
+    const box = await stage.boundingBox();
+    expect(box).not.toBeNull();
+    if (!box) return;
+
+    await page.mouse.move(box.x + 40, box.y + 40);
+    await page.mouse.down();
+    const firstClaim = await stage.getAttribute('data-incr-active-pointer-id');
+    expect(firstClaim).not.toBeNull();
+
+    await stage.evaluate((element) => {
+      const event = new PointerEvent('pointerdown', {
+        bubbles: true,
+        pointerId: 2,
+        clientX: 100,
+        clientY: 100,
+      });
+      Object.defineProperty(event, 'offsetX', { value: 100 });
+      Object.defineProperty(event, 'offsetY', { value: 100 });
+      element.dispatchEvent(event);
+    });
+    await expect(stage).toHaveAttribute(
+      'data-incr-active-pointer-id',
+      firstClaim ?? '',
+    );
+    await page.mouse.up();
+  });
+
+  test('recovers from lost capture before admitting the next pointer', async ({ page }) => {
+    await waitForEditorReady(page);
+    await page.getByRole('button', { name: 'Panels' }).click();
+    await page.getByRole('tab', { name: 'Incr Canvas' }).click();
+
+    const stage = page.locator('.incr-canvas-interaction');
+    await expect(stage).toBeVisible({ timeout: 5000 });
+    const box = await stage.boundingBox();
+    expect(box).not.toBeNull();
+    if (!box) return;
+
+    await page.mouse.move(box.x + box.width - 20, box.y + box.height / 2);
+    await page.mouse.down();
+    const pointerId = await stage.getAttribute('data-incr-active-pointer-id');
+    expect(pointerId).not.toBeNull();
+    if (!pointerId) return;
+    await expect(stage).toHaveAttribute('data-incr-reducer-pointer-id', pointerId);
+
+    await page.waitForTimeout(50);
+    await stage.evaluate((element, id) => {
+      element.dispatchEvent(new PointerEvent('lostpointercapture', {
+        bubbles: true,
+        pointerId: Number(id),
+      }));
+    }, pointerId);
+    await expect.poll(() => stage.getAttribute('data-incr-active-pointer-id'))
+      .toBeNull();
+    await expect(stage).not.toHaveAttribute('data-incr-reducer-pointer-id');
+    await page.mouse.up();
+
+    await page.mouse.down();
+    const nextPointerId = await stage.getAttribute('data-incr-active-pointer-id');
+    expect(nextPointerId).not.toBeNull();
+    await expect(stage).toHaveAttribute(
+      'data-incr-reducer-pointer-id',
+      nextPointerId ?? '',
+    );
+    await stage.evaluate((element) => {
+      element.dispatchEvent(new PointerEvent('lostpointercapture', {
+        bubbles: true,
+        pointerId: 999,
+      }));
+    });
+    await expect(stage).toHaveAttribute(
+      'data-incr-reducer-pointer-id',
+      nextPointerId ?? '',
+    );
+    await page.mouse.up();
+  });
+
+  test('rejects non-finite browser geometry without moving the graph', async ({ page }) => {
+    await waitForEditorReady(page);
+    await page.getByRole('button', { name: 'Panels' }).click();
+    await page.getByRole('tab', { name: 'Incr Canvas' }).click();
+
+    const panel = page.locator('#canopy-incr-canvas-container');
+    const node = panel.locator('.incr-canvas-node').first();
+    const stage = panel.locator('.incr-canvas-interaction');
+    await expect(node).toBeVisible({ timeout: 5000 });
+    const before = await node.getAttribute('transform');
+
+    await stage.evaluate((element) => {
+      const event = new PointerEvent('pointerdown', {
+        bubbles: true,
+        pointerId: 91,
+      });
+      Object.defineProperty(event, 'offsetX', { value: Number.NaN });
+      Object.defineProperty(event, 'offsetY', { value: 10 });
+      element.dispatchEvent(event);
+    });
+    await stage.evaluate((element) => {
+      const event = new WheelEvent('wheel', {
+        bubbles: true,
+        deltaY: 100,
+      });
+      Object.defineProperty(event, 'offsetX', { value: Number.NaN });
+      Object.defineProperty(event, 'offsetY', { value: 10 });
+      element.dispatchEvent(event);
+    });
+    await expect(node).toHaveAttribute('transform', before ?? '');
+    await expect(stage).not.toHaveAttribute('data-incr-active-pointer-id');
+    await expect(stage).not.toHaveAttribute('data-incr-reducer-pointer-id');
+  });
+
+  test('replaces raw SVG panels cleanly when switching tabs', async ({ page }) => {
+    await waitForEditorReady(page);
+    await page.getByRole('button', { name: 'Panels' }).click();
+    await page.getByRole('tab', { name: 'Incr Graph' }).click();
+    await expect(page.locator('#canopy-incr-container svg')).toHaveCount(1, {
+      timeout: 5000,
+    });
+
+    await page.getByRole('tab', { name: 'Incr Canvas' }).click();
+    await expect(page.locator('#canopy-incr-canvas-container')).toBeVisible();
+    await expect(page.locator('#canopy-incr-container')).toHaveCount(0);
+
+    await page.getByRole('tab', { name: 'Incr Graph' }).click();
+    await expect(page.locator('#canopy-incr-container svg')).toHaveCount(1, {
+      timeout: 5000,
+    });
+    await expect(page.locator('#canopy-incr-canvas-container')).toHaveCount(0);
+  });
+
+  test('supports background pan and anchor zoom without changing graph identity', async ({
+    page,
+  }) => {
+    await waitForEditorReady(page);
+    await page.getByRole('button', { name: 'Panels' }).click();
+    await page.getByRole('tab', { name: 'Incr Canvas' }).click();
+
+    const panel = page.locator('#canopy-incr-canvas-container');
+    const stage = panel.locator('.incr-canvas-interaction');
+    const node = panel.locator('.incr-canvas-node').first();
+    await expect(node).toBeVisible({ timeout: 5000 });
+    const before = await node.getAttribute('transform');
+    const cellId = await node.getAttribute('data-cell-id');
+    const stageBox = await stage.boundingBox();
+    expect(stageBox).not.toBeNull();
+    if (!stageBox) return;
+
+    await page.mouse.move(stageBox.x + stageBox.width - 24, stageBox.y + 120);
+    await page.mouse.down();
+    await page.mouse.move(stageBox.x + stageBox.width - 4, stageBox.y + 120);
+    await page.mouse.up();
+    await expect(node).not.toHaveAttribute('transform', before ?? '');
+
+    const afterPan = await node.getAttribute('transform');
+    await page.mouse.wheel(0, -120);
+    await expect(node).not.toHaveAttribute('transform', afterPan ?? '');
+    await expect(node).toHaveAttribute('data-cell-id', cellId ?? '');
+  });
+});

--- a/apps/ideal/web/styles/editor.css
+++ b/apps/ideal/web/styles/editor.css
@@ -774,6 +774,74 @@ canopy-editor {
   height: auto;
 }
 
+/* ── Interactive Incr canvas ───────────────────────────── */
+
+.incr-canvas-content {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  padding: 0;
+  overflow: hidden;
+}
+
+.incr-canvas-meta {
+  flex-shrink: 0;
+  padding: var(--space-xs) var(--space-md);
+  border-bottom: 1px solid var(--canopy-border);
+  color: var(--canopy-muted);
+  font-size: var(--text-label);
+}
+
+.incr-canvas-stage {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  background: var(--canopy-panel-bg);
+}
+
+.incr-canvas-interaction {
+  position: relative;
+  min-width: 720px;
+  height: 220px;
+  cursor: grab;
+  touch-action: none;
+  user-select: none;
+}
+
+.incr-canvas-interaction:active {
+  cursor: grabbing;
+}
+
+.incr-canvas-svg-host,
+.incr-canvas-svg {
+  display: block;
+  width: 100%;
+  height: 220px;
+}
+
+.incr-canvas-svg {
+  overflow: visible;
+}
+
+.incr-canvas-edge {
+  stroke: var(--canopy-muted);
+  stroke-width: 1.25;
+  opacity: 0.65;
+}
+
+.incr-canvas-node rect {
+  stroke-width: 1.5;
+}
+
+.incr-canvas-node text {
+  fill: #1f2933;
+  font-family: var(--canopy-font-mono);
+  font-size: 11px;
+  pointer-events: none;
+  user-select: none;
+}
+
 /* ── Panel scrim (mobile only — hidden on desktop) ─────── */
 
 .panel-scrim {


### PR DESCRIPTION
## Summary

- Add an Ideal Editor **Incr Canvas** bottom-panel tab that uses `@spatial` directly with `@incr.CellId` positions.
- Add local pan, anchor-preserving zoom, node drag, selection, identity-preserving layout reconciliation, and SVG rendering while retaining Graphviz and IncrGraph.
- Harden the Ideal Rabbita/DOM input seam: finite-coordinate admission, synchronous pointer claims, pointer-ID gating, pointer capture, scheduler-backed lost-capture recovery, and early rejection of unclaimed high-frequency pointer input.
- Reconcile from the live `RecomputeSnapshot` CellId membership rather than the editor's causal snapshot, so demand-driven Incr graph changes are reflected without source edits.

## UI and review evidence

- [x] Visible-label removal preserves accessible names, visible focus, and the keyboard path
- [x] Interactive bounds, pointer feedback, and viewport reflow were checked in the rendered UI
- [x] Any claimed Canopy rule cites its repository source; external guidance, recommendations, and preferences are labeled as such

The implementation follows the repository design context in `.impeccable.md`; the new canvas keeps the existing dark panel styling and preserves the existing Graphviz/IncrGraph tabs.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `@spatial.Viewport`, `ScreenPoint`, `WorldPoint`, `Scale` | `modules/canvas-graph/spatial` | Yes | Typed finite coordinate/scale boundaries and coordinate transforms. |
| `@spatial.Pan` / `@spatial.Drag` | `modules/canvas-graph/spatial` | Yes | Snapshot-based pan and drag semantics; no duplicate geometry logic. |
| `@incr.CellId` and `RecomputeSnapshot` | `deps/loom/incr`, `modules/visualizer` | Yes | Cell identity and live graph snapshot remain owned by Incr/visualizer. |
| `@graph_model` canvas state/reducers | `modules/canvas-graph/graph_model` | No | Ideal intentionally owns a local CellId layout and must remain independent of the workflow canvas model. |
| Rabbita DOM/event APIs | `deps/rabbita/rabbita/dom`, `rabbita/html`, `rabbita/cmd` | Yes | Existing event, pointer, attribute, and scheduler seams are used for the web shell. |
| MoonBit `Map`, `Set`, `Array`, `ReadOnlyArray`, `StringBuilder`, `Option` | MoonBit core | Yes | Identity layout, live-cell membership, selection reconciliation, immutable drag snapshots, SVG construction, and optional event IDs. |
| MoonBit `String`/`StringView` and `Bytes`/`BytesView` | MoonBit core | Checked; not needed | No byte-level processing is introduced; labels use existing HTML escaping. |
| MoonBit `Result` and `cmp`/`math` helpers | MoonBit core | Checked; not needed | Existing typed `raise`/`catch` and numeric methods fit these validation paths. |

New helpers added:

- `IncrCanvasState` / `IncrCanvasMsg`: Ideal-local interaction model; the state must not leak into `@spatial` or the visualizer.
- `reconcile_incr_positions`: identity-preserving local layout reconciliation, including deterministic collision-free slots for remove/add transitions.
- `sync_incr_canvas_state`: live CellId-membership invalidation seam; editor causal revisions are intentionally not consulted.
- `render_incr_canvas_svg`: small Ideal-specific adapter from visualizer snapshot data to escaped SVG.
- DOM pointer helpers: the browser shell owns pointer capture and scheduler lifecycle, which cannot belong in the pure spatial package.
- `incr_canvas_pointer_claim_matches`: pure claim/pointer identity predicate used by the DOM admission seam.

## Validation scope

Boundary matrix / first failing regression:

- CellId snapshot reconciliation: preserve live positions, remove stale positions, add deterministic positions, avoid retained/new slot collisions in both ordering directions, and invalidate when only the live RecomputeSnapshot membership changes.
- Geometry: reject NaN/Infinity pointer and wheel coordinates before DOM claim or reducer mutation; SVG node geometry and hit testing share the same constants.
- Input admission: unclaimed, missing, and secondary pointer moves/releases are rejected before dispatch; matching claimed pointer moves/releases are forwarded.
- Interaction: node drag, background pan, anchor-preserving zoom, inverse zoom round trip, zero-wheel no-op, pointer identity gating, secondary-pointer rejection, pointerup/cancel, and lost capture recovery.
- Rendering: CellId-backed node identity, SVG label escaping, status styling, stale innerHTML replacement when switching Incr Graph/Incr Canvas tabs.
- Accessibility/UI: tab remains keyboard-addressable and existing Graphviz/IncrGraph panels remain available.

Target packages:

- `apps/ideal/main`

Additional conditional gates:

- Ideal Incr Canvas Playwright E2E: 6 passed.
- Ideal MoonBit tests: 62 passed.
- Full PR-ready gate includes Ideal web build and repository-wide MoonBit/TypeScript/build checks.

## Review resolution

- Editor causal revisions were replaced with live `RecomputeSnapshot` node membership as the layout invalidation authority; a runtime-backed whitebox test covers expansion/removal without an editor revision.
- SVG rect dimensions now use the same constants as hit testing.
- Unclaimed `pointermove`, `pointerup`, and `pointercancel` events are rejected at the Ideal DOM seam before dispatch, avoiding idle hover updates and redundant snapshot/render work.
- Zoom-in/out uses inverse factors and has a round-trip scale regression test.
- The Rabbita submodule was intentionally not changed and no Rabbita PR is part of this change. Typed DOM exception handling for `set/release_pointer_capture` remains a separate follow-up to the Rabbita binding rather than an app-local `Bool` workaround.

## PR-ready evidence

Validated HEAD: `4d500cc18685c1a4c15aac66a4598742b85a025d`

Validated base: `origin/main@fa85221559323b54022ad848c1c6799cb311e7ef`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh --target apps/ideal/main
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for the exact HEAD and base above.
- [x] The base was fetched again and `--verify-evidence` passed immediately before this PR was updated.
- [x] The committed `.mbti` diff against the validated base was reviewed; only the intended Ideal `BottomTab` and opaque private state changes are present.
- [x] No `@spatial` interface drift.
- [x] No changed submodule commits; `deps/rabbita` remains at its existing pinned commit.
- [x] Independent review passed for the live-snapshot fix and the pointer-claim/zoom fix.
