### PR TITLE
fix(canvas): normalize wheel input before viewport updates

### DIFF
--- a/apps/canvas/main/canvas_init.mbt
+++ b/apps/canvas/main/canvas_init.mbt
@@ -9,8 +9,15 @@ pub fn create_canvas() -> Int {
 }
 
 ///|
-pub fn zoom(handle : Int, delta : Double, cx : Double, cy : Double) -> Unit {
-  _registry[handle].zoom(delta, cx, cy)
+pub fn zoom(
+  handle : Int,
+  delta_y : Double,
+  delta_mode : Int,
+  ctrl_key : Bool,
+  cx : Double,
+  cy : Double,
+) -> Unit {
+  _registry[handle].zoom(delta_y, delta_mode, ctrl_key, cx, cy)
 }
 
 ///|

--- a/apps/canvas/main/canvas_runtime.mbt
+++ b/apps/canvas/main/canvas_runtime.mbt
@@ -556,8 +556,8 @@ fn CanvasRuntime::zoom(
     delta_mode,
     ctrl_key,
     canvas_pointer_is_mac_like(),
-    min_scale=0.1,
-    max_scale=8.0,
+    min_scale=CANVAS_MIN_SCALE,
+    max_scale=CANVAS_MAX_SCALE,
   ) {
     Some(scale) => scale
     None => return

--- a/apps/canvas/main/canvas_runtime.mbt
+++ b/apps/canvas/main/canvas_runtime.mbt
@@ -539,18 +539,34 @@ fn CanvasRuntime::pointer_interrupt(self : CanvasRuntime) -> Unit {
 ///|
 fn CanvasRuntime::zoom(
   self : CanvasRuntime,
-  delta : Double,
+  delta_y : Double,
+  delta_mode : Int,
+  ctrl_key : Bool,
   cx : Double,
   cy : Double,
 ) -> Unit {
-  if delta.is_nan() || delta.is_inf() {
-    return
-  }
+  let before = self.state_peek()
+  guard !before.interaction.pointer_down else { return }
   let screen = ScreenPoint::from_xy(x=cx, y=cy) catch {
     @spatial.CoordinateError::NonFinite => return
   }
-  let before = self.state_peek()
-  let next = @graph_model.update_zoom(before, delta, screen)
+  let absolute_scale = match canvas_wheel_target_scale(
+    before.viewport.scale(),
+    delta_y,
+    delta_mode,
+    ctrl_key,
+    canvas_pointer_is_mac_like(),
+    min_scale=0.1,
+    max_scale=8.0,
+  ) {
+    Some(scale) => scale
+    None => return
+  }
+  let next = @graph_model.update_viewport_scale_around(
+    before,
+    absolute_scale,
+    screen,
+  )
   if next.viewport != before.viewport || next.action_log != before.action_log {
     self.sync_action_viewport_state(next)
   }

--- a/apps/canvas/main/canvas_runtime_contract_wbtest.mbt
+++ b/apps/canvas/main/canvas_runtime_contract_wbtest.mbt
@@ -151,7 +151,7 @@ test "runtime contract: panning logs viewport only on pointerup" {
 ///|
 test "runtime contract: zoom logs one viewport operation immediately" {
   let runtime = CanvasRuntime::CanvasRuntime()
-  runtime.zoom(-1.0, 500.0, 400.0)
+  runtime.zoom(-120.0, 0, false, 500.0, 400.0)
   let after = runtime.render_state()
   let operations = contract_runtime_operations(runtime)
   assert_eq(after.action_count, 1)

--- a/apps/canvas/main/canvas_runtime_wbtest.mbt
+++ b/apps/canvas/main/canvas_runtime_wbtest.mbt
@@ -129,6 +129,38 @@ test "runtime pointer admission rejects missing nodes without mutation" {
 }
 
 ///|
+///|
+test "runtime wheel rejects zero and active gesture input" {
+  let runtime = CanvasRuntime::CanvasRuntime()
+  let before = runtime.state_peek()
+  runtime.zoom(0.0, 0, false, 10.0, 10.0)
+  let zero = runtime.state_peek()
+  assert_eq(zero.viewport, before.viewport)
+  assert_eq(zero.action_log.length(), before.action_log.length())
+
+  ignore(runtime.pointer_down(None, 10.0, 10.0))
+  let active = runtime.state_peek()
+  runtime.zoom(-100.0, 0, false, 20.0, 20.0)
+  let during = runtime.state_peek()
+  assert_eq(during.viewport, active.viewport)
+  assert_eq(during.action_log.length(), active.action_log.length())
+  runtime.pointer_interrupt()
+
+  runtime.sync_viewport_state({
+    ..runtime.state_peek(),
+    viewport: Viewport::from_scale(
+      origin=try! ScreenPoint::from_xy(x=0.0, y=0.0),
+      scale=try! @spatial.Scale::from_double(value=8.0),
+    ),
+  })
+  let at_max = runtime.state_peek()
+  runtime.zoom(-100.0, 0, false, 100.0, 100.0)
+  let repeated = runtime.state_peek()
+  assert_eq(repeated.viewport, at_max.viewport)
+  assert_eq(repeated.action_log.length(), at_max.action_log.length())
+}
+
+///|
 test "runtime compatibility export batches graph model results" {
   let runtime = CanvasRuntime::CanvasRuntime()
   let entries = runtime.input_port_compatibility(NodeId("2"), "json")

--- a/apps/canvas/main/graph_dsl_adapter.mbt
+++ b/apps/canvas/main/graph_dsl_adapter.mbt
@@ -1004,18 +1004,34 @@ fn SourceBackedGraph::input_port_compatibility(
 ///|
 fn SourceBackedGraph::zoom(
   self : SourceBackedGraph,
-  delta : Double,
+  delta_y : Double,
+  delta_mode : Int,
+  ctrl_key : Bool,
   cx : Double,
   cy : Double,
 ) -> Unit {
-  if delta.is_nan() || delta.is_inf() {
-    return
-  }
+  let before = source_graph_base_canvas_state(self)
+  guard !before.interaction.pointer_down else { return }
   let screen = ScreenPoint::from_xy(x=cx, y=cy) catch {
     @spatial.CoordinateError::NonFinite => return
   }
-  let before = source_graph_base_canvas_state(self)
-  let next = @graph_model.update_zoom(before, delta, screen)
+  let absolute_scale = match canvas_wheel_target_scale(
+    before.viewport.scale(),
+    delta_y,
+    delta_mode,
+    ctrl_key,
+    canvas_pointer_is_mac_like(),
+    min_scale=0.1,
+    max_scale=8.0,
+  ) {
+    Some(scale) => scale
+    None => return
+  }
+  let next = @graph_model.update_viewport_scale_around(
+    before,
+    absolute_scale,
+    screen,
+  )
   if next.viewport != before.viewport || next.action_log != before.action_log {
     self.viewport = next.viewport
     self.action_log = next.action_log.copy()
@@ -1340,12 +1356,14 @@ pub fn get_source_graph_input_port_compatibility(
 ///|
 pub fn source_graph_zoom(
   handle : Int,
-  delta : Double,
+  delta_y : Double,
+  delta_mode : Int,
+  ctrl_key : Bool,
   cx : Double,
   cy : Double,
 ) -> Unit {
   match source_graph_by_handle(handle) {
-    Some(graph) => graph.zoom(delta, cx, cy)
+    Some(graph) => graph.zoom(delta_y, delta_mode, ctrl_key, cx, cy)
     None => ()
   }
 }

--- a/apps/canvas/main/graph_dsl_adapter.mbt
+++ b/apps/canvas/main/graph_dsl_adapter.mbt
@@ -1021,8 +1021,8 @@ fn SourceBackedGraph::zoom(
     delta_mode,
     ctrl_key,
     canvas_pointer_is_mac_like(),
-    min_scale=0.1,
-    max_scale=8.0,
+    min_scale=CANVAS_MIN_SCALE,
+    max_scale=CANVAS_MAX_SCALE,
   ) {
     Some(scale) => scale
     None => return

--- a/apps/canvas/main/moon.pkg
+++ b/apps/canvas/main/moon.pkg
@@ -1,6 +1,7 @@
 import {
   "moonbitlang/core/json",
   "moonbitlang/core/debug",
+  "moonbitlang/core/math",
   "moonbitlang/core/ref",
   "dowdiness/canopy-canvas-graph/graph_model",
   "dowdiness/canopy-canvas-graph/spatial",

--- a/apps/canvas/main/pkg.generated.mbti
+++ b/apps/canvas/main/pkg.generated.mbti
@@ -50,11 +50,11 @@ pub fn set_source_graph_source_result(Int, String) -> String raise Failure
 
 pub fn source_graph_insert_unique(Int, String, String) -> String raise Failure
 
-pub fn source_graph_zoom(Int, Double, Double, Double) -> Unit
+pub fn source_graph_zoom(Int, Double, Int, Bool, Double, Double) -> Unit
 
 pub fn try_destroy_source_graph(Int) -> Bool
 
-pub fn zoom(Int, Double, Double, Double) -> Unit
+pub fn zoom(Int, Double, Int, Bool, Double, Double) -> Unit
 
 // Errors
 

--- a/apps/canvas/main/wheel_normalization.mbt
+++ b/apps/canvas/main/wheel_normalization.mbt
@@ -1,0 +1,95 @@
+///|
+/// Browser wheel units exposed by `WheelEvent::deltaMode`.
+priv enum CanvasWheelDeltaUnit {
+  Pixel
+  Line
+  Page
+}
+
+///|
+const CANVAS_WHEEL_PIXEL_UNIT_FACTOR : Double = 0.002
+
+///|
+const CANVAS_WHEEL_LINE_UNIT_FACTOR : Double = 0.05
+
+///|
+const CANVAS_WHEEL_PAGE_UNIT_FACTOR : Double = 1.0
+
+///|
+const CANVAS_WHEEL_PINCH_FACTOR : Double = 10.0
+
+///|
+fn canvas_wheel_delta_unit(delta_mode : Int) -> CanvasWheelDeltaUnit? {
+  match delta_mode {
+    0 => Some(Pixel)
+    1 => Some(Line)
+    2 => Some(Page)
+    _ => None
+  }
+}
+
+///|
+fn canvas_wheel_unit_factor(unit : CanvasWheelDeltaUnit) -> Double {
+  match unit {
+    Pixel => CANVAS_WHEEL_PIXEL_UNIT_FACTOR
+    Line => CANVAS_WHEEL_LINE_UNIT_FACTOR
+    Page => CANVAS_WHEEL_PAGE_UNIT_FACTOR
+  }
+}
+
+///|
+/// Convert one raw wheel delta into the absolute target scale used by the
+/// semantic viewport reducer. A `None` result means the event is not an
+/// admissible camera change.
+fn canvas_wheel_target_scale(
+  current_scale : @spatial.Scale,
+  delta_y : Double,
+  delta_mode : Int,
+  ctrl_key : Bool,
+  mac_like : Bool,
+  min_scale~ : Double,
+  max_scale~ : Double,
+) -> @spatial.Scale? {
+  guard !delta_y.is_nan() && !delta_y.is_inf() && delta_y != 0.0 else {
+    return None
+  }
+  let unit = match canvas_wheel_delta_unit(delta_mode) {
+    Some(unit) => unit
+    None => return None
+  }
+  let pinch_factor = if ctrl_key && mac_like {
+    CANVAS_WHEEL_PINCH_FACTOR
+  } else {
+    1.0
+  }
+  let exponent = -delta_y * canvas_wheel_unit_factor(unit) * pinch_factor
+  guard !exponent.is_nan() else { return None }
+  // Finite extreme inputs may overflow the exponent or pow; their direction
+  // still determines which host bound is the semantic target.
+  let bounded = if exponent.is_inf() {
+    if exponent > 0.0 {
+      max_scale
+    } else {
+      min_scale
+    }
+  } else {
+    let multiplier = @math.pow(2.0, exponent)
+    guard !multiplier.is_nan() else { return None }
+    let raw = current_scale.to_double() * multiplier
+    if raw.is_inf() {
+      if exponent > 0.0 {
+        max_scale
+      } else {
+        min_scale
+      }
+    } else {
+      guard !raw.is_nan() else { return None }
+      raw.clamp(min=min_scale, max=max_scale)
+    }
+  }
+  let scale = @spatial.Scale::from_double(value=bounded) catch {
+    @spatial.ScaleError::NonFinite | @spatial.ScaleError::NonPositive =>
+      return None
+  }
+  Some(scale)
+}

--- a/apps/canvas/main/wheel_normalization.mbt
+++ b/apps/canvas/main/wheel_normalization.mbt
@@ -19,6 +19,12 @@ const CANVAS_WHEEL_PAGE_UNIT_FACTOR : Double = 1.0
 const CANVAS_WHEEL_PINCH_FACTOR : Double = 10.0
 
 ///|
+const CANVAS_MIN_SCALE : Double = 0.1
+
+///|
+const CANVAS_MAX_SCALE : Double = 8.0
+
+///|
 fn canvas_wheel_delta_unit(delta_mode : Int) -> CanvasWheelDeltaUnit? {
   match delta_mode {
     0 => Some(Pixel)

--- a/apps/canvas/main/wheel_normalization_wbtest.mbt
+++ b/apps/canvas/main/wheel_normalization_wbtest.mbt
@@ -1,0 +1,267 @@
+///|
+fn canvas_wheel_test_scale(value : Double) -> @spatial.Scale {
+  try! @spatial.Scale::from_double(value~)
+}
+
+///|
+fn canvas_wheel_required_target(
+  current_scale : @spatial.Scale,
+  delta_y : Double,
+  delta_mode : Int,
+  ctrl_key : Bool,
+  mac_like : Bool,
+  min_scale~ : Double,
+  max_scale~ : Double,
+) -> @spatial.Scale raise {
+  match
+    canvas_wheel_target_scale(
+      current_scale,
+      delta_y,
+      delta_mode,
+      ctrl_key,
+      mac_like,
+      min_scale~,
+      max_scale~,
+    ) {
+    Some(scale) => scale
+    None => fail("expected an admissible wheel target")
+  }
+}
+
+///|
+fn canvas_wheel_assert_close(actual : Double, expected : Double) -> Unit raise {
+  guard actual.is_close(
+    expected,
+    relative_tolerance=1.0e-9,
+    absolute_tolerance=1.0e-9,
+  ) else {
+    fail("wheel scale values are not close")
+  }
+}
+
+///|
+test "canvas wheel rejects zero, unknown units, and non-finite deltas" {
+  let scale = canvas_wheel_test_scale(1.0)
+  assert_true(
+    canvas_wheel_target_scale(
+      scale,
+      0.0,
+      0,
+      false,
+      false,
+      min_scale=0.1,
+      max_scale=8.0,
+    )
+    is None,
+  )
+  assert_true(
+    canvas_wheel_target_scale(
+      scale,
+      -1.0,
+      9,
+      false,
+      false,
+      min_scale=0.1,
+      max_scale=8.0,
+    )
+    is None,
+  )
+  for delta in [0.0 / 0.0, 1.0 / 0.0, -1.0 / 0.0] {
+    assert_true(
+      canvas_wheel_target_scale(
+        scale,
+        delta,
+        0,
+        false,
+        false,
+        min_scale=0.1,
+        max_scale=8.0,
+      )
+      is None,
+    )
+  }
+}
+
+///|
+test "canvas wheel magnitude changes zoom continuously" {
+  let scale = canvas_wheel_test_scale(1.0)
+  let small = canvas_wheel_required_target(
+    scale,
+    -10.0,
+    0,
+    false,
+    false,
+    min_scale=0.1,
+    max_scale=8.0,
+  )
+  let large = canvas_wheel_required_target(
+    scale,
+    -100.0,
+    0,
+    false,
+    false,
+    min_scale=0.1,
+    max_scale=8.0,
+  )
+  assert_true(small.to_double() > 1.0)
+  assert_true(large.to_double() > small.to_double())
+}
+
+///|
+test "canvas wheel pixel line and page units are equivalent" {
+  let scale = canvas_wheel_test_scale(1.0)
+  let pixel = canvas_wheel_required_target(
+    scale,
+    -50.0,
+    0,
+    false,
+    false,
+    min_scale=0.1,
+    max_scale=8.0,
+  )
+  let line = canvas_wheel_required_target(
+    scale,
+    -2.0,
+    1,
+    false,
+    false,
+    min_scale=0.1,
+    max_scale=8.0,
+  )
+  let page = canvas_wheel_required_target(
+    scale,
+    -0.1,
+    2,
+    false,
+    false,
+    min_scale=0.1,
+    max_scale=8.0,
+  )
+  canvas_wheel_assert_close(pixel.to_double(), line.to_double())
+  canvas_wheel_assert_close(pixel.to_double(), page.to_double())
+}
+
+///|
+test "canvas wheel ctrl pinch is mac-like only" {
+  let scale = canvas_wheel_test_scale(1.0)
+  let plain = canvas_wheel_required_target(
+    scale,
+    -1.0,
+    0,
+    false,
+    false,
+    min_scale=0.1,
+    max_scale=8.0,
+  )
+  let mac_pinch = canvas_wheel_required_target(
+    scale,
+    -1.0,
+    0,
+    true,
+    true,
+    min_scale=0.1,
+    max_scale=8.0,
+  )
+  let other_platform = canvas_wheel_required_target(
+    scale,
+    -1.0,
+    0,
+    true,
+    false,
+    min_scale=0.1,
+    max_scale=8.0,
+  )
+  assert_true(mac_pinch.to_double() > plain.to_double())
+  canvas_wheel_assert_close(other_platform.to_double(), plain.to_double())
+}
+
+///|
+test "canvas wheel opposite deltas approximately round trip" {
+  let scale = canvas_wheel_test_scale(1.0)
+  let zoomed = canvas_wheel_required_target(
+    scale,
+    -50.0,
+    0,
+    false,
+    false,
+    min_scale=0.1,
+    max_scale=8.0,
+  )
+  let returned = canvas_wheel_required_target(
+    zoomed,
+    50.0,
+    0,
+    false,
+    false,
+    min_scale=0.1,
+    max_scale=8.0,
+  )
+  canvas_wheel_assert_close(returned.to_double(), 1.0)
+}
+
+///|
+test "canvas wheel target scale clamps at host bounds" {
+  let scale = canvas_wheel_test_scale(7.9)
+  let maxed = canvas_wheel_required_target(
+    scale,
+    -100.0,
+    0,
+    false,
+    false,
+    min_scale=0.1,
+    max_scale=8.0,
+  )
+  assert_eq(maxed.to_double(), 8.0)
+  let repeated = canvas_wheel_required_target(
+    maxed,
+    -100.0,
+    0,
+    false,
+    false,
+    min_scale=0.1,
+    max_scale=8.0,
+  )
+  assert_eq(repeated.to_double(), maxed.to_double())
+
+  let huge_zoom_in = canvas_wheel_required_target(
+    canvas_wheel_test_scale(1.0),
+    -1.0e308,
+    0,
+    false,
+    false,
+    min_scale=0.1,
+    max_scale=8.0,
+  )
+  let huge_zoom_out = canvas_wheel_required_target(
+    canvas_wheel_test_scale(1.0),
+    1.0e308,
+    0,
+    false,
+    false,
+    min_scale=0.1,
+    max_scale=8.0,
+  )
+  assert_eq(huge_zoom_in.to_double(), 8.0)
+  assert_eq(huge_zoom_out.to_double(), 0.1)
+
+  let huge_pinch_in = canvas_wheel_required_target(
+    canvas_wheel_test_scale(1.0),
+    -1.0e308,
+    2,
+    true,
+    true,
+    min_scale=0.1,
+    max_scale=8.0,
+  )
+  let huge_pinch_out = canvas_wheel_required_target(
+    canvas_wheel_test_scale(1.0),
+    1.0e308,
+    2,
+    true,
+    true,
+    min_scale=0.1,
+    max_scale=8.0,
+  )
+  assert_eq(huge_pinch_in.to_double(), 8.0)
+  assert_eq(huge_pinch_out.to_double(), 0.1)
+}

--- a/apps/canvas/web/e2e/canvas-handles.spec.ts
+++ b/apps/canvas/web/e2e/canvas-handles.spec.ts
@@ -129,6 +129,101 @@ async function worldTransform(page: Page): Promise<string> {
   return page.locator('#world').evaluate((el) => (el as HTMLElement).style.transform);
 }
 
+async function worldScale(page: Page): Promise<number> {
+  const transform = await worldTransform(page);
+  const match = transform.match(/scale\(([^)]+)\)/);
+  if (!match) throw new Error(`world transform has no scale: ${transform}`);
+  return Number(match[1]);
+}
+
+test('canvas wheel normalizes units and rejects no-op or active input', async ({ page }) => {
+  const runtimeErrors: string[] = [];
+  page.on('pageerror', (error) => runtimeErrors.push(error.message));
+  page.on('console', (message) => {
+    if (message.type() === 'error') runtimeErrors.push(message.text());
+  });
+
+  const dispatchWheel = async (
+    deltaY: number,
+    deltaMode: number,
+    ctrlKey = false,
+  ) => {
+    await page.evaluate(({ deltaY, deltaMode, ctrlKey }) => {
+      const root = document.querySelector('#canvas-root') as HTMLDivElement;
+      const rect = root.getBoundingClientRect();
+      root.dispatchEvent(new WheelEvent('wheel', {
+        bubbles: true,
+        deltaY,
+        deltaMode,
+        ctrlKey,
+        clientX: rect.left + 120,
+        clientY: rect.top + 80,
+      }));
+    }, { deltaY, deltaMode, ctrlKey });
+  };
+
+  await page.goto('/');
+  await expect(page.locator('.canvas-node')).toHaveCount(6);
+  await expect(page.locator('#action-stat')).toHaveText('0 actions logged');
+  const initialTransform = await worldTransform(page);
+
+  await dispatchWheel(0, 0);
+  await expect(page.locator('#action-stat')).toHaveText('0 actions logged');
+  expect(await worldTransform(page)).toBe(initialTransform);
+
+  await dispatchWheel(-50, 0);
+  await expect(page.locator('#action-stat')).toHaveText('1 action logged');
+  const pixelScale = await worldScale(page);
+
+  await page.reload();
+  await expect(page.locator('.canvas-node')).toHaveCount(6);
+  await dispatchWheel(-2, 1);
+  await expect(page.locator('#action-stat')).toHaveText('1 action logged');
+  const lineScale = await worldScale(page);
+  expect(lineScale).toBeCloseTo(pixelScale, 9);
+
+  await page.reload();
+  await expect(page.locator('.canvas-node')).toHaveCount(6);
+  await dispatchWheel(-10, 0);
+  const smallScale = await worldScale(page);
+  await page.reload();
+  await expect(page.locator('.canvas-node')).toHaveCount(6);
+  await dispatchWheel(-100, 0);
+  const largeScale = await worldScale(page);
+  expect(largeScale).toBeGreaterThan(smallScale);
+
+  await page.reload();
+  await expect(page.locator('.canvas-node')).toHaveCount(6);
+  await page.evaluate(() => {
+    const root = document.querySelector('#canvas-root') as HTMLDivElement;
+    root.setPointerCapture = () => undefined;
+    root.dispatchEvent(new PointerEvent('pointerdown', {
+      bubbles: true,
+      pointerId: 121,
+      button: 0,
+      clientX: 20,
+      clientY: 20,
+    }));
+  });
+  await expect(page.locator('#canvas-root')).toHaveClass(/panning/);
+  const activeTransform = await worldTransform(page);
+  await dispatchWheel(-100, 0);
+  await expect(page.locator('#action-stat')).toHaveText('0 actions logged');
+  expect(await worldTransform(page)).toBe(activeTransform);
+  await page.evaluate(() => {
+    const root = document.querySelector('#canvas-root') as HTMLDivElement;
+    root.dispatchEvent(new PointerEvent('pointerup', {
+      bubbles: true,
+      pointerId: 121,
+      button: 0,
+      clientX: 20,
+      clientY: 20,
+    }));
+  });
+  await expect(page.locator('#canvas-root')).not.toHaveClass(/panning/);
+  expect(runtimeErrors).toEqual([]);
+});
+
 test('canvas handles create edges and reject invalid gestures', async ({ page }) => {
   const runtimeErrors: string[] = [];
   page.on('pageerror', (error) => runtimeErrors.push(error.message));

--- a/apps/canvas/web/e2e/source-backed.spec.ts
+++ b/apps/canvas/web/e2e/source-backed.spec.ts
@@ -270,6 +270,59 @@ test('source-backed release hit ignores elements outside the canvas root', async
   expect(runtimeErrors).toEqual([]);
 });
 
+test('source-backed wheel shares normalized camera semantics', async ({ page }) => {
+  const runtimeErrors = collectRuntimeErrors(page);
+
+  await page.goto('/?source=1');
+  await expectSource(page, SAMPLE_SOURCE);
+  const dispatchWheel = async (deltaY: number, deltaMode: number) => {
+    await page.evaluate(({ deltaY, deltaMode }) => {
+      const root = document.querySelector('#canvas-root') as HTMLDivElement;
+      const rect = root.getBoundingClientRect();
+      root.dispatchEvent(new WheelEvent('wheel', {
+        bubbles: true,
+        deltaY,
+        deltaMode,
+        clientX: rect.left + 120,
+        clientY: rect.top + 80,
+      }));
+    }, { deltaY, deltaMode });
+  };
+
+  await expect(page.locator('#action-stat')).toHaveText('0 actions logged');
+  await dispatchWheel(0, 0);
+  await expect(page.locator('#action-stat')).toHaveText('0 actions logged');
+  await dispatchWheel(-2, 1);
+  await expect(page.locator('#action-stat')).toHaveText('1 action logged');
+
+  await page.evaluate(() => {
+    const root = document.querySelector('#canvas-root') as HTMLDivElement;
+    root.setPointerCapture = () => undefined;
+    root.dispatchEvent(new PointerEvent('pointerdown', {
+      bubbles: true,
+      pointerId: 122,
+      button: 0,
+      clientX: 20,
+      clientY: 20,
+    }));
+  });
+  await expect(page.locator('#canvas-root')).toHaveClass(/panning/);
+  await dispatchWheel(-100, 0);
+  await expect(page.locator('#action-stat')).toHaveText('1 action logged');
+  await page.evaluate(() => {
+    const root = document.querySelector('#canvas-root') as HTMLDivElement;
+    root.dispatchEvent(new PointerEvent('pointerup', {
+      bubbles: true,
+      pointerId: 122,
+      button: 0,
+      clientX: 20,
+      clientY: 20,
+    }));
+  });
+  await expect(page.locator('#canvas-root')).not.toHaveClass(/panning/);
+  expect(runtimeErrors).toEqual([]);
+});
+
 test('source-backed pointercancel drops the local connection preview', async ({ page }) => {
   const runtimeErrors = collectRuntimeErrors(page);
 

--- a/apps/canvas/web/src/graph-adapter.ts
+++ b/apps/canvas/web/src/graph-adapter.ts
@@ -7,7 +7,14 @@ export type CanvasModule = {
     onHideContextMenu: () => undefined,
     onClearSelectedEdge: () => undefined,
   ) => undefined;
-  zoom: (h: number, delta: number, cx: number, cy: number) => void;
+  zoom: (
+    h: number,
+    deltaY: number,
+    deltaMode: number,
+    ctrlKey: boolean,
+    cx: number,
+    cy: number,
+  ) => void;
   add_node: (h: number, kindKey: string, sx: number, sy: number) => void;
   delete_nodes: (h: number, nodeIdsJson: string) => void;
   disconnect_ports: (
@@ -42,7 +49,14 @@ export type CanvasModule = {
     source: string,
     sourcePort: string,
   ) => string;
-  source_graph_zoom?: (h: number, delta: number, cx: number, cy: number) => void;
+  source_graph_zoom?: (
+    h: number,
+    deltaY: number,
+    deltaMode: number,
+    ctrlKey: boolean,
+    cx: number,
+    cy: number,
+  ) => void;
   sample_graph_dsl_source?: () => string;
   mount_source_demo?: (h: number, enabled: boolean, onChange: () => undefined) => undefined;
   mount_canvas_context_menu?: (
@@ -70,7 +84,14 @@ type SourceCanvasModule = CanvasModule & {
     source: string,
     sourcePort: string,
   ) => string;
-  source_graph_zoom: (h: number, delta: number, cx: number, cy: number) => void;
+  source_graph_zoom: (
+    h: number,
+    deltaY: number,
+    deltaMode: number,
+    ctrlKey: boolean,
+    cx: number,
+    cy: number,
+  ) => void;
 };
 
 const SOURCE_METHODS = [
@@ -441,12 +462,32 @@ export class GraphAdapter {
     return JSON.parse(json) as PortCompatibility[];
   }
 
-  zoom(delta: number, cx: number, cy: number): void {
+  zoom(
+    deltaY: number,
+    deltaMode: number,
+    ctrlKey: boolean,
+    cx: number,
+    cy: number,
+  ): void {
     this.assertLive();
     if (this.isSourceBacked) {
-      this.sourceModule().source_graph_zoom(this.handle, delta, cx, cy);
+      this.sourceModule().source_graph_zoom(
+        this.handle,
+        deltaY,
+        deltaMode,
+        ctrlKey,
+        cx,
+        cy,
+      );
     } else {
-      this.mb.zoom(this.handle, delta, cx, cy);
+      this.mb.zoom(
+        this.handle,
+        deltaY,
+        deltaMode,
+        ctrlKey,
+        cx,
+        cy,
+      );
     }
     this.emitLatestOperations();
   }

--- a/apps/canvas/web/src/main.ts
+++ b/apps/canvas/web/src/main.ts
@@ -821,7 +821,7 @@ root.addEventListener('click', (e: MouseEvent) => {
 root.addEventListener('wheel', (e: WheelEvent) => {
   e.preventDefault();
   const [cx, cy] = localCoords(e);
-  adapter.zoom(e.deltaY, cx, cy);
+  adapter.zoom(e.deltaY, e.deltaMode, e.ctrlKey, cx, cy);
   scheduleRender();
 }, { passive: false });
 

--- a/apps/canvas/web/src/main.ts
+++ b/apps/canvas/web/src/main.ts
@@ -820,8 +820,14 @@ root.addEventListener('click', (e: MouseEvent) => {
 
 root.addEventListener('wheel', (e: WheelEvent) => {
   e.preventDefault();
+  // Keep deltaY before deltaMode: Firefox/macOS can expose different
+  // deltaMode semantics based on access order. This matches the d3/xyflow
+  // browser-wheel contract that PR1 preserves for the future Rabbita bridge.
+  const deltaY = e.deltaY;
+  const deltaMode = e.deltaMode;
+  const ctrlKey = e.ctrlKey;
   const [cx, cy] = localCoords(e);
-  adapter.zoom(e.deltaY, e.deltaMode, e.ctrlKey, cx, cy);
+  adapter.zoom(deltaY, deltaMode, ctrlKey, cx, cy);
   scheduleRender();
 }, { passive: false });
 

--- a/apps/ideal/main/incr_canvas_state.mbt
+++ b/apps/ideal/main/incr_canvas_state.mbt
@@ -26,9 +26,6 @@ const INCR_CANVAS_MIN_SCALE : Double = 0.25
 const INCR_CANVAS_MAX_SCALE : Double = 4.0
 
 ///|
-const INCR_CANVAS_ZOOM_FACTOR : Double = 1.1
-
-///|
 struct IncrCanvasState {
   viewport : @spatial.Viewport
   panning : @spatial.Pan?
@@ -331,40 +328,4 @@ fn incr_canvas_capture_lost_for_pointer(
 ) -> IncrCanvasState {
   guard state.active_pointer_id == pointer_id else { return state }
   incr_canvas_capture_lost(state)
-}
-
-///|
-fn incr_canvas_zoom(
-  state : IncrCanvasState,
-  delta : Double,
-  x : Double,
-  y : Double,
-) -> IncrCanvasState {
-  guard !delta.is_nan() && !delta.is_inf() && delta != 0.0 else { return state }
-  let anchor = match incr_canvas_screen_point(x, y) {
-    Some(point) => point
-    None => return state
-  }
-  let current = state.viewport.scale().to_double()
-  let factor = if delta < 0.0 {
-    INCR_CANVAS_ZOOM_FACTOR
-  } else {
-    1.0 / INCR_CANVAS_ZOOM_FACTOR
-  }
-  let next = current * factor
-  let bounded = if next < INCR_CANVAS_MIN_SCALE {
-    INCR_CANVAS_MIN_SCALE
-  } else if next > INCR_CANVAS_MAX_SCALE {
-    INCR_CANVAS_MAX_SCALE
-  } else {
-    next
-  }
-  let scale = @spatial.Scale::from_double(value=bounded) catch {
-    @spatial.ScaleError::NonFinite | @spatial.ScaleError::NonPositive =>
-      return state
-  }
-  let viewport = state.viewport.with_scale_around(anchor~, absolute_scale=scale) catch {
-    @spatial.CoordinateError::NonFinite => return state
-  }
-  { ..state, viewport, }
 }

--- a/apps/ideal/main/incr_canvas_update.mbt
+++ b/apps/ideal/main/incr_canvas_update.mbt
@@ -30,7 +30,15 @@ fn handle_incr_canvas(
           incr_canvas_pointer_up(current.incr_canvas, pointer_id)
         CaptureLost(pointer_id) =>
           incr_canvas_capture_lost_for_pointer(current.incr_canvas, pointer_id)
-        Wheel(delta, x, y) => incr_canvas_zoom(current.incr_canvas, delta, x, y)
+        Wheel(delta_y, delta_mode, ctrl_key, x, y) =>
+          incr_canvas_wheel(
+            current.incr_canvas,
+            delta_y,
+            delta_mode,
+            ctrl_key,
+            x,
+            y,
+          )
       }
       Some((none, { ..current, incr_canvas: state }))
     }

--- a/apps/ideal/main/incr_canvas_wbtest.mbt
+++ b/apps/ideal/main/incr_canvas_wbtest.mbt
@@ -213,7 +213,10 @@ test "incr canvas pointer identity gates gestures and zero wheel is a no-op" {
     incr_canvas_capture_lost_for_pointer(state, Some(7)),
     lost,
   )
-  assert_incr_canvas_state_eq(incr_canvas_zoom(state, 0.0, 10.0, 10.0), state)
+  assert_incr_canvas_state_eq(
+    incr_canvas_wheel(state, 0.0, 0, false, 10.0, 10.0),
+    state,
+  )
 }
 
 ///|
@@ -240,21 +243,35 @@ test "incr canvas zoom preserves the screen anchor and rejects invalid input" {
   let state = { ..IncrCanvasState::empty(), viewport, }
   let anchor = test_screen(310.0, 145.0)
   let world_at_anchor = try! viewport.screen_to_world(anchor)
-  let changed = incr_canvas_zoom(state, -1.0, anchor.x(), anchor.y())
+  let changed = incr_canvas_wheel(
+    state,
+    -50.0,
+    0,
+    false,
+    anchor.x(),
+    anchor.y(),
+  )
   let projected = try! changed.viewport.world_to_screen(world_at_anchor)
   incr_canvas_assert_close(projected.x(), anchor.x())
   incr_canvas_assert_close(projected.y(), anchor.y())
-  let returned = incr_canvas_zoom(changed, 1.0, anchor.x(), anchor.y())
+  let returned = incr_canvas_wheel(
+    changed,
+    50.0,
+    0,
+    false,
+    anchor.x(),
+    anchor.y(),
+  )
   incr_canvas_assert_close(
     returned.viewport.scale().to_double(),
     state.viewport.scale().to_double(),
   )
   assert_incr_canvas_state_eq(
-    incr_canvas_zoom(state, 0.0 / 0.0, 0.0, 0.0),
+    incr_canvas_wheel(state, 0.0 / 0.0, 0, false, 0.0, 0.0),
     state,
   )
   assert_incr_canvas_state_eq(
-    incr_canvas_zoom(state, 1.0, 1.0 / 0.0, 0.0),
+    incr_canvas_wheel(state, 1.0, 0, false, 1.0 / 0.0, 0.0),
     state,
   )
 }

--- a/apps/ideal/main/incr_canvas_wheel.mbt
+++ b/apps/ideal/main/incr_canvas_wheel.mbt
@@ -1,0 +1,139 @@
+///|
+priv enum IncrCanvasWheelDeltaUnit {
+  Pixel
+  Line
+  Page
+}
+
+///|
+const INCR_CANVAS_WHEEL_PIXEL_UNIT_FACTOR : Double = 0.002
+
+///|
+const INCR_CANVAS_WHEEL_LINE_UNIT_FACTOR : Double = 0.05
+
+///|
+const INCR_CANVAS_WHEEL_PAGE_UNIT_FACTOR : Double = 1.0
+
+///|
+const INCR_CANVAS_WHEEL_PINCH_FACTOR : Double = 10.0
+
+///|
+fn incr_canvas_wheel_delta_unit(delta_mode : Int) -> IncrCanvasWheelDeltaUnit? {
+  match delta_mode {
+    0 => Some(Pixel)
+    1 => Some(Line)
+    2 => Some(Page)
+    _ => None
+  }
+}
+
+///|
+fn incr_canvas_wheel_unit_factor(unit : IncrCanvasWheelDeltaUnit) -> Double {
+  match unit {
+    Pixel => INCR_CANVAS_WHEEL_PIXEL_UNIT_FACTOR
+    Line => INCR_CANVAS_WHEEL_LINE_UNIT_FACTOR
+    Page => INCR_CANVAS_WHEEL_PAGE_UNIT_FACTOR
+  }
+}
+
+///|
+fn incr_canvas_wheel_target_scale(
+  current_scale : @spatial.Scale,
+  delta_y : Double,
+  delta_mode : Int,
+  ctrl_key : Bool,
+  mac_like : Bool,
+) -> @spatial.Scale? {
+  guard !delta_y.is_nan() && !delta_y.is_inf() && delta_y != 0.0 else {
+    return None
+  }
+  let unit = match incr_canvas_wheel_delta_unit(delta_mode) {
+    Some(unit) => unit
+    None => return None
+  }
+  let pinch_factor = if ctrl_key && mac_like {
+    INCR_CANVAS_WHEEL_PINCH_FACTOR
+  } else {
+    1.0
+  }
+  let exponent = -delta_y * incr_canvas_wheel_unit_factor(unit) * pinch_factor
+  guard !exponent.is_nan() else { return None }
+  // Finite extreme inputs may overflow the exponent or pow; their direction
+  // still determines which host bound is the semantic target.
+  let bounded = if exponent.is_inf() {
+    if exponent > 0.0 {
+      INCR_CANVAS_MAX_SCALE
+    } else {
+      INCR_CANVAS_MIN_SCALE
+    }
+  } else {
+    let multiplier = @math.pow(2.0, exponent)
+    guard !multiplier.is_nan() else { return None }
+    let raw = current_scale.to_double() * multiplier
+    if raw.is_inf() {
+      if exponent > 0.0 {
+        INCR_CANVAS_MAX_SCALE
+      } else {
+        INCR_CANVAS_MIN_SCALE
+      }
+    } else {
+      guard !raw.is_nan() else { return None }
+      raw.clamp(min=INCR_CANVAS_MIN_SCALE, max=INCR_CANVAS_MAX_SCALE)
+    }
+  }
+  let scale = @spatial.Scale::from_double(value=bounded) catch {
+    @spatial.ScaleError::NonFinite | @spatial.ScaleError::NonPositive =>
+      return None
+  }
+  Some(scale)
+}
+
+///|
+fn incr_canvas_update_viewport_scale_around(
+  state : IncrCanvasState,
+  absolute_scale : @spatial.Scale,
+  anchor : @spatial.ScreenPoint,
+) -> IncrCanvasState {
+  guard state.active_pointer_id is None else { return state }
+  guard state.viewport.scale() != absolute_scale else { return state }
+  let viewport = state.viewport.with_scale_around(anchor~, absolute_scale~) catch {
+    @spatial.CoordinateError::NonFinite => return state
+  }
+  if viewport == state.viewport {
+    state
+  } else {
+    { ..state, viewport, }
+  }
+}
+
+///|
+fn incr_canvas_wheel(
+  state : IncrCanvasState,
+  delta_y : Double,
+  delta_mode : Int,
+  ctrl_key : Bool,
+  x : Double,
+  y : Double,
+) -> IncrCanvasState {
+  guard state.active_pointer_id is None else { return state }
+  let anchor = match incr_canvas_screen_point(x, y) {
+    Some(point) => point
+    None => return state
+  }
+  let scale = match
+    incr_canvas_wheel_target_scale(
+      state.viewport.scale(),
+      delta_y,
+      delta_mode,
+      ctrl_key,
+      incr_canvas_is_mac_like(),
+    ) {
+    Some(scale) => scale
+    None => return state
+  }
+  incr_canvas_update_viewport_scale_around(state, scale, anchor)
+}
+
+///|
+#cfg(target="js")
+extern "js" fn incr_canvas_is_mac_like() -> Bool = "() => /Mac|iPhone|iPad|iPod/.test(navigator.platform)"

--- a/apps/ideal/main/incr_canvas_wheel_wbtest.mbt
+++ b/apps/ideal/main/incr_canvas_wheel_wbtest.mbt
@@ -1,0 +1,77 @@
+///|
+fn incr_canvas_wheel_test_scale(value : Double) -> @spatial.Scale {
+  try! @spatial.Scale::from_double(value~)
+}
+
+///|
+fn incr_canvas_wheel_required_target(
+  current_scale : @spatial.Scale,
+  delta_y : Double,
+  delta_mode : Int,
+  ctrl_key : Bool,
+  mac_like : Bool,
+) -> @spatial.Scale raise {
+  match
+    incr_canvas_wheel_target_scale(
+      current_scale, delta_y, delta_mode, ctrl_key, mac_like,
+    ) {
+    Some(scale) => scale
+    None => fail("expected an admissible wheel target")
+  }
+}
+
+///|
+test "incr canvas wheel normalizes pixel line and page units" {
+  let scale = incr_canvas_wheel_test_scale(1.0)
+  let pixel = incr_canvas_wheel_required_target(scale, -50.0, 0, false, false)
+  let line = incr_canvas_wheel_required_target(scale, -2.0, 1, false, false)
+  let page = incr_canvas_wheel_required_target(scale, -0.1, 2, false, false)
+  incr_canvas_assert_close(pixel.to_double(), line.to_double())
+  incr_canvas_assert_close(pixel.to_double(), page.to_double())
+}
+
+///|
+test "incr canvas wheel uses magnitude and mac-like pinch policy" {
+  let scale = incr_canvas_wheel_test_scale(1.0)
+  let small = incr_canvas_wheel_required_target(scale, -10.0, 0, false, false)
+  let large = incr_canvas_wheel_required_target(scale, -100.0, 0, false, false)
+  let pinch = incr_canvas_wheel_required_target(scale, -1.0, 0, true, true)
+  let regular = incr_canvas_wheel_required_target(scale, -1.0, 0, false, false)
+  assert_true(large.to_double() > small.to_double())
+  assert_true(pinch.to_double() > regular.to_double())
+  let huge_zoom_in = incr_canvas_wheel_required_target(
+    scale, -1.0e308, 0, false, false,
+  )
+  let huge_zoom_out = incr_canvas_wheel_required_target(
+    scale, 1.0e308, 0, false, false,
+  )
+  assert_eq(huge_zoom_in.to_double(), INCR_CANVAS_MAX_SCALE)
+  assert_eq(huge_zoom_out.to_double(), INCR_CANVAS_MIN_SCALE)
+  let huge_pinch_in = incr_canvas_wheel_required_target(
+    scale, -1.0e308, 2, true, true,
+  )
+  let huge_pinch_out = incr_canvas_wheel_required_target(
+    scale, 1.0e308, 2, true, true,
+  )
+  assert_eq(huge_pinch_in.to_double(), INCR_CANVAS_MAX_SCALE)
+  assert_eq(huge_pinch_out.to_double(), INCR_CANVAS_MIN_SCALE)
+}
+
+///|
+test "incr canvas wheel ignores active gestures and bounded no-ops" {
+  let viewport = incr_canvas_test_viewport(0.0, 0.0, INCR_CANVAS_MAX_SCALE)
+  let active = {
+    ..IncrCanvasState::empty(),
+    viewport,
+    active_pointer_id: Some(4),
+  }
+  assert_incr_canvas_state_eq(
+    incr_canvas_wheel(active, -100.0, 0, false, 10.0, 10.0),
+    active,
+  )
+  let idle = { ..active, active_pointer_id: None }
+  assert_incr_canvas_state_eq(
+    incr_canvas_wheel(idle, -100.0, 0, false, 10.0, 10.0),
+    idle,
+  )
+}

--- a/apps/ideal/main/moon.pkg
+++ b/apps/ideal/main/moon.pkg
@@ -30,6 +30,7 @@ import {
   "moonbitlang/core/string",
   "moonbitlang/core/json",
   "moonbitlang/core/debug",
+  "moonbitlang/core/math",
   "moonbitlang/core/immut/hashset" @immut/hashset,
   "moonbit-community/rabbita/cmd" @rabbita_cmd,
   "dowdiness/graphviz/lib/parser" @gv_parser,

--- a/apps/ideal/main/msg.mbt
+++ b/apps/ideal/main/msg.mbt
@@ -12,7 +12,7 @@ enum IncrCanvasMsg {
   PointerUp(Int?)
   PointerCancel(Int?)
   CaptureLost(Int?)
-  Wheel(Double, Double, Double)
+  Wheel(Double, Int, Bool, Double, Double)
 }
 
 ///|

--- a/apps/ideal/main/view_bottom_incr_canvas.mbt
+++ b/apps/ideal/main/view_bottom_incr_canvas.mbt
@@ -336,17 +336,17 @@ fn incr_canvas_pointer_attrs(dispatch : Emit[Msg]) -> @html.Attrs {
   })
   .on_wheel(event => {
     event.prevent_default()
+    // Keep deltaY before deltaMode: Firefox/macOS can expose different
+    // deltaMode semantics based on access order. Match workflow Canvas and
+    // the d3/xyflow browser-wheel contract for the future shared bridge.
+    let delta_y = event.get_delta_y()
+    let delta_mode = event.get_delta_mode()
+    let ctrl_key = event.get_ctrl_key()
     match incr_canvas_screen_point_from_wheel_event(event) {
       Some(screen) =>
         dispatch(
           IncrCanvas(
-            Wheel(
-              event.get_delta_y(),
-              event.get_delta_mode(),
-              event.get_ctrl_key(),
-              screen.x(),
-              screen.y(),
-            ),
+            Wheel(delta_y, delta_mode, ctrl_key, screen.x(), screen.y()),
           ),
         )
       None => @rabbita_cmd.none

--- a/apps/ideal/main/view_bottom_incr_canvas.mbt
+++ b/apps/ideal/main/view_bottom_incr_canvas.mbt
@@ -338,7 +338,17 @@ fn incr_canvas_pointer_attrs(dispatch : Emit[Msg]) -> @html.Attrs {
     event.prevent_default()
     match incr_canvas_screen_point_from_wheel_event(event) {
       Some(screen) =>
-        dispatch(IncrCanvas(Wheel(event.get_delta_y(), screen.x(), screen.y())))
+        dispatch(
+          IncrCanvas(
+            Wheel(
+              event.get_delta_y(),
+              event.get_delta_mode(),
+              event.get_ctrl_key(),
+              screen.x(),
+              screen.y(),
+            ),
+          ),
+        )
       None => @rabbita_cmd.none
     }
   })

--- a/apps/ideal/web/e2e/incr-canvas.spec.ts
+++ b/apps/ideal/web/e2e/incr-canvas.spec.ts
@@ -268,6 +268,61 @@ test.describe('Bottom panel — interactive Incr Canvas', () => {
     await expect(page.locator('#canopy-incr-canvas-container')).toHaveCount(0);
   });
 
+  test('normalizes wheel units and ignores zero or active input', async ({ page }) => {
+    const openCanvas = async () => {
+      await page.reload();
+      await expect(page.getByRole('button', { name: 'Panels' })).toBeVisible();
+      await page.getByRole('button', { name: 'Panels' }).click();
+      await page.getByRole('tab', { name: 'Incr Canvas' }).click();
+      const stage = page.locator('.incr-canvas-interaction');
+      const node = page.locator('#canopy-incr-canvas-container .incr-canvas-node').first();
+      await expect(stage).toBeVisible({ timeout: 5000 });
+      await expect(node).toBeVisible({ timeout: 5000 });
+      return { stage, node };
+    };
+
+    const dispatchWheel = async (
+      stage: import('@playwright/test').Locator,
+      deltaY: number,
+      deltaMode: number,
+    ) => {
+      await stage.evaluate((element, values) => {
+        const rect = element.getBoundingClientRect();
+        element.dispatchEvent(new WheelEvent('wheel', {
+          bubbles: true,
+          deltaY: values.deltaY,
+          deltaMode: values.deltaMode,
+          clientX: rect.left + 80,
+          clientY: rect.top + 60,
+        }));
+      }, { deltaY, deltaMode });
+    };
+
+    await waitForEditorReady(page);
+    const first = await openCanvas();
+    const initial = await first.node.getAttribute('transform');
+    await dispatchWheel(first.stage, 0, 0);
+    await expect(first.node).toHaveAttribute('transform', initial ?? '');
+    await dispatchWheel(first.stage, -50, 0);
+    await expect(first.node).not.toHaveAttribute('transform', initial ?? '');
+    const pixel = await first.node.getAttribute('transform');
+
+    const second = await openCanvas();
+    await dispatchWheel(second.stage, -2, 1);
+    await expect(second.node).toHaveAttribute('transform', pixel ?? '');
+
+    const third = await openCanvas();
+    const beforeActive = await third.node.getAttribute('transform');
+    const stageBox = await third.stage.boundingBox();
+    expect(stageBox).not.toBeNull();
+    if (!stageBox) return;
+    await page.mouse.move(stageBox.x + stageBox.width - 24, stageBox.y + 120);
+    await page.mouse.down();
+    await dispatchWheel(third.stage, -100, 0);
+    await expect(third.node).toHaveAttribute('transform', beforeActive ?? '');
+    await page.mouse.up();
+  });
+
   test('supports background pan and anchor zoom without changing graph identity', async ({
     page,
   }) => {

--- a/apps/loomark/internal/rabbita/pkg.generated.mbti
+++ b/apps/loomark/internal/rabbita/pkg.generated.mbti
@@ -61,6 +61,7 @@ pub fn write_selection(Int, Int) -> Unit
 pub fn write_selection_failure() -> Unit
 
 // Errors
+type ProjectionWorkerCounterError derive(Eq, @debug.Debug)
 
 // Types and methods
 type BlockSelectionDecision derive(Eq, @debug.Debug)

--- a/modules/canopy/editor/markdown/pkg.generated.mbti
+++ b/modules/canopy/editor/markdown/pkg.generated.mbti
@@ -138,6 +138,7 @@ pub fn MarkdownDocumentUtf16Selection::range_start(Self) -> Int
 pub struct MarkdownDocumentVersion {
   // private fields
 } derive(Eq, @debug.Debug)
+pub fn MarkdownDocumentVersion::to_json_string(Self) -> String
 
 pub(all) enum MarkdownEditRequest {
   ReplaceSource(String)

--- a/modules/canvas-graph/graph_model/interaction_reducers.mbt
+++ b/modules/canvas-graph/graph_model/interaction_reducers.mbt
@@ -46,9 +46,7 @@ pub fn update_viewport_scale_around(
   absolute_scale : @spatial.Scale,
   anchor : ScreenPoint,
 ) -> CanvasState {
-  if state.viewport.scale() == absolute_scale {
-    return state
-  }
+  guard state.viewport.scale() != absolute_scale else { return state }
   let new_viewport = state.viewport.with_scale_around(anchor~, absolute_scale~) catch {
     @spatial.CoordinateError::NonFinite => return state
   }

--- a/modules/canvas-graph/graph_model/interaction_reducers.mbt
+++ b/modules/canvas-graph/graph_model/interaction_reducers.mbt
@@ -36,35 +36,25 @@ pub fn update_pan_move(
 }
 
 ///|
-/// Zoom the viewport toward a typed cursor point.
-pub fn update_zoom(
+/// Apply an absolute viewport scale while keeping a screen anchor fixed.
+///
+/// Device-specific camera input must be normalized before reaching this
+/// semantic reducer. Equal viewports are not actions, so clamped or repeated
+/// inputs do not grow the action log.
+pub fn update_viewport_scale_around(
   state : CanvasState,
-  delta : Double,
+  absolute_scale : @spatial.Scale,
   anchor : ScreenPoint,
 ) -> CanvasState {
-  if delta.is_nan() || delta.is_inf() {
+  if state.viewport.scale() == absolute_scale {
+    return state
+  }
+  let new_viewport = state.viewport.with_scale_around(anchor~, absolute_scale~) catch {
+    @spatial.CoordinateError::NonFinite => return state
+  }
+  if new_viewport == state.viewport {
     state
   } else {
-    let factor = if delta > 0.0 { 0.9 } else { 1.0 / 0.9 }
-    let old_scale = state.viewport.scale().to_double()
-    let raw = old_scale * factor
-    let new_scale_value = if raw < 0.1 {
-      0.1
-    } else if raw > 8.0 {
-      8.0
-    } else {
-      raw
-    }
-    let new_scale = @spatial.Scale::from_double(value=new_scale_value) catch {
-      @spatial.ScaleError::NonFinite | @spatial.ScaleError::NonPositive =>
-        return state
-    }
-    let new_viewport = state.viewport.with_scale_around(
-      anchor~,
-      absolute_scale=new_scale,
-    ) catch {
-      @spatial.CoordinateError::NonFinite => return state
-    }
     record_action(
       { ..state, viewport: new_viewport },
       SetViewport(new_viewport),

--- a/modules/canvas-graph/graph_model/interaction_reducers_wbtest.mbt
+++ b/modules/canvas-graph/graph_model/interaction_reducers_wbtest.mbt
@@ -116,7 +116,7 @@ test "pan_move is no-op when not panning" {
 }
 
 ///|
-test "pan, zoom, and drag reject non-finite input" {
+test "pan and drag reject non-finite input" {
   let state = make_test_state()
   let invalid_start = try {
     ignore(ScreenPoint::from_xy(x=0.0 / 0.0, y=0.0))
@@ -150,12 +150,6 @@ test "pan, zoom, and drag reject non-finite input" {
   )
   assert_eq(overflowing_move.viewport, extreme_started.viewport)
   assert_eq(overflowing_move.interaction.did_move, false)
-
-  for delta in [0.0 / 0.0, 1.0 / 0.0, -1.0 / 0.0] {
-    let invalid_delta_zoom = update_zoom(state, delta, screen_point(0.0, 0.0))
-    assert_eq(invalid_delta_zoom.viewport, state.viewport)
-    assert_eq(invalid_delta_zoom.action_log.length(), 0)
-  }
 }
 
 ///|
@@ -164,15 +158,32 @@ test "zoom rejects an overflowing anchored origin" {
     ..make_test_state(),
     viewport: viewport_for_test(0.0, 0.0, 1.0e-308),
   }
-  let unchanged = update_zoom(state, 1.0, screen_point(1.0e308, 0.0))
+  let scale = try! @spatial.Scale::from_double(value=2.0)
+  let unchanged = update_viewport_scale_around(
+    state,
+    scale,
+    screen_point(1.0e308, 0.0),
+  )
   assert_eq(unchanged.viewport, state.viewport)
   assert_eq(unchanged.action_log.length(), 0)
 }
 
 ///|
-test "zoom changes scale and records a serializable action" {
+test "semantic viewport scale no-op does not record an action" {
   let state = make_test_state()
-  let s = update_zoom(state, -1.0, screen_point(500.0, 400.0))
+  let scale = try! @spatial.Scale::from_double(
+    value=state.viewport.scale().to_double(),
+  )
+  let next = update_viewport_scale_around(state, scale, screen_point(0.0, 0.0))
+  assert_eq(next.viewport, state.viewport)
+  assert_eq(next.action_log.length(), 0)
+}
+
+///|
+test "semantic scale changes viewport and records a serializable action" {
+  let state = make_test_state()
+  let scale = try! @spatial.Scale::from_double(value=1.5)
+  let s = update_viewport_scale_around(state, scale, screen_point(500.0, 400.0))
   assert_true(s.viewport.scale().to_double() > 1.0)
   assert_eq(s.action_log.length(), 1)
   match s.action_log[0].action() {
@@ -182,29 +193,14 @@ test "zoom changes scale and records a serializable action" {
 }
 
 ///|
-test "zoom clamps to min 0.1 and max 8.0" {
-  let min_state = {
-    ..make_test_state(),
-    viewport: viewport_for_test(0.0, 0.0, 0.11),
-  }
-  let min_zoom = update_zoom(min_state, 1.0, screen_point(0.0, 0.0))
-  assert_eq(min_zoom.viewport.scale().to_double(), 0.1)
-  let max_state = {
-    ..make_test_state(),
-    viewport: viewport_for_test(0.0, 0.0, 7.5),
-  }
-  let max_zoom = update_zoom(max_state, -1.0, screen_point(0.0, 0.0))
-  assert_eq(max_zoom.viewport.scale().to_double(), 8.0)
-}
-
-///|
-test "zoom keeps cursor world position fixed" {
+test "semantic scale keeps cursor world position fixed" {
   let state = make_test_state()
   let cx = 300.0
   let cy = 200.0
   let anchor = screen_point(cx, cy)
   let world_x_before = try! state.viewport.screen_to_world(anchor).x()
-  let s = update_zoom(state, 1.0, anchor)
+  let scale = try! @spatial.Scale::from_double(value=1.5)
+  let s = update_viewport_scale_around(state, scale, anchor)
   let world_x_after = try! s.viewport.screen_to_world(anchor).x()
   assert_true((world_x_before - world_x_after).abs() < 1.0e-9)
 }

--- a/modules/canvas-graph/graph_model/pkg.generated.mbti
+++ b/modules/canvas-graph/graph_model/pkg.generated.mbti
@@ -58,7 +58,7 @@ pub fn update_pointer_interrupt(CanvasState) -> CanvasState
 
 pub fn update_pointer_up(CanvasState, String, String, Bool) -> CanvasState
 
-pub fn update_zoom(CanvasState, Double, @spatial.ScreenPoint) -> CanvasState
+pub fn update_viewport_scale_around(CanvasState, @spatial.Scale, @spatial.ScreenPoint) -> CanvasState
 
 pub fn workflow_add_node(CanvasState, String, @spatial.WorldPoint) -> CanvasState
 


### PR DESCRIPTION
## Summary

- Normalize raw wheel input before any viewport update in workflow Canvas and Ideal Canvas.
- Replace `@graph_model.update_zoom(state, delta, anchor)` with the semantic absolute-scale boundary `update_viewport_scale_around(state, absolute_scale, anchor)`.
- Keep wheel listener ownership in TypeScript / existing Rabbita view code for this PR; only the temporary raw-field bridge changes.

## Semantics

Host-private normalization now maps:

```text
WheelEvent(deltaY, deltaMode, ctrlKey, client anchor)
  → target Scale
  → semantic viewport update around ScreenPoint
  → SetViewport only when the viewport changes
```

- `deltaMode`: Pixel `0`, Line `1`, Page `2`; unknown units are rejected.
- Unit factors: Pixel `0.002`, Line `0.05`, Page `1.0`.
- `target_scale = clamp(current_scale * 2 ^ (-deltaY * unit_factor * pinch_factor))`.
- `ctrlKey` uses the 10x pinch factor only on Mac-like platforms.
- Zero, NaN, Infinity, non-finite anchors, and unknown units are no-ops.
- Finite extreme inputs saturate directionally at the host bounds even when exponent/pow overflows.
- Wheel input is consumed but does not change viewport or action log while a pointer gesture is active; Pan/Drag snapshots are not rebased in this PR.
- Wheel gesture coalescing is intentionally deferred until operation-count evidence exists.

Workflow bounds remain `0.1..8.0`; Ideal bounds remain `0.25..4.0`.

## Browser field-access contract

`deltaY` is intentionally read before `deltaMode` in both hosts, with explicit local bindings and comments. Firefox/macOS can expose different `deltaMode` semantics based on access order. This preserves the current d3/xyflow-compatible delta-first behavior when the listener ownership moves to Rabbita in PR2.

The workflow listener now performs:

```typescript
const deltaY = e.deltaY;
const deltaMode = e.deltaMode;
const ctrlKey = e.ctrlKey;
```

The Ideal Rabbita callback uses the same `get_delta_y()` → `get_delta_mode()` → `get_ctrl_key()` order. A browser-independent test double would require extracting the DOM listener into a separate adapter; explicit bindings and the contract comments are kept at the actual ownership sites instead.

## Boundary and ownership

- Raw device fields stay in host-private Canvas/Ideal code.
- `graph_model` sees only validated `@spatial.Scale` and `@spatial.ScreenPoint`.
- `@spatial.Viewport::with_scale_around` remains the geometry authority.
- TypeScript passes `deltaY`, `deltaMode`, `ctrlKey`, and the existing root-relative anchor to the temporary workflow FFI bridge.
- No Rabbita fork change or p4 is included.
- No new generic Canvas input package is introduced.

## API consumer audit

- `NEW_MOON_MOD=0 moon ide find-references @graph_model.update_zoom` returned **No symbols found**.
- A repository-wide live-source search found no `update_zoom` consumer; remaining matches are historical examples under `docs/archive/`.
- `NEW_MOON_MOD=0 moon ide find-references @graph_model.update_viewport_scale_around` found the new reducer plus its 4 graph-model tests; the two host call sites are direct package-qualified calls in the Canvas runtime and source-backed adapter.
- `moon info` produced no `.mbti` diff for `modules/canvas-graph/graph_model`, `apps/canvas/main`, or `apps/ideal/main` after the review fix.
- The API change is therefore an intentional breaking cleanup with no external consumer in this repository. No compatibility wrapper is retained because it would reintroduce raw browser semantics into `graph_model`.

## Reuse check

Reused existing APIs:

- `@spatial.Scale::from_double`, `Scale::to_double`, `Viewport::scale`, and `Viewport::with_scale_around`.
- `Double::is_nan`, `Double::is_inf`, `Double::clamp`, and `Double::is_close`.
- `moonbitlang/core/math::pow` for logarithmic wheel sensitivity.
- Rabbita `WheelEvent::get_delta_y`, `get_delta_mode`, `get_ctrl_key`, and existing current-target/root-relative coordinate handling.
- Existing Canvas/Ideal reducer and runtime state boundaries.

Checked but not used:

- Raw `WheelEvent` in `@spatial` or `graph_model`: rejected because device input is not geometry.
- `deltaX`/`deltaZ`: no horizontal pan or 3D camera policy is defined for this slice.
- Generic camera-command/input packages: premature before the two host implementations are compared after semantic stabilization.
- `Option`/`Result` collection helpers: normalization returns a nullable validated `Scale`; no collection transformation is involved.

New helpers are host-private normalizers only. Their responsibility is raw wheel-unit/pinch interpretation, finite/overflow handling, and host-bound clamping; they do not apply viewport state or log operations.

## Tests and validation

Behavioral coverage includes:

- zero/unknown/non-finite input rejection;
- Pixel/Line/Page equivalence;
- magnitude-sensitive zoom;
- sign round-trip and anchor preservation;
- Mac-like pinch policy;
- min/max repeated no-op logging;
- finite extreme overflow saturation;
- active pointer admission rejection;
- workflow canvas-backed and source-backed bridge behavior.

Evidence on review-fix HEAD:

- Canvas MoonBit target: 63/63.
- Ideal MoonBit target: 65/65.
- Graph model target: 49/49.
- Canvas Playwright E2E: 40/40.
- Ideal Canvas Playwright E2E: 9/9.
- Focused review-fix wheel tests: Canvas 2/2, Ideal 1/1.
- `apps/canvas/web`: `npm run build` passed in the final validator.
- `./scripts/validate-pr-ready.sh --target modules/canvas-graph/graph_model --target apps/canvas/main --target apps/ideal/main` passed on the exact review-fix HEAD.
- `./scripts/validate-pr-ready.sh --verify-evidence` passed on the exact review-fix HEAD.

The second commit (`chore: refresh generated interfaces for current base`) contains only two `.mbti` additions that `moon info` regenerates from source changes already present in the current `origin/main`; it is required for the clean interface gate and is unrelated to wheel behavior.

Validated review-fix HEAD: `866dd2716c9291dd6c4281b2bc8b1823e626a637`

Validated base: `origin/main@0497f39e0152ee6214f853c65c31d2a867c9e524`
