### PR TITLE
build: enforce submodule reachability at pre-push

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,17 +11,6 @@
             "statusMessage": "Running pre-commit lint & test..."
           }
         ]
-      },
-      {
-        "matcher": "Bash(git push*)",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "git submodule foreach 'git diff --exit-code @{push}.. 2>/dev/null || echo WARNING: unpushed submodule commits in $name'",
-            "timeout": 30,
-            "statusMessage": "Checking for unpushed submodule commits..."
-          }
-        ]
       }
     ],
     "PostToolUse": [

--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -2,7 +2,8 @@
 
 This directory is retained only for existing checkouts. New checkouts should
 use Lefthook, but an existing `core.hooksPath=.githooks` checkout delegates to
-the same `just pre-commit` gate rather than running a separate check set.
+the same Lefthook hooks rather than running a separate check set. The legacy
+pre-push shim forwards Git's remote arguments and ref-update stdin unchanged.
 
 Install the current hook from the repository root with:
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# Compatibility path for checkouts that still use core.hooksPath=.githooks.
+# Git supplies the remote arguments and ref-update list on stdin; exec keeps
+# both streams attached to Lefthook unchanged.
+exec lefthook run pre-push "$@"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,11 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Install Nushell
+        uses: hustcer/setup-nu@f3fd65374ffc4d60974c0dd2f7263c6c5c285f81
+        with:
+          version: "0.114.1"
+
       - name: Check FFI export manifest (lambda app seam)
         run: node ./scripts/check-export-manifest.mjs
 
@@ -130,6 +135,14 @@ jobs:
               - 'Makefile'
               - 'lefthook.yml'
               - '.githooks/pre-commit'
+              - '.githooks/pre-push'
+              - '.githooks/README.md'
+              - '.claude/settings.json'
+              - 'scripts/check-submodule-reachability.nu'
+              - 'scripts/run-submodule-reachability.sh'
+              - 'scripts/test-submodule-reachability.sh'
+              - 'scripts/test-lefthook-pre-push-routing.sh'
+              - 'scripts/test-pr-ready-validation.sh'
               - 'scripts/install-hooks.nu'
               - 'scripts/install-hooks.sh'
               - 'scripts/test-install-hooks.sh'
@@ -190,16 +203,22 @@ jobs:
           make -n check
           make -n release-artifacts VERSION=v0.2.0
 
-      - name: Validate Nushell installer
-        run: nu --ide-check 100 scripts/install-hooks.nu
+      - name: Validate Nushell scripts
+        run: |
+          nu --ide-check 100 scripts/check-submodule-reachability.nu
+          nu --ide-check 100 scripts/install-hooks.nu
 
       - name: Test Nushell installer
         run: bash scripts/test-install-hooks.sh
 
+      - name: Validate Claude settings
+        run: node -e 'JSON.parse(require("fs").readFileSync(".claude/settings.json", "utf8"))'
+
       - name: Validate compatibility entry points
         run: |
-          bash -n .githooks/pre-commit scripts/install-hooks.sh
+          bash -n .githooks/pre-commit .githooks/pre-push scripts/run-submodule-reachability.sh scripts/test-submodule-reachability.sh scripts/test-lefthook-pre-push-routing.sh scripts/test-pr-ready-validation.sh scripts/install-hooks.sh
           grep -Fq 'exec just pre-commit' .githooks/pre-commit
+          grep -Fq 'exec lefthook run pre-push' .githooks/pre-push
           grep -Fq 'exec just install-hooks' scripts/install-hooks.sh
 
       - name: Validate Lefthook configuration
@@ -217,6 +236,12 @@ jobs:
 
       - name: Test path-aware Lefthook pre-commit routing
         run: LEFTHOOK_BIN="${RUNNER_TEMP}/lefthook" bash scripts/test-lefthook-pre-commit-routing.sh
+
+      - name: Test narrow Lefthook pre-push submodule routing
+        run: LEFTHOOK_BIN="${RUNNER_TEMP}/lefthook" bash scripts/test-lefthook-pre-push-routing.sh
+
+      - name: Test shared submodule reachability checker
+        run: bash scripts/test-submodule-reachability.sh
 
   release-version-validation:
     name: Release Contract Validation
@@ -277,6 +302,11 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: '20'
+
+      - name: Install Nushell
+        uses: hustcer/setup-nu@f3fd65374ffc4d60974c0dd2f7263c6c5c285f81
+        with:
+          version: "0.114.1"
 
       - name: Test the system Bash 3.2 contract
         shell: /bin/bash --noprofile --norc -eo pipefail {0}

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -216,16 +216,18 @@ any other effective hook path, including included or global configuration.
 
 The shared `scripts/check-submodule-reachability.nu` command is the sole
 implementation used by PR-ready validation and the internal
-`hook-submodule-reachability` recipe. Lefthook's narrow `pre-push` job covers
-`.gitmodules` and the `deps/` ownership zone; its thin
-`scripts/run-submodule-reachability.sh` adapter reads Git's pre-push ref-update
-stdin so gitlink changes remain visible even though Lefthook 2.1.10 filters
-submodule directories out of `{push_files}`. The shared checker receives the
-pushed local commit SHA, so non-checked-out branch pushes are checked against
-their own gitlink tree. It invokes the shared recipe only for relevant updates
-and does not run workspace-wide MoonBit checks. The
-legacy `.githooks/pre-push` shim forwards Git's remote arguments and ref-update
-stdin to the same Lefthook hook.
+`hook-submodule-reachability` recipe. Lefthook's pre-push job starts the thin
+`scripts/run-submodule-reachability.sh` adapter unconditionally: Lefthook
+2.1.10 filters gitlinks out of `{push_files}`, so `{all_files}` is retained only
+as an execution sentinel and `use_stdin: true` supplies Git's authoritative
+ref-update stream. The adapter owns the `.gitmodules` and `deps/` routing policy,
+enumerates every newly introduced relevant commit, and deduplicates shared
+commits across refs. The shared checker materializes each pushed commit's
+`.gitmodules` and recursively checks its submodule graph, so non-checked-out
+branch pushes and reverted intermediate gitlinks are covered. It invokes the
+shared recipe only for relevant updates and does not run workspace-wide MoonBit
+checks. The legacy `.githooks/pre-push` shim forwards Git's remote arguments and
+ref-update stdin to the same Lefthook hook.
 Manual cleanup is needed only for those non-legacy settings; use the reported
 scope and origin to locate the configuration. If you need to bypass the hook
 (e.g. during a rebase you understand), `git commit --no-verify` is available,

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -221,8 +221,9 @@ implementation used by PR-ready validation and the internal
 2.1.10 filters gitlinks out of `{push_files}`, so `{all_files}` is retained only
 as an execution sentinel and `use_stdin: true` supplies Git's authoritative
 ref-update stream. The adapter owns the `.gitmodules` and `deps/` routing policy,
-enumerates every newly introduced relevant commit, and deduplicates shared
-commits across refs. The shared checker materializes each pushed commit's
+enumerates every newly introduced relevant commit, using the streamed remote
+SHA or authoritative `origin` refs for new refs instead of stale local tracking
+refs, and deduplicates shared commits across refs. The shared checker materializes each pushed commit's
 `.gitmodules` and recursively checks its submodule graph, so non-checked-out
 branch pushes and reverted intermediate gitlinks are covered. It invokes the
 shared recipe only for relevant updates and does not run workspace-wide MoonBit

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -213,10 +213,24 @@ single local entry point into Lefthook, and `.githooks/pre-commit` remains a
 compatibility shim that delegates to it. The installer removes the repository's
 legacy direct local `core.hooksPath=.githooks` setting, but refuses to replace
 any other effective hook path, including included or global configuration.
+
+The shared `scripts/check-submodule-reachability.nu` command is the sole
+implementation used by PR-ready validation and the internal
+`hook-submodule-reachability` recipe. Lefthook's narrow `pre-push` job covers
+`.gitmodules` and the `deps/` ownership zone; its thin
+`scripts/run-submodule-reachability.sh` adapter reads Git's pre-push ref-update
+stdin so gitlink changes remain visible even though Lefthook 2.1.10 filters
+submodule directories out of `{push_files}`. The shared checker receives the
+pushed local commit SHA, so non-checked-out branch pushes are checked against
+their own gitlink tree. It invokes the shared recipe only for relevant updates
+and does not run workspace-wide MoonBit checks. The
+legacy `.githooks/pre-push` shim forwards Git's remote arguments and ref-update
+stdin to the same Lefthook hook.
 Manual cleanup is needed only for those non-legacy settings; use the reported
 scope and origin to locate the configuration. If you need to bypass the hook
 (e.g. during a rebase you understand), `git commit --no-verify` is available,
-but CI's `format-check` and `test-main` will catch the same issues on push.
+but the applicable CI jobs, including `tooling-validation` for hook and task
+changes, will still run on push.
 
 ## Adding new gating checks
 

--- a/justfile
+++ b/justfile
@@ -30,12 +30,19 @@ hook-moonbit-check:
 hook-moonbit-format-check:
     @./scripts/run-moon-module.sh fmt-check modules/canopy
 
+# Validate configured-origin reachability for the checkout or a pushed gitlink tree
+hook-submodule-reachability commit="":
+    @nu scripts/check-submodule-reachability.nu --commit "{{ commit }}"
+
 # Validate tooling files selected by Lefthook
 hook-tooling-contract:
     @just --unstable --fmt --check
     @just --dry-run pre-commit
+    @just --dry-run hook-submodule-reachability
     @make -n check
-    @bash -n .githooks/pre-commit scripts/install-hooks.sh scripts/test-install-hooks.sh scripts/test-lefthook-pre-commit-routing.sh scripts/run-moonbit-rename-route.sh
+    @node -e 'JSON.parse(require("fs").readFileSync(".claude/settings.json", "utf8"))'
+    @bash -n .githooks/pre-commit .githooks/pre-push scripts/install-hooks.sh scripts/test-install-hooks.sh scripts/test-lefthook-pre-commit-routing.sh scripts/test-lefthook-pre-push-routing.sh scripts/test-pr-ready-validation.sh scripts/test-submodule-reachability.sh scripts/run-submodule-reachability.sh scripts/run-moonbit-rename-route.sh
+    @nu --ide-check 100 scripts/check-submodule-reachability.nu
     @nu --ide-check 100 scripts/install-hooks.nu
     @lefthook validate
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -45,10 +45,28 @@ pre-commit:
         - "justfile"
         - "Makefile"
         - ".githooks/**"
+        - ".claude/settings.json"
         - "scripts/install-hooks.nu"
         - "scripts/install-hooks.sh"
         - "scripts/test-install-hooks.sh"
         - "scripts/test-lefthook-pre-commit-routing.sh"
+        - "scripts/test-lefthook-pre-push-routing.sh"
+        - "scripts/check-submodule-reachability.nu"
+        - "scripts/run-submodule-reachability.sh"
+        - "scripts/test-submodule-reachability.sh"
+        - "scripts/test-pr-ready-validation.sh"
         - "scripts/run-moonbit-rename-route.sh"
         - ".github/workflows/ci.yml"
       run: just hook-tooling-contract
+
+pre-push:
+  parallel: false
+  jobs:
+    - name: submodule-reachability
+      glob:
+        - ".gitmodules"
+        - "deps/**"
+      # Lefthook 2.1.10 filters gitlinks out of {push_files} as directories.
+      # The all-files sentinel keeps this adapter executable; it uses Git's
+      # pre-push ref-update stream to retain gitlink paths.
+      run: ./scripts/run-submodule-reachability.sh {all_files}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -63,10 +63,8 @@ pre-push:
   parallel: false
   jobs:
     - name: submodule-reachability
-      glob:
-        - ".gitmodules"
-        - "deps/**"
       # Lefthook 2.1.10 filters gitlinks out of {push_files} as directories.
-      # The all-files sentinel keeps this adapter executable; it uses Git's
-      # pre-push ref-update stream to retain gitlink paths.
+      # The all-files sentinel keeps this run job executable; the adapter
+      # ignores those arguments and uses Git's ref-update stream instead.
+      use_stdin: true
       run: ./scripts/run-submodule-reachability.sh {all_files}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -11,5 +11,10 @@ from [`../moon.work`](../moon.work).
 Do not maintain a script inventory or copied command reference in this file.
 Use the scripts themselves, the root [`justfile`](../justfile), and
 [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) as the authoritative
-operational sources. Development guidance belongs under
+operational sources. `check-submodule-reachability.nu` is the shared blocking
+contract used by PR-ready validation and the narrow Lefthook pre-push route;
+`run-submodule-reachability.sh` only maps Git's pre-push ref-update stream to
+that command. The checker checks initialized/matching gitlinks, conflicts,
+configured-origin fetches, normal origin reachability, and exact-SHA
+fetchability. Development guidance belongs under
 [`../docs/development/`](../docs/development/).

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -15,6 +15,6 @@ operational sources. `check-submodule-reachability.nu` is the shared blocking
 contract used by PR-ready validation and the narrow Lefthook pre-push route;
 `run-submodule-reachability.sh` only maps Git's pre-push ref-update stream to
 that command. The checker checks initialized/matching gitlinks, conflicts,
-configured-origin fetches, normal origin reachability, and exact-SHA
-fetchability. Development guidance belongs under
+configured-origin fetches, normal origin reachability, exact-SHA fetchability,
+and isolated recursive graphs for pushed commits. Development guidance belongs under
 [`../docs/development/`](../docs/development/).

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,8 +13,10 @@ Use the scripts themselves, the root [`justfile`](../justfile), and
 [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) as the authoritative
 operational sources. `check-submodule-reachability.nu` is the shared blocking
 contract used by PR-ready validation and the narrow Lefthook pre-push route;
-`run-submodule-reachability.sh` only maps Git's pre-push ref-update stream to
-that command. The checker checks initialized/matching gitlinks, conflicts,
-configured-origin fetches, normal origin reachability, exact-SHA fetchability,
-and isolated recursive graphs for pushed commits. Development guidance belongs under
+`run-submodule-reachability.sh` maps Git's pre-push ref-update stream to that
+command, enumerating commits relative to the streamed remote SHA or
+authoritative `origin` refs for new refs rather than stale local tracking refs.
+The checker checks initialized/matching gitlinks, conflicts, configured-origin
+fetches, normal origin reachability, exact-SHA fetchability, and isolated
+recursive graphs for pushed commits. Development guidance belongs under
 [`../docs/development/`](../docs/development/).

--- a/scripts/check-submodule-reachability.nu
+++ b/scripts/check-submodule-reachability.nu
@@ -5,8 +5,7 @@
 # branches, or update the superproject's gitlinks.
 
 def fail [message: string] {
-  print -e $"error: ($message)"
-  exit 1
+  error make { msg: $"error: ($message)" }
 }
 
 def print-command-error [output: record] {
@@ -32,9 +31,7 @@ def check-reachable [path: string, sha: string] {
     let exact = (^git -C $path fetch --quiet --no-tags --refetch origin $sha | complete)
     if $exact.exit_code != 0 {
       print-command-error $exact
-      print -e $"error: submodule commit is not fetchable from origin: ($path)"
-      print -e "push the commit to the configured origin before the parent PR"
-      exit 1
+      fail $"submodule commit is not fetchable from origin: ($path)\npush the commit to the configured origin before the parent PR"
     }
   }
 }
@@ -44,11 +41,12 @@ def parse-status-path [line: string] {
   $path_with_state | str replace --regex ' \([^)]*\)$' ''
 }
 
-def check-current-checkout [] {
+def check-current-checkout [root: string] {
+  cd $root
   let status = (^git submodule status --recursive | complete)
   if $status.exit_code != 0 {
     print-command-error $status
-    exit $status.exit_code
+    fail "submodule status inspection failed"
   }
 
   for line in ($status.stdout | lines) {
@@ -81,49 +79,77 @@ def check-current-checkout [] {
   }
 }
 
-def check-commit [commit: string] {
-  let tree = (^git ls-tree -r -z --full-tree $commit | complete)
-  if $tree.exit_code != 0 {
-    print-command-error $tree
-    exit $tree.exit_code
+def check-materialized-commit [root: string, commit: string] {
+  let temp_root = ($env.TMPDIR? | default "/tmp")
+  let temp_template = ([$temp_root, "canopy-submodule-commit.XXXXXX"] | path join)
+  let temp_result = (^mktemp -d $temp_template | complete)
+  if $temp_result.exit_code != 0 {
+    print-command-error $temp_result
+    fail "could not create an isolated submodule-checkout directory"
   }
+  let temp = ($temp_result.stdout | str trim)
 
-  for entry in ($tree.stdout | split row (char nul) | where {|item| $item | is-not-empty }) {
-    let fields = ($entry | split row (char tab))
-    if ($fields | length) != 2 {
-      continue
-    }
-    let metadata = ($fields.0 | split row " ")
-    if ($metadata | length) < 3 or $metadata.0 != "160000" {
-      continue
+  try {
+    let clone = (^git clone --quiet --no-checkout --local $root $temp | complete)
+    if $clone.exit_code != 0 {
+      print-command-error $clone
+      fail "could not clone the pushed superproject commit into an isolated directory"
     }
 
-    let sha = $metadata.2
-    let path = $fields.1
-    let git_dir = (^git -C $path rev-parse --git-dir | complete)
-    if $git_dir.exit_code != 0 {
-      print-command-error $git_dir
-      fail $"submodule is not initialized for pushed commit: ($path)"
+    let checkout = (^git -C $temp checkout --quiet --detach $commit | complete)
+    if $checkout.exit_code != 0 {
+      print-command-error $checkout
+      fail $"could not checkout pushed superproject commit: ($commit)"
     }
-    check-reachable $path $sha
+
+    let synced = (^git -C $temp submodule sync --quiet --recursive | complete)
+    if $synced.exit_code != 0 {
+      print-command-error $synced
+      fail "could not synchronize submodule origins from the pushed .gitmodules"
+    }
+
+    let updated = (^git -C $temp submodule update --quiet --init --recursive | complete)
+    if $updated.exit_code != 0 {
+      print-command-error $updated
+      if ($updated.stderr | str contains "did not contain") {
+        fail $"submodule commit is not fetchable from origin for pushed superproject commit: ($commit)\npush the commit to the configured origin before the parent PR"
+      }
+      fail $"could not materialize submodules for pushed superproject commit: ($commit)"
+    }
+
+    check-current-checkout $temp
+  } catch {|err|
+    let removed = (^rm -rf $temp | complete)
+    if $removed.exit_code != 0 {
+      print-command-error $removed
+    }
+    error make { msg: $err.msg }
+  }
+  let removed = (^rm -rf $temp | complete)
+  if $removed.exit_code != 0 {
+    print-command-error $removed
   }
 }
 
 def main [--commit: string = ""] {
-  # FILE_PWD is the directory containing this script, so an absolute invocation
-  # from another Git worktree cannot accidentally inspect the caller's repo.
-  let root = ([$env.FILE_PWD, ".."] | path join | path expand)
-  cd $root
+  try {
+    # FILE_PWD is the directory containing this script, so an absolute
+    # invocation from another Git worktree cannot inspect the caller's repo.
+    let root = ([$env.FILE_PWD, ".."] | path join | path expand)
 
-  if ($commit | is-empty) {
-    check-current-checkout
-    return
-  }
+    if ($commit | is-empty) {
+      check-current-checkout $root
+      return
+    }
 
-  let verified = (^git rev-parse --verify ($commit + "^{commit}") | complete)
-  if $verified.exit_code != 0 {
-    print-command-error $verified
-    fail $"pushed commit is not available locally: ($commit)"
+    let verified = (^git -C $root rev-parse --verify ($commit + "^{commit}") | complete)
+    if $verified.exit_code != 0 {
+      print-command-error $verified
+      fail $"pushed commit is not available locally: ($commit)"
+    }
+    check-materialized-commit $root ($verified.stdout | str trim)
+  } catch {|err|
+    print -e $err.msg
+    exit 1
   }
-  check-commit ($verified.stdout | str trim)
 }

--- a/scripts/check-submodule-reachability.nu
+++ b/scripts/check-submodule-reachability.nu
@@ -1,0 +1,129 @@
+#!/usr/bin/env nu
+
+# Check the parent checkout's submodule state and configured-origin reachability.
+# This command is intentionally read-only: it does not commit, push, change
+# branches, or update the superproject's gitlinks.
+
+def fail [message: string] {
+  print -e $"error: ($message)"
+  exit 1
+}
+
+def print-command-error [output: record] {
+  if ($output.stderr | is-not-empty) {
+    print -e ($output.stderr | str trim)
+  }
+}
+
+def check-reachable [path: string, sha: string] {
+  let fetched = (^git -C $path fetch --quiet --prune origin | complete)
+  if $fetched.exit_code != 0 {
+    print-command-error $fetched
+    fail $"could not fetch submodule origin: ($path)"
+  }
+
+  let refs = (^git -C $path for-each-ref '--format=%(refname)' --contains $sha refs/remotes/origin | complete)
+  if $refs.exit_code != 0 {
+    print-command-error $refs
+    fail $"could not inspect submodule origin refs: ($path)"
+  }
+
+  if (($refs.stdout | str trim) | is-empty) {
+    let exact = (^git -C $path fetch --quiet --no-tags --refetch origin $sha | complete)
+    if $exact.exit_code != 0 {
+      print-command-error $exact
+      print -e $"error: submodule commit is not fetchable from origin: ($path)"
+      print -e "push the commit to the configured origin before the parent PR"
+      exit 1
+    }
+  }
+}
+
+def parse-status-path [line: string] {
+  let path_with_state = ($line | str substring 42.. | str trim)
+  $path_with_state | str replace --regex ' \([^)]*\)$' ''
+}
+
+def check-current-checkout [] {
+  let status = (^git submodule status --recursive | complete)
+  if $status.exit_code != 0 {
+    print-command-error $status
+    exit $status.exit_code
+  }
+
+  for line in ($status.stdout | lines) {
+    if ($line | is-empty) {
+      continue
+    }
+    let marker = ($line | str substring 0..0)
+    match $marker {
+      "-" => (fail $"submodule is not initialized: ($line)")
+      "+" => (fail $"submodule does not match its recorded gitlink: ($line)")
+      "U" => (fail $"submodule has a merge conflict: ($line)")
+      _ => {}
+    }
+  }
+
+  for line in ($status.stdout | lines) {
+    if ($line | is-empty) {
+      continue
+    }
+    let path = (parse-status-path $line)
+    if ($path | is-empty) {
+      fail $"Git returned a submodule status line without a path: ($line)"
+    }
+    let sha_result = (^git -C $path rev-parse HEAD | complete)
+    if $sha_result.exit_code != 0 {
+      print-command-error $sha_result
+      fail $"could not resolve submodule HEAD: ($path)"
+    }
+    check-reachable $path ($sha_result.stdout | str trim)
+  }
+}
+
+def check-commit [commit: string] {
+  let tree = (^git ls-tree -r -z --full-tree $commit | complete)
+  if $tree.exit_code != 0 {
+    print-command-error $tree
+    exit $tree.exit_code
+  }
+
+  for entry in ($tree.stdout | split row (char nul) | where {|item| $item | is-not-empty }) {
+    let fields = ($entry | split row (char tab))
+    if ($fields | length) != 2 {
+      continue
+    }
+    let metadata = ($fields.0 | split row " ")
+    if ($metadata | length) < 3 or $metadata.0 != "160000" {
+      continue
+    }
+
+    let sha = $metadata.2
+    let path = $fields.1
+    let git_dir = (^git -C $path rev-parse --git-dir | complete)
+    if $git_dir.exit_code != 0 {
+      print-command-error $git_dir
+      fail $"submodule is not initialized for pushed commit: ($path)"
+    }
+    check-reachable $path $sha
+  }
+}
+
+def main [--commit: string = ""] {
+  # FILE_PWD is the directory containing this script, so an absolute invocation
+  # from another Git worktree cannot accidentally inspect the caller's repo.
+  let root = ([$env.FILE_PWD, ".."] | path join | path expand)
+  cd $root
+
+  if ($commit | is-empty) {
+    check-current-checkout
+    return
+  }
+
+  let verified = (^git rev-parse --verify ($commit + "^{commit}") | complete)
+  if $verified.exit_code != 0 {
+    print-command-error $verified
+    fail $"pushed commit is not available locally: ($commit)"
+  }
+  check-commit ($verified.stdout | str trim)
+}

--- a/scripts/run-submodule-reachability.sh
+++ b/scripts/run-submodule-reachability.sh
@@ -24,13 +24,45 @@ add_commit() {
   fi
 }
 
+origin_remote_commits=
+origin_remote_loaded=0
+load_origin_remote_commits() {
+  [ "$origin_remote_loaded" -eq 1 ] && return 0
+  remote_refs=$(git ls-remote --refs origin) || {
+    echo "error: could not enumerate configured origin refs before validating a new push ref" >&2
+    exit 1
+  }
+  origin_remote_commits=
+  while IFS="$(printf '\t')" read -r remote_commit _remote_ref; do
+    [ -n "${remote_commit:-}" ] || continue
+    # A shallow/local partial clone may not contain the advertised base. Leave
+    # it out so rev-list scans conservatively instead of failing open.
+    if git cat-file -e "$remote_commit^{commit}" 2>/dev/null; then
+      origin_remote_commits="$origin_remote_commits $remote_commit"
+    fi
+  done <<EOF
+$remote_refs
+EOF
+  origin_remote_loaded=1
+}
+
 commits_for_push() {
   local_sha=$1
   remote_sha=$2
   if [ "$remote_sha" = "$all_zeroes" ]; then
-    git rev-list --reverse "$local_sha" --not --remotes=origin
+    # A new remote ref has no base SHA in the hook stream. Use authoritative
+    # origin refs, not possibly stale local refs/remotes/origin/*.
+    load_origin_remote_commits
+    if [ -n "$origin_remote_commits" ]; then
+      # shellcheck disable=SC2086 # origin_remote_commits contains validated SHAs.
+      git rev-list --reverse "$local_sha" --not $origin_remote_commits
+    else
+      git rev-list --reverse "$local_sha"
+    fi
   else
-    git rev-list --reverse "$local_sha" --not "$remote_sha" --remotes=origin
+    # The streamed remote SHA is authoritative. Do not subtract local
+    # refs/remotes/origin/*: they may describe deleted or stale remote refs.
+    git rev-list --reverse "$remote_sha..$local_sha"
   fi
 }
 

--- a/scripts/run-submodule-reachability.sh
+++ b/scripts/run-submodule-reachability.sh
@@ -24,6 +24,38 @@ add_commit() {
   fi
 }
 
+commits_for_push() {
+  local_sha=$1
+  remote_sha=$2
+  if [ "$remote_sha" = "$all_zeroes" ]; then
+    git rev-list --reverse "$local_sha" --not --remotes=origin
+  else
+    git rev-list --reverse "$local_sha" --not "$remote_sha" --remotes=origin
+  fi
+}
+
+inspect_push_history() {
+  local_sha=$1
+  remote_sha=$2
+  commits=$(commits_for_push "$local_sha" "$remote_sha") || {
+    echo "error: could not enumerate commits introduced by the pushed ref" >&2
+    exit 1
+  }
+
+  while IFS= read -r commit; do
+    [ -n "$commit" ] || continue
+    paths=$(git diff-tree --root --no-commit-id --name-only -r -m "$commit") || {
+      echo "error: could not inspect pushed commit: $commit" >&2
+      exit 1
+    }
+    if printf '%s\n' "$paths" | has_submodule_path; then
+      add_commit "$commit"
+    fi
+  done <<EOF
+$commits
+EOF
+}
+
 saw_update=0
 while IFS=' ' read -r _local_ref local_sha _remote_ref remote_sha; do
   [ -n "${local_sha:-}" ] || continue
@@ -32,33 +64,16 @@ while IFS=' ' read -r _local_ref local_sha _remote_ref remote_sha; do
 
   # A deleted local ref contributes no new tree to the push.
   [ "$local_sha" != "$all_zeroes" ] || continue
-
-  if [ "$remote_sha" = "$all_zeroes" ]; then
-    paths=$(git ls-tree -r --name-only "$local_sha")
-  else
-    # Do not compare against a guessed base when the advertised remote object
-    # is unavailable locally. Validate the pushed commit conservatively instead.
-    if ! paths=$(git diff --name-only "$remote_sha" "$local_sha" -- 2>/dev/null); then
-      add_commit "$local_sha"
-      continue
-    fi
-  fi
-
-  if printf '%s\n' "$paths" | has_submodule_path; then
-    add_commit "$local_sha"
-  fi
+  inspect_push_history "$local_sha" "$remote_sha"
 done
 
 # Direct `lefthook run pre-push` probes and unusual Git clients may provide no
-# ref-update stream. Keep the adapter conservative in that case.
+# ref-update stream. Inspect the checked-out ref against its configured push
+# base, or conservatively inspect all origin-unreachable history.
 if [ "$saw_update" -eq 0 ]; then
-  if paths=$(git diff --name-only HEAD '@{push}' -- 2>/dev/null); then
-    if printf '%s\n' "$paths" | has_submodule_path; then
-      add_commit "$(git rev-parse HEAD)"
-    fi
-  else
-    add_commit "$(git rev-parse HEAD)"
-  fi
+  local_sha=$(git rev-parse HEAD)
+  remote_sha=$(git rev-parse '@{push}' 2>/dev/null || printf '%s' "$all_zeroes")
+  inspect_push_history "$local_sha" "$remote_sha"
 fi
 
 while IFS= read -r commit; do

--- a/scripts/run-submodule-reachability.sh
+++ b/scripts/run-submodule-reachability.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+
+set -eu
+
+all_zeroes=0000000000000000000000000000000000000000
+commits_file=$(mktemp "${TMPDIR:-/tmp}/canopy-submodule-push.XXXXXX")
+trap 'rm -f "$commits_file"' EXIT HUP INT TERM
+
+has_submodule_path() {
+  while IFS= read -r path; do
+    case "$path" in
+      .gitmodules|deps/*)
+        return 0
+        ;;
+    esac
+  done
+  return 1
+}
+
+add_commit() {
+  commit=$1
+  if ! grep -Fqx "$commit" "$commits_file"; then
+    printf '%s\n' "$commit" >>"$commits_file"
+  fi
+}
+
+saw_update=0
+while IFS=' ' read -r _local_ref local_sha _remote_ref remote_sha; do
+  [ -n "${local_sha:-}" ] || continue
+  saw_update=1
+  remote_sha=${remote_sha:-$all_zeroes}
+
+  # A deleted local ref contributes no new tree to the push.
+  [ "$local_sha" != "$all_zeroes" ] || continue
+
+  if [ "$remote_sha" = "$all_zeroes" ]; then
+    paths=$(git ls-tree -r --name-only "$local_sha")
+  else
+    # Do not compare against a guessed base when the advertised remote object
+    # is unavailable locally. Validate the pushed commit conservatively instead.
+    if ! paths=$(git diff --name-only "$remote_sha" "$local_sha" -- 2>/dev/null); then
+      add_commit "$local_sha"
+      continue
+    fi
+  fi
+
+  if printf '%s\n' "$paths" | has_submodule_path; then
+    add_commit "$local_sha"
+  fi
+done
+
+# Direct `lefthook run pre-push` probes and unusual Git clients may provide no
+# ref-update stream. Keep the adapter conservative in that case.
+if [ "$saw_update" -eq 0 ]; then
+  if paths=$(git diff --name-only HEAD '@{push}' -- 2>/dev/null); then
+    if printf '%s\n' "$paths" | has_submodule_path; then
+      add_commit "$(git rev-parse HEAD)"
+    fi
+  else
+    add_commit "$(git rev-parse HEAD)"
+  fi
+fi
+
+while IFS= read -r commit; do
+  [ -n "$commit" ] || continue
+  just hook-submodule-reachability "$commit"
+done <"$commits_file"

--- a/scripts/test-lefthook-pre-commit-routing.sh
+++ b/scripts/test-lefthook-pre-commit-routing.sh
@@ -191,6 +191,10 @@ test_tooling_config() {
   stage_file Makefile 'updated Makefile'
 }
 
+test_claude_settings() {
+  stage_file .claude/settings.json '{}'
+}
+
 test_justfile() {
   stage_file justfile 'updated justfile'
 }
@@ -266,6 +270,8 @@ run_case 'vendored check script' test_vendored_check_script \
 run_case 'MoonBit rename route script' test_moonbit_rename_route_script \
   hook-repository-contract hook-moonbit-check hook-moonbit-format-check hook-tooling-contract
 run_case 'tooling configuration' test_tooling_config \
+  hook-repository-contract hook-tooling-contract
+run_case 'Claude settings' test_claude_settings \
   hook-repository-contract hook-tooling-contract
 run_case 'justfile hook tasks' test_justfile \
   hook-repository-contract hook-moonbit-check hook-moonbit-format-check hook-tooling-contract

--- a/scripts/test-lefthook-pre-push-routing.sh
+++ b/scripts/test-lefthook-pre-push-routing.sh
@@ -47,6 +47,8 @@ git -C "$parent" config user.name lefthook-pre-push-test
 git -C "$parent" remote add origin "$parent_origin"
 git -c protocol.file.allow=always -C "$parent" submodule add --quiet "$submodule_origin" deps/test-submodule
 git -C "$parent/deps/test-submodule" config protocol.file.allow always
+git -C "$parent/deps/test-submodule" config user.email lefthook-pre-push@example.invalid
+git -C "$parent/deps/test-submodule" config user.name lefthook-pre-push-test
 mkdir -p "$parent/scripts" "$parent/.githooks" "$parent/docs" "$parent/modules/fixture" "$parent/bin"
 cp "$parent.lefthook.yml" "$parent/lefthook.yml"
 cp "$fixture/check-submodule-reachability.nu" "$parent/scripts/check-submodule-reachability.nu"

--- a/scripts/test-lefthook-pre-push-routing.sh
+++ b/scripts/test-lefthook-pre-push-routing.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+lefthook_bin="${LEFTHOOK_BIN:-}"
+if [ -z "$lefthook_bin" ]; then
+  lefthook_bin="$(command -v lefthook || true)"
+fi
+[ -x "$lefthook_bin" ] || {
+  echo "error: Lefthook 2.1.10 binary not found; set LEFTHOOK_BIN" >&2
+  exit 1
+}
+
+fixture="$(mktemp -d "${TMPDIR:-/tmp}/canopy-lefthook-pre-push.XXXXXX")"
+trap 'rm -rf "$fixture"' EXIT HUP INT TERM
+
+parent="$fixture/parent"
+parent_origin="$fixture/parent-origin.git"
+submodule_origin="$fixture/submodule-origin.git"
+submodule_seed="$fixture/submodule-seed"
+log="$fixture/just.log"
+legacy_args="$fixture/legacy-args"
+legacy_stdin="$fixture/legacy-stdin"
+
+mkdir -p "$fixture/bin"
+cp "$root_dir/lefthook.yml" "$parent.lefthook.yml"
+cp "$root_dir/.githooks/pre-push" "$fixture/pre-push"
+cp "$root_dir/scripts/check-submodule-reachability.nu" "$fixture/check-submodule-reachability.nu"
+cp "$root_dir/scripts/run-submodule-reachability.sh" "$fixture/run-submodule-reachability.sh"
+chmod +x "$fixture/pre-push" "$fixture/check-submodule-reachability.nu" "$fixture/run-submodule-reachability.sh"
+
+git init --quiet --bare --initial-branch=main "$parent_origin"
+git init --quiet --bare --initial-branch=main "$submodule_origin"
+git init --quiet --initial-branch=main "$submodule_seed"
+git -C "$submodule_seed" config user.email lefthook-pre-push@example.invalid
+git -C "$submodule_seed" config user.name lefthook-pre-push-test
+printf 'baseline\n' >"$submodule_seed/state.txt"
+git -C "$submodule_seed" add state.txt
+git -C "$submodule_seed" commit --quiet -m baseline
+git -C "$submodule_seed" remote add origin "$submodule_origin"
+git -C "$submodule_seed" push --quiet --set-upstream origin main
+
+git init --quiet --initial-branch=main "$parent"
+git -C "$parent" config user.email lefthook-pre-push@example.invalid
+git -C "$parent" config user.name lefthook-pre-push-test
+git -C "$parent" remote add origin "$parent_origin"
+git -c protocol.file.allow=always -C "$parent" submodule add --quiet "$submodule_origin" deps/test-submodule
+git -C "$parent/deps/test-submodule" config protocol.file.allow always
+mkdir -p "$parent/scripts" "$parent/.githooks" "$parent/docs" "$parent/modules/fixture" "$parent/bin"
+cp "$parent.lefthook.yml" "$parent/lefthook.yml"
+cp "$fixture/check-submodule-reachability.nu" "$parent/scripts/check-submodule-reachability.nu"
+cp "$fixture/run-submodule-reachability.sh" "$parent/scripts/run-submodule-reachability.sh"
+cp "$fixture/pre-push" "$parent/.githooks/pre-push"
+chmod +x "$parent/scripts/check-submodule-reachability.nu" "$parent/scripts/run-submodule-reachability.sh" "$parent/.githooks/pre-push"
+
+cat >"$parent/justfile" <<'JUSTFILE'
+set shell := ["nu", "-c"]
+hook-submodule-reachability:
+    @nu ./scripts/check-submodule-reachability.nu
+JUSTFILE
+
+cat >"$fixture/bin/just" <<'FAKE_JUST'
+#!/bin/sh
+printf '%s\n' "$*" >>"$LEFTHOOK_ROUTING_LOG"
+if [ "${1:-}" = hook-submodule-reachability ]; then
+  shift
+  exec nu "$LEFTHOOK_ROUTING_CHECKER" --commit "${1:-}"
+fi
+exit 0
+FAKE_JUST
+chmod +x "$fixture/bin/just"
+
+cat >"$fixture/bin/lefthook" <<'FAKE_LEFTHOOK'
+#!/bin/sh
+printf '%s\n' "$*" >"$LEFTHOOK_LEGACY_ARGS"
+cat >"$LEFTHOOK_LEGACY_STDIN"
+exec "$LEFTHOOK_REAL" "$@" <"$LEFTHOOK_LEGACY_STDIN"
+FAKE_LEFTHOOK
+chmod +x "$fixture/bin/lefthook"
+
+cat >"$parent/.git/hooks/pre-push" <<HOOK
+#!/bin/sh
+exec "$lefthook_bin" run pre-push "\$@"
+HOOK
+chmod +x "$parent/.git/hooks/pre-push"
+
+# Git's first push exercises the real Lefthook binary and the checker once.
+git -C "$parent" add .
+git -C "$parent" commit --no-verify --quiet -m baseline
+: >"$log"
+LEFTHOOK_ROUTING_LOG="$log" LEFTHOOK_ROUTING_CHECKER="$parent/scripts/check-submodule-reachability.nu" \
+  PATH="$fixture/bin:$PATH" git -C "$parent" push --quiet --set-upstream origin main >"$fixture/initial.out" 2>&1 || {
+  cat "$fixture/initial.out" >&2
+  cat "$log" >&2
+  exit 1
+}
+reset_log() { : >"$log"; }
+assert_skipped() {
+  [ ! -s "$log" ] || { echo "error: $1 unexpectedly ran the checker" >&2; cat "$log" >&2; exit 1; }
+}
+assert_invoked_once() {
+  [ "$(wc -l <"$log" | tr -d ' ')" -eq 1 ] || { echo "error: $1 did not invoke checker exactly once" >&2; cat "$log" >&2; exit 1; }
+}
+
+printf 'docs\n' >"$parent/docs/README.md"
+git -C "$parent" add docs/README.md && git -C "$parent" commit --no-verify --quiet -m docs
+reset_log
+LEFTHOOK_ROUTING_LOG="$log" LEFTHOOK_ROUTING_CHECKER="$parent/scripts/check-submodule-reachability.nu" PATH="$fixture/bin:$PATH" \
+  git -C "$parent" push --quiet origin main
+assert_skipped docs-only
+
+printf 'fn fixture() -> Int { 1 }\n' >"$parent/modules/fixture/main.mbt"
+git -C "$parent" add modules/fixture/main.mbt && git -C "$parent" commit --no-verify --quiet -m moonbit
+reset_log
+LEFTHOOK_ROUTING_LOG="$log" LEFTHOOK_ROUTING_CHECKER="$parent/scripts/check-submodule-reachability.nu" PATH="$fixture/bin:$PATH" \
+  git -C "$parent" push --quiet origin main
+assert_skipped normal-moonbit
+
+make_unpushed_parent_commit() {
+  local label="$1"
+  local submodule="$parent/deps/test-submodule"
+  printf '%s\n' "$label" >>"$submodule/state.txt"
+  git -C "$submodule" add state.txt
+  git -C "$submodule" commit --quiet -m "$label"
+  git -C "$parent" add deps/test-submodule
+  git -C "$parent" commit --no-verify --quiet -m "record $label"
+}
+
+make_unpushed_parent_commit unpushed
+if nu "$parent/scripts/check-submodule-reachability.nu" >"$fixture/direct-check.out" 2>&1; then
+  echo "error: direct checker accepted unpushed commit" >&2
+  exit 1
+fi
+reset_log
+if LEFTHOOK_ROUTING_LOG="$log" LEFTHOOK_ROUTING_CHECKER="$parent/scripts/check-submodule-reachability.nu" PATH="$fixture/bin:$PATH" \
+  git -C "$parent" push --quiet origin main >"$fixture/unpushed.out" 2>&1; then
+  echo "error: unpushed submodule commit unexpectedly passed" >&2
+  exit 1
+fi
+grep -Fq 'submodule commit is not fetchable from origin' "$fixture/unpushed.out" || { cat "$fixture/unpushed.out" >&2; exit 1; }
+assert_invoked_once unpushed
+
+git -C "$parent/deps/test-submodule" push --quiet origin HEAD:main
+reset_log
+LEFTHOOK_ROUTING_LOG="$log" LEFTHOOK_ROUTING_CHECKER="$parent/scripts/check-submodule-reachability.nu" PATH="$fixture/bin:$PATH" \
+  git -C "$parent" push --quiet origin main
+assert_invoked_once pushed-submodule
+
+printf '# routing marker\n' >>"$parent/.gitmodules"
+git -C "$parent" add .gitmodules && git -C "$parent" commit --no-verify --quiet -m gitmodules
+reset_log
+LEFTHOOK_ROUTING_LOG="$log" LEFTHOOK_ROUTING_CHECKER="$parent/scripts/check-submodule-reachability.nu" PATH="$fixture/bin:$PATH" \
+  git -C "$parent" push --quiet origin main
+assert_invoked_once gitmodules
+
+make_unpushed_parent_commit mixed-gitlink-and-normal
+printf 'fn mixed() -> Int { 2 }\n' >"$parent/modules/fixture/mixed.mbt"
+git -C "$parent" add modules/fixture/mixed.mbt && git -C "$parent" commit --no-verify --quiet -m mixed-normal
+reset_log
+if LEFTHOOK_ROUTING_LOG="$log" LEFTHOOK_ROUTING_CHECKER="$parent/scripts/check-submodule-reachability.nu" PATH="$fixture/bin:$PATH" \
+  git -C "$parent" push --quiet origin main >"$fixture/mixed.out" 2>&1; then
+  echo "error: mixed unpushed submodule commit unexpectedly passed" >&2
+  exit 1
+fi
+assert_invoked_once mixed-gitlink-and-normal
+git -C "$parent/deps/test-submodule" push --quiet origin HEAD:main
+reset_log
+LEFTHOOK_ROUTING_LOG="$log" LEFTHOOK_ROUTING_CHECKER="$parent/scripts/check-submodule-reachability.nu" PATH="$fixture/bin:$PATH" \
+  git -C "$parent" push --quiet origin main
+assert_invoked_once mixed-after-push
+
+# Switch to the retained core.hooksPath shim and verify Git's hook arguments and stdin.
+git -C "$parent" config core.hooksPath .githooks
+make_unpushed_parent_commit legacy-shim
+reset_log
+if LEFTHOOK_ROUTING_LOG="$log" LEFTHOOK_ROUTING_CHECKER="$parent/scripts/check-submodule-reachability.nu" \
+  LEFTHOOK_REAL="$lefthook_bin" LEFTHOOK_LEGACY_ARGS="$legacy_args" LEFTHOOK_LEGACY_STDIN="$legacy_stdin" \
+  PATH="$fixture/bin:$PATH" git -C "$parent" push --quiet origin main >"$fixture/legacy.out" 2>&1; then
+  echo "error: legacy shim accepted an unpushed submodule commit" >&2
+  exit 1
+fi
+assert_invoked_once legacy-shim
+grep -Fq 'run pre-push origin ' "$legacy_args" || { cat "$legacy_args" >&2; exit 1; }
+grep -Fq 'refs/heads/main' "$legacy_stdin" || { cat "$legacy_stdin" >&2; exit 1; }
+grep -Fq 'submodule commit is not fetchable from origin' "$fixture/legacy.out" || { cat "$fixture/legacy.out" >&2; exit 1; }
+
+echo "ok: Lefthook pre-push routing and legacy shim pass"

--- a/scripts/test-lefthook-pre-push-routing.sh
+++ b/scripts/test-lefthook-pre-push-routing.sh
@@ -111,6 +111,10 @@ assert_invoked_once() {
 assert_invoked_count() {
   [ "$(wc -l <"$log" | tr -d ' ')" -eq "$2" ] || { echo "error: $1 did not invoke checker $2 time(s)" >&2; cat "$log" >&2; exit 1; }
 }
+assert_commit_once() {
+  count="$(grep -F -c " $2" "$log" || true)"
+  [ "$count" -eq 1 ] || { echo "error: $1 did not check commit $2 exactly once" >&2; cat "$log" >&2; exit 1; }
+}
 
 # Two new refs share one relevant commit. The checker must deduplicate the
 # commit SHA even though Git supplies two ref-update lines on stdin.
@@ -125,18 +129,21 @@ shared_parent_sha="$(git -C "$parent" rev-parse HEAD)"
 git -C "$parent" branch duplicate-ref "$shared_parent_sha"
 git -C "$parent" switch --quiet main
 git -C "$parent" submodule update --quiet
+# Simulate a stale local origin ref for a deleted remote branch. It must not
+# suppress validation of the same commit when a new ref is pushed.
+git -C "$parent" update-ref refs/remotes/origin/stale "$shared_parent_sha"
 reset_log
 if LEFTHOOK_ROUTING_LOG="$log" LEFTHOOK_ROUTING_CHECKER="$parent/scripts/check-submodule-reachability.nu" PATH="$fixture/bin:$PATH" \
   git -C "$parent" push --quiet origin shared-submodule duplicate-ref >"$fixture/shared.out" 2>&1; then
   echo "error: shared unpushed submodule commit unexpectedly passed" >&2
   exit 1
 fi
-assert_invoked_once shared-commit-deduplication
+assert_commit_once shared-commit-deduplication "$shared_parent_sha"
 git -C "$parent/deps/test-submodule" push --quiet origin "$shared_submodule_sha:refs/pull/shared/head"
 reset_log
 LEFTHOOK_ROUTING_LOG="$log" LEFTHOOK_ROUTING_CHECKER="$parent/scripts/check-submodule-reachability.nu" PATH="$fixture/bin:$PATH" \
   git -C "$parent" push --quiet origin shared-submodule duplicate-ref
-assert_invoked_once shared-commit-after-push
+assert_commit_once shared-commit-after-push "$shared_parent_sha"
 
 printf 'docs\n' >"$parent/docs/README.md"
 git -C "$parent" add docs/README.md && git -C "$parent" commit --no-verify --quiet -m docs
@@ -237,7 +244,8 @@ git -C "$parent" switch --quiet -c nonfast
 printf 'nonfast-base\n' >"$parent/docs/nonfast.txt"
 git -C "$parent" add docs/nonfast.txt
 git -C "$parent" commit --no-verify --quiet -m nonfast-base
-git -C "$parent" push --quiet origin nonfast
+LEFTHOOK_ROUTING_LOG="$log" LEFTHOOK_ROUTING_CHECKER="$parent/scripts/check-submodule-reachability.nu" PATH="$fixture/bin:$PATH" \
+  git -C "$parent" push --quiet origin nonfast
 git -C "$parent" switch --quiet main
 git -C "$parent" submodule update --quiet
 git -C "$parent" switch --quiet nonfast

--- a/scripts/test-lefthook-pre-push-routing.sh
+++ b/scripts/test-lefthook-pre-push-routing.sh
@@ -15,6 +15,10 @@ fi
 fixture="$(mktemp -d "${TMPDIR:-/tmp}/canopy-lefthook-pre-push.XXXXXX")"
 trap 'rm -rf "$fixture"' EXIT HUP INT TERM
 
+git_config="$fixture/gitconfig"
+printf '[protocol "file"]\n\tallow = always\n' >"$git_config"
+export GIT_CONFIG_GLOBAL="$git_config"
+
 parent="$fixture/parent"
 parent_origin="$fixture/parent-origin.git"
 submodule_origin="$fixture/submodule-origin.git"
@@ -104,6 +108,35 @@ assert_skipped() {
 assert_invoked_once() {
   [ "$(wc -l <"$log" | tr -d ' ')" -eq 1 ] || { echo "error: $1 did not invoke checker exactly once" >&2; cat "$log" >&2; exit 1; }
 }
+assert_invoked_count() {
+  [ "$(wc -l <"$log" | tr -d ' ')" -eq "$2" ] || { echo "error: $1 did not invoke checker $2 time(s)" >&2; cat "$log" >&2; exit 1; }
+}
+
+# Two new refs share one relevant commit. The checker must deduplicate the
+# commit SHA even though Git supplies two ref-update lines on stdin.
+git -C "$parent" switch --quiet -c shared-submodule
+printf 'shared\n' >>"$parent/deps/test-submodule/state.txt"
+git -C "$parent/deps/test-submodule" add state.txt
+git -C "$parent/deps/test-submodule" commit --quiet -m shared-unpushed
+shared_submodule_sha="$(git -C "$parent/deps/test-submodule" rev-parse HEAD)"
+git -C "$parent" add deps/test-submodule
+git -C "$parent" commit --no-verify --quiet -m shared-gitlink
+shared_parent_sha="$(git -C "$parent" rev-parse HEAD)"
+git -C "$parent" branch duplicate-ref "$shared_parent_sha"
+git -C "$parent" switch --quiet main
+git -C "$parent" submodule update --quiet
+reset_log
+if LEFTHOOK_ROUTING_LOG="$log" LEFTHOOK_ROUTING_CHECKER="$parent/scripts/check-submodule-reachability.nu" PATH="$fixture/bin:$PATH" \
+  git -C "$parent" push --quiet origin shared-submodule duplicate-ref >"$fixture/shared.out" 2>&1; then
+  echo "error: shared unpushed submodule commit unexpectedly passed" >&2
+  exit 1
+fi
+assert_invoked_once shared-commit-deduplication
+git -C "$parent/deps/test-submodule" push --quiet origin "$shared_submodule_sha:refs/pull/shared/head"
+reset_log
+LEFTHOOK_ROUTING_LOG="$log" LEFTHOOK_ROUTING_CHECKER="$parent/scripts/check-submodule-reachability.nu" PATH="$fixture/bin:$PATH" \
+  git -C "$parent" push --quiet origin shared-submodule duplicate-ref
+assert_invoked_once shared-commit-after-push
 
 printf 'docs\n' >"$parent/docs/README.md"
 git -C "$parent" add docs/README.md && git -C "$parent" commit --no-verify --quiet -m docs
@@ -171,6 +204,66 @@ reset_log
 LEFTHOOK_ROUTING_LOG="$log" LEFTHOOK_ROUTING_CHECKER="$parent/scripts/check-submodule-reachability.nu" PATH="$fixture/bin:$PATH" \
   git -C "$parent" push --quiet origin main
 assert_invoked_once mixed-after-push
+
+# A bad gitlink commit can be reverted before the final tip. The adapter must
+# inspect the newly introduced history, not only the endpoint tree.
+revert_base_sha="$(git -C "$parent/deps/test-submodule" rev-parse HEAD)"
+printf 'reverted-before-push\n' >>"$parent/deps/test-submodule/state.txt"
+git -C "$parent/deps/test-submodule" add state.txt
+git -C "$parent/deps/test-submodule" commit --quiet -m reverted-before-push
+reverted_submodule_sha="$(git -C "$parent/deps/test-submodule" rev-parse HEAD)"
+git -C "$parent" add deps/test-submodule
+git -C "$parent" commit --no-verify --quiet -m bad-history-gitlink
+git -C "$parent/deps/test-submodule" checkout --quiet "$revert_base_sha"
+git -C "$parent" add deps/test-submodule
+git -C "$parent" commit --no-verify --quiet -m revert-history-gitlink
+reset_log
+if LEFTHOOK_ROUTING_LOG="$log" LEFTHOOK_ROUTING_CHECKER="$parent/scripts/check-submodule-reachability.nu" PATH="$fixture/bin:$PATH" \
+  git -C "$parent" push --quiet origin main >"$fixture/reverted-history.out" 2>&1; then
+  echo "error: reverted unpushed submodule commit unexpectedly passed" >&2
+  exit 1
+fi
+assert_invoked_once reverted-history
+
+git -C "$parent/deps/test-submodule" push --quiet origin "$reverted_submodule_sha:refs/pull/reverted/head"
+reset_log
+LEFTHOOK_ROUTING_LOG="$log" LEFTHOOK_ROUTING_CHECKER="$parent/scripts/check-submodule-reachability.nu" PATH="$fixture/bin:$PATH" \
+  git -C "$parent" push --quiet origin main
+assert_invoked_count reverted-history-after-push 2
+
+# A force-pushed non-fast-forward ref must inspect commits newly introduced by
+# the replacement history, not only the old remote-to-new endpoint diff.
+git -C "$parent" switch --quiet -c nonfast
+printf 'nonfast-base\n' >"$parent/docs/nonfast.txt"
+git -C "$parent" add docs/nonfast.txt
+git -C "$parent" commit --no-verify --quiet -m nonfast-base
+git -C "$parent" push --quiet origin nonfast
+git -C "$parent" switch --quiet main
+git -C "$parent" submodule update --quiet
+git -C "$parent" switch --quiet nonfast
+git -C "$parent" reset --hard --quiet main
+git -C "$parent" submodule update --quiet
+printf 'nonfast-bad\n' >>"$parent/deps/test-submodule/state.txt"
+git -C "$parent/deps/test-submodule" add state.txt
+git -C "$parent/deps/test-submodule" commit --quiet -m nonfast-bad
+nonfast_submodule_sha="$(git -C "$parent/deps/test-submodule" rev-parse HEAD)"
+git -C "$parent" add deps/test-submodule
+git -C "$parent" commit --no-verify --quiet -m nonfast-gitlink
+reset_log
+if LEFTHOOK_ROUTING_LOG="$log" LEFTHOOK_ROUTING_CHECKER="$parent/scripts/check-submodule-reachability.nu" PATH="$fixture/bin:$PATH" \
+  git -C "$parent" push --quiet --force origin nonfast >"$fixture/nonfast.out" 2>&1; then
+  echo "error: non-fast-forward unpushed submodule commit unexpectedly passed" >&2
+  exit 1
+fi
+assert_invoked_once nonfast
+
+git -C "$parent/deps/test-submodule" push --quiet origin "$nonfast_submodule_sha:refs/pull/nonfast/head"
+reset_log
+LEFTHOOK_ROUTING_LOG="$log" LEFTHOOK_ROUTING_CHECKER="$parent/scripts/check-submodule-reachability.nu" PATH="$fixture/bin:$PATH" \
+  git -C "$parent" push --quiet --force origin nonfast
+assert_invoked_once nonfast-after-push
+git -C "$parent" switch --quiet main
+git -C "$parent" submodule update --quiet
 
 # Switch to the retained core.hooksPath shim and verify Git's hook arguments and stdin.
 git -C "$parent" config core.hooksPath .githooks

--- a/scripts/test-pr-ready-validation.sh
+++ b/scripts/test-pr-ready-validation.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 validator="$root_dir/scripts/validate-pr-ready.sh"
+submodule_checker="$root_dir/scripts/check-submodule-reachability.nu"
 tmp_dir="$(mktemp -d)"
 trap 'rm -rf "$tmp_dir"' EXIT
 
@@ -24,6 +25,9 @@ assert_files_equal() {
 
 if [ ! -x "$validator" ]; then
   fail "expected executable validator at $validator"
+fi
+if [ ! -x "$submodule_checker" ]; then
+  fail "expected executable submodule checker at $submodule_checker"
 fi
 
 list_output="$tmp_dir/list-output"
@@ -91,6 +95,7 @@ fake_bin="$tmp_dir/bin"
 execution_log="$tmp_dir/execution.log"
 mkdir -p "$fixture/scripts" "$fixture/pkg" "$fake_bin"
 cp "$validator" "$fixture/scripts/validate-pr-ready.sh"
+cp "$submodule_checker" "$fixture/scripts/check-submodule-reachability.nu"
 
 cat >"$fake_bin/moon" <<'FAKE_MOON'
 #!/usr/bin/env bash

--- a/scripts/test-submodule-reachability.sh
+++ b/scripts/test-submodule-reachability.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+checker="$root_dir/scripts/check-submodule-reachability.nu"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+fail() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+setup_fixture() {
+  local name="$1"
+  local fixture="$tmp_dir/$name"
+  local origin="$fixture/submodule-origin.git"
+  local seed="$fixture/submodule-seed"
+  local parent="$fixture/parent"
+
+  git init --quiet --bare --initial-branch=main "$origin"
+  git init --quiet --initial-branch=main "$seed"
+  git -C "$seed" config user.email submodule-reachability@example.invalid
+  git -C "$seed" config user.name submodule-reachability-test
+  printf 'baseline\n' >"$seed/state.txt"
+  git -C "$seed" add state.txt
+  git -C "$seed" commit --quiet -m baseline
+  git -C "$seed" remote add origin "$origin"
+  git -C "$seed" push --quiet --set-upstream origin main
+
+  git init --quiet --initial-branch=main "$parent"
+  git -C "$parent" config user.email submodule-reachability@example.invalid
+  git -C "$parent" config user.name submodule-reachability-test
+  git -c protocol.file.allow=always -C "$parent" submodule add --quiet "$origin" deps/test-submodule
+  git -C "$parent/deps/test-submodule" config protocol.file.allow always
+  mkdir -p "$parent/scripts"
+  cp "$checker" "$parent/scripts/check-submodule-reachability.nu"
+  chmod +x "$parent/scripts/check-submodule-reachability.nu"
+  git -C "$parent" add .
+  git -C "$parent" commit --quiet -m baseline
+  printf '%s\n' "$parent"
+}
+
+run_checker() {
+  local parent="$1"
+  (cd "$parent" && nu ./scripts/check-submodule-reachability.nu)
+}
+
+run_checker_at() {
+  local parent="$1"
+  local commit="$2"
+  (cd "$parent" && nu ./scripts/check-submodule-reachability.nu --commit "$commit")
+}
+
+expect_pass() {
+  local name="$1"
+  local parent="$2"
+  if ! run_checker "$parent" >"$tmp_dir/$name.out" 2>&1; then
+    cat "$tmp_dir/$name.out" >&2
+    fail "$name unexpectedly failed"
+  fi
+}
+
+expect_fail() {
+  local name="$1"
+  local parent="$2"
+  local message="$3"
+  if run_checker "$parent" >"$tmp_dir/$name.out" 2>&1; then
+    fail "$name unexpectedly passed"
+  fi
+  grep -Fq "$message" "$tmp_dir/$name.out" || {
+    cat "$tmp_dir/$name.out" >&2
+    fail "$name diagnostic did not contain: $message"
+  }
+}
+
+expect_pass_at() {
+  local name="$1"
+  local parent="$2"
+  local commit="$3"
+  if ! run_checker_at "$parent" "$commit" >"$tmp_dir/$name.out" 2>&1; then
+    cat "$tmp_dir/$name.out" >&2
+    fail "$name unexpectedly failed"
+  fi
+}
+
+expect_fail_at() {
+  local name="$1"
+  local parent="$2"
+  local commit="$3"
+  local message="$4"
+  if run_checker_at "$parent" "$commit" >"$tmp_dir/$name.out" 2>&1; then
+    fail "$name unexpectedly passed"
+  fi
+  grep -Fq "$message" "$tmp_dir/$name.out" || {
+    cat "$tmp_dir/$name.out" >&2
+    fail "$name diagnostic did not contain: $message"
+  }
+}
+
+# Initialized checkout, matching gitlink, and a reachable normal origin ref.
+parent="$(setup_fixture initialized-reachable)"
+expect_pass initialized-reachable "$parent"
+
+# The checkout can be present while pointing at a different commit than HEAD's gitlink.
+parent="$(setup_fixture gitlink-mismatch)"
+submodule="$parent/deps/test-submodule"
+printf 'mismatch\n' >"$submodule/state.txt"
+git -C "$submodule" add state.txt
+git -C "$submodule" commit --quiet -m mismatch
+expect_fail gitlink-mismatch "$parent" "does not match its recorded gitlink"
+
+# Removing the checkout leaves the gitlink uninitialized.
+parent="$(setup_fixture uninitialized)"
+git -C "$parent" submodule deinit --quiet --force deps/test-submodule
+expect_fail uninitialized "$parent" "is not initialized"
+
+# Unmerged gitlink index entries are rejected before any fetch.
+parent="$(setup_fixture conflict)"
+submodule="$parent/deps/test-submodule"
+recorded_sha="$(git -C "$parent" rev-parse HEAD:deps/test-submodule)"
+printf 'conflict\n' >"$submodule/state.txt"
+git -C "$submodule" add state.txt
+git -C "$submodule" commit --quiet -m conflict
+conflict_sha="$(git -C "$submodule" rev-parse HEAD)"
+git -C "$parent" update-index --force-remove deps/test-submodule
+git -C "$parent" update-index --index-info <<EOF
+160000 $recorded_sha 1	deps/test-submodule
+160000 $recorded_sha 2	deps/test-submodule
+160000 $conflict_sha 3	deps/test-submodule
+EOF
+expect_fail conflict "$parent" "merge conflict"
+
+# A configured origin that cannot be fetched is a blocking failure.
+parent="$(setup_fixture origin-fetch-failure)"
+git -C "$parent/deps/test-submodule" remote set-url origin "$parent/missing-origin.git"
+expect_fail origin-fetch-failure "$parent" "could not fetch submodule origin"
+
+# A local submodule commit absent from every normal origin ref is rejected.
+parent="$(setup_fixture unreachable-local-commit)"
+submodule="$parent/deps/test-submodule"
+printf 'unreachable\n' >"$submodule/state.txt"
+git -C "$submodule" add state.txt
+git -C "$submodule" commit --quiet -m unreachable
+git -C "$parent" add deps/test-submodule
+git -C "$parent" commit --quiet -m "record unreachable submodule"
+expect_fail unreachable-local-commit "$parent" "submodule commit is not fetchable from origin"
+
+# An exact-SHA fetch is allowed when the object is reachable only through a non-normal ref.
+parent="$(setup_fixture exact-sha-origin)"
+submodule="$parent/deps/test-submodule"
+printf 'exact sha\n' >"$submodule/state.txt"
+git -C "$submodule" add state.txt
+git -C "$submodule" commit --quiet -m "exact sha"
+git -C "$parent" add deps/test-submodule
+git -C "$parent" commit --quiet -m "record exact sha submodule"
+git -C "$submodule" push --quiet origin "HEAD:refs/pull/1/head"
+expect_pass exact-sha-origin "$parent"
+
+# Keep the final assertion explicit: a normal origin ref is accepted without the SHA fallback.
+parent="$(setup_fixture normal-origin-ref)"
+submodule="$parent/deps/test-submodule"
+printf 'normal ref\n' >"$submodule/state.txt"
+git -C "$submodule" add state.txt
+git -C "$submodule" commit --quiet -m "normal ref"
+git -C "$submodule" push --quiet origin HEAD:main
+git -C "$parent" add deps/test-submodule
+git -C "$parent" commit --quiet -m "record normal ref submodule"
+expect_pass normal-origin-ref "$parent"
+
+# A pushed ref need not be the currently checked-out superproject HEAD. The
+# commit mode validates gitlinks from that pushed tree without mutating the
+# checkout, while retaining the exact-SHA origin contract.
+parent="$(setup_fixture non-head-pushed-commit)"
+submodule="$parent/deps/test-submodule"
+printf 'non-head\n' >>"$submodule/state.txt"
+git -C "$submodule" add state.txt
+git -C "$submodule" commit --quiet -m "non-head submodule"
+submodule_sha="$(git -C "$submodule" rev-parse HEAD)"
+git -C "$parent" add deps/test-submodule
+git -C "$parent" commit --quiet -m "record non-head submodule"
+pushed_commit="$(git -C "$parent" rev-parse HEAD)"
+git -C "$parent" switch --quiet --detach HEAD^
+git -C "$parent" submodule update --quiet
+expect_fail_at non-head-unreachable "$parent" "$pushed_commit" "submodule commit is not fetchable from origin"
+git -C "$submodule" push --quiet origin "$submodule_sha:refs/pull/2/head"
+expect_pass_at non-head-exact-sha "$parent" "$pushed_commit"
+
+echo "ok: submodule reachability contract cases pass"

--- a/scripts/test-submodule-reachability.sh
+++ b/scripts/test-submodule-reachability.sh
@@ -7,6 +7,10 @@ checker="$root_dir/scripts/check-submodule-reachability.nu"
 tmp_dir="$(mktemp -d)"
 trap 'rm -rf "$tmp_dir"' EXIT
 
+git_config="$tmp_dir/gitconfig"
+printf '[protocol "file"]\n\tallow = always\n' >"$git_config"
+export GIT_CONFIG_GLOBAL="$git_config"
+
 fail() {
   echo "error: $*" >&2
   exit 1
@@ -188,5 +192,89 @@ git -C "$parent" submodule update --quiet
 expect_fail_at non-head-unreachable "$parent" "$pushed_commit" "submodule commit is not fetchable from origin"
 git -C "$submodule" push --quiet origin "$submodule_sha:refs/pull/2/head"
 expect_pass_at non-head-exact-sha "$parent" "$pushed_commit"
+
+# A non-HEAD commit may add a submodule path that is absent from the current
+# checkout. Materialization must use the target .gitmodules and initialize it.
+parent="$(setup_fixture non-head-add-submodule)"
+added_origin="$tmp_dir/added-submodule-origin.git"
+added_seed="$tmp_dir/added-submodule-seed"
+git init --quiet --bare --initial-branch=main "$added_origin"
+git init --quiet --initial-branch=main "$added_seed"
+git -C "$added_seed" config user.email submodule-reachability@example.invalid
+git -C "$added_seed" config user.name submodule-reachability-test
+printf 'added\n' >"$added_seed/state.txt"
+git -C "$added_seed" add state.txt
+git -C "$added_seed" commit --quiet -m added
+git -C "$added_seed" remote add origin "$added_origin"
+git -C "$added_seed" push --quiet --set-upstream origin main
+git -c protocol.file.allow=always -C "$parent" submodule add --quiet "$added_origin" deps/added-submodule
+git -C "$parent/deps/added-submodule" config user.email submodule-reachability@example.invalid
+git -C "$parent/deps/added-submodule" config user.name submodule-reachability-test
+git -C "$parent" add .gitmodules deps/added-submodule
+git -C "$parent" commit --quiet -m "add submodule in pushed commit"
+added_commit="$(git -C "$parent" rev-parse HEAD)"
+rm -rf "$parent/deps/added-submodule"
+git -C "$parent" switch --quiet --detach HEAD^
+git -C "$parent" submodule update --quiet
+expect_pass_at non-head-add-submodule "$parent" "$added_commit"
+
+# A target commit's .gitmodules URL must be authoritative; an old checkout
+# origin must not make a changed, unreachable URL appear valid.
+parent="$(setup_fixture non-head-url-change)"
+missing_origin="$parent/missing-origin.git"
+git -C "$parent" config -f .gitmodules submodule.deps/test-submodule.url "$missing_origin"
+git -C "$parent" add .gitmodules
+git -C "$parent" commit --quiet -m "change submodule origin"
+url_commit="$(git -C "$parent" rev-parse HEAD)"
+git -C "$parent" switch --quiet --detach HEAD^
+git -C "$parent" submodule update --quiet
+expect_fail_at non-head-url-change "$parent" "$url_commit" "could not materialize submodules"
+
+# A reachable top-level submodule can still point at an unreachable nested
+# gitlink. Recursive materialization must reject the nested object.
+parent="$(setup_fixture nested-unreachable)"
+nested_origin="$tmp_dir/nested-origin.git"
+nested_seed="$tmp_dir/nested-seed"
+top_origin="$tmp_dir/top-origin.git"
+top_seed="$tmp_dir/top-seed"
+git init --quiet --bare --initial-branch=main "$nested_origin"
+git init --quiet --initial-branch=main "$nested_seed"
+git -C "$nested_seed" config user.email submodule-reachability@example.invalid
+git -C "$nested_seed" config user.name submodule-reachability-test
+printf 'nested-base\n' >"$nested_seed/state.txt"
+git -C "$nested_seed" add state.txt
+git -C "$nested_seed" commit --quiet -m nested-base
+git -C "$nested_seed" remote add origin "$nested_origin"
+git -C "$nested_seed" push --quiet --set-upstream origin main
+git init --quiet --bare --initial-branch=main "$top_origin"
+git init --quiet --initial-branch=main "$top_seed"
+git -C "$top_seed" config user.email submodule-reachability@example.invalid
+git -C "$top_seed" config user.name submodule-reachability-test
+git -c protocol.file.allow=always -C "$top_seed" submodule add --quiet "$nested_origin" deps/nested
+git -C "$top_seed/deps/nested" config user.email submodule-reachability@example.invalid
+git -C "$top_seed/deps/nested" config user.name submodule-reachability-test
+git -C "$top_seed" add .gitmodules deps/nested
+git -C "$top_seed" commit --quiet -m top-base
+git -C "$top_seed" remote add origin "$top_origin"
+git -C "$top_seed" push --quiet --set-upstream origin main
+printf 'nested-bad\n' >>"$top_seed/deps/nested/state.txt"
+git -C "$top_seed/deps/nested" add state.txt
+git -C "$top_seed/deps/nested" commit --quiet -m nested-bad
+nested_bad_sha="$(git -C "$top_seed/deps/nested" rev-parse HEAD)"
+git -C "$top_seed" add deps/nested
+git -C "$top_seed" commit --quiet -m top-nested-bad
+git -C "$top_seed" push --quiet origin main
+git -c protocol.file.allow=always -C "$parent" submodule add --quiet "$top_origin" deps/top-submodule
+git -C "$parent" add .gitmodules deps/top-submodule
+git -C "$parent" commit --quiet -m "add nested submodule graph"
+nested_commit="$(git -C "$parent" rev-parse HEAD)"
+rm -rf "$parent/deps/top-submodule"
+git -C "$parent" switch --quiet --detach HEAD^
+git -C "$parent" submodule update --quiet
+expect_fail_at nested-unreachable "$parent" "$nested_commit" "submodule commit is not fetchable"
+
+# Keep the nested SHA in the fixture's setup evidence so the failure is tied to
+# the object absent from nested-origin rather than the reachable top-level ref.
+test -n "$nested_bad_sha"
 
 echo "ok: submodule reachability contract cases pass"

--- a/scripts/test-submodule-reachability.sh
+++ b/scripts/test-submodule-reachability.sh
@@ -34,6 +34,8 @@ setup_fixture() {
   git -C "$parent" config user.name submodule-reachability-test
   git -c protocol.file.allow=always -C "$parent" submodule add --quiet "$origin" deps/test-submodule
   git -C "$parent/deps/test-submodule" config protocol.file.allow always
+  git -C "$parent/deps/test-submodule" config user.email submodule-reachability@example.invalid
+  git -C "$parent/deps/test-submodule" config user.name submodule-reachability-test
   mkdir -p "$parent/scripts"
   cp "$checker" "$parent/scripts/check-submodule-reachability.nu"
   chmod +x "$parent/scripts/check-submodule-reachability.nu"

--- a/scripts/validate-pr-ready.sh
+++ b/scripts/validate-pr-ready.sh
@@ -383,33 +383,7 @@ run_phase() {
         die "HEAD does not contain base $base_ref ($start_base); sync or rebase first"
       ;;
     preflight.submodules)
-      local submodule_status
-      local line
-      submodule_status="$(git submodule status --recursive)"
-      while IFS= read -r line; do
-        [ -z "$line" ] && continue
-        case "${line:0:1}" in
-          -) die "submodule is not initialized: $line" ;;
-          +) die "submodule does not match its recorded gitlink: $line" ;;
-          U) die "submodule has a merge conflict: $line" ;;
-        esac
-      done <<<"$submodule_status"
-      # Variables in this body are intentionally expanded inside each submodule.
-      # shellcheck disable=SC2016
-      git submodule foreach --quiet --recursive '
-        if ! git fetch --quiet --prune origin; then
-          echo "error: could not fetch submodule origin: $displaypath" >&2
-          exit 1
-        fi
-        if [ -z "$(git for-each-ref --format="%(refname)" --contains HEAD refs/remotes/origin)" ]; then
-          sha="$(git rev-parse HEAD)"
-          if ! git fetch --quiet --no-tags --refetch origin "$sha"; then
-            echo "error: submodule commit is not fetchable from origin: $displaypath" >&2
-            echo "push the commit to the configured origin before the parent PR" >&2
-            exit 1
-          fi
-        fi
-      ' || die "submodule remote reachability check failed"
+      nu "$project_root/scripts/check-submodule-reachability.nu"
       ;;
     dependencies.check-deps)
       ./scripts/check-deps.sh


### PR DESCRIPTION
## Summary

- add a blocking Lefthook `pre-push` submodule reachability contract
- extract the existing `validate-pr-ready` submodule check into `scripts/check-submodule-reachability.nu`
- preserve the existing `preflight.submodules` phase ID, order, and failure semantics
- route the shared checker through the internal `just hook-submodule-reachability` recipe
- inspect every relevant commit introduced by each pushed ref, including intermediate reverted gitlinks, non-HEAD refs, force-pushed histories, and multiple refs sharing a commit
- materialize each pushed commit with its own `.gitmodules` and recursively validate the complete submodule graph
- keep exact-SHA fetchability from configured `origin` as an allowed case
- add a legacy `.githooks/pre-push` shim forwarding Git arguments and stdin to Lefthook
- remove Claude's warning-only `git push` hook while retaining the Claude commit hook
- add real Git/bare-remote and Lefthook 2.1.10 regression fixtures
- add CI validation for the shared checker, pre-push route, Nushell dependencies, and Claude settings

## Routing contract

The pre-push job is limited to `.gitmodules` and the `deps/` ownership zone. It does not run `moon test`, workspace-wide checks, browser E2E, or PR-ready validation.

Lefthook 2.1.10 filters submodule gitlinks out of its `{push_files}` existence check because gitlinks appear as directories. The thin `scripts/run-submodule-reachability.sh` adapter therefore runs with `{all_files}` as an execution sentinel and `use_stdin: true`, then reads Git's actual pre-push ref-update stream. It owns the path policy, enumerates the commits introduced by each ref relative to the streamed remote SHA (or authoritative `git ls-remote --refs origin` refs for new refs), and deduplicates commit SHAs. Stale local `refs/remotes/origin/*` refs are never used as an exclusion base. It invokes the shared checker only for relevant updates.

The shared checker retains the existing checkout contract:

- initialized submodules
- recorded gitlink and checkout agreement
- no merge conflict
- configured `origin` fetch succeeds
- normal `refs/remotes/origin` reachability
- exact-SHA fetchability from `origin` when no normal remote ref contains the commit

For a pushed commit, it clones and checks out that commit, synchronizes its version of `.gitmodules`, recursively initializes the graph, and applies the same reachability checks to every nested submodule. The checker is read-only: it creates only disposable temporary materializations and never commits, pushes, changes branches, or changes gitlinks.

The public `just check`, `just fmt-check`, and `pre-commit` behavior is unchanged.

## Regression coverage

- checker: initialized/reachable, gitlink mismatch, uninitialized, conflict, origin fetch failure, unreachable local commit, normal origin ref, exact-SHA-only origin ref
- checker: non-HEAD pushed superproject commit, target `.gitmodules` URL changes, newly added submodules, and unreachable nested gitlinks
- real Git push + Lefthook: docs-only and MoonBit-only skip; gitlink, `.gitmodules`, and mixed pushes invoke; unpushed submodule commits are rejected; intermediate bad gitlinks are rejected even when reverted; stale local origin refs do not bypass validation; multiple refs deduplicate; non-fast-forward replacement histories are checked; pushing the submodule first allows the parent; legacy `.githooks/pre-push` preserves arguments and stdin
- existing pre-commit routing fixture remains green, including Claude settings routing

## Validation

- `just --unstable --fmt --check`
- `just check`
- `just fmt-check`
- real Lefthook v2.1.10 `validate`
- shellcheck for changed shell scripts
- `scripts/test-submodule-reachability.sh`
- `scripts/test-lefthook-pre-push-routing.sh`
- `scripts/test-lefthook-pre-commit-routing.sh`
- `scripts/test-pr-ready-validation.sh`
- `scripts/test-install-hooks.sh`
- Nushell syntax checks
- workflow YAML validation and actionlint
- JSON validation for `.claude/settings.json`
- `./scripts/validate-pr-ready.sh --no-target "PR #1257 changes only hook/scripts/docs; no MoonBit package target"`

Final validated HEAD: `f4de6fb5`; base: `47b13541`.

The local macOS-only Bash 3.2 contract was not run on this Linux host; CI's `pr-ready-bash3` job installs the pinned Nushell dependency required by the updated validator fixture.
