### PR TITLE
release: make changelog range explicit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,9 @@ jobs:
             run_release_version_validation:
               - '.github/workflows/ci.yml'
               - '.github/workflows/release.yml'
+              - 'scripts/release-version-policy.nu'
+              - 'scripts/generate-release-changelog.nu'
+              - 'scripts/test-generate-release-changelog.nu'
               - 'scripts/resolve-release-version.nu'
               - 'scripts/test-resolve-release-version.nu'
               - 'scripts/verify-release-target.nu'
@@ -209,7 +212,7 @@ jobs:
           "${RUNNER_TEMP}/lefthook" validate
 
   release-version-validation:
-    name: Release Version and Target Validation
+    name: Release Contract Validation
     needs: changes
     if: needs.changes.outputs.run_release_version_validation == 'true'
     runs-on: ubuntu-latest
@@ -224,12 +227,42 @@ jobs:
         with:
           version: "0.114.1"
 
-      - name: Validate resolver syntax
+      - name: Validate release script syntax
         run: |
+          nu --ide-check 100 scripts/release-version-policy.nu
+          nu --ide-check 100 scripts/generate-release-changelog.nu
+          nu --ide-check 100 scripts/test-generate-release-changelog.nu
           nu --ide-check 100 scripts/resolve-release-version.nu
           nu --ide-check 100 scripts/test-resolve-release-version.nu
           nu --ide-check 100 scripts/verify-release-target.nu
           bash -n scripts/test-verify-release-target.sh
+
+      - name: Check release workflow wiring
+        run: |
+          grep -Fq 'fetch-depth: 0' .github/workflows/release.yml
+          grep -Fq 'body_path: CHANGELOG.txt' .github/workflows/release.yml
+          if grep -Fq 'generate_release_notes: true' .github/workflows/release.yml; then
+            echo 'error: release workflow must not enable generated release notes' >&2
+            exit 1
+          fi
+
+          changelog_step="$({
+            awk '
+              /^      - name: Generate changelog$/ { in_step=1 }
+              in_step { print }
+              in_step && /^      - name: Verify release target before publish$/ { exit }
+            ' .github/workflows/release.yml
+          })"
+          printf '%s\n' "$changelog_step" | grep -Fq 'nu scripts/generate-release-changelog.nu'
+          printf '%s\n' "$changelog_step" | grep -Fq 'SOURCE_SHA:'
+          printf '%s\n' "$changelog_step" | grep -Fq 'github.sha'
+          printf '%s\n' "$changelog_step" | grep -Fq 'REPOSITORY:'
+          printf '%s\n' "$changelog_step" | grep -Fq 'github.repository'
+          printf '%s\n' "$changelog_step" | grep -Fq 'OUTPUT_PATH: CHANGELOG.txt'
+          printf '%s\n' "$changelog_step" | grep -Fq "\"\$VERSION\" \"\$SOURCE_SHA\" \"\$REPOSITORY\" \"\$OUTPUT_PATH\""
+
+      - name: Run release changelog regression tests
+        run: scripts/test-generate-release-changelog.nu
 
       - name: Run resolver regression tests
         run: scripts/test-resolve-release-version.nu

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,7 @@ jobs:
               - 'scripts/release-version-policy.nu'
               - 'scripts/generate-release-changelog.nu'
               - 'scripts/test-generate-release-changelog.nu'
+              - 'scripts/test-release-workflow-wiring.mjs'
               - 'scripts/resolve-release-version.nu'
               - 'scripts/test-resolve-release-version.nu'
               - 'scripts/verify-release-target.nu'
@@ -239,27 +240,8 @@ jobs:
 
       - name: Check release workflow wiring
         run: |
