### PR TITLE
build: make Lefthook pre-commit path-aware

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,7 @@ jobs:
               - 'scripts/install-hooks.nu'
               - 'scripts/install-hooks.sh'
               - 'scripts/test-install-hooks.sh'
+              - 'scripts/test-lefthook-pre-commit-routing.sh'
               - '.github/workflows/ci.yml'
               - '.github/workflows/release.yml'
             run_release_version_validation:
@@ -178,6 +179,7 @@ jobs:
           just --list
           just --dry-run check
           just --dry-run fmt-check
+          just --dry-run pre-commit
           just --dry-run update
           just --dry-run release-artifacts v0.2.0
 
@@ -211,6 +213,9 @@ jobs:
             "${RUNNER_TEMP}/lefthook" | sha256sum --check --status
           chmod +x "${RUNNER_TEMP}/lefthook"
           "${RUNNER_TEMP}/lefthook" validate
+
+      - name: Test path-aware Lefthook pre-commit routing
+        run: LEFTHOOK_BIN="${RUNNER_TEMP}/lefthook" bash scripts/test-lefthook-pre-commit-routing.sh
 
   release-version-validation:
     name: Release Contract Validation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,7 @@ jobs:
               - 'scripts/install-hooks.sh'
               - 'scripts/test-install-hooks.sh'
               - 'scripts/test-lefthook-pre-commit-routing.sh'
+              - 'scripts/run-moonbit-rename-route.sh'
               - '.github/workflows/ci.yml'
               - '.github/workflows/release.yml'
             run_release_version_validation:

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -39,7 +39,7 @@ than duplicating its globs.
 | `test-examples` | Matrix over `apps/ideal`, `apps/block-editor`, `apps/canvas` — each runs `./scripts/run-moon-module.sh ci <path>` |
 | `prove` | `moon prove` in `modules/semantic/proof` after installing Why3 1.7.2 + Z3 via opam (cached) |
 | `benchmark` | PR only: `moon bench --release` at the root and in `deps/event-graph-walker` |
-| `format-check` | `./scripts/check-agent-doc-links.sh` and `./scripts/run-moon-module.sh fmt-check modules/canopy` |
+| `format-check` | `./scripts/check-agent-doc-links.sh`, `./scripts/check-documentation-lifecycle.sh`, `NEW_MOON_MOD=0 moon fmt`, and a diff check that rejects Canopy-owned formatting changes |
 | `build-js` | `./scripts/update-moon-deps.sh`, `./scripts/build-js.sh`; uploads the generated JS/d.ts/mbti artifacts listed below |
 | `web-build` | Default Waku build plus TypeScript/boundary checks for `apps/web`, then the ProseMirror typecheck |
 | `waku-build` | Builds the production Worker from downloaded MoonBit artifacts, verifies bundle/type boundaries, runs preview/production Wrangler dry-runs and startup analysis, and uploads the release artifacts |
@@ -198,7 +198,14 @@ jobs only when staged MoonBit-related paths match, and runs the tooling
 contract only for hook/task/compatibility changes. The MoonBit jobs receive no
 staged-file arguments: they retain the existing `modules/canopy` module scope.
 `glob_matcher: doublestar` covers root and nested paths, while the piped group
-keeps MoonBit `check` before `fmt-check`.
+keeps MoonBit `check` before `fmt-check`. The MoonBit route also includes the
+just recipe and the scripts that implement its module and vendored checks, so
+changing those operations exercises the operations themselves.
+
+A separate `moonbit-rename` job reads staged rename metadata with Git's
+pre-image and post-image paths. If a MoonBit source is moved outside the normal
+route, it runs the same `check` then `fmt-check` tasks; ordinary staged
+additions, modifications, and deletions continue through the glob group.
 
 The public `just check` and `just fmt-check` recipes retain their explicit
 repository-contract plus main-module behavior. The `pre-commit` recipe is the

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -192,15 +192,24 @@ MoonBit, JavaScript, proof, or browser gates.
 ## Pre-commit hook
 
 Lefthook is the current hook manager. Run `just install-hooks` to install the
