### PR TITLE
fix(rabbita): preserve typed pointer events and fractional coordinates

### DIFF
--- a/apps/ideal/main/view_bottom_incr_canvas.mbt
+++ b/apps/ideal/main/view_bottom_incr_canvas.mbt
@@ -123,46 +123,74 @@ fn render_incr_canvas_svg(
 const INCR_CANVAS_ACTIVE_POINTER_ATTRIBUTE : String = "data-incr-active-pointer-id"
 
 ///|
-#cfg(target="js")
-extern "js" fn incr_canvas_offset_x(event : @dom.MouseEvent) -> Double = "(event) => event.offsetX"
-
-///|
-#cfg(target="js")
-extern "js" fn incr_canvas_offset_y(event : @dom.MouseEvent) -> Double = "(event) => event.offsetY"
-
-///|
-#cfg(target="js")
-extern "js" fn incr_canvas_wheel_offset_x(event : @dom.WheelEvent) -> Double = "(event) => event.offsetX"
-
-///|
-#cfg(target="js")
-extern "js" fn incr_canvas_wheel_offset_y(event : @dom.WheelEvent) -> Double = "(event) => event.offsetY"
-
-///|
-fn incr_canvas_pointer_id(event : @dom.MouseEvent) -> Int? {
-  event.to_pointer_event().map(pointer => pointer.get_pointer_id())
+fn incr_canvas_screen_point_from_target(
+  target : @dom.EventTarget,
+  client_x : Double,
+  client_y : Double,
+) -> @spatial.ScreenPoint? {
+  guard target.to_element() is Some(element) else { return None }
+  let rect = element.get_bounding_client_rect()
+  incr_canvas_screen_point(
+    client_x - rect.get_left(),
+    client_y - rect.get_top(),
+  )
 }
 
 ///|
-fn incr_canvas_pointer_is_claimed(event : @dom.MouseEvent) -> Bool {
-  match (event.to_pointer_event(), event.current_target().to_option()) {
-    (Some(pointer), Some(target)) =>
-      match target.to_element() {
-        Some(element) =>
-          incr_canvas_pointer_claim_matches(
-            element.get_attribute(INCR_CANVAS_ACTIVE_POINTER_ATTRIBUTE),
-            Some(pointer.get_pointer_id()),
-          )
-        None => false
-      }
-    _ => false
+fn incr_canvas_screen_point_from_pointer_event(
+  event : @dom.PointerEvent,
+) -> @spatial.ScreenPoint? {
+  match event.current_target().to_option() {
+    Some(target) =>
+      incr_canvas_screen_point_from_target(
+        target,
+        event.get_client_x(),
+        event.get_client_y(),
+      )
+    None => None
   }
 }
 
 ///|
-fn incr_canvas_try_claim_pointer(event : @dom.MouseEvent) -> Bool {
-  match (event.to_pointer_event(), event.current_target().to_option()) {
-    (Some(pointer), Some(target)) =>
+fn incr_canvas_screen_point_from_wheel_event(
+  event : @dom.WheelEvent,
+) -> @spatial.ScreenPoint? {
+  match event.current_target().to_option() {
+    Some(target) =>
+      incr_canvas_screen_point_from_target(
+        target,
+        event.get_client_x(),
+        event.get_client_y(),
+      )
+    None => None
+  }
+}
+
+///|
+fn incr_canvas_pointer_id(event : @dom.PointerEvent) -> Int {
+  event.get_pointer_id()
+}
+
+///|
+fn incr_canvas_pointer_is_claimed(event : @dom.PointerEvent) -> Bool {
+  match event.current_target().to_option() {
+    Some(target) =>
+      match target.to_element() {
+        Some(element) =>
+          incr_canvas_pointer_claim_matches(
+            element.get_attribute(INCR_CANVAS_ACTIVE_POINTER_ATTRIBUTE),
+            Some(event.get_pointer_id()),
+          )
+        None => false
+      }
+    None => false
+  }
+}
+
+///|
+fn incr_canvas_try_claim_pointer(event : @dom.PointerEvent) -> Bool {
+  match event.current_target().to_option() {
+    Some(target) =>
       match target.to_element() {
         Some(element) =>
           match element.get_attribute(INCR_CANVAS_ACTIVE_POINTER_ATTRIBUTE) {
@@ -170,14 +198,14 @@ fn incr_canvas_try_claim_pointer(event : @dom.MouseEvent) -> Bool {
             None => {
               element.set_attribute(
                 INCR_CANVAS_ACTIVE_POINTER_ATTRIBUTE,
-                pointer.get_pointer_id().to_string(),
+                event.get_pointer_id().to_string(),
               )
               true
             }
           }
         None => false
       }
-    _ => false
+    None => false
   }
 }
 
@@ -202,39 +230,35 @@ fn incr_canvas_clear_pointer_claim(
 
 ///|
 fn incr_canvas_set_pointer_capture(
-  event : @dom.MouseEvent,
+  event : @dom.PointerEvent,
 ) -> Unit raise @dom.DOMExceptionError {
-  match (event.to_pointer_event(), event.current_target().to_option()) {
-    (Some(pointer), Some(target)) =>
+  match event.current_target().to_option() {
+    Some(target) =>
       match target.to_element() {
-        Some(element) => element.set_pointer_capture(pointer.get_pointer_id())
+        Some(element) => element.set_pointer_capture(event.get_pointer_id())
         None => ()
       }
-    _ => ()
+    None => ()
   }
 }
 
 ///|
-fn incr_canvas_release_pointer_capture(event : @dom.MouseEvent) -> Unit {
-  match event.to_pointer_event() {
-    Some(pointer) =>
-      match event.current_target().to_option() {
-        Some(target) =>
-          match target.to_element() {
-            Some(element) => {
-              let pointer_id = pointer.get_pointer_id()
-              if element.get_attribute(INCR_CANVAS_ACTIVE_POINTER_ATTRIBUTE) ==
-                Some(pointer_id.to_string()) {
-                if element.has_pointer_capture(pointer_id) {
-                  element.release_pointer_capture(pointer_id) catch {
-                    @dom.DOMExceptionError(..) => ()
-                  }
-                }
-                element.remove_attribute(INCR_CANVAS_ACTIVE_POINTER_ATTRIBUTE)
+fn incr_canvas_release_pointer_capture(event : @dom.PointerEvent) -> Unit {
+  match event.current_target().to_option() {
+    Some(target) =>
+      match target.to_element() {
+        Some(element) => {
+          let pointer_id = event.get_pointer_id()
+          if element.get_attribute(INCR_CANVAS_ACTIVE_POINTER_ATTRIBUTE) ==
+            Some(pointer_id.to_string()) {
+            if element.has_pointer_capture(pointer_id) {
+              element.release_pointer_capture(pointer_id) catch {
+                @dom.DOMExceptionError(..) => ()
               }
             }
-            None => ()
+            element.remove_attribute(INCR_CANVAS_ACTIVE_POINTER_ATTRIBUTE)
           }
+        }
         None => ()
       }
     None => ()
@@ -246,14 +270,15 @@ fn incr_canvas_pointer_attrs(dispatch : Emit[Msg]) -> @html.Attrs {
   @html.Attrs::build()
   .on_pointerdown(event => {
     event.prevent_default()
-    let x = incr_canvas_offset_x(event)
-    let y = incr_canvas_offset_y(event)
-    match (incr_canvas_screen_point(x, y), incr_canvas_pointer_id(event)) {
-      (Some(_), Some(pointer_id)) =>
+    match incr_canvas_screen_point_from_pointer_event(event) {
+      Some(screen) => {
+        let pointer_id = incr_canvas_pointer_id(event)
         if incr_canvas_try_claim_pointer(event) {
           try {
             incr_canvas_set_pointer_capture(event)
-            dispatch(IncrCanvas(PointerDown(x, y, Some(pointer_id))))
+            dispatch(
+              IncrCanvas(PointerDown(screen.x(), screen.y(), Some(pointer_id))),
+            )
           } catch {
             @dom.DOMExceptionError(..) => {
               incr_canvas_clear_pointer_claim(event.as_event(), pointer_id)
@@ -263,20 +288,25 @@ fn incr_canvas_pointer_attrs(dispatch : Emit[Msg]) -> @html.Attrs {
         } else {
           @rabbita_cmd.none
         }
-      _ => @rabbita_cmd.none
+      }
+      None => @rabbita_cmd.none
     }
   })
   .on_pointermove(event => {
     if incr_canvas_pointer_is_claimed(event) {
-      dispatch(
-        IncrCanvas(
-          PointerMove(
-            incr_canvas_offset_x(event),
-            incr_canvas_offset_y(event),
-            incr_canvas_pointer_id(event),
-          ),
-        ),
-      )
+      match incr_canvas_screen_point_from_pointer_event(event) {
+        Some(screen) =>
+          dispatch(
+            IncrCanvas(
+              PointerMove(
+                screen.x(),
+                screen.y(),
+                Some(incr_canvas_pointer_id(event)),
+              ),
+            ),
+          )
+        None => @rabbita_cmd.none
+      }
     } else {
       @rabbita_cmd.none
     }
@@ -285,7 +315,7 @@ fn incr_canvas_pointer_attrs(dispatch : Emit[Msg]) -> @html.Attrs {
     event.prevent_default()
     if incr_canvas_pointer_is_claimed(event) {
       incr_canvas_release_pointer_capture(event)
-      dispatch(IncrCanvas(PointerUp(incr_canvas_pointer_id(event))))
+      dispatch(IncrCanvas(PointerUp(Some(incr_canvas_pointer_id(event)))))
     } else {
       @rabbita_cmd.none
     }
@@ -294,7 +324,7 @@ fn incr_canvas_pointer_attrs(dispatch : Emit[Msg]) -> @html.Attrs {
     event.prevent_default()
     if incr_canvas_pointer_is_claimed(event) {
       incr_canvas_release_pointer_capture(event)
-      dispatch(IncrCanvas(PointerCancel(incr_canvas_pointer_id(event))))
+      dispatch(IncrCanvas(PointerCancel(Some(incr_canvas_pointer_id(event)))))
     } else {
       @rabbita_cmd.none
     }
@@ -306,15 +336,11 @@ fn incr_canvas_pointer_attrs(dispatch : Emit[Msg]) -> @html.Attrs {
   })
   .on_wheel(event => {
     event.prevent_default()
-    dispatch(
-      IncrCanvas(
-        Wheel(
-          event.get_delta_y(),
-          incr_canvas_wheel_offset_x(event),
-          incr_canvas_wheel_offset_y(event),
-        ),
-      ),
-    )
+    match incr_canvas_screen_point_from_wheel_event(event) {
+      Some(screen) =>
+        dispatch(IncrCanvas(Wheel(event.get_delta_y(), screen.x(), screen.y())))
+      None => @rabbita_cmd.none
+    }
   })
 }
 

--- a/apps/ideal/web/e2e/incr-canvas.spec.ts
+++ b/apps/ideal/web/e2e/incr-canvas.spec.ts
@@ -58,8 +58,6 @@ test.describe('Bottom panel — interactive Incr Canvas', () => {
         clientX: 100,
         clientY: 100,
       });
-      Object.defineProperty(event, 'offsetX', { value: 100 });
-      Object.defineProperty(event, 'offsetY', { value: 100 });
       element.dispatchEvent(event);
     });
     await expect(stage).toHaveAttribute(
@@ -133,9 +131,9 @@ test.describe('Bottom panel — interactive Incr Canvas', () => {
       const event = new PointerEvent('pointerdown', {
         bubbles: true,
         pointerId: 92,
+        clientX: 20,
+        clientY: 20,
       });
-      Object.defineProperty(event, 'offsetX', { value: 20 });
-      Object.defineProperty(event, 'offsetY', { value: 20 });
       element.dispatchEvent(event);
     });
 
@@ -158,23 +156,97 @@ test.describe('Bottom panel — interactive Incr Canvas', () => {
       const event = new PointerEvent('pointerdown', {
         bubbles: true,
         pointerId: 91,
+        clientX: 0,
+        clientY: 10,
       });
-      Object.defineProperty(event, 'offsetX', { value: Number.NaN });
-      Object.defineProperty(event, 'offsetY', { value: 10 });
+      Object.defineProperty(event, 'clientX', { value: Number.NaN });
       element.dispatchEvent(event);
     });
     await stage.evaluate((element) => {
       const event = new WheelEvent('wheel', {
         bubbles: true,
         deltaY: 100,
+        clientX: 0,
+        clientY: 10,
       });
-      Object.defineProperty(event, 'offsetX', { value: Number.NaN });
-      Object.defineProperty(event, 'offsetY', { value: 10 });
+      Object.defineProperty(event, 'clientX', { value: Number.NaN });
       element.dispatchEvent(event);
     });
     await expect(node).toHaveAttribute('transform', before ?? '');
     await expect(stage).not.toHaveAttribute('data-incr-active-pointer-id');
     await expect(stage).not.toHaveAttribute('data-incr-reducer-pointer-id');
+  });
+
+  test('keeps fractional root coordinates and currentTarget origin stable', async ({ page }) => {
+    const openCanvas = async () => {
+      await page.reload();
+      await expect(page.getByRole('button', { name: 'Panels' })).toBeVisible();
+      await page.getByRole('button', { name: 'Panels' }).click();
+      await page.getByRole('tab', { name: 'Incr Canvas' }).click();
+      const stage = page.locator('.incr-canvas-interaction');
+      const node = page.locator('#canopy-incr-canvas-container .incr-canvas-node').first();
+      await expect(stage).toBeVisible({ timeout: 5000 });
+      await expect(node).toBeVisible({ timeout: 5000 });
+      return { stage, node };
+    };
+
+    await waitForEditorReady(page);
+    const first = await openCanvas();
+    const firstBox = await first.stage.boundingBox();
+    expect(firstBox).not.toBeNull();
+    if (!firstBox) return;
+    const fractional = {
+      x: firstBox.x + 20.25,
+      y: firstBox.y + 20.75,
+    };
+    const child = first.stage.locator('.incr-canvas-svg-host');
+    const beforeChild = await first.node.getAttribute('transform');
+    await child.evaluate((element, point) => {
+      const event = new WheelEvent('wheel', {
+        bubbles: true,
+        deltaY: -120,
+        clientX: 0,
+        clientY: 0,
+      });
+      Object.defineProperty(event, 'clientX', { value: point.x });
+      Object.defineProperty(event, 'clientY', { value: point.y });
+      element.dispatchEvent(event);
+    }, fractional);
+    await expect(first.node).not.toHaveAttribute('transform', beforeChild ?? '');
+    const childTransform = await first.node.getAttribute('transform');
+
+    const second = await openCanvas();
+    const beforeRoot = await second.node.getAttribute('transform');
+    await second.stage.evaluate((element, point) => {
+      const event = new WheelEvent('wheel', {
+        bubbles: true,
+        deltaY: -120,
+        clientX: 0,
+        clientY: 0,
+      });
+      Object.defineProperty(event, 'clientX', { value: point.x });
+      Object.defineProperty(event, 'clientY', { value: point.y });
+      element.dispatchEvent(event);
+    }, fractional);
+    await expect(second.node).not.toHaveAttribute('transform', beforeRoot ?? '');
+    expect(await second.node.getAttribute('transform')).toBe(childTransform);
+
+    const third = await openCanvas();
+    const beforeRounded = await third.node.getAttribute('transform');
+    const rounded = { x: Math.round(fractional.x), y: Math.round(fractional.y) };
+    await third.stage.evaluate((element, point) => {
+      const event = new WheelEvent('wheel', {
+        bubbles: true,
+        deltaY: -120,
+        clientX: 0,
+        clientY: 0,
+      });
+      Object.defineProperty(event, 'clientX', { value: point.x });
+      Object.defineProperty(event, 'clientY', { value: point.y });
+      element.dispatchEvent(event);
+    }, rounded);
+    await expect(third.node).not.toHaveAttribute('transform', beforeRounded ?? '');
+    expect(await third.node.getAttribute('transform')).not.toBe(childTransform);
   });
 
   test('replaces raw SVG panels cleanly when switching tabs', async ({ page }) => {

--- a/docs/development/rabbita-fork.md
+++ b/docs/development/rabbita-fork.md
@@ -1,15 +1,15 @@
 # Canopy Rabbita fork
 
-Canopy uses a downstream fork of Rabbita for the pointer-capture DOM boundary.
+Canopy uses a downstream fork of Rabbita for typed pointer-event and pointer-capture DOM boundaries.
 The fork is an owned dependency line, not an upstream release dependency.
 
 ## Ownership
 
 - **Fork:** [`dowdiness/rabbita`](https://github.com/dowdiness/rabbita)
 - **Upstream:** [`moonbit-community/rabbita`](https://github.com/moonbit-community/rabbita)
-- **Downstream branch:** `feat/pointer-capture-typed-errors`
-- **Pinned commit:** `6f538c4b2461ca71d523b652f50740d9d0dbd030`
-- **Pinned tag:** `canopy-rabbita-0.14.2-p1`
+- **Downstream branch:** `canopy/0.14.x`
+- **Pinned commit:** `126569ac3fda2669d70d4b22fc0344bb20528cf6`
+- **Pinned tag:** `canopy-rabbita-0.14.2-p2`
 - **Canopy submodule:** `deps/rabbita`
 
 The Canopy `.gitmodules` entry intentionally points at the fork. The
@@ -25,7 +25,12 @@ The pinned fork contains:
 - preservation of standard DOM exception `name` and `message`, with safe
   normalization of non-standard JavaScript throws;
 - `Attrs::on_lostpointercapture` with a `PointerEvent` callback;
-- migration of Rabbita/RUI pointer-capture consumers to the new effect.
+- `Attrs::on_pointerdown`, `on_pointermove`, `on_pointerup`, and
+  `on_pointercancel` with `PointerEvent` callbacks;
+- `IsMouseEvent` coordinate getters with `Double` results, including
+  fractional-coordinate coverage for pointer, mouse, and wheel events;
+- migration of Rabbita/RUI pointer-capture consumers to the new effect and
+  fractional coordinate contract.
 
 Canopy needs a MoonBit-typed pointer-capture boundary for its Canvas hosts. This
 patch is intentionally maintained downstream rather than proposed as an

--- a/modules/rabbita-resizable/resizable/attrs.mbt
+++ b/modules/rabbita-resizable/resizable/attrs.mbt
@@ -133,7 +133,13 @@ pub fn Model::handle_attrs(
   .base_handle_attrs(edge)
   .on_mousedown(event => {
     event.prevent_default()
-    dispatch(StartResize(edge~, x=event.get_client_x(), y=event.get_client_y()))
+    dispatch(
+      StartResize(
+        edge~,
+        x=event.get_client_x().to_int(),
+        y=event.get_client_y().to_int(),
+      ),
+    )
   })
   .on_keydown(event => {
     match edge.keydown_nudge(event.key()) {

--- a/scripts/install-local-warren.sh
+++ b/scripts/install-local-warren.sh
@@ -5,7 +5,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 RABBITA_ROOT="$PROJECT_ROOT/deps/rabbita"
 RABBITA_REMOTE="$(git -C "$PROJECT_ROOT" config -f .gitmodules --get submodule.rabbita.url)"
-EXPECTED_RABBITA="6f538c4b2461ca71d523b652f50740d9d0dbd030"
+EXPECTED_RABBITA="126569ac3fda2669d70d4b22fc0344bb20528cf6"
 BIN_DIR="${1:-$PROJECT_ROOT/_build/tools/bin}"
 
 actual_remote="$(git -C "$RABBITA_ROOT" remote get-url origin)"


### PR DESCRIPTION
## Summary

- Update the Canopy-owned Rabbita line so `on_pointerdown`, `on_pointermove`, `on_pointerup`, and `on_pointercancel` deliver `PointerEvent` directly.
- Change all `IsMouseEvent` CSSOM coordinate getters and JS externs from `Int` to `Double`, with fractional pointer/mouse/wheel coverage.
- Migrate Ideal's Incr Canvas to currentTarget-root-relative `clientX/Y`, removing its app-local offset JS bridges and `MouseEvent -> PointerEvent` recovery.

## Scope

This is the DOM binding fidelity p2 only. It does not add Canvas abstractions, move workflow pointer transport ownership, change `@spatial`, alter `WorkflowAction`/`GraphOperation`, redesign source-backed connections, or change click/context-menu event types.

The fork contains two reviewable commits:

- `56532e4 fix(dom): deliver pointer callbacks as PointerEvent`
- `126569a fix(dom): preserve fractional mouse coordinates`

Published downstream line:

- branch: `canopy/0.14.x`
- tag: `canopy-rabbita-0.14.2-p2`
- commit: `126569ac3fda2669d70d4b22fc0344bb20528cf6`

## Canopy changes

- `apps/ideal/main/view_bottom_incr_canvas.mbt`
  - removes the four pointer/wheel `offsetX/Y` JS externs;
  - consumes typed `PointerEvent` callbacks directly;
  - uses `clientX/Y - currentTarget.getBoundingClientRect().left/top` for both pointer and wheel coordinates;
  - preserves finite-coordinate admission, pointer claiming, capture failure cleanup, pointer-ID gating, release ordering, and lost-capture handling;
  - keeps pointer IDs as direct `PointerEvent::get_pointer_id()` values at the DOM boundary.
- `modules/rabbita-resizable/resizable/attrs.mbt`
  - makes its existing integer `StartResize` contract explicit with `Double::to_int()`.
- `docs/development/rabbita-fork.md` and `scripts/install-local-warren.sh`
  - pin and document the same exact p2 SHA.

The fork's high-level `@common.Mouse/Pos` API remains integer-valued; its two existing conversion boundaries now explicitly convert the new DOM `Double` values. RUI geometry that benefits from precision remains `Double`; only consumers whose existing domain contract is `Int` convert explicitly.

## Tests and validation

Rabbita fork, from `dowdiness/rabbita` at `126569ac`:

- `NEW_MOON_MOD=0 moon check --deny-warn` — pass
- `NEW_MOON_MOD=0 moon check --target js --deny-warn` — pass
- `NEW_MOON_MOD=0 moon test --target js` — **396/396 pass**
- `NEW_MOON_MOD=0 moon test --target native` — **61/61 pass**
- `NEW_MOON_MOD=0 moon build --target js --release` — pass
- `moon fmt` / `moon info` — pass; only intended `dom`/`html` interfaces changed

Canopy:

- `moon test --target js` — **7413/7413 pass**
- `moon build --target js --release` — pass
- Ideal Incr Canvas E2E — **8/8 pass**, one worker
- Canvas E2E — **30/30 pass**, one worker
- `scripts/install-local-warren.sh` with the p2 pin — pass
- fresh recursive clone — pass; submodule and installer both resolve to `126569ac3fda2669d70d4b22fc0344bb20528cf6`
- `./scripts/validate-pr-ready.sh --target apps/ideal/main --target modules/rabbita-resizable/resizable` — pass
- `./scripts/validate-pr-ready.sh --verify-evidence` — pass

Known workspace deprecation warnings in existing Canvas/menu/context-menu code remain unchanged and are covered by the repository's existing vendored/ci-lenient policy.

Validated HEAD: `7ddd2fca6ab73b43e9b3a281e29cb3688d89d956`

Validated base: `origin/main@a38bbaa4463b406ed74ad7cca904682933811298`
