### PR TITLE
fix(ideal): use typed Rabbita pointer capture lifecycle

### DIFF
--- a/apps/ideal/main/view_bottom_incr_canvas.mbt
+++ b/apps/ideal/main/view_bottom_incr_canvas.mbt
@@ -201,61 +201,16 @@ fn incr_canvas_clear_pointer_claim(
 }
 
 ///|
-fn incr_canvas_handle_lost_pointer_capture(
-  scheduler : &@rabbita_cmd.Scheduler,
-  dispatch : Emit[Msg],
-  event : @dom.Event,
-) -> Unit {
-  match event.to_pointer_event() {
-    Some(pointer) => {
-      let pointer_id = pointer.get_pointer_id()
-      incr_canvas_clear_pointer_claim(event, pointer_id)
-      scheduler.add(dispatch(IncrCanvas(CaptureLost(Some(pointer_id)))))
-    }
-    None => ()
-  }
-}
-
-///|
-fn incr_canvas_capture_listener_cmd(
-  element : @dom.Element,
-  dispatch : Emit[Msg],
-) -> @rabbita_cmd.Cmd {
-  @rabbita_cmd.custom_cmd(scheduler => {
-    element.add_event_listener("lostpointercapture", event => {
-      incr_canvas_handle_lost_pointer_capture(scheduler, dispatch, event)
-    })
-  })
-}
-
-///|
 fn incr_canvas_set_pointer_capture(
   event : @dom.MouseEvent,
-  dispatch : Emit[Msg],
-) -> @rabbita_cmd.Cmd {
-  match event.to_pointer_event() {
-    Some(pointer) =>
-      match event.current_target().to_option() {
-        Some(target) =>
-          match target.to_element() {
-            Some(element) => {
-              let listener_cmd = if element.get_attribute(
-                  "data-incr-capture-listener",
-                )
-                is None {
-                element.set_attribute("data-incr-capture-listener", "true")
-                incr_canvas_capture_listener_cmd(element, dispatch)
-              } else {
-                @rabbita_cmd.none
-              }
-              element.set_pointer_capture(pointer.get_pointer_id())
-              listener_cmd
-            }
-            None => @rabbita_cmd.none
-          }
-        None => @rabbita_cmd.none
+) -> Unit raise @dom.DOMExceptionError {
+  match (event.to_pointer_event(), event.current_target().to_option()) {
+    (Some(pointer), Some(target)) =>
+      match target.to_element() {
+        Some(element) => element.set_pointer_capture(pointer.get_pointer_id())
+        None => ()
       }
-    None => @rabbita_cmd.none
+    _ => ()
   }
 }
 
@@ -271,7 +226,9 @@ fn incr_canvas_release_pointer_capture(event : @dom.MouseEvent) -> Unit {
               if element.get_attribute(INCR_CANVAS_ACTIVE_POINTER_ATTRIBUTE) ==
                 Some(pointer_id.to_string()) {
                 if element.has_pointer_capture(pointer_id) {
-                  element.release_pointer_capture(pointer_id)
+                  element.release_pointer_capture(pointer_id) catch {
+                    @dom.DOMExceptionError(..) => ()
+                  }
                 }
                 element.remove_attribute(INCR_CANVAS_ACTIVE_POINTER_ATTRIBUTE)
               }
@@ -291,16 +248,22 @@ fn incr_canvas_pointer_attrs(dispatch : Emit[Msg]) -> @html.Attrs {
     event.prevent_default()
     let x = incr_canvas_offset_x(event)
     let y = incr_canvas_offset_y(event)
-    let pointer_id = incr_canvas_pointer_id(event)
-    let admitted = incr_canvas_screen_point(x, y) is Some(_) &&
-      pointer_id is Some(_)
-    if admitted && incr_canvas_try_claim_pointer(event) {
-      @rabbita_cmd.batch([
-        incr_canvas_set_pointer_capture(event, dispatch),
-        dispatch(IncrCanvas(PointerDown(x, y, pointer_id))),
-      ])
-    } else {
-      @rabbita_cmd.none
+    match (incr_canvas_screen_point(x, y), incr_canvas_pointer_id(event)) {
+      (Some(_), Some(pointer_id)) =>
+        if incr_canvas_try_claim_pointer(event) {
+          try {
+            incr_canvas_set_pointer_capture(event)
+            dispatch(IncrCanvas(PointerDown(x, y, Some(pointer_id))))
+          } catch {
+            @dom.DOMExceptionError(..) => {
+              incr_canvas_clear_pointer_claim(event.as_event(), pointer_id)
+              @rabbita_cmd.none
+            }
+          }
+        } else {
+          @rabbita_cmd.none
+        }
+      _ => @rabbita_cmd.none
     }
   })
   .on_pointermove(event => {
@@ -335,6 +298,11 @@ fn incr_canvas_pointer_attrs(dispatch : Emit[Msg]) -> @html.Attrs {
     } else {
       @rabbita_cmd.none
     }
+  })
+  .on_lostpointercapture(event => {
+    let pointer_id = event.get_pointer_id()
+    incr_canvas_clear_pointer_claim(event.as_event(), pointer_id)
+    dispatch(IncrCanvas(CaptureLost(Some(pointer_id))))
   })
   .on_wheel(event => {
     event.prevent_default()

--- a/apps/ideal/web/e2e/incr-canvas.spec.ts
+++ b/apps/ideal/web/e2e/incr-canvas.spec.ts
@@ -119,6 +119,30 @@ test.describe('Bottom panel — interactive Incr Canvas', () => {
     await page.mouse.up();
   });
 
+  test('rejects a DOM pointer-capture failure before entering the reducer', async ({ page }) => {
+    await waitForEditorReady(page);
+    await page.getByRole('button', { name: 'Panels' }).click();
+    await page.getByRole('tab', { name: 'Incr Canvas' }).click();
+
+    const stage = page.locator('.incr-canvas-interaction');
+    await expect(stage).toBeVisible({ timeout: 5000 });
+    await stage.evaluate((element) => {
+      element.setPointerCapture = () => {
+        throw new DOMException('pointer is no longer active', 'NotFoundError');
+      };
+      const event = new PointerEvent('pointerdown', {
+        bubbles: true,
+        pointerId: 92,
+      });
+      Object.defineProperty(event, 'offsetX', { value: 20 });
+      Object.defineProperty(event, 'offsetY', { value: 20 });
+      element.dispatchEvent(event);
+    });
+
+    await expect(stage).not.toHaveAttribute('data-incr-active-pointer-id');
+    await expect(stage).not.toHaveAttribute('data-incr-reducer-pointer-id');
+  });
+
   test('rejects non-finite browser geometry without moving the graph', async ({ page }) => {
     await waitForEditorReady(page);
     await page.getByRole('button', { name: 'Panels' }).click();

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -31,6 +31,8 @@ files inside `docs/development/`.
   workspace modules, examples, and submodules.
 - **[Monorepo & Submodules](monorepo.md)** — git submodule setup and daily
   cheat sheet.
+- **[Rabbita fork](rabbita-fork.md)** — ownership, pinned commits, and upgrade
+  procedure for Canopy's downstream Rabbita dependency.
 
 ## Process and maintenance
 

--- a/docs/development/rabbita-fork.md
+++ b/docs/development/rabbita-fork.md
@@ -38,7 +38,8 @@ upstream Rabbita change.
 3. Run the full Rabbita test suite.
 4. Run the full Canopy test suite and the affected Ideal E2E tests.
 5. Build the JavaScript artifacts.
-6. Update the `deps/rabbita` submodule to the verified downstream commit.
+6. Update the `deps/rabbita` submodule and
+   `scripts/install-local-warren.sh` to the same verified downstream commit.
 7. Record the new commit and tag here, then verify the superproject is clean.
 
 A downstream commit must be pushed to `dowdiness/rabbita` before its gitlink is

--- a/docs/development/rabbita-fork.md
+++ b/docs/development/rabbita-fork.md
@@ -1,0 +1,45 @@
+# Canopy Rabbita fork
+
+Canopy uses a downstream fork of Rabbita for the pointer-capture DOM boundary.
+The fork is an owned dependency line, not an upstream release dependency.
+
+## Ownership
+
+- **Fork:** [`dowdiness/rabbita`](https://github.com/dowdiness/rabbita)
+- **Upstream:** [`moonbit-community/rabbita`](https://github.com/moonbit-community/rabbita)
+- **Downstream branch:** `feat/pointer-capture-typed-errors`
+- **Pinned commit:** `6f538c4b2461ca71d523b652f50740d9d0dbd030`
+- **Pinned tag:** `canopy-rabbita-0.14.2-p1`
+- **Canopy submodule:** `deps/rabbita`
+
+The Canopy `.gitmodules` entry intentionally points at the fork. The
+superproject pins the exact downstream commit; it must not depend on a moving
+branch reference at checkout time.
+
+## Downstream changes
+
+The pinned fork contains:
+
+- typed `DOMExceptionError` effects for `set_pointer_capture` and
+  `release_pointer_capture`;
+- preservation of standard DOM exception `name` and `message`, with safe
+  normalization of non-standard JavaScript throws;
+- `Attrs::on_lostpointercapture` with a `PointerEvent` callback;
+- migration of Rabbita/RUI pointer-capture consumers to the new effect.
+
+Canopy needs a MoonBit-typed pointer-capture boundary for its Canvas hosts. This
+patch is intentionally maintained downstream rather than proposed as an
+upstream Rabbita change.
+
+## Upgrade procedure
+
+1. Fetch the upstream and downstream repositories.
+2. Merge or rebase the downstream branch as appropriate.
+3. Run the full Rabbita test suite.
+4. Run the full Canopy test suite and the affected Ideal E2E tests.
+5. Build the JavaScript artifacts.
+6. Update the `deps/rabbita` submodule to the verified downstream commit.
+7. Record the new commit and tag here, then verify the superproject is clean.
+
+A downstream commit must be pushed to `dowdiness/rabbita` before its gitlink is
+updated in Canopy so fresh recursive checkouts can resolve it.

--- a/scripts/install-local-warren.sh
+++ b/scripts/install-local-warren.sh
@@ -5,7 +5,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 RABBITA_ROOT="$PROJECT_ROOT/deps/rabbita"
 RABBITA_REMOTE="$(git -C "$PROJECT_ROOT" config -f .gitmodules --get submodule.rabbita.url)"
-EXPECTED_RABBITA="539002a5a3fbd114097de1fedc758a92182cdfa7"
+EXPECTED_RABBITA="6f538c4b2461ca71d523b652f50740d9d0dbd030"
 BIN_DIR="${1:-$PROJECT_ROOT/_build/tools/bin}"
 
 actual_remote="$(git -C "$RABBITA_ROOT" remote get-url origin)"


### PR DESCRIPTION
## Summary

- Pin Canopy's `deps/rabbita` submodule to the owned downstream fork commit `6f538c4`.
- Pin `scripts/install-local-warren.sh` to the same downstream commit.
- Consume Rabbita's typed pointer-capture errors and `on_lostpointercapture` in the Ideal Incr Canvas.
- Record the fork ownership and upgrade procedure in `docs/development/rabbita-fork.md`.

The Rabbita change is intentionally maintained in `dowdiness/rabbita`; no Rabbita PR is being opened.

## UI and review evidence

N/A — this changes pointer lifecycle correctness and recovery, not visual styling or layout.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `@js.Error_::wrap` | `deps/rabbita/rabbita/js/error.mbt` | Yes | Existing JS exception transport; avoids a new FFI result protocol. |
| `@html.Attrs::handler` / pointer event helpers | `deps/rabbita/rabbita/html/attrs_event.mbt` | Yes | `on_lostpointercapture` uses the normal Rabbita event-attribute path. |
| `@dom.IsElement` pointer-capture methods | `deps/rabbita/rabbita/dom/element.mbt` | Yes | The existing DOM binding owns the Web API and now exposes its failure effect. |
| `@spatial` geometry admission | `apps/ideal/main` existing canvas helpers | Yes | Pointer capture is attempted only after existing finite-coordinate admission. |

New helpers added:

- `dom_exception_field` in the Rabbita fork safely extracts string fields from arbitrary JS throws without exposing raw JS values to consumers.
- `Attrs::on_pointer_event` / `Attrs::on_lostpointercapture` provide the missing normal event-attribute boundary for `PointerEvent` callbacks.

## Validation scope

Boundary matrix / first failing regression:

- finite coordinate and pointer-ID admission before capture;
- capture failure leaves no DOM claim, reducer pointer, or gesture;
- successful capture dispatches `PointerDown` only after capture succeeds;
- unrelated pointer IDs are ignored;
- `lostpointercapture` cancels only the claimed pointer and remains idempotent;
- release failure does not restore local gesture state;
- malformed JavaScript throws (`null` and primitive) normalize safely.

Target packages:

- `apps/ideal/main`

Additional conditional gates:

- Rabbita fork: `moon check --deny-warn`, `moon test --target js` — 396 passed.
- Canopy: `moon check --deny-warn`, `moon test --target js` — 7408 passed.
- `moon build --target js --release`.
- `scripts/install-local-warren.sh /tmp/canopy-warren-bin` installs Warren against the pinned fork commit.
- Ideal Incr Canvas Playwright: 7/7 passed with one worker.
- Fresh recursive clone verified the `deps/rabbita` gitlink resolves to `6f538c4`.

## PR-ready evidence

Validated HEAD: `345c38c918713713da5538c52b8739454f8a1f45`

Validated base: `origin/main@69734c45745b5a2a581ee6d50fd0bea7b9c894b0`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh --target apps/ideal/main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for the exact HEAD and base above.
- [x] The base was fetched again and `--verify-evidence` passed immediately before this PR was opened.
- [x] The committed `.mbti` diff against the validated base was reviewed; only the intended Rabbita submodule commit is present in the Canopy diff.
- [x] The changed Rabbita commit is pushed and reachable from `dowdiness/rabbita`.
- [x] Validation was rerun after the doc commit, rebase, submodule-pointer update, and installer pin update.
- [x] Independent review findings were resolved before final validation.