-hook described by `lefthook.yml`; it runs `just check` followed by
-`just fmt-check`. The `pre-commit` recipe is the single local gate, and the
-installer removes the repository's legacy direct local
-`core.hooksPath=.githooks` setting, but refuses to replace any other effective
-hook path, including included or global configuration. Manual cleanup is needed only for those non-legacy settings; use the reported
+hook described by `lefthook.yml`. Its path-aware `pre-commit` routing always
+runs the repository contract, runs the main-module MoonBit check and format
+jobs only when staged MoonBit-related paths match, and runs the tooling
+contract only for hook/task/compatibility changes. The MoonBit jobs receive no
+staged-file arguments: they retain the existing `modules/canopy` module scope.
+`glob_matcher: doublestar` covers root and nested paths, while the piped group
+keeps MoonBit `check` before `fmt-check`.
+
+The public `just check` and `just fmt-check` recipes retain their explicit
+repository-contract plus main-module behavior. The `pre-commit` recipe is the
+single local entry point into Lefthook, and `.githooks/pre-commit` remains a
+compatibility shim that delegates to it. The installer removes the repository's
+legacy direct local `core.hooksPath=.githooks` setting, but refuses to replace
+any other effective hook path, including included or global configuration.
+Manual cleanup is needed only for those non-legacy settings; use the reported
 scope and origin to locate the configuration. If you need to bypass the hook
-(e.g. during a rebase you understand),
-`git commit --no-verify` is available, but CI's `format-check` and
-`test-main` will catch the same issues on push.
+(e.g. during a rebase you understand), `git commit --no-verify` is available,
+but CI's `format-check` and `test-main` will catch the same issues on push.
 
 ## Adding new gating checks
 

--- a/justfile
+++ b/justfile
@@ -35,7 +35,7 @@ hook-tooling-contract:
     @just --unstable --fmt --check
     @just --dry-run pre-commit
     @make -n check
-    @bash -n .githooks/pre-commit scripts/install-hooks.sh scripts/test-install-hooks.sh scripts/test-lefthook-pre-commit-routing.sh
+    @bash -n .githooks/pre-commit scripts/install-hooks.sh scripts/test-install-hooks.sh scripts/test-lefthook-pre-commit-routing.sh scripts/run-moonbit-rename-route.sh
     @nu --ide-check 100 scripts/install-hooks.nu
     @lefthook validate
 

--- a/justfile
+++ b/justfile
@@ -18,10 +18,29 @@ test:
 test-all:
     @moon test
 
-# Run moon check for main module
-check:
+# Verify the repository-level contract used by every pre-commit route
+hook-repository-contract:
     @bash ./scripts/check-agent-doc-links.sh
+
+# Run the main module's MoonBit check from Lefthook
+hook-moonbit-check:
     @./scripts/run-moon-module.sh check modules/canopy
+
+# Run the main module's MoonBit format check from Lefthook
+hook-moonbit-format-check:
+    @./scripts/run-moon-module.sh fmt-check modules/canopy
+
+# Validate tooling files selected by Lefthook
+hook-tooling-contract:
+    @just --unstable --fmt --check
+    @just --dry-run pre-commit
+    @make -n check
+    @bash -n .githooks/pre-commit scripts/install-hooks.sh scripts/test-install-hooks.sh scripts/test-lefthook-pre-commit-routing.sh
+    @nu --ide-check 100 scripts/install-hooks.nu
+    @lefthook validate
+
+# Run moon check for main module
+check: hook-repository-contract hook-moonbit-check
 
 # Run strict checks and formatting for the root MoonBit workspace
 check-all:
@@ -35,9 +54,7 @@ fmt:
     cd modules/canopy; moon info
 
 # Check formatting for the main module without keeping changes
-fmt-check:
-    @bash ./scripts/check-agent-doc-links.sh
-    @./scripts/run-moon-module.sh fmt-check modules/canopy
+fmt-check: hook-repository-contract hook-moonbit-format-check
 
 # Build main module (default target)
 build:
