### PR TITLE
release: make workflow_dispatch version authoritative

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,7 @@ jobs:
       run_loomark_standalone_e2e: ${{ steps.filter.outputs.run_loomark_standalone_e2e }}
       run_pr_ready_bash3: ${{ steps.filter.outputs.run_pr_ready_bash3 }}
       run_tooling_validation: ${{ steps.filter.outputs.run_tooling_validation }}
+      run_release_version_validation: ${{ steps.filter.outputs.run_release_version_validation }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -134,6 +135,13 @@ jobs:
               - 'scripts/test-install-hooks.sh'
               - '.github/workflows/ci.yml'
               - '.github/workflows/release.yml'
+            run_release_version_validation:
+              - '.github/workflows/ci.yml'
+              - '.github/workflows/release.yml'
+              - 'scripts/resolve-release-version.nu'
+              - 'scripts/test-resolve-release-version.nu'
+              - 'scripts/verify-release-target.nu'
+              - 'scripts/test-verify-release-target.sh'
 
   tooling-validation:
     name: Just, Make, and Lefthook Configuration
@@ -199,6 +207,35 @@ jobs:
             "${RUNNER_TEMP}/lefthook" | sha256sum --check --status
           chmod +x "${RUNNER_TEMP}/lefthook"
           "${RUNNER_TEMP}/lefthook" validate
+
+  release-version-validation:
+    name: Release Version and Target Validation
+    needs: changes
+    if: needs.changes.outputs.run_release_version_validation == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Install Nushell
+        uses: hustcer/setup-nu@f3fd65374ffc4d60974c0dd2f7263c6c5c285f81
+        with:
+          version: "0.114.1"
+
+      - name: Validate resolver syntax
+        run: |
+          nu --ide-check 100 scripts/resolve-release-version.nu
+          nu --ide-check 100 scripts/test-resolve-release-version.nu
+          nu --ide-check 100 scripts/verify-release-target.nu
+          bash -n scripts/test-verify-release-target.sh
+
+      - name: Run resolver regression tests
+        run: scripts/test-resolve-release-version.nu
+
+      - name: Run release target regression tests
+        run: scripts/test-verify-release-target.sh
 
   pr-ready-bash3:
     name: PR-ready Bash 3.2 Contract
@@ -959,6 +996,7 @@ jobs:
       - waku-e2e
       - waku-workerd
       - tooling-validation
+      - release-version-validation
       - ideal-web-e2e
       - demo-react-e2e
       - canvas-e2e
@@ -992,6 +1030,9 @@ jobs:
              ! path_filtered_ok \
                "${{ needs.tooling-validation.result }}" \
                "${{ needs.changes.outputs.run_tooling_validation }}" || \
+             ! path_filtered_ok \
+               "${{ needs.release-version-validation.result }}" \
+               "${{ needs.changes.outputs.run_release_version_validation }}" || \
              ! ok "${{ needs.ideal-web-e2e.result }}" || \
              ! ok "${{ needs.demo-react-e2e.result }}" || \
              ! path_filtered_ok \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ on:
 concurrency:
   group: canopy-release
   cancel-in-progress: false
+  queue: max
 
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,10 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: canopy-release
+  cancel-in-progress: false
+
 permissions:
   contents: write
 
@@ -33,6 +37,24 @@ jobs:
         uses: hustcer/setup-nu@f3fd65374ffc4d60974c0dd2f7263c6c5c285f81
         with:
           version: "0.114.1"
+
+      - name: Resolve release version
+        id: resolve-version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_TYPE: ${{ github.ref_type }}
+          REF_NAME: ${{ github.ref_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          VERSION="$(nu scripts/resolve-release-version.nu \
+            "$EVENT_NAME" "$REF_TYPE" "$REF_NAME" "$INPUT_VERSION")"
+          printf 'version=%s\n' "$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Verify release target before build
+        env:
+          VERSION: ${{ steps.resolve-version.outputs.version }}
+          SOURCE_SHA: ${{ github.sha }}
+        run: nu scripts/verify-release-target.nu "$VERSION" "$SOURCE_SHA" origin
 
       - name: Set up MoonBit
         uses: ./.github/actions/setup-moonbit
@@ -57,42 +79,44 @@ jobs:
         run: just build-web
 
       - name: Create release archive
-        run: |
-          VERSION=${{ github.ref_name }}
-          if [ -z "$VERSION" ]; then
-            VERSION=${{ inputs.version }}
-          fi
-
-          just release-artifacts "$VERSION"
+        env:
+          VERSION: ${{ steps.resolve-version.outputs.version }}
+        run: just release-artifacts "$VERSION"
 
       - name: Generate changelog
         id: changelog
+        env:
+          VERSION: ${{ steps.resolve-version.outputs.version }}
         run: |
-          VERSION=${{ github.ref_name }}
-          if [ -z "$VERSION" ]; then
-            VERSION=${{ inputs.version }}
-          fi
+          {
+            echo "## What's Changed"
+            echo ""
 
-          echo "## What's Changed" > CHANGELOG.txt
-          echo "" >> CHANGELOG.txt
+            # Get commits since last tag
+            LAST_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
+            if [ -n "$LAST_TAG" ]; then
+              git log "${LAST_TAG}..HEAD" --pretty=format:"- %s (%h)"
+            else
+              git log --pretty=format:"- %s (%h)" -10
+            fi
 
-          # Get commits since last tag
-          LAST_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
-          if [ -n "$LAST_TAG" ]; then
-            git log ${LAST_TAG}..HEAD --pretty=format:"- %s (%h)" >> CHANGELOG.txt
-          else
-            git log --pretty=format:"- %s (%h)" -10 >> CHANGELOG.txt
-          fi
+            echo ""
+            echo ""
+            echo "**Full Changelog**: https://github.com/${{ github.repository }}/commits/${VERSION}"
+          } > CHANGELOG.txt
 
-          echo "" >> CHANGELOG.txt
-          echo "" >> CHANGELOG.txt
-          echo "**Full Changelog**: https://github.com/${{ github.repository }}/commits/${VERSION}" >> CHANGELOG.txt
+      - name: Verify release target before publish
+        env:
+          VERSION: ${{ steps.resolve-version.outputs.version }}
+          SOURCE_SHA: ${{ github.sha }}
+        run: nu scripts/verify-release-target.nu "$VERSION" "$SOURCE_SHA" origin
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
-          tag_name: ${{ github.ref_name || inputs.version }}
-          name: Release ${{ github.ref_name || inputs.version }}
+          tag_name: ${{ steps.resolve-version.outputs.version }}
+          target_commitish: ${{ github.sha }}
+          name: Release ${{ steps.resolve-version.outputs.version }}
           body_path: CHANGELOG.txt
           draft: false
           prerelease: false

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -33,6 +33,7 @@ than duplicating its globs.
 | `dep-check` | `./scripts/check-deps.sh` (module-scope rules [A]–[E] + canopy package-layering rules [F]–[I]; the rules table lives in the script header), `./scripts/check-shared-substrate.sh`, `./scripts/check-egw-resolver-identity.sh`, `./scripts/check-moon-update-wrapped.sh`, `node ./scripts/check-export-manifest.mjs`, `./scripts/test-moon-update-wrapper.sh`, `./scripts/test-pr-ready-validation.sh` |
 | `pr-ready-bash3` | Path-filtered macOS check that asserts `/bin/bash` 3.2, exercises local submodule failures, and runs the real PR-ready shell graph with only compiler work faked |
 | `tooling-validation` | Path-filtered Ubuntu validation for the pinned justfile, Make compatibility wrapper, Nushell installer script, and Lefthook configuration |
+| `release-version-validation` | Path-filtered Ubuntu regression tests for release version and remote target resolution |
 | `test-main` | `./scripts/update-moon-deps.sh`, `./scripts/check-agent-doc-links.sh`, `./scripts/run-moon-module.sh check modules/canopy`, `./scripts/run-moon-module.sh test modules/canopy`, `moon build --release` |
 | `test-submodules` | Matrix over `deps/event-graph-walker`, `deps/loom/loom`, `deps/svg-dsl`, `deps/graphviz` — each runs `./scripts/run-moon-module.sh ci <path>` |
 | `test-examples` | Matrix over `apps/ideal`, `apps/block-editor`, `apps/canvas` — each runs `./scripts/run-moon-module.sh ci <path>` |

--- a/scripts/resolve-release-version.nu
+++ b/scripts/resolve-release-version.nu
@@ -1,0 +1,43 @@
+#!/usr/bin/env nu
+# Resolve one release version for the supported release events.
+# Policy: stable SemVer with a v prefix (vMAJOR.MINOR.PATCH), without leading
+# zeroes. This is intentionally narrower than the v*.*.* workflow trigger.
+
+def invalid [message: string] {
+  print -e $"error: ($message)"
+  exit 1
+}
+
+def validate-version [version: string] {
+  let matches = ($version | parse -r '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$')
+  if ($matches | is-empty) {
+    invalid $"invalid release version '($version)'; expected vMAJOR.MINOR.PATCH"
+  }
+  $version
+}
+
+def main [event_name?: string ref_type?: string ref_name?: string input_version?: string] {
+  let event_name = ($event_name | default "")
+  let ref_type = ($ref_type | default "")
+  let ref_name = ($ref_name | default "")
+  let input_version = ($input_version | default "")
+  let candidate = match $event_name {
+    "workflow_dispatch" => {
+      if ($input_version | is-empty) {
+        invalid "workflow_dispatch requires a non-empty version input"
+      }
+      $input_version
+    }
+    "push" => {
+      if $ref_type != "tag" {
+        invalid $"push event must reference a tag, got ref type '($ref_type)'"
+      }
+      $ref_name
+    }
+    _ => {
+      invalid $"unsupported release event '($event_name)'"
+    }
+  }
+
+  validate-version $candidate
+}

--- a/scripts/test-resolve-release-version.nu
+++ b/scripts/test-resolve-release-version.nu
@@ -1,0 +1,32 @@
+#!/usr/bin/env nu
+# Regression tests for the release version event policy.
+
+def run-case [resolver: string name: string event_name: string ref_type: string ref_name: string input_version: string expected_status: int expected_version: string] {
+  let result = (^nu $resolver $event_name $ref_type $ref_name $input_version | complete)
+  let actual_version = ($result.stdout | str trim)
+  if $result.exit_code != $expected_status {
+    print -e $"FAIL ($name): expected exit ($expected_status), got ($result.exit_code)"
+    if ($result.stderr | is-not-empty) {
+      print -e $result.stderr
+    }
+    exit 1
+  }
+  if $actual_version != $expected_version {
+    print -e $"FAIL ($name): expected output '($expected_version)', got '($actual_version)'"
+    exit 1
+  }
+  print $"PASS ($name)"
+}
+
+def main [] {
+  let resolver = ($env.FILE_PWD | path expand | path join "resolve-release-version.nu")
+  run-case $resolver "workflow dispatch uses input on main" "workflow_dispatch" "branch" "main" "v0.2.0" 0 "v0.2.0"
+  run-case $resolver "workflow dispatch ignores feature ref" "workflow_dispatch" "branch" "feature/foo" "v0.2.0" 0 "v0.2.0"
+  run-case $resolver "push tag uses tag ref" "push" "tag" "v0.2.0" "" 0 "v0.2.0"
+  run-case $resolver "push branch fails" "push" "branch" "main" "" 1 ""
+  run-case $resolver "unsupported event fails" "pull_request" "branch" "main" "v0.2.0" 1 ""
+  run-case $resolver "empty manual version fails" "workflow_dispatch" "branch" "main" "" 1 ""
+  run-case $resolver "invalid manual version fails" "workflow_dispatch" "branch" "main" "0.2.0" 1 ""
+  run-case $resolver "pre-release version fails under stable policy" "workflow_dispatch" "branch" "main" "v0.2.0-rc.1" 1 ""
+  run-case $resolver "invalid push tag fails" "push" "tag" "v0.2.0-rc.1" "" 1 ""
+}

--- a/scripts/test-verify-release-target.sh
+++ b/scripts/test-verify-release-target.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+VERIFIER="$ROOT/scripts/verify-release-target.nu"
+TEMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+REMOTE="$TEMP_DIR/remote.git"
+WORK="$TEMP_DIR/work"
+git init --bare "$REMOTE" >/dev/null
+git init "$WORK" >/dev/null
+git -C "$WORK" config user.email release-target-test@example.invalid
+git -C "$WORK" config user.name release-target-test
+printf 'source\n' > "$WORK/source.txt"
+git -C "$WORK" add source.txt
+git -C "$WORK" commit -m source >/dev/null
+SOURCE_SHA=$(git -C "$WORK" rev-parse HEAD)
+
+run_case() {
+  local name=$1 expected_status=$2 version=$3 source_sha=$4
+  local output status
+  set +e
+  output=$(nu "$VERIFIER" "$version" "$source_sha" "$REMOTE" 2>&1)
+  status=$?
+  set -e
+  if [[ "$status" -ne "$expected_status" ]]; then
+    printf 'FAIL %s: expected exit %s, got %s\n%s\n' \
+      "$name" "$expected_status" "$status" "$output" >&2
+    exit 1
+  fi
+  printf 'PASS %s\n' "$name"
+}
+
+run_case "absent tag allowed" 0 v0.2.0 "$SOURCE_SHA"
+
+git -C "$WORK" tag v0.2.0 "$SOURCE_SHA"
+git -C "$WORK" push "$REMOTE" refs/tags/v0.2.0 >/dev/null
+run_case "pushed tag source commit accepted" 0 v0.2.0 "$SOURCE_SHA"
+run_case "existing tag same commit allowed" 0 v0.2.0 "$SOURCE_SHA"
+
+git -C "$WORK" tag -a v0.2.1 "$SOURCE_SHA" -m annotated
+git -C "$WORK" push "$REMOTE" refs/tags/v0.2.1 >/dev/null
+run_case "annotated tag dereferences to commit" 0 v0.2.1 "$SOURCE_SHA"
+
+printf 'different\n' >> "$WORK/source.txt"
+git -C "$WORK" add source.txt
+git -C "$WORK" commit -m different >/dev/null
+OTHER_SHA=$(git -C "$WORK" rev-parse HEAD)
+git -C "$WORK" tag v0.2.2 "$OTHER_SHA"
+git -C "$WORK" push "$REMOTE" refs/tags/v0.2.2 >/dev/null
+run_case "existing tag different commit rejected" 1 v0.2.2 "$SOURCE_SHA"

--- a/scripts/verify-release-target.nu
+++ b/scripts/verify-release-target.nu
@@ -1,0 +1,69 @@
+#!/usr/bin/env nu
+# Verify that a release tag is absent or resolves to the release source commit.
+# The decision is independent of GitHub environment variables; the remote is an
+# explicit argument so local callers and regression tests can use a bare repo.
+
+def resolve-tag-commit [remote_output: string tag_ref: string] {
+  let rows = ($remote_output
+    | lines
+    | each {|line| $line | parse -r '^(?P<sha>[0-9a-fA-F]+)[[:space:]]+(?P<ref>.+)$' }
+    | flatten)
+  let peeled_ref = $tag_ref + "^{}"
+  let peeled = ($rows | where ref == $peeled_ref)
+  if ($peeled | is-not-empty) {
+    $peeled | first | get sha
+  } else {
+    let direct = ($rows | where ref == $tag_ref)
+    if ($direct | is-not-empty) {
+      $direct | first | get sha
+    } else {
+      ""
+    }
+  }
+}
+
+def tag-state [source_sha: string resolved_commit: string] {
+  if ($resolved_commit | is-empty) {
+    "absent"
+  } else if $resolved_commit == $source_sha {
+    "same"
+  } else {
+    "different"
+  }
+}
+
+def allowed-state [state: string] {
+  $state == "absent" or $state == "same"
+}
+
+def main [version: string source_sha: string remote: string] {
+  if ($source_sha | is-empty) {
+    print -e "error: release source SHA must not be empty"
+    exit 2
+  }
+
+  let tag_ref = "refs/tags/" + $version
+  let peeled_ref = $tag_ref + "^{}"
+  let result = (^git ls-remote --exit-code $remote $tag_ref $peeled_ref | complete)
+  if $result.exit_code != 0 and $result.exit_code != 2 {
+    print -e $"error: failed to inspect release tag ($version) on remote ($remote)"
+    if ($result.stderr | is-not-empty) {
+      print -e $result.stderr
+    }
+    exit $result.exit_code
+  }
+
+  let resolved_commit = if $result.exit_code == 2 {
+    ""
+  } else {
+    resolve-tag-commit $result.stdout $tag_ref
+  }
+  let state = tag-state $source_sha $resolved_commit
+
+  if not (allowed-state $state) {
+    print -e $"error: release tag ($version) resolves to ($resolved_commit), but source is ($source_sha)"
+    exit 1
+  }
+
+  print $"release target verified: ($version) ($state)"
+}


### PR DESCRIPTION
## Summary
- make `workflow_dispatch`'s version input authoritative instead of the selected branch name
- resolve release version once and share it across archive, changelog, and GitHub Release consumers
- verify the remote release tag resolves to the checked-out `github.sha` before build and before publish
- serialize release runs and pass `target_commitish: github.sha` for new tags
- add isolated version/target regression tests and path-filtered CI validation

## Scope
This PR fixes release version and source-commit authority. It does not change package contents or changelog history depth.

## Validation
- Nushell syntax checks
- release version regression tests
- release target regression tests (absent, same, different, annotated tags)
- `actionlint`
- `./scripts/validate-ci-yaml.sh`
- `./scripts/validate-pr-ready.sh --no-target "release version authority and release target integrity workflow, resolver, regression tests, and CI validation only"`
- `./scripts/validate-pr-ready.sh --verify-evidence`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated release-version validation for manual and tag-triggered releases.
  - Added release-target verification to prevent publishing artifacts from the wrong commit.
  - Release workflows now consistently use the validated version for tags, artifacts, changelogs, and release names.
  - Concurrent releases are serialized to avoid conflicts.

- **Bug Fixes**
  - Releases now reject unsupported events, invalid versions, and mismatched existing tags.

- **Documentation**
  - Updated CI/CD documentation with the new release validation gate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->