-          grep -Fq 'fetch-depth: 0' .github/workflows/release.yml
-          grep -Fq 'body_path: CHANGELOG.txt' .github/workflows/release.yml
-          if grep -Fq 'generate_release_notes: true' .github/workflows/release.yml; then
-            echo 'error: release workflow must not enable generated release notes' >&2
-            exit 1
-          fi
-
-          changelog_step="$({
-            awk '
-              /^      - name: Generate changelog$/ { in_step=1 }
-              in_step { print }
-              in_step && /^      - name: Verify release target before publish$/ { exit }
-            ' .github/workflows/release.yml
-          })"
-          printf '%s\n' "$changelog_step" | grep -Fq 'nu scripts/generate-release-changelog.nu'
-          printf '%s\n' "$changelog_step" | grep -Fq 'SOURCE_SHA:'
-          printf '%s\n' "$changelog_step" | grep -Fq 'github.sha'
-          printf '%s\n' "$changelog_step" | grep -Fq 'REPOSITORY:'
-          printf '%s\n' "$changelog_step" | grep -Fq 'github.repository'
-          printf '%s\n' "$changelog_step" | grep -Fq 'OUTPUT_PATH: CHANGELOG.txt'
-          printf '%s\n' "$changelog_step" | grep -Fq "\"\$VERSION\" \"\$SOURCE_SHA\" \"\$REPOSITORY\" \"\$OUTPUT_PATH\""
+          ./scripts/validate-ci-yaml.sh
+          node scripts/test-release-workflow-wiring.mjs
 
       - name: Run release changelog regression tests
         run: scripts/test-generate-release-changelog.nu

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           submodules: recursive
+          fetch-depth: 0
 
       - name: Install just
         uses: taiki-e/install-action@7f4eb899022d8fe70b20c4f3de697aa85c309026
@@ -85,26 +86,13 @@ jobs:
         run: just release-artifacts "$VERSION"
 
       - name: Generate changelog
-        id: changelog
         env:
           VERSION: ${{ steps.resolve-version.outputs.version }}
-        run: |
-          {
-            echo "## What's Changed"
-            echo ""
-
-            # Get commits since last tag
-            LAST_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
-            if [ -n "$LAST_TAG" ]; then
-              git log "${LAST_TAG}..HEAD" --pretty=format:"- %s (%h)"
-            else
-              git log --pretty=format:"- %s (%h)" -10
-            fi
-
-            echo ""
-            echo ""
-            echo "**Full Changelog**: https://github.com/${{ github.repository }}/commits/${VERSION}"
-          } > CHANGELOG.txt
+          SOURCE_SHA: ${{ github.sha }}
+          REPOSITORY: ${{ github.repository }}
+          OUTPUT_PATH: CHANGELOG.txt
+        run: nu scripts/generate-release-changelog.nu \
+          "$VERSION" "$SOURCE_SHA" "$REPOSITORY" "$OUTPUT_PATH"
 
       - name: Verify release target before publish
         env:
@@ -123,7 +111,6 @@ jobs:
           prerelease: false
           files: |
             release/*.tar.gz
-          generate_release_notes: true
 
       - name: Upload release artifacts
         uses: actions/upload-artifact@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,8 +91,7 @@ jobs:
           SOURCE_SHA: ${{ github.sha }}
           REPOSITORY: ${{ github.repository }}
           OUTPUT_PATH: CHANGELOG.txt
-        run: nu scripts/generate-release-changelog.nu \
-          "$VERSION" "$SOURCE_SHA" "$REPOSITORY" "$OUTPUT_PATH"
+        run: nu scripts/generate-release-changelog.nu "$VERSION" "$SOURCE_SHA" "$REPOSITORY" "$OUTPUT_PATH"
 
       - name: Verify release target before publish
         env:

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -33,7 +33,7 @@ than duplicating its globs.
 | `dep-check` | `./scripts/check-deps.sh` (module-scope rules [A]–[E] + canopy package-layering rules [F]–[I]; the rules table lives in the script header), `./scripts/check-shared-substrate.sh`, `./scripts/check-egw-resolver-identity.sh`, `./scripts/check-moon-update-wrapped.sh`, `node ./scripts/check-export-manifest.mjs`, `./scripts/test-moon-update-wrapper.sh`, `./scripts/test-pr-ready-validation.sh` |
 | `pr-ready-bash3` | Path-filtered macOS check that asserts `/bin/bash` 3.2, exercises local submodule failures, and runs the real PR-ready shell graph with only compiler work faked |
 | `tooling-validation` | Path-filtered Ubuntu validation for the pinned justfile, Make compatibility wrapper, Nushell installer script, and Lefthook configuration |
-| `release-version-validation` | Path-filtered Ubuntu regression tests for release version and remote target resolution |
+| `release-version-validation` | Path-filtered Ubuntu release-contract syntax and regression tests for version resolution, changelog ranges, and remote target resolution |
 | `test-main` | `./scripts/update-moon-deps.sh`, `./scripts/check-agent-doc-links.sh`, `./scripts/run-moon-module.sh check modules/canopy`, `./scripts/run-moon-module.sh test modules/canopy`, `moon build --release` |
 | `test-submodules` | Matrix over `deps/event-graph-walker`, `deps/loom/loom`, `deps/svg-dsl`, `deps/graphviz` — each runs `./scripts/run-moon-module.sh ci <path>` |
 | `test-examples` | Matrix over `apps/ideal`, `apps/block-editor`, `apps/canvas` — each runs `./scripts/run-moon-module.sh ci <path>` |
@@ -108,6 +108,19 @@ settings are documented in
 Packages release artifacts using `./scripts/package-release.sh`. Currently
 covers **native** and **JavaScript**; WebAssembly is not part of the release
 workflow.
+
+The release checkout uses full history (`fetch-depth: 0`) so the changelog
+ generator can inspect tags reachable from the explicit `SOURCE_SHA`. It
+accepts only strict stable Canopy tags (`vMAJOR.MINOR.PATCH` without leading
+zeroes), peels annotated tags, excludes the current version, and selects the
+nearest previous reachable tag by commit history. A shallow repository fails
+rather than producing incomplete notes. If no previous tag is reachable, the
+generator falls back to the latest 10 commits through `SOURCE_SHA`.
+
+The generated `CHANGELOG.txt` is the sole release-note source: the GitHub
+Release action uses `body_path` and does not request auto-generated release
+notes. Releases with a previous tag link to its compare range; first releases
+link to the version's commits page.
 
 ## Running locally
 

--- a/scripts/generate-release-changelog.nu
+++ b/scripts/generate-release-changelog.nu
@@ -49,7 +49,7 @@ def tag-candidate [tag: string source: string version: string] {
 }
 
 def reachable-stable-tags [source: string version: string] {
-  let tags = (git-output ["for-each-ref", "--format=%(refname:short)", "refs/tags"] | lines)
+  let tags = (git-output ["for-each-ref", "--format=%(refname:strip=2)", "refs/tags"] | lines)
   $tags | each {|tag| tag-candidate $tag $source $version } | compact
 }
 

--- a/scripts/generate-release-changelog.nu
+++ b/scripts/generate-release-changelog.nu
@@ -1,0 +1,93 @@
+#!/usr/bin/env nu
+# Generate deterministic release notes for a reachable stable Canopy release range.
+
+const SCRIPT_DIR = (path self | path dirname)
+source ($SCRIPT_DIR | path join "release-version-policy.nu")
+
+def fail [message: string] {
+  print -e $"error: ($message)"
+  exit 1
+}
+
+def git-output [args: list<string>] {
+  let result = (^git ...$args | complete)
+  if $result.exit_code != 0 {
+    let detail = if ($result.stderr | is-empty) { "" } else { $"\n($result.stderr)" }
+    let message = "git command failed: git " + ($args | str join " ") + $detail
+    fail $message
+  }
+  $result.stdout | str trim
+}
+
+def git-status [args: list<string>] {
+  let result = (^git ...$args | complete)
+  $result.exit_code
+}
+
+def resolve-source [source_sha: string] {
+  let result = (^git rev-parse --verify ($source_sha + "^{commit}") | complete)
+  if $result.exit_code != 0 {
+    fail $"source commit '($source_sha)' was not found"
+  }
+  $result.stdout | str trim
+}
+
+def tag-candidate [tag: string source: string version: string] {
+  if $tag == $version or not (is-stable-version $tag) {
+    return null
+  }
+  let commit_result = (^git rev-parse --verify ("refs/tags/" + $tag + "^{commit}") | complete)
+  if $commit_result.exit_code != 0 {
+    return null
+  }
+  let commit = ($commit_result.stdout | str trim)
+  if (git-status ["merge-base", "--is-ancestor", $commit, $source]) != 0 {
+    return null
+  }
+  let distance = (git-output ["rev-list", "--count", ($commit + ".." + $source)] | into int)
+  { tag: $tag, commit: $commit, distance: $distance }
+}
+
+def reachable-stable-tags [source: string version: string] {
+  let tags = (git-output ["for-each-ref", "--format=%(refname:short)", "refs/tags"] | lines)
+  $tags | each {|tag| tag-candidate $tag $source $version } | compact
+}
+
+def previous-tag [source: string version: string] {
+  let candidates = (reachable-stable-tags $source $version)
+  if ($candidates | is-empty) {
+    null
+  } else {
+    $candidates | sort-by distance tag | first
+  }
+}
+
+def commit-lines [source: string previous: any] {
+  if ($previous | is-empty) {
+    git-output ["log", $source, "-10", "--pretty=format:- %s (%h)"]
+  } else {
+    git-output ["log", ($previous.commit + ".." + $source), "--pretty=format:- %s (%h)"]
+  }
+}
+
+def main [version: string source_sha: string repository: string output_path: string] {
+  if not (is-stable-version $version) {
+    fail $"invalid release version '($version)'; expected vMAJOR.MINOR.PATCH"
+  }
+
+  let shallow = (git-output ["rev-parse", "--is-shallow-repository"])
+  if $shallow == "true" {
+    fail "cannot generate release changelog from a shallow repository"
+  }
+
+  let source = (resolve-source $source_sha)
+  let previous = (previous-tag $source $version)
+  let lines = (commit-lines $source $previous)
+  let link = if ($previous | is-empty) {
+    $"https://github.com/($repository)/commits/($version)"
+  } else {
+    $"https://github.com/($repository)/compare/($previous.tag)...($version)"
+  }
+  let changelog = $"## What's Changed\n\n($lines)\n\n**Full Changelog**: ($link)\n"
+  $changelog | save --raw -f $output_path
+}

--- a/scripts/release-version-policy.nu
+++ b/scripts/release-version-policy.nu
@@ -1,0 +1,16 @@
+#!/usr/bin/env nu
+# Shared strict stable release-version policy.
+# Accepted values are vMAJOR.MINOR.PATCH with no leading zeroes.
+
+def parse-stable-version [version: string] {
+  let matches = ($version | parse -r '^v(?P<major>0|[1-9][0-9]*)\.(?P<minor>0|[1-9][0-9]*)\.(?P<patch>0|[1-9][0-9]*)$')
+  if ($matches | is-empty) {
+    null
+  } else {
+    $matches | first
+  }
+}
+
+def is-stable-version [version: string] {
+  (parse-stable-version $version | is-not-empty)
+}

--- a/scripts/resolve-release-version.nu
+++ b/scripts/resolve-release-version.nu
@@ -3,14 +3,16 @@
 # Policy: stable SemVer with a v prefix (vMAJOR.MINOR.PATCH), without leading
 # zeroes. This is intentionally narrower than the v*.*.* workflow trigger.
 
+const SCRIPT_DIR = (path self | path dirname)
+source ($SCRIPT_DIR | path join "release-version-policy.nu")
+
 def invalid [message: string] {
   print -e $"error: ($message)"
   exit 1
 }
 
 def validate-version [version: string] {
-  let matches = ($version | parse -r '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$')
-  if ($matches | is-empty) {
+  if not (is-stable-version $version) {
     invalid $"invalid release version '($version)'; expected vMAJOR.MINOR.PATCH"
   }
   $version

--- a/scripts/test-generate-release-changelog.nu
+++ b/scripts/test-generate-release-changelog.nu
@@ -1,0 +1,121 @@
+#!/usr/bin/env nu
+# Regression tests for deterministic, reachable release changelog generation.
+
+def fail [message: string] {
+  error make { msg: $message }
+}
+
+def git [repo: string args: list<string>] {
+  let result = (^git -C $repo ...$args | complete)
+  if $result.exit_code != 0 {
+    fail $"git failed in ($repo): git ($args | str join ' ')\n($result.stderr)"
+  }
+  $result.stdout | str trim
+}
+
+def make-repo [root: string name: string] {
+  let repo = ($root | path join $name)
+  mkdir $repo
+  git $repo ["init", "--quiet", "--initial-branch=main"] | ignore
+  git $repo ["config", "user.email", "release-changelog-test@example.invalid"] | ignore
+  git $repo ["config", "user.name", "release-changelog-test"] | ignore
+  $repo
+}
+
+def commit [repo: string message: string] {
+  let file = ($repo | path join "history.txt")
+  $message | save -f $file
+  git $repo ["add", "history.txt"] | ignore
+  git $repo ["commit", "--quiet", "-m", $message] | ignore
+  git $repo ["rev-parse", "HEAD"]
+}
+
+def run-generator [generator: string repo: string version: string source_sha: string] {
+  let output = ($repo | path join "CHANGELOG.txt")
+  let result = (do {
+    cd $repo
+    ^nu $generator $version $source_sha "dowdiness/canopy" $output
+  } | complete)
+  { result: $result, output: $output }
+}
+
+def assert-status [name: string result: record expected: int] {
+  if $result.result.exit_code != $expected {
+    fail $"FAIL ($name): expected exit ($expected), got ($result.result.exit_code)\n($result.result.stdout)\n($result.result.stderr)"
+  }
+  print $"PASS ($name)"
+}
+
+def commit-line [repo: string sha: string] {
+  let subject = (git $repo ["show", "-s", "--format=%s", $sha])
+  let abbreviated = (git $repo ["show", "-s", "--format=%h", $sha])
+  "- " + $subject + " (" + $abbreviated + ")"
+}
+
+def assert-output [name: string output: string expected: string] {
+  let actual = (open $output --raw)
+  if $actual != $expected {
+    fail $"FAIL ($name): changelog snapshot mismatch\nexpected:\n($expected)\nactual:\n($actual)"
+  }
+  print $"PASS ($name)"
+}
+
+def test-shallow-fails [root: string generator: string] {
+  let source = (make-repo $root "shallow")
+  let sha = (commit $source "shallow source")
+  let shallow = ($root | path join "shallow-clone")
+  ^git clone --quiet --depth 1 --no-local $source $shallow
+  let result = (run-generator $generator $shallow "v9.0.0" (git $shallow ["rev-parse", "HEAD"]))
+  assert-status "shallow repository fails" $result 1
+}
+
+def test-first-release [root: string generator: string] {
+  let repo = (make-repo $root "first-release")
+  mut shas = []
+  for index in 1..12 {
+    $shas = ($shas | append (commit $repo $"commit ($index)"))
+  }
+  let source = ($shas | last)
+  let result = (run-generator $generator $repo "v1.0.0" $source)
+  assert-status "first release succeeds" $result 0
+  let lines = ($shas | skip 2 | reverse | each {|sha| commit-line $repo $sha } | str join "\n")
+  let expected = $"## What's Changed\n\n($lines)\n\n**Full Changelog**: https://github.com/dowdiness/canopy/commits/v1.0.0\n"
+  assert-output "first release uses latest 10 and commits link" $result.output $expected
+}
+
+def test-reachable-tag-selection [root: string generator: string] {
+  let repo = (make-repo $root "reachable-tags")
+  let first = (commit $repo "older release commit")
+  git $repo ["tag", "-a", "v0.1.0", $first, "-m", "annotated previous"] | ignore
+  let second = (commit $repo "selected range commit")
+  git $repo ["tag", "btree-v0.2.0", $second] | ignore
+  git $repo ["tag", "v0.2.0-rc.1", $second] | ignore
+  let source = (commit $repo "release source")
+  git $repo ["tag", "v0.2.0", $source] | ignore
+
+  git $repo ["switch", "--quiet", "-c", "side"] | ignore
+  let side = (commit $repo "side branch only")
+  git $repo ["tag", "v0.1.5", $side] | ignore
+  git $repo ["switch", "--quiet", "main"] | ignore
+
+  let result = (run-generator $generator $repo "v0.2.0" $source)
+  assert-status "reachable stable tag selection succeeds" $result 0
+  let commits = ([(commit-line $repo $source), (commit-line $repo $second)] | str join "\n")
+  let expected = $"## What's Changed\n\n($commits)\n\n**Full Changelog**: https://github.com/dowdiness/canopy/compare/v0.1.0...v0.2.0\n"
+  assert-output "annotated previous tag is peeled and range is rendered" $result.output $expected
+}
+
+def main [] {
+  let generator = ($env.FILE_PWD | path expand | path join "generate-release-changelog.nu")
+  let root = (^mktemp -d | str trim)
+  try {
+    test-shallow-fails $root $generator
+    test-first-release $root $generator
+    test-reachable-tag-selection $root $generator
+  } catch {|err|
+    ^rm -rf $root
+    print -e $err.msg
+    exit 1
+  }
+  ^rm -rf $root
+}

--- a/scripts/test-release-workflow-wiring.mjs
+++ b/scripts/test-release-workflow-wiring.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+// Verify the parsed release workflow passes the changelog generator's exact argv.
+
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const require = createRequire(import.meta.url);
+const yaml = require("js-yaml");
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const workflowPath = join(repoRoot, ".github/workflows/release.yml");
+const workflow = yaml.load(readFileSync(workflowPath, "utf8"));
+
+function fail(message) {
+  console.error(`FAIL release workflow wiring: ${message}`);
+  process.exit(1);
+}
+
+function findStep(job, name) {
+  const step = job?.steps?.find((candidate) => candidate.name === name);
+  if (!step) {
+    fail(`missing ${name} step`);
+  }
+  return step;
+}
+
+const build = workflow.jobs?.["build-release"];
+if (!build) {
+  fail("missing build-release job");
+}
+
+const checkout = findStep(build, "Checkout code");
+if (checkout.with?.["fetch-depth"] !== 0) {
+  fail(`Checkout code must use fetch-depth 0, got ${JSON.stringify(checkout.with?.["fetch-depth"])}`);
+}
+
+const changelog = findStep(build, "Generate changelog");
+const expectedRun =
+  'nu scripts/generate-release-changelog.nu "$VERSION" "$SOURCE_SHA" "$REPOSITORY" "$OUTPUT_PATH"';
+if (changelog.run !== expectedRun) {
+  fail(`Generate changelog run mismatch: ${JSON.stringify(changelog.run)}`);
+}
+
+const expectedEnv = {
+  VERSION: "${{ steps.resolve-version.outputs.version }}",
+  SOURCE_SHA: "${{ github.sha }}",
+  REPOSITORY: "${{ github.repository }}",
+  OUTPUT_PATH: "CHANGELOG.txt",
+};
+for (const [name, expected] of Object.entries(expectedEnv)) {
+  if (changelog.env?.[name] !== expected) {
+    fail(`Generate changelog env ${name} mismatch: ${JSON.stringify(changelog.env?.[name])}`);
+  }
+}
+
+const release = findStep(build, "Create GitHub Release");
+if (release.with?.body_path !== "CHANGELOG.txt") {
+  fail(`Create GitHub Release must use body_path CHANGELOG.txt, got ${JSON.stringify(release.with?.body_path)}`);
+}
+if (Object.hasOwn(release.with ?? {}, "generate_release_notes")) {
+  fail("Create GitHub Release must not enable generated release notes");
+}
+
+console.log("PASS release workflow parsed wiring");

--- a/scripts/test-resolve-release-version.nu
+++ b/scripts/test-resolve-release-version.nu
@@ -27,6 +27,9 @@ def main [] {
   run-case $resolver "unsupported event fails" "pull_request" "branch" "main" "v0.2.0" 1 ""
   run-case $resolver "empty manual version fails" "workflow_dispatch" "branch" "main" "" 1 ""
   run-case $resolver "invalid manual version fails" "workflow_dispatch" "branch" "main" "0.2.0" 1 ""
+  run-case $resolver "leading-zero major fails" "workflow_dispatch" "branch" "main" "v01.2.3" 1 ""
+  run-case $resolver "leading-zero minor fails" "workflow_dispatch" "branch" "main" "v1.02.3" 1 ""
+  run-case $resolver "leading-zero patch fails" "workflow_dispatch" "branch" "main" "v1.2.03" 1 ""
   run-case $resolver "pre-release version fails under stable policy" "workflow_dispatch" "branch" "main" "v0.2.0-rc.1" 1 ""
   run-case $resolver "invalid push tag fails" "push" "tag" "v0.2.0-rc.1" "" 1 ""
 }


### PR DESCRIPTION
## Summary

- extract strict stable release-version parsing into a shared policy used by the resolver and changelog generator
- make the release checkout fetch full history and derive the changelog range from the explicit `SOURCE_SHA`
- select only reachable strict Canopy release tags, excluding the current release, component tags, prereleases, and unreachable side-branch tags
- reject shallow repositories instead of silently generating incomplete notes
- make custom `CHANGELOG.txt` the sole release-note source
- add isolated temporary-Git-repository regression coverage
- parse the release workflow with `js-yaml` and assert the exact changelog command and argv wiring

## Scope

This PR makes the release changelog range explicit and deterministic:

- stable release version判定を共有policyへ抽出
- full Git historyを明示的にcheckout
- release対象SHAから到達可能な直近のstable Canopy tagを比較起点にする
- 現在のrelease tag、component固有tag、到達不能tagを除外
- shallow repositoryでは不完全なchangelogを生成せず拒否
- previous releaseがない場合のfirst-release fallbackを固定
- custom changelogをrelease notesの単一正本にする
- temporary Git repositoryによるrange・tag・出力回帰試験
- parse後のworkflow command/argvを検証する回帰試験
- path-filtered CIとaggregate gateへ接続

## Non-goals

- release archive contents
- release asset naming
- `package-release.sh` migration
- `moon update` behavior
- actual release publication

## Validation

- `node scripts/test-release-workflow-wiring.mjs`
- resolver, changelog-generator, and release-target regression tests
- strict stable-version leading-zero cases
- shallow, first-release, annotated-tag, component-tag, prerelease, current-tag, and unreachable-tag fixtures
- `./scripts/validate-ci-yaml.sh`
- `actionlint` with the already-known `concurrency.queue` schema warning excluded; other findings remain enabled
- `./scripts/validate-pr-ready.sh --no-target "release changelog range authority and parsed workflow argv contract: YAML command semantics, shared stable tag policy, Nu generator, regression tests, CI wiring, and documentation only"`
- `./scripts/validate-pr-ready.sh --verify-evidence`

The final validated HEAD is `a1cc733a` with `origin/main` at `06eb2f0d`.