@@ -81,8 +98,9 @@ clean:
     @rm -rf target _build
     @rm -rf apps/web/dist release
 
-# Run the local pre-commit gate
-pre-commit: check fmt-check
+# Run the path-aware local pre-commit gate through Lefthook
+pre-commit:
+    @lefthook run pre-commit
 
 # Install git pre-commit hooks through Lefthook
 install-hooks:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,7 +1,46 @@
 min_version: 2.1.0
 assert_lefthook_installed: true
+glob_matcher: doublestar
 
 pre-commit:
-  commands:
-    gate:
-      run: just pre-commit
+  parallel: false
+  jobs:
+    - name: repository-contract
+      run: just hook-repository-contract
+
+    - name: moonbit
+      glob:
+        - "**/*.mbt"
+        - "**/*.mbt.md"
+        - "**/*.mbti"
+        - "**/moon.mod"
+        - "**/moon.mod.json"
+        - "**/moon.pkg"
+        - "**/moon.pkg.json"
+        - "moon.work"
+        - "moon.work.json"
+        - "modules/**"
+        - "apps/**"
+        - "examples/**"
+        - "adapters/**"
+        - "deps/**"
+      group:
+        piped: true
+        jobs:
+          - name: check
+            run: just hook-moonbit-check
+          - name: format
+            run: just hook-moonbit-format-check
+
+    - name: tooling
+      glob:
+        - "lefthook.yml"
+        - "justfile"
+        - "Makefile"
+        - ".githooks/**"
+        - "scripts/install-hooks.nu"
+        - "scripts/install-hooks.sh"
+        - "scripts/test-install-hooks.sh"
+        - "scripts/test-lefthook-pre-commit-routing.sh"
+        - ".github/workflows/ci.yml"
+      run: just hook-tooling-contract

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -19,6 +19,10 @@ pre-commit:
         - "**/moon.pkg.json"
         - "moon.work"
         - "moon.work.json"
+        - "justfile"
+        - "scripts/run-moon-module.sh"
+        - "scripts/vendored-check-common.sh"
+        - "scripts/run-moonbit-rename-route.sh"
         - "modules/**"
         - "apps/**"
         - "examples/**"
@@ -32,6 +36,9 @@ pre-commit:
           - name: format
             run: just hook-moonbit-format-check
 
+    - name: moonbit-rename
+      run: ./scripts/run-moonbit-rename-route.sh
+
     - name: tooling
       glob:
         - "lefthook.yml"
@@ -42,5 +49,6 @@ pre-commit:
         - "scripts/install-hooks.sh"
         - "scripts/test-install-hooks.sh"
         - "scripts/test-lefthook-pre-commit-routing.sh"
+        - "scripts/run-moonbit-rename-route.sh"
         - ".github/workflows/ci.yml"
       run: just hook-tooling-contract

--- a/scripts/run-moonbit-rename-route.sh
+++ b/scripts/run-moonbit-rename-route.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+set -eu
+
+is_moonbit_route() {
+  case "$1" in
+    *.mbt|*.mbt.md|*.mbti|moon.mod|moon.mod.json|moon.pkg|moon.pkg.json|moon.work|moon.work.json|*/moon.mod|*/moon.mod.json|*/moon.pkg|*/moon.pkg.json|modules/*|apps/*|examples/*|adapters/*|deps/*|justfile|scripts/run-moon-module.sh|scripts/vendored-check-common.sh|scripts/run-moonbit-rename-route.sh)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+# Lefthook's normal staged-file glob sees the post-image path of a detected
+# rename. If another post-image already routes through the normal MoonBit
+# group, that group will exercise the operation once and this fallback must
+# stay quiet.
+POST_IMAGE=$(mktemp "${TMPDIR:-/tmp}/canopy-moonbit-post-image.XXXXXX")
+trap 'rm -f "$POST_IMAGE"' EXIT HUP INT TERM
+
+git diff --cached --name-only --diff-filter=ACMRD -- > "$POST_IMAGE"
+while IFS= read -r path; do
+  if is_moonbit_route "$path"; then
+    exit 0
+  fi
+done < "$POST_IMAGE"
+
+# Otherwise inspect the pre-image explicitly so moving MoonBit input out of
+# the routed tree still exercises the operation it used to feed.
+git diff --cached --name-status --find-renames --diff-filter=R -- | while IFS="$(printf '\t')" read -r status source destination; do
+  case "$status" in
+    R*)
+      if is_moonbit_route "$source" && ! is_moonbit_route "$destination"; then
+        just hook-moonbit-check
+        just hook-moonbit-format-check
+        exit 0
+      fi
+      ;;
+  esac
+done

--- a/scripts/test-lefthook-pre-commit-routing.sh
+++ b/scripts/test-lefthook-pre-commit-routing.sh
@@ -24,8 +24,10 @@ OUTPUT="$FIXTURE/lefthook-output.log"
 EXPECTED="$FIXTURE/expected.log"
 trap 'rm -rf "$FIXTURE"' EXIT HUP INT TERM
 
-mkdir -p "$FIXTURE/bin" "$FIXTURE/modules/canopy/core"
+mkdir -p "$FIXTURE/bin" "$FIXTURE/modules/canopy/core" "$FIXTURE/scripts"
 cp "$REPO_ROOT/lefthook.yml" "$FIXTURE/lefthook.yml"
+cp "$REPO_ROOT/scripts/run-moonbit-rename-route.sh" "$FIXTURE/scripts/run-moonbit-rename-route.sh"
+chmod +x "$FIXTURE/scripts/run-moonbit-rename-route.sh"
 
 cat > "$FIXTURE/bin/just" <<'EOF'
 #!/bin/sh
@@ -41,6 +43,8 @@ printf '%s\n' 'baseline' > "$FIXTURE/README.md"
 printf '%s\n' 'baseline' > "$FIXTURE/justfile"
 printf '%s\n' 'baseline' > "$FIXTURE/modules/canopy/core/deleted.mbt"
 printf '%s\n' 'baseline' > "$FIXTURE/modules/canopy/core/rename-before.mbt"
+printf '%s\n' 'baseline' > "$FIXTURE/scripts/run-moon-module.sh"
+printf '%s\n' 'baseline' > "$FIXTURE/scripts/vendored-check-common.sh"
 
 git -C "$FIXTURE" init --quiet
 git -C "$FIXTURE" symbolic-ref HEAD refs/heads/main
@@ -169,7 +173,25 @@ test_dependencies_zone() {
   stage_file deps/fixture/config.txt 'dependency change'
 }
 
-test_tooling() {
+test_moonbit_runner_script() {
+  stage_file scripts/run-moon-module.sh 'updated MoonBit runner'
+}
+
+test_vendored_check_script() {
+  stage_file scripts/vendored-check-common.sh 'updated vendored check helper'
+}
+
+test_moonbit_rename_route_script() {
+  cp "$REPO_ROOT/scripts/run-moonbit-rename-route.sh" "$FIXTURE/scripts/run-moonbit-rename-route.sh"
+  printf '%s\n' '# staged route implementation change' >> "$FIXTURE/scripts/run-moonbit-rename-route.sh"
+  git -C "$FIXTURE" add scripts/run-moonbit-rename-route.sh
+}
+
+test_tooling_config() {
+  stage_file Makefile 'updated Makefile'
+}
+
+test_justfile() {
   stage_file justfile 'updated justfile'
 }
 
@@ -184,6 +206,23 @@ test_deleted_moonbit() {
 
 test_renamed_moonbit() {
   git -C "$FIXTURE" mv modules/canopy/core/rename-before.mbt modules/canopy/core/rename-after.mbt
+}
+
+test_renamed_moonbit_outside_route() {
+  mkdir -p "$FIXTURE/docs"
+  git -C "$FIXTURE" mv modules/canopy/core/rename-before.mbt docs/rename-after.txt
+}
+
+test_renamed_moonbit_with_normal_route() {
+  mkdir -p "$FIXTURE/docs"
+  git -C "$FIXTURE" mv modules/canopy/core/rename-before.mbt docs/rename-after.txt
+  stage_file modules/canopy/core/other.mbt 'normal MoonBit change'
+}
+
+test_renamed_moonbit_with_deleted_route() {
+  mkdir -p "$FIXTURE/docs"
+  git -C "$FIXTURE" mv modules/canopy/core/rename-before.mbt docs/rename-after.txt
+  git -C "$FIXTURE" rm --quiet modules/canopy/core/deleted.mbt
 }
 
 run_case 'unrelated text only' test_unrelated \
@@ -220,11 +259,25 @@ run_case 'adapters zone' test_adapters_zone \
   hook-repository-contract hook-moonbit-check hook-moonbit-format-check
 run_case 'dependencies zone' test_dependencies_zone \
   hook-repository-contract hook-moonbit-check hook-moonbit-format-check
-run_case 'tooling configuration' test_tooling \
+run_case 'MoonBit runner script' test_moonbit_runner_script \
+  hook-repository-contract hook-moonbit-check hook-moonbit-format-check
+run_case 'vendored check script' test_vendored_check_script \
+  hook-repository-contract hook-moonbit-check hook-moonbit-format-check
+run_case 'MoonBit rename route script' test_moonbit_rename_route_script \
+  hook-repository-contract hook-moonbit-check hook-moonbit-format-check hook-tooling-contract
+run_case 'tooling configuration' test_tooling_config \
   hook-repository-contract hook-tooling-contract
+run_case 'justfile hook tasks' test_justfile \
+  hook-repository-contract hook-moonbit-check hook-moonbit-format-check hook-tooling-contract
 run_case 'MoonBit and tooling' test_moonbit_and_tooling \
   hook-repository-contract hook-moonbit-check hook-moonbit-format-check hook-tooling-contract
 run_case 'deleted MoonBit file' test_deleted_moonbit \
   hook-repository-contract hook-moonbit-check hook-moonbit-format-check
 run_case 'renamed MoonBit file' test_renamed_moonbit \
+  hook-repository-contract hook-moonbit-check hook-moonbit-format-check
+run_case 'renamed MoonBit file outside route' test_renamed_moonbit_outside_route \
+  hook-repository-contract hook-moonbit-check hook-moonbit-format-check
+run_case 'renamed MoonBit file with normal route' test_renamed_moonbit_with_normal_route \
+  hook-repository-contract hook-moonbit-check hook-moonbit-format-check
+run_case 'renamed MoonBit file with deleted route' test_renamed_moonbit_with_deleted_route \
   hook-repository-contract hook-moonbit-check hook-moonbit-format-check

--- a/scripts/test-lefthook-pre-commit-routing.sh
+++ b/scripts/test-lefthook-pre-commit-routing.sh
@@ -1,0 +1,230 @@
+#!/bin/sh
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(CDPATH= cd "$SCRIPT_DIR/.." && pwd)
+
+LEFTHOOK_BIN=${LEFTHOOK_BIN:-lefthook}
+if [ -x "$LEFTHOOK_BIN" ]; then
+  case "$LEFTHOOK_BIN" in
+    /*) ;;
+    *) LEFTHOOK_BIN=$(CDPATH= cd "$(dirname "$LEFTHOOK_BIN")" && pwd)/$(basename "$LEFTHOOK_BIN") ;;
+  esac
+elif command -v "$LEFTHOOK_BIN" >/dev/null 2>&1; then
+  LEFTHOOK_BIN=$(command -v "$LEFTHOOK_BIN")
+else
+  echo "error: Lefthook binary not found; set LEFTHOOK_BIN" >&2
+  exit 1
+fi
+
+FIXTURE=$(mktemp -d "${TMPDIR:-/tmp}/canopy-lefthook-routing.XXXXXX")
+LOG="$FIXTURE/calls.log"
+OUTPUT="$FIXTURE/lefthook-output.log"
+EXPECTED="$FIXTURE/expected.log"
+trap 'rm -rf "$FIXTURE"' EXIT HUP INT TERM
+
+mkdir -p "$FIXTURE/bin" "$FIXTURE/modules/canopy/core"
+cp "$REPO_ROOT/lefthook.yml" "$FIXTURE/lefthook.yml"
+
+cat > "$FIXTURE/bin/just" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$*" >> "$LEFTHOOK_ROUTING_LOG"
+EOF
+chmod +x "$FIXTURE/bin/just"
+export LEFTHOOK_ROUTING_LOG="$LOG"
+export PATH="$FIXTURE/bin:$PATH"
+
+printf '%s\n' 'AGENTS fixture' > "$FIXTURE/AGENTS.md"
+ln -s AGENTS.md "$FIXTURE/CLAUDE.md"
+printf '%s\n' 'baseline' > "$FIXTURE/README.md"
+printf '%s\n' 'baseline' > "$FIXTURE/justfile"
+printf '%s\n' 'baseline' > "$FIXTURE/modules/canopy/core/deleted.mbt"
+printf '%s\n' 'baseline' > "$FIXTURE/modules/canopy/core/rename-before.mbt"
+
+git -C "$FIXTURE" init --quiet
+git -C "$FIXTURE" symbolic-ref HEAD refs/heads/main
+git -C "$FIXTURE" config user.email lefthook-routing@example.invalid
+git -C "$FIXTURE" config user.name lefthook-routing-test
+git -C "$FIXTURE" add -A
+git -C "$FIXTURE" commit --quiet -m baseline
+
+if ! (cd "$FIXTURE" && "$LEFTHOOK_BIN" validate >"$OUTPUT" 2>&1); then
+  cat "$OUTPUT" >&2
+  echo "FAIL Lefthook configuration validation" >&2
+  exit 1
+fi
+
+reset_fixture() {
+  git -C "$FIXTURE" reset --hard --quiet HEAD
+  git -C "$FIXTURE" clean -fdq
+  : > "$LOG"
+}
+
+stage_file() {
+  path=$1
+  contents=$2
+  mkdir -p "$FIXTURE/$(dirname "$path")"
+  printf '%s\n' "$contents" > "$FIXTURE/$path"
+  git -C "$FIXTURE" add -- "$path"
+}
+
+assert_calls() {
+  name=$1
+  shift
+  : > "$EXPECTED"
+  for expected_call in "$@"; do
+    printf '%s\n' "$expected_call" >> "$EXPECTED"
+  done
+  if ! cmp -s "$EXPECTED" "$LOG"; then
+    echo "FAIL $name: Lefthook call sequence mismatch" >&2
+    echo 'expected:' >&2
+    cat "$EXPECTED" >&2
+    echo 'actual:' >&2
+    cat "$LOG" >&2
+    exit 1
+  fi
+  echo "PASS $name"
+}
+
+run_case() {
+  name=$1
+  setup=$2
+  shift 2
+  reset_fixture
+  "$setup"
+  if ! (cd "$FIXTURE" && "$LEFTHOOK_BIN" run pre-commit >"$OUTPUT" 2>&1); then
+    cat "$OUTPUT" >&2
+    echo "FAIL $name: Lefthook run failed" >&2
+    exit 1
+  fi
+  assert_calls "$name" "$@"
+}
+
+test_unrelated() {
+  stage_file notes.txt 'unrelated'
+}
+
+test_agent_docs() {
+  stage_file AGENTS.md 'updated AGENTS fixture'
+}
+
+test_root_moonbit() {
+  stage_file root.mbt 'root MoonBit source'
+}
+
+test_nested_moonbit() {
+  stage_file modules/canopy/core/nested.mbt 'nested MoonBit source'
+}
+
+test_package_manifest() {
+  stage_file moon.pkg 'package manifest'
+}
+
+test_package_manifest_json() {
+  stage_file moon.pkg.json '{}'
+}
+
+test_module_manifest() {
+  stage_file moon.mod 'module manifest'
+}
+
+test_module_manifest_json() {
+  stage_file moon.mod.json '{}'
+}
+
+test_workspace_manifest() {
+  stage_file moon.work 'workspace manifest'
+}
+
+test_workspace_manifest_json() {
+  stage_file moon.work.json '{}'
+}
+
+test_moonbit_documentation() {
+  stage_file guide.mbt.md 'MoonBit documentation'
+}
+
+test_generated_interface() {
+  stage_file interface.mbti 'generated interface'
+}
+
+test_modules_zone() {
+  stage_file modules/fixture/config.txt 'module change'
+}
+
+test_apps_zone() {
+  stage_file apps/fixture/config.txt 'app change'
+}
+
+test_examples_zone() {
+  stage_file examples/fixture/config.txt 'example change'
+}
+
+test_adapters_zone() {
+  stage_file adapters/fixture/config.txt 'adapter change'
+}
+
+test_dependencies_zone() {
+  stage_file deps/fixture/config.txt 'dependency change'
+}
+
+test_tooling() {
+  stage_file justfile 'updated justfile'
+}
+
+test_moonbit_and_tooling() {
+  stage_file modules/canopy/core/nested.mbt 'nested MoonBit source'
+  stage_file .github/workflows/ci.yml 'updated CI workflow'
+}
+
+test_deleted_moonbit() {
+  git -C "$FIXTURE" rm --quiet modules/canopy/core/deleted.mbt
+}
+
+test_renamed_moonbit() {
+  git -C "$FIXTURE" mv modules/canopy/core/rename-before.mbt modules/canopy/core/rename-after.mbt
+}
+
+run_case 'unrelated text only' test_unrelated \
+  hook-repository-contract
+run_case 'AGENTS.md only' test_agent_docs \
+  hook-repository-contract
+run_case 'root MoonBit file' test_root_moonbit \
+  hook-repository-contract hook-moonbit-check hook-moonbit-format-check
+run_case 'nested MoonBit file' test_nested_moonbit \
+  hook-repository-contract hook-moonbit-check hook-moonbit-format-check
+run_case 'Moon package manifest' test_package_manifest \
+  hook-repository-contract hook-moonbit-check hook-moonbit-format-check
+run_case 'Moon package JSON manifest' test_package_manifest_json \
+  hook-repository-contract hook-moonbit-check hook-moonbit-format-check
+run_case 'Moon module manifest' test_module_manifest \
+  hook-repository-contract hook-moonbit-check hook-moonbit-format-check
+run_case 'Moon module JSON manifest' test_module_manifest_json \
+  hook-repository-contract hook-moonbit-check hook-moonbit-format-check
+run_case 'Moon workspace manifest' test_workspace_manifest \
+  hook-repository-contract hook-moonbit-check hook-moonbit-format-check
+run_case 'Moon workspace JSON manifest' test_workspace_manifest_json \
+  hook-repository-contract hook-moonbit-check hook-moonbit-format-check
+run_case 'MoonBit documentation' test_moonbit_documentation \
+  hook-repository-contract hook-moonbit-check hook-moonbit-format-check
+run_case 'generated interface' test_generated_interface \
+  hook-repository-contract hook-moonbit-check hook-moonbit-format-check
+run_case 'modules zone' test_modules_zone \
+  hook-repository-contract hook-moonbit-check hook-moonbit-format-check
+run_case 'apps zone' test_apps_zone \
+  hook-repository-contract hook-moonbit-check hook-moonbit-format-check
+run_case 'examples zone' test_examples_zone \
+  hook-repository-contract hook-moonbit-check hook-moonbit-format-check
+run_case 'adapters zone' test_adapters_zone \
+  hook-repository-contract hook-moonbit-check hook-moonbit-format-check
+run_case 'dependencies zone' test_dependencies_zone \
+  hook-repository-contract hook-moonbit-check hook-moonbit-format-check
+run_case 'tooling configuration' test_tooling \
+  hook-repository-contract hook-tooling-contract
+run_case 'MoonBit and tooling' test_moonbit_and_tooling \
+  hook-repository-contract hook-moonbit-check hook-moonbit-format-check hook-tooling-contract
+run_case 'deleted MoonBit file' test_deleted_moonbit \
+  hook-repository-contract hook-moonbit-check hook-moonbit-format-check
+run_case 'renamed MoonBit file' test_renamed_moonbit \
+  hook-repository-contract hook-moonbit-check hook-moonbit-format-check


### PR DESCRIPTION
## Summary

- make Lefthook `pre-commit` route staged paths to repository, MoonBit, and tooling contracts
- keep MoonBit checks module-scoped to `modules/canopy` and run check before format without passing staged files to Moon
- decompose the existing public `just check` and `just fmt-check` recipes into reusable hook tasks without changing their validation scope
- route the public and legacy `.githooks/pre-commit` entry points through Lefthook
- add a rename-aware fallback that preserves MoonBit checks when a MoonBit source moves outside the normal route
- include direct MoonBit operation dependencies (`justfile`, `run-moon-module.sh`, and `vendored-check-common.sh`) in routing
- add a real Lefthook binary regression fixture using temporary Git repositories and a recording fake `just`
- validate the pinned Lefthook binary and routing fixture in CI

## Routing contract

- repository contract runs once for any staged change
- MoonBit check/format runs once for root or nested source, interfaces, manifests, workspace files, operation dependencies, and changes under the workspace/module zones
- MoonBit jobs are piped as `check` then `fmt-check`
- tooling contract runs for Lefthook, just, Make, compatibility hooks, installer/test scripts, the rename router, and CI workflow changes
- unrelated text and `AGENTS.md` changes do not trigger MoonBit or tooling jobs
- staged deletion and rename of MoonBit files remain covered
- a MoonBit source renamed outside the normal route is checked through the pre-image/post-image fallback
- mixed route-out rename plus a normal MoonBit addition or deletion executes the MoonBit pair exactly once

`glob_matcher: doublestar` handles root and nested paths. The routing fixture independently tests each configured trigger, direct operation dependency, deletion, rename, route-out rename, and mixed route case.

## Implementation note

Lefthook 2.1.10's hook-level custom `files` command was tested with
`git diff --cached --no-renames --name-only`, but its internal existing-file
lookup drops deleted paths before glob inspection. This PR therefore keeps the
built-in staged/deleted-file behavior for the normal glob group and uses a
small unconditional rename fallback that reads Git's rename pre-image and
post-image metadata. The fallback suppresses itself whenever the normal
post-image route already runs the MoonBit pair.

## Non-goals

- pre-push hooks
- workspace-wide test fan-out
- submodule reachability checks
- Claude commit/push hook removal
- parallel execution
- `stage_fixed` or automatic formatting
- installer simplification
- module-specific fan-out

## Validation

- real Lefthook v2.1.10 `validate`
- `scripts/test-lefthook-pre-commit-routing.sh` (temporary Git repositories, real Lefthook, recording fake `just`)
- root/nested MoonBit, `.mbt.md`, `.mbti`, `moon.pkg(.json)`, `moon.mod(.json)`, `moon.work(.json)`, workspace zones, operation scripts, tooling, deletion, rename, route-out rename, and mixed-route fixtures
- `just --unstable --fmt --check`
- `just` dry-runs for public check, fmt-check, and pre-commit
- existing `just check` and `just fmt-check`
- existing installer regression tests and Nushell syntax check
- `.githooks/pre-commit` compatibility entry point
- workflow YAML validation and actionlint
- `./scripts/validate-pr-ready.sh --no-target "Lefthook path-aware pre-commit routing, rename pre-image fallback, MoonBit operation dependency routing, real-binary regression tests, CI tooling validation, and documentation only"`
- `./scripts/validate-pr-ready.sh --verify-evidence`

Final validated HEAD: `e55aa8ec`; base: `f60d4277`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pre-commit checks now run selectively based on changed files.
  * Added dedicated routing for repository, MoonBit, and tooling validations.
  * MoonBit renames are handled correctly, including files moved outside monitored paths.
  * Unrelated changes avoid unnecessary validation steps.

* **Documentation**
  * Updated CI/CD guidance for path-aware checks and formatting validation.

* **Tests**
  * Added coverage for additions, deletions, renames, and combined changes.
  * CI now validates routing behavior automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->