### PR TITLE
docs(plan): define EGW P1 typed admission transition

### DIFF
--- a/docs/plans/2026-08-15-egw-p1-typed-admission-transition.md
+++ b/docs/plans/2026-08-15-egw-p1-typed-admission-transition.md
@@ -53,6 +53,8 @@ The EGW submodule, starting from the P0 merge on a fresh branch:
 - the intentionally changed EGW `internal/oplog/pkg.generated.mbti`
 - `deps/event-graph-walker/text/errors.mbt` for the intentional pending-limit
   error mapping
+- a docs-only clarification to the accepted
+  `deps/event-graph-walker/docs/adr/0008-core-owned-batch-remote-admission-over-legacy-op.md`
 - package-local ownership, partial-transition, retry, and capacity properties
 
 The P1 boundary includes:
@@ -82,7 +84,8 @@ The P1 boundary includes:
 - `TextReplica`, Persistence Coordinator, Worker replay, or reconnect work;
 - public Canopy API redesign;
 - Canopy submodule/gitlink changes;
-- a new ADR for this phase.
+- a new ADR for this phase; ADR 0008 receives only the explicit clarification
+  needed to distinguish the prospective capability from its actual outcome.
 
 P1 may intentionally change the EGW internal oplog generated interface and
 text error mapping for the new typed capability/limit variant. It must not
@@ -159,7 +162,9 @@ remain a plan-review decision, but its semantic contents are not optional:
   where that provenance matters;
 - the uncommitted suffix identities, with staged versus retained provenance;
 - the before/after frontier needed to prove authority movement;
-- complete versus partial status, with the causal graph failure on `Partial`.
+The receipt is common evidence for both outcome variants; status and causal
+failure belong only to `AdmissionOutcome`, so a complete receipt cannot carry a
+partial cause.
 
 Arrays returned in a receipt must be owning or immutable views according to the
 EGW API convention; no mutable planner collection may escape. The receipt must
@@ -255,28 +260,31 @@ prepared admissions.
 
 ### 4. Make ownership partitions explicit and disjoint
 
-For every identity delivered by an admission attempt, the final ownership
-partition is exactly one of:
+For every unique incoming delivery occurrence, the outcome disposition is
+exactly one of:
 
 ```text
-Authority
+newly committed into Authority
+DuplicateOfAuthority (non-owning disposition)
 core pending
-duplicate of an admitted identity
-discarded / rejected
+Discarded / rejected
 ```
 
-`retained`, `staged`, and `discarded` are provenance partitions used to explain
-how a prepared identity reached its final category; they must not create a
-second owner. In particular:
+The canonical ownership partition is therefore `Authority ∪ core pending ∪
+Discarded`; a duplicate is reported separately because its incoming occurrence
+was a no-op, but its `RawVersion` remains owned by Authority rather than by a
+second duplicate owner. `retained`, `staged`, and `discarded` are provenance
+partitions used to explain how an admission-coverage identity reached its final
+category; they must not create a second owner. In particular:
 
 - a committed identity is never also retained or retried;
-- a duplicate is not re-committed and is not counted as pending;
-- a partial suffix is exactly the uncommitted staged identities that are now
-  core pending;
+- a matching admitted duplicate is not re-committed or counted as pending;
+- a partial suffix contains uncommitted planned identities from both retained
+  pending and newly staged provenance;
 - invalid-root dependents are discarded exactly once;
 - unrelated retained pending identities survive unless explicitly in the
   rejection closure;
-- no delivered identity is lost or present in two ownership sets.
+- no incoming occurrence is lost or assigned two dispositions.
 
 ## Decisions Required at Plan Review
 
@@ -291,18 +299,22 @@ plan review before implementation:
 3. **Capacity contract:** accept the exact peak formula above, with full staged
    registration as the current shell's one-time reservation and no independent
    live reservation counter in P1.
-4. **Limit vocabulary:** rename the optional preparation policy from
+4. **ADR 0008 clarification:** accept that the ADR's phrase "prepared admission
+   records" names the complete P1 transition capability, not a requirement to
+   mutate `PreparedAdmission` with a post-commit prefix. Add a docs-only
+   clarification before implementation; create no new ADR.
+5. **Limit vocabulary:** rename the optional preparation policy from
    `max_pending_after_complete?` to `max_pending?`, replace the complete-only
    `PendingForecastExceeded(limit~, predicted~)` contract with
    `PendingLimitExceeded(limit~, required~)`, and update its EGW text error
    mapping. If API inventory finds an external caller, retain only a clearly
    named compatibility adapter; never give one label two meanings.
-5. **Compatibility lifetime:** keep `commit_remote` as the legacy wrapper
+6. **Compatibility lifetime:** keep `commit_remote` as the legacy wrapper
    through P2; do not change Branch, Document, SyncSession, or Canopy callers
    in P1.
-6. **Interface delta:** permit only the intentional internal oplog generated
+7. **Interface delta:** permit only the intentional internal oplog generated
    interface and EGW error-mapping changes; reject unrelated `.mbti` drift.
-7. **Receipt shape:** settle the exact field names and whether identity
+8. **Receipt shape:** settle the exact field names and whether identity
    collections are arrays, immutable views, or another owning representation.
 
 No implementation branch should be created until these decisions are accepted.
@@ -321,7 +333,8 @@ No implementation branch should be created until these decisions are accepted.
    `PreparedAdmission`, `OpLog::prepare_remote`, `OpLog::begin_admission`,
    `OpLog::commit_remote`, `PartialRemoteAdmission`, and the generated oplog
    interface. Record the actual existing APIs before defining any new one.
-4. Write the first failing ownership and capacity tests before changing the
+4. Add the ADR 0008 docs-only clarification before code changes, then write
+   the first failing ownership and capacity tests before changing the
    transition implementation.
 
 ### P1.1 — Model the prospective transition
@@ -385,8 +398,10 @@ No implementation branch should be created until these decisions are accepted.
 
 ### P1.4 — Close exact ownership and lifecycle properties
 
-17. Add complete-admission tests with duplicates, retained pending work, staged
-    arrivals, invalid-root discard, and no pending suffix.
+17. Add complete-admission tests with admitted duplicates, pending duplicates,
+    retained pending work, staged arrivals, invalid-root discard, and no
+    pending suffix. A pending duplicate must remain a pending no-op rather than
+    being misclassified as an admitted duplicate.
 18. Add partial tests for zero-prefix failure, middle-prefix failure, and
     n-minus-one-prefix failure. Each test must assert committed operations,
     exact suffix identities, pending-after membership, staged/retained
@@ -405,9 +420,10 @@ No implementation branch should be created until these decisions are accepted.
 23. Add a property/model test for the ownership partition:
 
     ```text
-    admission coverage identities = Authority ∪ core-pending ∪ Duplicate ∪ Discarded
-    these sets are pairwise disjoint
-    every committed identity is in Authority exactly once
+    incoming occurrences = NewlyCommitted ∪ DuplicateOfAuthority ∪
+      Pending ∪ Discarded
+    these occurrence dispositions are pairwise disjoint
+    DuplicateOfAuthority identities are already in Authority, not a second owner
     every retained suffix identity is in core pending exactly once
     ```
 
@@ -436,14 +452,16 @@ No implementation branch should be created until these decisions are accepted.
 - [ ] `PreparedAdmission` remains non-mutating, generation-bound, single-use,
       and contains only prospective transition evidence.
 - [ ] A separate typed `AdmissionOutcome` distinguishes complete and partial
-      actual transitions; partial carries a receipt and causal cause as a
-      normal value.
+      actual transitions; partial carries a common receipt and causal cause as
+      a normal value, while receipt status/cause fields cannot contradict the
+      enum variant.
 - [ ] `AdmissionReceipt` exposes exact identity-level evidence for committed,
       duplicate, pending-after, staged, retained, and discarded membership,
       including the before/after frontier needed by callers.
-- [ ] The final ownership partition for every admission-coverage identity is
-      exactly one of Authority, core pending, admitted duplicate, or discarded;
-      no identity is lost or dual-owned.
+- [ ] Every incoming occurrence has exactly one disposition: newly committed,
+      `DuplicateOfAuthority`, core pending, or discarded. Duplicate evidence is
+      non-owning; canonical RawVersion ownership remains disjoint across
+      Authority, core pending, and discarded.
 - [ ] Prepare remains non-mutating, including generation, pending membership,
       live capacity, and capability consumption.
 - [ ] Stale, consumed, invalid, and pending-capacity rejection all occur before
@@ -465,6 +483,8 @@ No implementation branch should be created until these decisions are accepted.
 - [ ] Existing Branch/Document behavior and public Canopy interfaces remain
       unchanged; only the EGW text error mapping for the intentional new
       pending-limit variant may change; no production cutover occurs in P1.
+- [ ] The ADR 0008 docs-only clarification records the two-value boundary; no
+      new ADR is created.
 - [ ] Only intentionally reviewed EGW internal oplog interface changes and
       pending-limit error-mapping changes exist.
 - [ ] EGW targeted tests, `moon check --deny-warn`, `moon test`, formatting,
@@ -543,8 +563,10 @@ pending, failing, or unapproved skipped.
 
 - Related accepted decision: [ADR 0008 at the P0 merge](https://github.com/dowdiness/event-graph-walker/blob/99ab59012a31abb8454468509dd790be03c3b391/docs/adr/0008-core-owned-batch-remote-admission-over-legacy-op.md).
 - Related implementation: [EGW PR #118](https://github.com/dowdiness/event-graph-walker/pull/118).
-- The P1 plan deliberately does not introduce a new ADR; it operationalizes
-  the P1 ownership boundary already accepted by ADR 0008.
+- The P1 plan deliberately does not introduce a new ADR. It requires a
+  docs-only clarification of ADR 0008 so its accepted transition shorthand is
+  consistent with the prospective `PreparedAdmission` / actual
+  `AdmissionOutcome` split.
 - P2 may move the typed outcome through a Document batch shell and projection
   boundary. P1 must not anticipate that cutover by changing outer pending,
   publication, or Canopy-facing APIs.

--- a/docs/plans/2026-08-15-egw-p1-typed-admission-transition.md
+++ b/docs/plans/2026-08-15-egw-p1-typed-admission-transition.md
@@ -1,0 +1,497 @@
+# EGW P1: typed prepared-admission transition
+
+## GitHub Issue
+
+Canonical issue: <https://github.com/dowdiness/canopy/issues/1256>
+
+This plan is the implementation plan for the issue above. The issue must link
+back to this plan before implementation starts.
+
+**This plan must be reviewed and accepted before a fresh P1 EGW branch is
+created from the current `origin/main`.**
+
+## Why
+
+EGW P0 is complete and merged in PR [#118](https://github.com/dowdiness/event-graph-walker/pull/118)
+at merge commit
+[`99ab590`](https://github.com/dowdiness/event-graph-walker/commit/99ab59012a31abb8454468509dd790be03c3b391).
+ADR 0008 is accepted there. P0 establishes core-owned semantic admission over
+the retained legacy `@core.Op` payload, but it does not yet make production
+admission a single pending-owner, single-authority-transition, or
+single-projection-publish path.
+
+The current `PreparedAdmission` already contains more than an operation array:
+planned operations, staged representation, discard roots, discarded pending and
+staged identities, generation, and single-use state. Its prospective transition
+is nevertheless separate from the facts learned while committing. The committed
+prefix, retained suffix, duplicates, and partial cause are currently distributed
+between the commit return value, `PartialRemoteAdmission`, and mutable planner
+state.
+
+P1 makes one admission's ownership transition readable from typed values. It
+must distinguish:
+
+- the prospective, generation-bound capability known before authority mutation;
+- the actual complete or partial outcome known only after the commit attempt;
+- the hard pending capacity needed before either complete or partial execution.
+
+This is a typed transition boundary, not a new dependency planner and not a
+production Canopy cutover.
+
+## Scope
+
+### In
+
+The EGW submodule, starting from the P0 merge on a fresh branch:
+
+- `deps/event-graph-walker/internal/oplog/remote_admission_planner.mbt`
+- `deps/event-graph-walker/internal/oplog/oplog.mbt`
+- `deps/event-graph-walker/internal/oplog/errors.mbt`
+- `deps/event-graph-walker/internal/oplog/*_wbtest.mbt` and related oplog tests
+- the intentionally changed EGW `internal/oplog/pkg.generated.mbti`
+- package-local ownership, partial-transition, retry, and capacity properties
+
+The P1 boundary includes:
+
+- extending `PreparedAdmission` with the complete prospective transition;
+- introducing a typed `AdmissionOutcome` and `AdmissionReceipt` for actual
+  commit results;
+- exact identity-level accounting for committed, duplicate, retained,
+  staged, and discarded membership;
+- a hard pending-capacity reservation that is checked before authority
+  mutation and remains safe for a partial suffix;
+- a new core capability for typed admission, while preserving the existing
+  `commit_remote` compatibility behavior through P2;
+- no new planner algorithm: `RemoteAdmissionPlanner` remains the sole owner of
+  core pending membership and readiness.
+
+### Out
+
+- `Document` batch-admission shell;
+- projection update or publication;
+- `SyncSession` changes or removal of its outer pending lifecycle;
+- Canopy production-ingress cutover;
+- archive or wire schema changes;
+- canonical `TextEvent` or position-based authority payload changes;
+- `TextReplica`, Persistence Coordinator, Worker replay, or reconnect work;
+- public Canopy API redesign;
+- Canopy submodule/gitlink changes;
+- a new ADR for this phase.
+
+P1 may intentionally change the EGW internal oplog generated interface for the
+new typed capability. It must not widen or otherwise change unrelated
+Branch/Document/Text or Canopy-facing interfaces. Every `.mbti` change must be
+reviewed as an explicit compatibility decision.
+
+## Current State
+
+The P0 baseline at EGW merge commit `99ab590` provides:
+
+- `OpLog::prepare_remote(incoming, max_pending_after_complete?)` as a
+  non-mutating preparation boundary returning `PreparedAdmission`;
+- private prepared storage containing planned operations, staged nodes,
+  discard roots, discarded-pending and discarded-staged identity sets,
+  generation, and single-use `consumed` state;
+- `OpLog::begin_admission`, which validates the prepared capability, applies
+  the prepared planner transition, advances generation, and consumes the
+  capability before the authority commit loop;
+- `OpLog::commit_remote`, which commits prepared operations one at a time and
+  acknowledges successful identities in the planner;
+- `PartialRemoteAdmission`, which carries only the committed prefix and causal
+  graph error when a later operation fails;
+- the remaining uncommitted suffix in core pending state after a partial
+  commit, while mutable planner state also contains retained pending work;
+- `StaleAdmission`, `ConsumedAdmission`, and `InvalidAdmission` as lifecycle
+  errors that must be decided before authority mutation;
+- `PendingForecastExceeded(limit~, predicted~)` as a complete-transition
+  forecast, explicitly not a hard post-partial limit;
+- `Branch` and `Document` compatibility paths that still consume the legacy
+  `commit_remote` result and partial-error shape.
+
+The Canopy submodule pointer is intentionally not at this P0 merge. The local
+pointer must not be moved merely to implement or review P1. A P1 implementation
+worktree must fetch and verify EGW `origin/main` at or after `99ab590` before
+editing.
+
+## Desired State
+
+### 1. Separate prospective capability from actual outcome
+
+`PreparedAdmission` remains a prospective value. It may contain, at minimum:
+
+- commit order and planned operation representations;
+- duplicate identities detected during preparation;
+- retained-pending identities already known to survive the transition;
+- newly staged identities;
+- discarded pending and discarded staged identities, with their provenance;
+- generation and any policy revision used for validation;
+- the prospective maximum pending membership and its capacity requirement;
+- single-use state.
+
+It must not claim to contain a committed prefix. The committed prefix is not
+knowable until the authority commit loop reaches its failure boundary.
+
+`AdmissionOutcome` is the actual result of one accepted commit attempt. The
+proposed shape is:
+
+```moonbit
+pub enum AdmissionOutcome {
+  Complete(AdmissionReceipt)
+  Partial(receipt~ : AdmissionReceipt, error~ : @causal_graph.CausalGraphError)
+}
+```
+
+`AdmissionReceipt` must expose enough immutable evidence to account for the
+attempt without inspecting planner internals. The exact MoonBit field names
+remain a plan-review decision, but its semantic contents are not optional:
+
+- committed operations and their `RawVersion` identities;
+- duplicate identities accepted as already-admitted no-ops;
+- the complete pending-after identity view, including unrelated retained work;
+- discarded identities, partitioned by retained-pending versus staged origin
+  where that provenance matters;
+- the staged identities that became the uncommitted partial suffix;
+- the before/after frontier needed to prove authority movement;
+- complete versus partial status, with the causal graph failure on `Partial`.
+
+Arrays returned in a receipt must be owning or immutable views according to the
+EGW API convention; no mutable planner collection may escape.
+
+### 2. Make partial a normal typed outcome
+
+The new core capability should be shaped as:
+
+```moonbit
+pub fn OpLog::commit_admission(
+  self : OpLog,
+  prepared : PreparedAdmission,
+) -> AdmissionOutcome raise OpLogError
+```
+
+The name is a proposal for plan review, not permission to add a second commit
+algorithm. `AdmissionOutcome::Partial` is a normal returned value because the
+authority has advanced and the exact suffix ownership is meaningful. The
+following remain pre-mutation errors raised by the capability:
+
+- `StaleAdmission`;
+- `ConsumedAdmission`;
+- `InvalidAdmission`;
+- the hard pending-capacity error, using the reviewed `limit~` and
+  `required~` vocabulary rather than a complete-only `predicted~` claim.
+
+The compatibility method keeps its existing caller contract through P2:
+
+```moonbit
+pub fn OpLog::commit_remote(
+  self : OpLog,
+  prepared : PreparedAdmission,
+) -> Array[@core.Op] raise OpLogError
+```
+
+It delegates to the typed capability. A complete outcome returns committed
+operations. A partial outcome is translated back to the existing
+`PartialRemoteAdmission` error for legacy callers; the new typed path retains
+the full receipt. No `Document` or `Branch` migration belongs in P1.
+
+### 3. Reserve pending capacity for both completion paths
+
+Preparation remains non-mutating. It calculates the maximum pending membership
+that can be required by any permitted commit result, including the worst case
+where the first authority operation fails and the whole planned suffix remains
+pending. The prepared value carries this prospective requirement.
+
+At the begin transition, after stale/consumed/invalid validation and before any
+authority mutation, the core atomically checks and records the capacity needed
+for either complete or partial execution. The transition must then obey:
+
+```text
+complete:
+  release capacity that is no longer needed
+
+partial:
+  transfer the exact uncommitted suffix's capacity to core pending
+
+rejected before mutation:
+  change neither authority, planner membership, generation, nor capacity
+```
+
+The accounting must count unique pending membership rather than operation
+attempts. It must account for existing retained pending identities, new staged
+identities, duplicates, and discard closure. The exact formula and internal
+reservation representation are plan-review items, but a post-prefix
+`PendingLimitExceeded` is not an acceptable design: capacity failure must not
+be discovered after authority has advanced.
+
+### 4. Make ownership partitions explicit and disjoint
+
+For every identity delivered by an admission attempt, the final ownership
+partition is exactly one of:
+
+```text
+Authority
+core pending
+duplicate of an admitted identity
+discarded / rejected
+```
+
+`retained`, `staged`, and `discarded` are provenance partitions used to explain
+how a prepared identity reached its final category; they must not create a
+second owner. In particular:
+
+- a committed identity is never also retained or retried;
+- a duplicate is not re-committed and is not counted as pending;
+- a partial suffix is exactly the uncommitted staged identities that are now
+  core pending;
+- invalid-root dependents are discarded exactly once;
+- unrelated retained pending identities survive unless explicitly in the
+  rejection closure;
+- no delivered identity is lost or present in two ownership sets.
+
+## Decisions Required at Plan Review
+
+The following decisions are proposed by this plan and must be recorded in the
+plan review before implementation:
+
+1. **Value boundary:** accept the strict separation between prospective
+   `PreparedAdmission` and actual `AdmissionOutcome`/`AdmissionReceipt`.
+2. **Partial algebra:** accept `Partial` as an ordinary typed outcome carrying
+   both the receipt and causal failure, while pre-mutation lifecycle and
+   capacity failures remain errors.
+3. **Capacity contract:** accept a worst-case pre-mutation reservation covering
+   both complete and partial suffixes, and settle the exact required-capacity
+   formula and `PendingLimitExceeded(limit~, required~)` spelling.
+4. **Compatibility lifetime:** keep `commit_remote` as the legacy wrapper
+   through P2; do not change Branch, Document, SyncSession, or Canopy callers
+   in P1.
+5. **Interface delta:** permit only the intentional internal oplog generated
+   interface change for the typed capability and receipt; reject unrelated
+   `.mbti` drift.
+6. **Receipt shape:** settle the exact field names and whether identity
+   collections are arrays, immutable views, or another owning representation.
+
+No implementation branch should be created until these decisions are accepted.
+
+## Steps
+
+### P1.0 — Freeze the merged baseline and API evidence
+
+1. Fetch EGW `origin/main` and verify that it contains merge commit `99ab590`.
+   Create a dedicated P1 EGW worktree from that current main; do not start from
+   the pre-merge PR head and do not update the Canopy gitlink.
+2. Initialize submodules and inspect the package roots and current interfaces:
+   `internal/oplog`, `internal/core`, `internal/causal_graph`,
+   `internal/branch`, and `internal/document`.
+3. Run `moon ide outline`, `peek-def`, and `find-references` for
+   `PreparedAdmission`, `OpLog::prepare_remote`, `OpLog::begin_admission`,
+   `OpLog::commit_remote`, `PartialRemoteAdmission`, and the generated oplog
+   interface. Record the actual existing APIs before defining any new one.
+4. Write the first failing ownership and capacity tests before changing the
+   transition implementation.
+
+### P1.1 — Model the prospective transition
+
+5. Extend the private `PreparedAdmission` representation only with data that
+   is knowable before authority mutation: ordered planned identities,
+   duplicate/retained/staged/discarded provenance, generation/policy evidence,
+   and the worst-case pending-capacity requirement.
+6. Preserve non-mutating `prepare_remote`: it must not advance planner
+   generation, alter pending membership, consume a capability, or reserve live
+   capacity. Repeated preparation with unchanged state must produce equivalent
+   prospective evidence.
+7. Add private constructors/validation that make the prepared value internally
+   self-consistent and preserve defensive ownership of mutable arrays and
+   identity sets.
+8. Define the reviewed `AdmissionReceipt` and `AdmissionOutcome` values. Keep
+   actual committed-prefix data out of `PreparedAdmission`.
+
+### P1.2 — Add the hard capacity transition
+
+9. Define the unique-membership calculation for the maximum pending state over
+   every commit prefix, including first-operation failure, retained existing
+   pending work, newly staged work, duplicate identities, and rejection
+   closure.
+10. At `begin_admission`, validate generation, single-use state, structure,
+    and required capacity before applying discard/register/consume changes.
+    A rejected begin leaves planner, generation, capacity, and authority
+    unchanged.
+11. Transfer the prospective capacity to the actual transition exactly once.
+    Complete releases unused capacity; partial transfers capacity for the
+    exact suffix retained by the planner. Add assertions preventing capacity
+    leaks, double release, and post-mutation capacity failure.
+12. Replace the complete-only forecast contract with the reviewed hard-limit
+    error semantics. Keep the compatibility mapping explicit if the error
+    variant changes.
+
+### P1.3 — Implement the typed commit capability and wrapper
+
+13. Add `commit_admission` as the one implementation path for the typed result.
+    It must commit in prepared order, acknowledge only successful identities,
+    and construct the receipt from the exact prefix, suffix, duplicate,
+    retained, staged, and discarded partitions.
+14. On a causal graph failure, return `AdmissionOutcome::Partial` with the
+    committed prefix, exact pending-after view, staged-to-pending suffix,
+    discard evidence, and causal cause. Never authorize retry of the committed
+    prefix.
+15. Keep `commit_remote` as a thin compatibility wrapper that maps complete to
+    its existing array result and partial to the existing legacy error shape.
+    Do not add a second planner or a second authority commit loop.
+16. Confirm that all semantic decisions, discard closure, capacity checks, and
+    ownership transfers occur before the first authority mutation or are
+    deterministic acknowledgements of an already committed prefix.
+
+### P1.4 — Close exact ownership and lifecycle properties
+
+17. Add complete-admission tests with duplicates, retained pending work, staged
+    arrivals, invalid-root discard, and no pending suffix.
+18. Add partial tests for zero-prefix failure, middle-prefix failure, and
+    n-minus-one-prefix failure. Each test must assert committed operations,
+    exact suffix identities, pending-after membership, staged/retained
+    provenance, discarded identities, capacity, and causal cause.
+19. Add retry-after-partial tests. Re-prepare only the exact pending suffix,
+    complete it, and prove that no committed identity is attempted twice.
+20. Add stale, consumed, invalid, and capacity-rejection tests. Each must prove
+    operation count, frontier, pending membership, generation, reservation,
+    and receipt state are unchanged.
+21. Add duplicate and conflicting-identity tests that distinguish full payload
+    equality from identity reuse. A matching duplicate is an admitted no-op;
+    a conflicting identity is rejected before mutation.
+22. Add unrelated-retained tests that prove pending work outside the current
+    rejection closure remains intact and is represented in the pending-after
+    view.
+23. Add a property/model test for the ownership partition:
+
+    ```text
+    delivered identities = Authority ∪ core-pending ∪ Duplicate ∪ Discarded
+    these sets are pairwise disjoint
+    every committed identity is in Authority exactly once
+    every retained suffix identity is in core pending exactly once
+    ```
+
+24. Preserve existing planner fixed-point, atomic rejection, alias-mutation,
+    and ancestry regressions from P0. The new typed receipt must agree with the
+    existing planner state and compatibility wrapper.
+
+### P1.5 — Validate the internal capability without production cutover
+
+25. Run targeted oplog tests and benchmarks, then the full EGW check/test gate.
+26. Run `moon fmt` and `moon info`; inspect every generated interface diff.
+    Accept only the intentional internal oplog typed-capability delta.
+27. Verify that Branch, Document, Text, SyncSession, wire/archive, projection,
+    and Canopy gitlink files are unchanged by the P1 implementation.
+28. Open the EGW P1 PR only after local validation. Inspect raw CI with
+    `gh pr checks <NUMBER>` and do not merge while any required check is
+    pending, failing, or unapproved skipped.
+29. After merge, record the P1 merge SHA and validation evidence in issue
+    #1256. Start P2 only from that updated EGW `main`.
+
+## Acceptance Criteria
+
+- [ ] `PreparedAdmission` remains non-mutating, generation-bound, single-use,
+      and contains only prospective transition evidence.
+- [ ] A separate typed `AdmissionOutcome` distinguishes complete and partial
+      actual transitions; partial carries a receipt and causal cause as a
+      normal value.
+- [ ] `AdmissionReceipt` exposes exact identity-level evidence for committed,
+      duplicate, pending-after, staged, retained, and discarded membership,
+      including the before/after frontier needed by callers.
+- [ ] The final ownership partition for every delivered identity is exactly one
+      of Authority, core pending, admitted duplicate, or discarded; no identity
+      is lost or dual-owned.
+- [ ] Prepare remains non-mutating, including generation, pending membership,
+      live capacity, and capability consumption.
+- [ ] Stale, consumed, invalid, and pending-capacity rejection all occur before
+      authority mutation and leave authority, planner, generation, capacity,
+      and prepared lifecycle state unchanged.
+- [ ] Capacity is checked/reserved before the first authority mutation for the
+      worst complete or partial pending membership; partial suffix retention
+      cannot fail later for lack of capacity.
+- [ ] Complete, zero-prefix partial, middle partial, and n-minus-one partial
+      cases return exact receipts and preserve unrelated retained pending work.
+- [ ] Retrying a partial suffix never retries a committed identity and ends
+      with the exact suffix either in Authority, as a duplicate, or discarded.
+- [ ] Matching duplicate delivery is idempotent; conflicting identity reuse is
+      rejected atomically.
+- [ ] `commit_remote` remains a compatibility wrapper through P2, while the
+      typed capability retains receipt information for new callers.
+- [ ] Existing Branch/Document/Text behavior and public Canopy interfaces remain
+      unchanged; no production cutover occurs in P1.
+- [ ] Only intentionally reviewed EGW internal oplog `.mbti` changes exist.
+- [ ] EGW targeted tests, `moon check --deny-warn`, `moon test`, formatting,
+      interface inspection, and raw PR checks pass.
+
+## Validation
+
+Create a fresh EGW P1 worktree from current `origin/main`, then run from the
+EGW root:
+
+```bash
+git fetch origin main
+git merge-base --is-ancestor 99ab590 origin/main
+NEW_MOON_MOD=0 moon ide outline internal/oplog
+NEW_MOON_MOD=0 moon ide peek-def PreparedAdmission
+NEW_MOON_MOD=0 moon ide peek-def OpLog::prepare_remote
+NEW_MOON_MOD=0 moon ide peek-def OpLog::begin_admission
+NEW_MOON_MOD=0 moon ide peek-def OpLog::commit_remote
+NEW_MOON_MOD=0 moon ide find-references PartialRemoteAdmission
+NEW_MOON_MOD=0 moon check --deny-warn
+NEW_MOON_MOD=0 moon test
+NEW_MOON_MOD=0 moon fmt
+NEW_MOON_MOD=0 moon info
+git diff --check
+git diff -- '*.mbti'
+```
+
+Run focused tests for the new oplog ownership/capacity files and the existing
+planner lifecycle, ancestry, semantic parity, and remote-delivery tests before
+running the full suite. Use the repository's supported MoonBit test-selection
+syntax rather than inventing a new harness.
+
+The parent Canopy workspace is not part of this P1 validation because the
+submodule pointer and production integration remain unchanged. A temporary
+post-merge integration worktree may point the submodule at the merged P1 EGW
+SHA for compatibility checks, but must not commit the parent gitlink.
+
+Before opening or merging the implementation PR:
+
+```bash
+gh pr checks <NUMBER>
+```
+
+Every repository-owned required check must be `pass`; no required check may be
+pending, failing, or unapproved skipped.
+
+## Risks
+
+- The partial commit boundary is inherently discovered during authority
+  execution. Treating the partial prefix as preparation data would make the
+  receipt false; keep it exclusively in `AdmissionOutcome`.
+- A capacity calculation based only on complete-after membership recreates the
+  P0 limitation. The first-operation failure case must be included before
+  `begin_admission` mutates planner or authority state.
+- Retained, staged, duplicate, and discarded are provenance categories, not
+  four additional owners. Receipt construction must enforce disjoint final
+  ownership rather than merely report overlapping counters.
+- A compatibility wrapper can hide receipt information from legacy callers.
+  That is intentional through P2, but the typed capability must remain the
+  canonical implementation path so P2 does not need to reconstruct history.
+- `PreparedAdmission` and receipt arrays cross package boundaries only through
+  reviewed owning/immutable representations. Exposing planner-owned mutable
+  collections would violate the state boundary.
+- The internal oplog `.mbti` may change for the new capability. Any unrelated
+  generated-interface change is an API regression and must stop the PR.
+- The Canopy submodule remains at its existing pointer. Mixing a local P1 EGW
+  checkout into a parent commit would accidentally turn an internal capability
+  experiment into a production integration change.
+
+## Notes
+
+- Related accepted decision: [ADR 0008 at the P0 merge](https://github.com/dowdiness/event-graph-walker/blob/99ab59012a31abb8454468509dd790be03c3b391/docs/adr/0008-core-owned-batch-remote-admission-over-legacy-op.md).
+- Related implementation: [EGW PR #118](https://github.com/dowdiness/event-graph-walker/pull/118).
+- The P1 plan deliberately does not introduce a new ADR; it operationalizes
+  the P1 ownership boundary already accepted by ADR 0008.
+- P2 may move the typed outcome through a Document batch shell and projection
+  boundary. P1 must not anticipate that cutover by changing outer pending,
+  publication, or Canopy-facing APIs.
+- The exact receipt field names, capacity formula, and final capability method
+  spelling are the explicit plan-review decisions listed above. Once accepted,
+  implementation must update this plan if any of them change.

--- a/docs/plans/2026-08-15-egw-p1-typed-admission-transition.md
+++ b/docs/plans/2026-08-15-egw-p1-typed-admission-transition.md
@@ -35,7 +35,8 @@ must distinguish:
 
 - the prospective, generation-bound capability known before authority mutation;
 - the actual complete or partial outcome known only after the commit attempt;
-- the hard pending capacity needed before either complete or partial execution.
+- the hard pending-membership precondition that must hold immediately after
+  `begin_admission` and therefore before either complete or partial execution.
 
 This is a typed transition boundary, not a new dependency planner and not a
 production Canopy cutover.
@@ -53,21 +54,21 @@ The EGW submodule, starting from the P0 merge on a fresh branch:
 - the intentionally changed EGW `internal/oplog/pkg.generated.mbti`
 - `deps/event-graph-walker/text/errors.mbt` for the intentional pending-limit
   error mapping
-- a docs-only clarification to the accepted
+- the prerequisite, separately merged EGW docs-only amendment to the accepted
   `deps/event-graph-walker/docs/adr/0008-core-owned-batch-remote-admission-over-legacy-op.md`
-- package-local ownership, partial-transition, retry, and capacity properties
+- package-local ownership, partial-transition, retry, and pending-limit properties
 
 The P1 boundary includes:
 
 - extending `PreparedAdmission` with the complete prospective transition;
 - introducing a typed `AdmissionOutcome` and `AdmissionReceipt` for actual
   commit results;
-- exact identity-level accounting for committed, duplicate, retained,
-  staged, and discarded membership;
-- an exact peak pending-capacity gate checked before authority mutation and
-  safe for a partial suffix; the live planner pending membership is the
-  reservation in the current synchronous shell, with no independent reserved
-  counter unless a future reentrant shell requires one;
+- exact affected-identity accounting for committed, `already_admitted`,
+  pending, and discarded membership, with retained/staged provenance and
+  duplicate-delivery evidence kept on separate axes;
+- an exact pending-membership precondition checked before authority mutation
+  and safe for a partial suffix; the current synchronous shell proves the
+  bound from planner membership without an independent pending-limit counter;
 - a new core capability for typed admission, while preserving the existing
   `commit_remote` compatibility behavior through P2;
 - no new planner algorithm: `RemoteAdmissionPlanner` remains the sole owner of
@@ -84,8 +85,9 @@ The P1 boundary includes:
 - `TextReplica`, Persistence Coordinator, Worker replay, or reconnect work;
 - public Canopy API redesign;
 - Canopy submodule/gitlink changes;
-- a new ADR for this phase; ADR 0008 receives only the explicit clarification
-  needed to distinguish the prospective capability from its actual outcome.
+- a new ADR for this phase; a separate EGW docs-only amendment to ADR 0008
+  must land before the P1 implementation branch so the accepted decision
+  explicitly distinguishes prospective capability from actual outcome.
 
 P1 may intentionally change the EGW internal oplog generated interface and
 text error mapping for the new typed capability/limit variant. It must not
@@ -130,12 +132,13 @@ editing.
 `PreparedAdmission` remains a prospective value. It may contain, at minimum:
 
 - commit order and planned operation representations;
-- duplicate identities detected during preparation;
+- duplicate-delivery evidence detected during preparation, without treating it
+  as a canonical owner;
 - retained-pending identities already known to survive the transition;
 - newly staged identities;
 - discarded pending and discarded staged identities, with their provenance;
 - generation and any policy revision used for validation;
-- the prospective maximum pending membership and its capacity requirement;
+- the prospective maximum pending membership and its required-pending value;
 - single-use state.
 
 It must not claim to contain a committed prefix. The committed prefix is not
@@ -152,27 +155,60 @@ pub enum AdmissionOutcome {
 ```
 
 `AdmissionReceipt` must expose enough immutable evidence to account for the
-attempt without inspecting planner internals. The exact MoonBit field names
-remain a plan-review decision, but its semantic contents are not optional:
+transition without inspecting planner internals. It must remain
+transition-local rather than copying the complete planner state. The exact MoonBit field
+names remain a plan-review decision, but its semantic contents are not optional:
 
 - committed operations and their `RawVersion` identities;
-- duplicate identities accepted as already-admitted no-ops;
-- the complete pending-after identity view, including unrelated retained work;
-- discarded identities, partitioned by retained-pending versus staged origin
-  where that provenance matters;
-- the uncommitted suffix identities, with staged versus retained provenance;
-- the before/after frontier needed to prove authority movement;
-The receipt is common evidence for both outcome variants; status and causal
-failure belong only to `AdmissionOutcome`, so a complete receipt cannot carry a
-partial cause.
+- `already_admitted` identities accepted as authority-owned no-ops;
+- `pending_from_transition` identities whose terminal owner is core pending,
+  including the exact retained/staged uncommitted suffix and any pending
+  identity delivered as a no-op, represented at most once;
+- discarded identities split into `discarded_pending` and `discarded_staged`;
+- `pending_before_count` and `pending_after_count`, counting unique live
+  pending membership without copying unrelated pending identities;
+- non-fallible, receipt-owned `frontier_before` and `frontier_after` snapshots;
+- optional duplicate-delivery counts or provenance, kept separate from the
+  identity ownership partition.
 
-Arrays returned in a receipt must be owning or immutable views according to the
-EGW API convention; no mutable planner collection may escape. The receipt must
-also distinguish the complete pending-after snapshot from the pending identities
-in this admission's coverage: unrelated retained pending work belongs in the
-snapshot but must not be misclassified as delivered input. Terminal ownership
-and staged/retained/discarded provenance are separate views of the same
-transition, not overlapping owners.
+Conceptually, the receipt storage is equivalent to owning fields such as:
+
+```moonbit
+pub struct AdmissionReceipt {
+  priv committed : Array[@core.Op]
+  priv already_admitted : Array[@core.RawVersion]
+  priv pending_from_transition : Array[@core.RawVersion]
+  priv discarded_pending : Array[@core.RawVersion]
+  priv discarded_staged : Array[@core.RawVersion]
+  priv pending_before_count : Int
+  priv pending_after_count : Int
+  priv frontier_before : @core.Frontier
+  priv frontier_after : @core.Frontier
+}
+```
+
+`pending_from_transition` must preserve retained-versus-staged provenance for
+the suffix, whether through separate accessors or an explicitly tagged local
+representation. Unrelated retained pending identities are reflected only by
+the global counts and white-box planner assertions, not by a receipt-wide
+identity snapshot. The receipt is common evidence for both outcome variants;
+status and causal failure belong only to `AdmissionOutcome`, so a complete
+receipt cannot carry a partial cause.
+
+Receipt fields that contain identities or operations must be defensive,
+receipt-owned `Array` snapshots. Accessors may return `ArrayView` values over
+those receipt-owned arrays, for example:
+
+```moonbit
+pub fn AdmissionReceipt::pending_from_transition(
+  self : AdmissionReceipt,
+) -> ArrayView[@core.RawVersion]
+```
+
+No view over planner-owned mutable storage may escape. Frontier snapshots follow the same rule and must be constructed without
+a fallible post-mutation step. Terminal ownership and
+staged/retained/discarded provenance are separate views of the same transition,
+not overlapping owners.
 
 ### 2. Make partial a normal typed outcome
 
@@ -193,7 +229,7 @@ following remain pre-mutation errors raised by the capability:
 - `StaleAdmission`;
 - `ConsumedAdmission`;
 - `InvalidAdmission`;
-- the hard pending-capacity error, using the reviewed `limit~` and
+- the hard pending-limit error, using the reviewed `limit~` and
   `required~` vocabulary rather than a complete-only `predicted~` claim.
 
 The compatibility method keeps its existing caller contract through P2:
@@ -210,83 +246,145 @@ operations. A partial outcome is translated back to the existing
 `PartialRemoteAdmission` error for legacy callers; the new typed path retains
 the full receipt. No `Document` or `Branch` migration belongs in P1.
 
-### 3. Reserve pending capacity for both completion paths
+### 3. Validate the pending-membership precondition
 
-Preparation remains non-mutating. It calculates the maximum pending membership
-that can be required by any permitted commit result, including the worst case
-where the first authority operation fails and the whole planned suffix remains
-pending. The prepared value carries this prospective requirement.
+Preparation remains non-mutating. It calculates the unique pending membership
+that must exist immediately after `begin_admission` applies the discard and
+staged-node transition, before the first authority operation is attempted. The
+prepared value carries this prospective requirement.
 
-At the begin transition, after stale/consumed/invalid validation and before any
-authority mutation, the core checks the peak requirement. Registering the full
-non-discarded staged set is the current synchronous shell's one-time capacity
-reservation; successful acknowledgements only remove live pending nodes. The
-transition must obey:
+For the current generation, the exact requirement is:
 
 ```text
+required_pending = count_unique(
+  (pending_before - discarded_pending)
+  ∪ staged_unique_not_admitted_not_discarded
+)
+```
+
+`pending_before` is the live planner pending membership before begin.
+`staged_unique_not_admitted_not_discarded` contains every unique staged identity
+that is not already admitted, already pending, or in the rejection closure.
+Because the staged set excludes existing pending identities, the equivalent
+shorthand is `live_pending_before - discarded_pending_count +
+new_staged_count`, but the set expression is the normative contract. For
+`DeferredFast`, the staged count equals the unique planned count; for
+`ImmediateGeneral`, it equals the materialized staged-node count and may be
+larger than `planned.length()`.
+
+When `max_pending?` is supplied, preparation raises
+`PendingLimitExceeded(limit~, required~)` if the requirement exceeds the
+bound, without creating a usable capability. At begin, after stale/consumed/
+invalid/structure validation and before removing or registering any planner
+node, the core revalidates the same generation-bound requirement. A rejected
+begin changes neither authority, planner membership, generation, nor pending
+policy.
+
+The current lifecycle then obeys:
+
+```text
+begin:
+  apply discard/register once, leaving pending membership at or below the
+  accepted bound
+
 complete:
-  all planned identities are acknowledged or duplicate; remaining pending is
-  the complete-after set
+  all planned identities are acknowledged or duplicate; pending membership
+  can only decrease from the begin-after value
 
 partial:
-  the exact uncommitted suffix remains in core pending with its provenance
+  the exact uncommitted suffix remains in core pending with its provenance;
+  pending membership can only decrease from the begin-after value
 
-rejected before mutation:
-  change neither authority, planner membership, generation, nor pending policy
+commit:
+  each successful acknowledgement removes one live pending identity; commit
+  never adds a new pending identity
 ```
 
-The accounting must count unique live pending membership rather than operation
-attempts or stale index entries. For the current generation, the peak before
-any acknowledgement is:
+Therefore the maximum pending membership is immediately after begin and before
+the first authority commit. A post-prefix `PendingLimitExceeded` is not an
+acceptable design: the hard precondition must be satisfied before authority has
+advanced. No mutable pending-limit state or separate planner counter belongs
+in P1; a future reentrant or asynchronous shell may revisit that decision with
+new evidence.
+
+### 4. Make affected ownership partitions explicit and disjoint
+
+For the unique identities in the transition-local affected domain, the final
+partition is:
 
 ```text
-required_pending =
-  live_pending_before_begin
-  - discarded_pending_count
-  + new_staged_count
+affected identities =
+  committed
+  ∪ already_admitted
+  ∪ pending
+  ∪ discarded
+
+committed, already_admitted, pending, and discarded are pairwise disjoint
 ```
 
-`new_staged_count` includes every unique, non-admitted, non-existing-pending,
-non-discarded staged identity, including unresolved nodes that are not in the
-compatibility-ordered `planned` list. For `DeferredFast` it equals the unique
-planned count; for `ImmediateGeneral` it equals the materialized staged-node
-count, which may be larger than `planned.length()`. The formula must be
-calculated during preparation and rechecked at begin. Begin validates it before removing or
-registering any planner node; registering the full staged set is the one-time
-reservation, and successful acknowledgements only decrease live pending
-membership. A post-prefix `PendingLimitExceeded` is not an acceptable design:
-capacity failure must not be discovered after authority has advanced. A
-separate mutable planner reservation counter is deferred because the current
-OpLog commit shell is synchronous and generation-invalidates interleaving
-prepared admissions.
-
-### 4. Make ownership partitions explicit and disjoint
-
-For every unique incoming delivery occurrence, the outcome disposition is
-exactly one of:
+Their canonical ownership is:
 
 ```text
-newly committed into Authority
-DuplicateOfAuthority (non-owning disposition)
-core pending
-Discarded / rejected
+committed        → Authority
+already_admitted → Authority
+pending          → core pending
+discarded        → no owner
 ```
 
-The canonical ownership partition is therefore `Authority ∪ core pending ∪
-Discarded`; a duplicate is reported separately because its incoming occurrence
-was a no-op, but its `RawVersion` remains owned by Authority rather than by a
-second duplicate owner. `retained`, `staged`, and `discarded` are provenance
-partitions used to explain how an admission-coverage identity reached its final
-category; they must not create a second owner. In particular:
+`already_admitted` is the authority-owned disposition for an incoming matching
+identity. A matching pending identity belongs to `pending`, not to a generic
+duplicate owner. Delivery evidence may distinguish:
+
+```text
+already-admitted duplicate  → identity is in already_admitted
+pending duplicate           → identity is in pending
+same-batch duplicate        → occurrence evidence only
+```
+
+Same-batch duplicate occurrences and retransmission counts are separate
+delivery evidence; they may record coalescing or duplicate provenance but
+never create another identity set in the ownership partition.
+
+`retained`, `staged`, and `discarded` are provenance partitions used to explain
+how an affected identity reached its final category; they must not create a
+second owner. In particular:
 
 - a committed identity is never also retained or retried;
-- a matching admitted duplicate is not re-committed or counted as pending;
-- a partial suffix contains uncommitted planned identities from both retained
-  pending and newly staged provenance;
+- an admitted duplicate is not re-committed and is represented in
+  `already_admitted` at most once;
+- a pending duplicate is represented in `pending` at most once, with any
+  duplicate occurrence evidence kept separately;
+- the partial suffix is the exact uncommitted suffix of
+  `PreparedAdmission::operations()` and may contain both retained-pending and
+  newly staged provenance;
 - invalid-root dependents are discarded exactly once;
 - unrelated retained pending identities survive unless explicitly in the
   rejection closure;
-- no incoming occurrence is lost or assigned two dispositions.
+- no affected identity is lost or assigned two final owners.
+
+## Prerequisite ADR amendment
+
+ADR 0008 is accepted and must not be silently reinterpreted by this Plan. Its
+P1 wording currently describes one prepared admission as recording committed,
+retained, discarded, duplicate, and partial ownership, while the source-backed
+transition boundary proves that a prospective `PreparedAdmission` cannot know
+a committed prefix.
+
+Before creating the P1 implementation branch, land a separate EGW docs-only
+amendment to ADR 0008 with this meaning:
+
+```text
+P1 — typed transition boundary:
+PreparedAdmission records the prospective, generation-bound transition.
+AdmissionOutcome and AdmissionReceipt record the actual complete or partial
+ownership result after the commit attempt.
+The boundary owns the hard pending-limit contract.
+```
+
+This amendment preserves ADR 0008 as the architecture decision and moves the
+prospective/actual distinction into its accepted wording. It is a prerequisite
+for implementation, not a new ADR and not a decision to be deferred into the
+Plan review.
 
 ## Decisions Required at Plan Review
 
@@ -297,27 +395,28 @@ plan review before implementation:
    `PreparedAdmission` and actual `AdmissionOutcome`/`AdmissionReceipt`.
 2. **Partial algebra:** accept `Partial` as an ordinary typed outcome carrying
    both the receipt and causal failure, while pre-mutation lifecycle and
-   capacity failures remain errors.
-3. **Capacity contract:** accept the exact peak formula above, with full staged
-   registration as the current shell's one-time reservation and no independent
-   live reservation counter in P1.
-4. **ADR 0008 clarification:** accept that the ADR's phrase "prepared admission
-   records" names the complete P1 transition capability, not a requirement to
-   mutate `PreparedAdmission` with a post-commit prefix. Add a docs-only
-   clarification before implementation; create no new ADR.
-5. **Limit vocabulary:** rename the optional preparation policy from
+   pending-limit failures remain errors.
+3. **Pending-limit contract:** accept the exact set-based requirement above and the
+   begin-time hard precondition. `PendingLimitExceeded(limit~, required~)`
+   must be raised before authority mutation; pending membership must be
+   monotonic non-increasing after begin, with no stateful pending-limit
+   counter in P1.
+4. **Limit vocabulary:** rename the optional preparation policy from
    `max_pending_after_complete?` to `max_pending?`, replace the complete-only
    `PendingForecastExceeded(limit~, predicted~)` contract with
    `PendingLimitExceeded(limit~, required~)`, and update its EGW text error
    mapping. If API inventory finds an external caller, retain only a clearly
    named compatibility adapter; never give one label two meanings.
-6. **Compatibility lifetime:** keep `commit_remote` as the legacy wrapper
+5. **Compatibility lifetime:** keep `commit_remote` as the legacy wrapper
    through P2; do not change Branch, Document, SyncSession, or Canopy callers
    in P1.
-7. **Interface delta:** permit only the intentional internal oplog generated
+6. **Interface delta:** permit only the intentional internal oplog generated
    interface and EGW error-mapping changes; reject unrelated `.mbti` drift.
-8. **Receipt shape:** settle the exact field names and whether identity
-   collections are arrays, immutable views, or another owning representation.
+7. **Receipt shape:** accept transition-local defensive snapshots only:
+   committed, `already_admitted`, `pending_from_transition`, discarded
+   provenance, global pending before/after counts, and receipt-owned frontier
+   snapshots. No complete global pending identity snapshot or planner-owned
+   view may escape.
 
 No implementation branch should be created until these decisions are accepted.
 
@@ -325,9 +424,10 @@ No implementation branch should be created until these decisions are accepted.
 
 ### P1.0 — Freeze the merged baseline and API evidence
 
-1. Fetch EGW `origin/main` and verify that it contains merge commit `99ab590`.
-   Create a dedicated P1 EGW worktree from that current main; do not start from
-   the pre-merge PR head and do not update the Canopy gitlink.
+1. Fetch EGW `origin/main` and verify that it contains merge commit `99ab590`
+   and the separate docs-only amendment to ADR 0008. Only then create a
+   dedicated P1 EGW worktree from that current main; do not start from the
+   pre-merge PR head and do not update the Canopy gitlink.
 2. Initialize submodules and inspect the package roots and current interfaces:
    `internal/oplog`, `internal/core`, `internal/causal_graph`,
    `internal/branch`, and `internal/document`.
@@ -335,46 +435,44 @@ No implementation branch should be created until these decisions are accepted.
    `PreparedAdmission`, `OpLog::prepare_remote`, `OpLog::begin_admission`,
    `OpLog::commit_remote`, `PartialRemoteAdmission`, and the generated oplog
    interface. Record the actual existing APIs before defining any new one.
-4. Add the ADR 0008 docs-only clarification before code changes, then write
-   the first failing ownership and capacity tests before changing the
-   transition implementation.
+4. Write the first failing ownership, pending-limit, receipt-scope, and
+   core-owned-retry tests before changing the transition implementation.
 
 ### P1.1 — Model the prospective transition
 
 5. Extend the private `PreparedAdmission` representation only with data that
    is knowable before authority mutation: ordered planned identities,
    duplicate/retained/staged/discarded provenance, generation/policy evidence,
-   the exact `new_staged_count`, and the worst-case `required_pending` value.
+   the exact staged identity set or its equivalent count, and the
+   `required_pending` value derived from the set-based contract.
 6. Preserve non-mutating `prepare_remote`: it must not advance planner
-   generation, alter pending membership, consume a capability, or reserve live
-   capacity. Repeated preparation with unchanged state must produce equivalent
-   prospective evidence.
+   generation, alter pending membership, consume a capability, or mutate any
+   pending-limit state. Repeated preparation with unchanged state must produce
+   equivalent prospective evidence.
 7. Add private constructors/validation that make the prepared value internally
    self-consistent and preserve defensive ownership of mutable arrays and
-   identity sets. Do not add a live `reserved` planner counter in this phase.
+   identity sets. Do not add a live pending-limit planner counter in this
+   phase.
 8. Define the reviewed `AdmissionReceipt` and `AdmissionOutcome` values. Keep
    actual committed-prefix data out of `PreparedAdmission`.
 
-### P1.2 — Add the hard capacity transition
+### P1.2 — Enforce the hard pending-membership precondition
 
-9. Define and test the exact unique-membership calculation:
-    `live_pending_before_begin - discarded_pending_count + new_staged_count`.
-    Include first-operation failure, retained existing pending work, every
-    unresolved staged node, duplicate identities, and rejection closure; do
-    not substitute `planned.length()` for `new_staged_count`. When
-    `max_pending?` is supplied, preparation rejects `required_pending > limit`
-    without creating a capability, and begin repeats the check for stale-safe
-    atomicity.
+9. Define and test the exact set-based requirement in §3. Include
+    first-operation failure, retained existing pending work, every unresolved
+    staged node, duplicate identities, and rejection closure; do not substitute
+    `planned.length()` for the staged identity set. When `max_pending?` is
+    supplied, preparation rejects `required_pending > limit` without creating
+    a capability, and begin repeats the generation-bound precondition.
 10. At `begin_admission`, validate generation, single-use state, structure,
-    and `required_pending <= max_pending?` before applying discard/register/
-    consume changes. A rejected begin leaves planner, generation, pending
-    membership, and authority unchanged.
-11. Register the complete non-discarded staged set as the one-time live
-    reservation. Complete and partial acknowledgements only remove successful
-    identities, so the live pending membership cannot grow after begin. Add
-    assertions preventing over-limit registration, lost suffixes, and
-    double-accounting; do not add a separate reservation counter unless the
-    API inventory finds reentrant admissions.
+    and the exact required pending membership against `max_pending?` before
+    applying discard/register/consume changes. A rejected begin leaves planner,
+    generation, pending membership, and authority unchanged.
+11. Register the complete non-discarded staged set once. Complete and partial
+    acknowledgements only remove successful identities, so pending membership
+    cannot grow after begin. Assert that the begin-after count stays within the
+    accepted bound, that suffixes are not lost, and that no identity is counted
+    twice; do not add a stateful pending-limit counter.
 12. Replace the complete-only forecast API with the reviewed hard-limit
     vocabulary: `max_pending?` and
     `PendingLimitExceeded(limit~, required~)`. Update the EGW text error
@@ -385,17 +483,19 @@ No implementation branch should be created until these decisions are accepted.
 
 13. Add `commit_admission` as the one implementation path for the typed result.
     It must commit in prepared order, acknowledge only successful identities,
-    and construct the receipt from the exact prefix, suffix, duplicate,
-    retained, staged, and discarded partitions.
+    and construct receipt-owned snapshots for committed,
+    `already_admitted`, `pending_from_transition`, discarded provenance,
+    pending before/after counts, and before/after frontiers.
 14. On a causal graph failure, return `AdmissionOutcome::Partial` with the
-    committed prefix, exact pending-after view, uncommitted suffix with
-    staged/retained provenance, discard evidence, and causal cause. Never
-    authorize retry of the committed prefix.
+    committed prefix, the exact uncommitted suffix in
+    `pending_from_transition`, retained/staged suffix provenance, discard
+    evidence, `pending_after_count`, owning frontier snapshot, and causal
+    cause. Never authorize retry of the committed prefix.
 15. Keep `commit_remote` as a thin compatibility wrapper that maps complete to
     its existing array result and partial to the existing legacy error shape.
     Do not add a second planner or a second authority commit loop.
-16. Confirm that all semantic decisions, discard closure, capacity checks, and
-    ownership transfers occur before the first authority mutation or are
+16. Confirm that all semantic decisions, discard closure, pending-limit checks,
+    and ownership transfers occur before the first authority mutation or are
     deterministic acknowledgements of an already committed prefix.
 
 ### P1.4 — Close exact ownership and lifecycle properties
@@ -406,28 +506,37 @@ No implementation branch should be created until these decisions are accepted.
     being misclassified as an admitted duplicate.
 18. Add partial tests for zero-prefix failure, middle-prefix failure, and
     n-minus-one-prefix failure. Each test must assert committed operations,
-    exact suffix identities, pending-after membership, staged/retained
-    provenance, discarded identities, capacity, and causal cause.
-19. Add retry-after-partial tests. Re-prepare only the exact pending suffix,
-    complete it, and prove that no committed identity is attempted twice.
-20. Add stale, consumed, invalid, and capacity-rejection tests. Each must prove
-    operation count, frontier, pending membership, generation, required-capacity
+    exact suffix identities, pending-from-transition membership,
+    staged/retained provenance, discarded identities, before/after counts,
+    required-pending value, and causal cause. White-box assertions may compare the complete
+    planner pending maps; the receipt must not copy them.
+19. Add core-owned recovery tests after partial admission. The suffix is
+    already in core pending: re-plan it with `prepare_remote([])` or with a
+    later dependency-bearing batch, and prove that no committed identity is
+    attempted twice. Add network-resend idempotence as a separate test; do not
+    make reconstructing and resending the receipt suffix the recovery protocol.
+20. Add stale, consumed, invalid, and pending-limit-rejection tests. Each must prove
+    operation count, frontier, pending membership, generation, required-pending
     calculation, and receipt state are unchanged.
 21. Add duplicate and conflicting-identity tests that distinguish full payload
     equality from identity reuse. A matching duplicate is an admitted no-op;
     a conflicting identity is rejected before mutation.
 22. Add unrelated-retained tests that prove pending work outside the current
-    rejection closure remains intact and is represented in the pending-after
-    view.
+    rejection closure remains intact. Compare planner pending membership in
+    white-box tests and assert only the before/after counts appear in the
+    production receipt.
 23. Add a property/model test for the ownership partition:
 
     ```text
-    incoming occurrences = NewlyCommitted ∪ DuplicateOfAuthority ∪
-      Pending ∪ Discarded
-    these occurrence dispositions are pairwise disjoint
-    DuplicateOfAuthority identities are already in Authority, not a second owner
-    every retained suffix identity is in core pending exactly once
+    affected identities = committed ∪ already_admitted ∪ pending ∪ discarded
+    committed, already_admitted, pending, and discarded are pairwise disjoint
+    committed ∪ already_admitted ⊆ Authority after
+    pending ⊆ core pending after
+    discarded ∩ (Authority after ∪ core pending after) = {}
     ```
+
+    Track same-batch duplicate occurrences and pending retransmissions only as
+    separate delivery evidence; never add them to the ownership partition.
 
 24. Preserve existing planner fixed-point, atomic rejection, alias-mutation,
     and ancestry regressions from P0. The new typed receipt must agree with the
@@ -457,27 +566,30 @@ No implementation branch should be created until these decisions are accepted.
       actual transitions; partial carries a common receipt and causal cause as
       a normal value, while receipt status/cause fields cannot contradict the
       enum variant.
-- [ ] `AdmissionReceipt` exposes exact identity-level evidence for committed,
-      duplicate, pending-after, staged, retained, and discarded membership,
-      including the before/after frontier needed by callers.
-- [ ] Every incoming occurrence has exactly one disposition: newly committed,
-      `DuplicateOfAuthority`, core pending, or discarded. Duplicate evidence is
-      non-owning; canonical RawVersion ownership remains disjoint across
-      Authority, core pending, and discarded.
+- [ ] `AdmissionReceipt` exposes only transition-local owning evidence:
+      committed, `already_admitted`, `pending_from_transition`, discarded
+      provenance, unique pending before/after counts, and receipt-owned
+      before/after frontier snapshots. It never copies the complete global
+      pending identity set or returns a planner-owned view.
+- [ ] The affected identity partition is exactly
+      `committed ∪ already_admitted ∪ pending ∪ discarded`; these sets are
+      pairwise disjoint, with committed/already-admitted owned by Authority,
+      pending owned by core, and discarded owned by neither. Duplicate
+      occurrence evidence is kept on a separate axis.
 - [ ] Prepare remains non-mutating, including generation, pending membership,
-      live capacity, and capability consumption.
-- [ ] Stale, consumed, invalid, and pending-capacity rejection all occur before
+      pending-limit evidence, and capability consumption.
+- [ ] Stale, consumed, invalid, and pending-limit rejection all occur before
       authority mutation and leave authority, planner, generation, pending
       membership, and prepared lifecycle state unchanged.
-- [ ] Capacity uses the exact peak formula
-      `live_pending_before_begin - discarded_pending_count + new_staged_count`,
-      is checked before the first authority mutation, and registers the full
-      staged set as the current shell's one-time reservation; partial suffix
-      retention cannot fail later for lack of capacity.
+- [ ] Pending membership uses the exact set-based requirement
+      `count_unique((pending_before - discarded_pending) ∪ staged_unique_not_admitted_not_discarded)`,
+      is checked before the first authority mutation, and pending membership
+      remains monotonically non-increasing after begin.
 - [ ] Complete, zero-prefix partial, middle partial, and n-minus-one partial
-      cases return exact receipts and preserve unrelated retained pending work.
-- [ ] Retrying a partial suffix never retries a committed identity and ends
-      with the exact suffix either in Authority, as a duplicate, or discarded.
+      cases return exact transition-local receipts and preserve unrelated
+      retained pending work, which is verified through white-box planner state.
+- [ ] Core-owned recovery re-plans the pending suffix without retrying a
+      committed identity; network resend idempotence is tested separately.
 - [ ] Matching duplicate delivery is idempotent; conflicting identity reuse is
       rejected atomically.
 - [ ] `commit_remote` remains a compatibility wrapper through P2, while the
@@ -485,8 +597,9 @@ No implementation branch should be created until these decisions are accepted.
 - [ ] Existing Branch/Document behavior and public Canopy interfaces remain
       unchanged; only the EGW text error mapping for the intentional new
       pending-limit variant may change; no production cutover occurs in P1.
-- [ ] The ADR 0008 docs-only clarification records the two-value boundary; no
-      new ADR is created.
+- [ ] A separate EGW docs-only amendment to ADR 0008 records the two-value
+      boundary before the P1 implementation branch is created; no new ADR is
+      created.
 - [ ] Only intentionally reviewed EGW internal oplog interface changes and
       pending-limit error-mapping changes exist.
 - [ ] EGW targeted tests, `moon check --deny-warn`, `moon test`, formatting,
@@ -514,7 +627,7 @@ git diff --check
 git diff -- '*.mbti'
 ```
 
-Run focused tests for the new oplog ownership/capacity files and the existing
+Run focused tests for the new oplog ownership/pending-limit files and the existing
 planner lifecycle, ancestry, semantic parity, and remote-delivery tests before
 running the full suite. Use the repository's supported MoonBit test-selection
 syntax rather than inventing a new harness.
@@ -538,16 +651,17 @@ pending, failing, or unapproved skipped.
 - The partial commit boundary is inherently discovered during authority
   execution. Treating the partial prefix as preparation data would make the
   receipt false; keep it exclusively in `AdmissionOutcome`.
-- A capacity calculation based only on complete-after membership, or on
+- A required-pending calculation based only on complete-after membership, or on
   `planned.length()`, recreates the P0 limitation. The first-operation failure
-  case must include every staged node before `begin_admission` mutates planner
-  or authority state.
-- Retained, staged, duplicate, and discarded are provenance categories, not
-  four additional owners. Receipt construction must enforce disjoint final
-  ownership rather than merely report overlapping counters.
-- A separate live reservation counter would create release/compaction/stale
-  invariants without a current reentrant admission need. If future execution
-  becomes asynchronous or reentrant, revisit this as a new design boundary.
+  case must include every staged node in the set-based begin-after requirement
+  before `begin_admission` mutates planner or authority state.
+- Retained, staged, duplicate, and discarded are provenance or delivery
+  categories, not four additional owners. Receipt construction must enforce the
+  disjoint affected-identity partition rather than merely report overlapping
+  counters.
+- A separate mutable pending-limit state would add invariants without a
+  current reentrant admission need. If future execution becomes asynchronous
+  or reentrant, revisit this as a new design boundary.
 - A compatibility wrapper can hide receipt information from legacy callers.
   That is intentional through P2, but the typed capability must remain the
   canonical implementation path so P2 does not need to reconstruct history.
@@ -565,16 +679,17 @@ pending, failing, or unapproved skipped.
 
 - Related accepted decision: [ADR 0008 at the P0 merge](https://github.com/dowdiness/event-graph-walker/blob/99ab59012a31abb8454468509dd790be03c3b391/docs/adr/0008-core-owned-batch-remote-admission-over-legacy-op.md).
 - Related implementation: [EGW PR #118](https://github.com/dowdiness/event-graph-walker/pull/118).
-- The P1 plan deliberately does not introduce a new ADR. It requires a
-  docs-only clarification of ADR 0008 so its accepted transition shorthand is
-  consistent with the prospective `PreparedAdmission` / actual
-  `AdmissionOutcome` split.
+- The P1 plan deliberately does not introduce a new ADR or reinterpret ADR
+  0008. A separate EGW docs-only amendment must land before the implementation
+  branch so the accepted decision explicitly states the prospective
+  `PreparedAdmission` / actual `AdmissionOutcome` split.
 - P2 may move the typed outcome through a Document batch shell and projection
   boundary. P1 must not anticipate that cutover by changing outer pending,
   publication, or Canopy-facing APIs.
 - The exact receipt field names and final capability method spelling remain the
-  explicit plan-review decisions listed above. The peak-capacity formula and
-  no-live-counter choice are now the recommended result of the alternatives
-  research; implementation must update this plan if review rejects either.
+  explicit plan-review decisions listed above. The set-based required-pending
+  formula, transition-local receipt scope, and no-stateful-counter choice are
+  now the recommended result of the alternatives research; implementation must
+  update this plan if review rejects any of them.
 - The alternatives and source citations are recorded in
   `docs/research/2026-08-15-egw-p1-admission-transition-options.md`.

--- a/docs/plans/2026-08-15-egw-p1-typed-admission-transition.md
+++ b/docs/plans/2026-08-15-egw-p1-typed-admission-transition.md
@@ -248,8 +248,10 @@ required_pending =
 
 `new_staged_count` includes every unique, non-admitted, non-existing-pending,
 non-discarded staged identity, including unresolved nodes that are not in the
-compatibility-ordered `planned` list. The formula must be calculated during
-preparation and rechecked at begin. Begin validates it before removing or
+compatibility-ordered `planned` list. For `DeferredFast` it equals the unique
+planned count; for `ImmediateGeneral` it equals the materialized staged-node
+count, which may be larger than `planned.length()`. The formula must be
+calculated during preparation and rechecked at begin. Begin validates it before removing or
 registering any planner node; registering the full staged set is the one-time
 reservation, and successful acknowledgements only decrease live pending
 membership. A post-prefix `PendingLimitExceeded` is not an acceptable design:

--- a/docs/plans/2026-08-15-egw-p1-typed-admission-transition.md
+++ b/docs/plans/2026-08-15-egw-p1-typed-admission-transition.md
@@ -7,6 +7,8 @@ Canonical issue: <https://github.com/dowdiness/canopy/issues/1256>
 This plan is the implementation plan for the issue above. The issue must link
 back to this plan before implementation starts.
 
+Research record: [`docs/research/2026-08-15-egw-p1-admission-transition-options.md`](../research/2026-08-15-egw-p1-admission-transition-options.md).
+
 **This plan must be reviewed and accepted before a fresh P1 EGW branch is
 created from the current `origin/main`.**
 
@@ -49,6 +51,8 @@ The EGW submodule, starting from the P0 merge on a fresh branch:
 - `deps/event-graph-walker/internal/oplog/errors.mbt`
 - `deps/event-graph-walker/internal/oplog/*_wbtest.mbt` and related oplog tests
 - the intentionally changed EGW `internal/oplog/pkg.generated.mbti`
+- `deps/event-graph-walker/text/errors.mbt` for the intentional pending-limit
+  error mapping
 - package-local ownership, partial-transition, retry, and capacity properties
 
 The P1 boundary includes:
@@ -58,8 +62,10 @@ The P1 boundary includes:
   commit results;
 - exact identity-level accounting for committed, duplicate, retained,
   staged, and discarded membership;
-- a hard pending-capacity reservation that is checked before authority
-  mutation and remains safe for a partial suffix;
+- an exact peak pending-capacity gate checked before authority mutation and
+  safe for a partial suffix; the live planner pending membership is the
+  reservation in the current synchronous shell, with no independent reserved
+  counter unless a future reentrant shell requires one;
 - a new core capability for typed admission, while preserving the existing
   `commit_remote` compatibility behavior through P2;
 - no new planner algorithm: `RemoteAdmissionPlanner` remains the sole owner of
@@ -78,10 +84,11 @@ The P1 boundary includes:
 - Canopy submodule/gitlink changes;
 - a new ADR for this phase.
 
-P1 may intentionally change the EGW internal oplog generated interface for the
-new typed capability. It must not widen or otherwise change unrelated
-Branch/Document/Text or Canopy-facing interfaces. Every `.mbti` change must be
-reviewed as an explicit compatibility decision.
+P1 may intentionally change the EGW internal oplog generated interface and
+text error mapping for the new typed capability/limit variant. It must not
+widen or otherwise change unrelated Branch/Document or Canopy-facing
+interfaces. Every `.mbti` change must be reviewed as an explicit compatibility
+decision.
 
 ## Current State
 
@@ -150,12 +157,17 @@ remain a plan-review decision, but its semantic contents are not optional:
 - the complete pending-after identity view, including unrelated retained work;
 - discarded identities, partitioned by retained-pending versus staged origin
   where that provenance matters;
-- the staged identities that became the uncommitted partial suffix;
+- the uncommitted suffix identities, with staged versus retained provenance;
 - the before/after frontier needed to prove authority movement;
 - complete versus partial status, with the causal graph failure on `Partial`.
 
 Arrays returned in a receipt must be owning or immutable views according to the
-EGW API convention; no mutable planner collection may escape.
+EGW API convention; no mutable planner collection may escape. The receipt must
+also distinguish the complete pending-after snapshot from the pending identities
+in this admission's coverage: unrelated retained pending work belongs in the
+snapshot but must not be misclassified as delivered input. Terminal ownership
+and staged/retained/discarded provenance are separate views of the same
+transition, not overlapping owners.
 
 ### 2. Make partial a normal typed outcome
 
@@ -201,26 +213,45 @@ where the first authority operation fails and the whole planned suffix remains
 pending. The prepared value carries this prospective requirement.
 
 At the begin transition, after stale/consumed/invalid validation and before any
-authority mutation, the core atomically checks and records the capacity needed
-for either complete or partial execution. The transition must then obey:
+authority mutation, the core checks the peak requirement. Registering the full
+non-discarded staged set is the current synchronous shell's one-time capacity
+reservation; successful acknowledgements only remove live pending nodes. The
+transition must obey:
 
 ```text
 complete:
-  release capacity that is no longer needed
+  all planned identities are acknowledged or duplicate; remaining pending is
+  the complete-after set
 
 partial:
-  transfer the exact uncommitted suffix's capacity to core pending
+  the exact uncommitted suffix remains in core pending with its provenance
 
 rejected before mutation:
-  change neither authority, planner membership, generation, nor capacity
+  change neither authority, planner membership, generation, nor pending policy
 ```
 
-The accounting must count unique pending membership rather than operation
-attempts. It must account for existing retained pending identities, new staged
-identities, duplicates, and discard closure. The exact formula and internal
-reservation representation are plan-review items, but a post-prefix
-`PendingLimitExceeded` is not an acceptable design: capacity failure must not
-be discovered after authority has advanced.
+The accounting must count unique live pending membership rather than operation
+attempts or stale index entries. For the current generation, the peak before
+any acknowledgement is:
+
+```text
+required_pending =
+  live_pending_before_begin
+  - discarded_pending_count
+  + new_staged_count
+```
+
+`new_staged_count` includes every unique, non-admitted, non-existing-pending,
+non-discarded staged identity, including unresolved nodes that are not in the
+compatibility-ordered `planned` list. The formula must be calculated during
+preparation and rechecked at begin. Begin validates it before removing or
+registering any planner node; registering the full staged set is the one-time
+reservation, and successful acknowledgements only decrease live pending
+membership. A post-prefix `PendingLimitExceeded` is not an acceptable design:
+capacity failure must not be discovered after authority has advanced. A
+separate mutable planner reservation counter is deferred because the current
+OpLog commit shell is synchronous and generation-invalidates interleaving
+prepared admissions.
 
 ### 4. Make ownership partitions explicit and disjoint
 
@@ -257,16 +288,21 @@ plan review before implementation:
 2. **Partial algebra:** accept `Partial` as an ordinary typed outcome carrying
    both the receipt and causal failure, while pre-mutation lifecycle and
    capacity failures remain errors.
-3. **Capacity contract:** accept a worst-case pre-mutation reservation covering
-   both complete and partial suffixes, and settle the exact required-capacity
-   formula and `PendingLimitExceeded(limit~, required~)` spelling.
-4. **Compatibility lifetime:** keep `commit_remote` as the legacy wrapper
+3. **Capacity contract:** accept the exact peak formula above, with full staged
+   registration as the current shell's one-time reservation and no independent
+   live reservation counter in P1.
+4. **Limit vocabulary:** rename the optional preparation policy from
+   `max_pending_after_complete?` to `max_pending?`, replace the complete-only
+   `PendingForecastExceeded(limit~, predicted~)` contract with
+   `PendingLimitExceeded(limit~, required~)`, and update its EGW text error
+   mapping. If API inventory finds an external caller, retain only a clearly
+   named compatibility adapter; never give one label two meanings.
+5. **Compatibility lifetime:** keep `commit_remote` as the legacy wrapper
    through P2; do not change Branch, Document, SyncSession, or Canopy callers
    in P1.
-5. **Interface delta:** permit only the intentional internal oplog generated
-   interface change for the typed capability and receipt; reject unrelated
-   `.mbti` drift.
-6. **Receipt shape:** settle the exact field names and whether identity
+6. **Interface delta:** permit only the intentional internal oplog generated
+   interface and EGW error-mapping changes; reject unrelated `.mbti` drift.
+7. **Receipt shape:** settle the exact field names and whether identity
    collections are arrays, immutable views, or another owning representation.
 
 No implementation branch should be created until these decisions are accepted.
@@ -293,34 +329,42 @@ No implementation branch should be created until these decisions are accepted.
 5. Extend the private `PreparedAdmission` representation only with data that
    is knowable before authority mutation: ordered planned identities,
    duplicate/retained/staged/discarded provenance, generation/policy evidence,
-   and the worst-case pending-capacity requirement.
+   the exact `new_staged_count`, and the worst-case `required_pending` value.
 6. Preserve non-mutating `prepare_remote`: it must not advance planner
    generation, alter pending membership, consume a capability, or reserve live
    capacity. Repeated preparation with unchanged state must produce equivalent
    prospective evidence.
 7. Add private constructors/validation that make the prepared value internally
    self-consistent and preserve defensive ownership of mutable arrays and
-   identity sets.
+   identity sets. Do not add a live `reserved` planner counter in this phase.
 8. Define the reviewed `AdmissionReceipt` and `AdmissionOutcome` values. Keep
    actual committed-prefix data out of `PreparedAdmission`.
 
 ### P1.2 — Add the hard capacity transition
 
-9. Define the unique-membership calculation for the maximum pending state over
-   every commit prefix, including first-operation failure, retained existing
-   pending work, newly staged work, duplicate identities, and rejection
-   closure.
+9. Define and test the exact unique-membership calculation:
+    `live_pending_before_begin - discarded_pending_count + new_staged_count`.
+    Include first-operation failure, retained existing pending work, every
+    unresolved staged node, duplicate identities, and rejection closure; do
+    not substitute `planned.length()` for `new_staged_count`. When
+    `max_pending?` is supplied, preparation rejects `required_pending > limit`
+    without creating a capability, and begin repeats the check for stale-safe
+    atomicity.
 10. At `begin_admission`, validate generation, single-use state, structure,
-    and required capacity before applying discard/register/consume changes.
-    A rejected begin leaves planner, generation, capacity, and authority
-    unchanged.
-11. Transfer the prospective capacity to the actual transition exactly once.
-    Complete releases unused capacity; partial transfers capacity for the
-    exact suffix retained by the planner. Add assertions preventing capacity
-    leaks, double release, and post-mutation capacity failure.
-12. Replace the complete-only forecast contract with the reviewed hard-limit
-    error semantics. Keep the compatibility mapping explicit if the error
-    variant changes.
+    and `required_pending <= max_pending?` before applying discard/register/
+    consume changes. A rejected begin leaves planner, generation, pending
+    membership, and authority unchanged.
+11. Register the complete non-discarded staged set as the one-time live
+    reservation. Complete and partial acknowledgements only remove successful
+    identities, so the live pending membership cannot grow after begin. Add
+    assertions preventing over-limit registration, lost suffixes, and
+    double-accounting; do not add a separate reservation counter unless the
+    API inventory finds reentrant admissions.
+12. Replace the complete-only forecast API with the reviewed hard-limit
+    vocabulary: `max_pending?` and
+    `PendingLimitExceeded(limit~, required~)`. Update the EGW text error
+    mapping and all P0 forecast tests without changing Document/Branch
+    behavior.
 
 ### P1.3 — Implement the typed commit capability and wrapper
 
@@ -329,9 +373,9 @@ No implementation branch should be created until these decisions are accepted.
     and construct the receipt from the exact prefix, suffix, duplicate,
     retained, staged, and discarded partitions.
 14. On a causal graph failure, return `AdmissionOutcome::Partial` with the
-    committed prefix, exact pending-after view, staged-to-pending suffix,
-    discard evidence, and causal cause. Never authorize retry of the committed
-    prefix.
+    committed prefix, exact pending-after view, uncommitted suffix with
+    staged/retained provenance, discard evidence, and causal cause. Never
+    authorize retry of the committed prefix.
 15. Keep `commit_remote` as a thin compatibility wrapper that maps complete to
     its existing array result and partial to the existing legacy error shape.
     Do not add a second planner or a second authority commit loop.
@@ -350,8 +394,8 @@ No implementation branch should be created until these decisions are accepted.
 19. Add retry-after-partial tests. Re-prepare only the exact pending suffix,
     complete it, and prove that no committed identity is attempted twice.
 20. Add stale, consumed, invalid, and capacity-rejection tests. Each must prove
-    operation count, frontier, pending membership, generation, reservation,
-    and receipt state are unchanged.
+    operation count, frontier, pending membership, generation, required-capacity
+    calculation, and receipt state are unchanged.
 21. Add duplicate and conflicting-identity tests that distinguish full payload
     equality from identity reuse. A matching duplicate is an admitted no-op;
     a conflicting identity is rejected before mutation.
@@ -361,7 +405,7 @@ No implementation branch should be created until these decisions are accepted.
 23. Add a property/model test for the ownership partition:
 
     ```text
-    delivered identities = Authority ∪ core-pending ∪ Duplicate ∪ Discarded
+    admission coverage identities = Authority ∪ core-pending ∪ Duplicate ∪ Discarded
     these sets are pairwise disjoint
     every committed identity is in Authority exactly once
     every retained suffix identity is in core pending exactly once
@@ -375,9 +419,12 @@ No implementation branch should be created until these decisions are accepted.
 
 25. Run targeted oplog tests and benchmarks, then the full EGW check/test gate.
 26. Run `moon fmt` and `moon info`; inspect every generated interface diff.
-    Accept only the intentional internal oplog typed-capability delta.
-27. Verify that Branch, Document, Text, SyncSession, wire/archive, projection,
-    and Canopy gitlink files are unchanged by the P1 implementation.
+    Accept only the intentional internal oplog typed-capability/limit delta;
+    the new error mapping must not widen unrelated public surfaces.
+27. Verify that Branch and Document behavior, SyncSession, wire/archive,
+    projection, and the Canopy gitlink are unchanged by the P1 implementation.
+    The EGW text error mapping may gain the new pending-limit variant, but no
+    text admission behavior or public Canopy API may change.
 28. Open the EGW P1 PR only after local validation. Inspect raw CI with
     `gh pr checks <NUMBER>` and do not merge while any required check is
     pending, failing, or unapproved skipped.
@@ -394,17 +441,19 @@ No implementation branch should be created until these decisions are accepted.
 - [ ] `AdmissionReceipt` exposes exact identity-level evidence for committed,
       duplicate, pending-after, staged, retained, and discarded membership,
       including the before/after frontier needed by callers.
-- [ ] The final ownership partition for every delivered identity is exactly one
-      of Authority, core pending, admitted duplicate, or discarded; no identity
-      is lost or dual-owned.
+- [ ] The final ownership partition for every admission-coverage identity is
+      exactly one of Authority, core pending, admitted duplicate, or discarded;
+      no identity is lost or dual-owned.
 - [ ] Prepare remains non-mutating, including generation, pending membership,
       live capacity, and capability consumption.
 - [ ] Stale, consumed, invalid, and pending-capacity rejection all occur before
-      authority mutation and leave authority, planner, generation, capacity,
-      and prepared lifecycle state unchanged.
-- [ ] Capacity is checked/reserved before the first authority mutation for the
-      worst complete or partial pending membership; partial suffix retention
-      cannot fail later for lack of capacity.
+      authority mutation and leave authority, planner, generation, pending
+      membership, and prepared lifecycle state unchanged.
+- [ ] Capacity uses the exact peak formula
+      `live_pending_before_begin - discarded_pending_count + new_staged_count`,
+      is checked before the first authority mutation, and registers the full
+      staged set as the current shell's one-time reservation; partial suffix
+      retention cannot fail later for lack of capacity.
 - [ ] Complete, zero-prefix partial, middle partial, and n-minus-one partial
       cases return exact receipts and preserve unrelated retained pending work.
 - [ ] Retrying a partial suffix never retries a committed identity and ends
@@ -413,9 +462,11 @@ No implementation branch should be created until these decisions are accepted.
       rejected atomically.
 - [ ] `commit_remote` remains a compatibility wrapper through P2, while the
       typed capability retains receipt information for new callers.
-- [ ] Existing Branch/Document/Text behavior and public Canopy interfaces remain
-      unchanged; no production cutover occurs in P1.
-- [ ] Only intentionally reviewed EGW internal oplog `.mbti` changes exist.
+- [ ] Existing Branch/Document behavior and public Canopy interfaces remain
+      unchanged; only the EGW text error mapping for the intentional new
+      pending-limit variant may change; no production cutover occurs in P1.
+- [ ] Only intentionally reviewed EGW internal oplog interface changes and
+      pending-limit error-mapping changes exist.
 - [ ] EGW targeted tests, `moon check --deny-warn`, `moon test`, formatting,
       interface inspection, and raw PR checks pass.
 
@@ -465,20 +516,25 @@ pending, failing, or unapproved skipped.
 - The partial commit boundary is inherently discovered during authority
   execution. Treating the partial prefix as preparation data would make the
   receipt false; keep it exclusively in `AdmissionOutcome`.
-- A capacity calculation based only on complete-after membership recreates the
-  P0 limitation. The first-operation failure case must be included before
-  `begin_admission` mutates planner or authority state.
+- A capacity calculation based only on complete-after membership, or on
+  `planned.length()`, recreates the P0 limitation. The first-operation failure
+  case must include every staged node before `begin_admission` mutates planner
+  or authority state.
 - Retained, staged, duplicate, and discarded are provenance categories, not
   four additional owners. Receipt construction must enforce disjoint final
   ownership rather than merely report overlapping counters.
+- A separate live reservation counter would create release/compaction/stale
+  invariants without a current reentrant admission need. If future execution
+  becomes asynchronous or reentrant, revisit this as a new design boundary.
 - A compatibility wrapper can hide receipt information from legacy callers.
   That is intentional through P2, but the typed capability must remain the
   canonical implementation path so P2 does not need to reconstruct history.
 - `PreparedAdmission` and receipt arrays cross package boundaries only through
   reviewed owning/immutable representations. Exposing planner-owned mutable
   collections would violate the state boundary.
-- The internal oplog `.mbti` may change for the new capability. Any unrelated
-  generated-interface change is an API regression and must stop the PR.
+- The internal oplog `.mbti` and EGW text error mapping may change for the new
+  capability/limit variant. Any unrelated generated-interface change is an API
+  regression and must stop the PR.
 - The Canopy submodule remains at its existing pointer. Mixing a local P1 EGW
   checkout into a parent commit would accidentally turn an internal capability
   experiment into a production integration change.
@@ -492,6 +548,9 @@ pending, failing, or unapproved skipped.
 - P2 may move the typed outcome through a Document batch shell and projection
   boundary. P1 must not anticipate that cutover by changing outer pending,
   publication, or Canopy-facing APIs.
-- The exact receipt field names, capacity formula, and final capability method
-  spelling are the explicit plan-review decisions listed above. Once accepted,
-  implementation must update this plan if any of them change.
+- The exact receipt field names and final capability method spelling remain the
+  explicit plan-review decisions listed above. The peak-capacity formula and
+  no-live-counter choice are now the recommended result of the alternatives
+  research; implementation must update this plan if review rejects either.
+- The alternatives and source citations are recorded in
+  `docs/research/2026-08-15-egw-p1-admission-transition-options.md`.

--- a/docs/plans/2026-08-15-egw-p1-typed-admission-transition.md
+++ b/docs/plans/2026-08-15-egw-p1-typed-admission-transition.md
@@ -161,9 +161,11 @@ names remain a plan-review decision, but its semantic contents are not optional:
 
 - committed operations and their `RawVersion` identities;
 - `already_admitted` identities accepted as authority-owned no-ops;
-- `pending_from_transition` identities whose terminal owner is core pending,
-  including the exact retained/staged uncommitted suffix and any pending
-  identity delivered as a no-op, represented at most once;
+- `pending_from_transition` identities whose terminal owner is still core
+  pending after the actual commit attempt, including the exact retained/staged
+  uncommitted suffix; a `duplicate_of_pending` identity appears here only if
+  it remains pending after the attempt, never merely because of its arrival
+  provenance;
 - discarded identities split into `discarded_pending` and `discarded_staged`;
 - `pending_before_count` and `pending_after_count`, counting unique live
   pending membership without copying unrelated pending identities;
@@ -210,6 +212,16 @@ a fallible post-mutation step. Terminal ownership and
 staged/retained/discarded provenance are separate views of the same transition,
 not overlapping owners.
 
+### Receipt collection ordering
+
+Receipt arrays are deterministic for diagnostics, but their element order is
+not part of the P1 contract. Callers must treat identity collections as sets
+unless an accessor explicitly documents an ordering guarantee. The commit loop
+may still execute `PreparedAdmission::operations()` in prepared order; that
+implementation order must not silently become a public receipt-order promise.
+This leaves P2 free to change planner collection mechanics without changing
+semantic ownership.
+
 ### 2. Make partial a normal typed outcome
 
 The new core capability should be shaped as:
@@ -245,6 +257,37 @@ It delegates to the typed capability. A complete outcome returns committed
 operations. A partial outcome is translated back to the existing
 `PartialRemoteAdmission` error for legacy callers; the new typed path retains
 the full receipt. No `Document` or `Branch` migration belongs in P1.
+
+### Close the post-begin error algebra
+
+`commit_admission` has a phase-indexed error boundary:
+
+```text
+before begin_admission succeeds / the internal result is Applied:
+  lifecycle, structure, and pending-limit failures may raise OpLogError
+
+after begin_admission succeeds with Applied:
+  commit_admission returns AdmissionOutcome::Complete or
+  AdmissionOutcome::Partial
+```
+
+No recoverable `OpLogError` may escape after the planner transition has been
+applied or after an authority prefix may have been committed. Prefer a private
+post-begin seam equivalent to
+`(@core.Op) -> @core.Op raise @causal_graph.CausalGraphError`; if the existing
+production adapter still has a wider error type, translate supposedly
+impossible variants to an invariant defect at that boundary. The post-begin
+commit seam is narrowed to `CausalGraphError`, which becomes
+`AdmissionOutcome::Partial`. Any other supposedly impossible internal error is
+an invariant defect and must not be exposed as an ordinary recoverable
+`OpLogError`; if a real recoverable post-begin condition is discovered, P1 must
+add an explicit `AdmissionOutcome` variant before allowing it to escape.
+
+The legacy `commit_remote` wrapper may translate a returned `Partial` outcome
+into `PartialRemoteAdmission` after the canonical typed capability has produced
+its receipt. That compatibility translation is outside the typed capability's
+post-begin guarantee and must not be implemented as an unstructured error from
+`commit_admission` itself.
 
 ### 3. Validate the pending-membership precondition
 
@@ -331,19 +374,24 @@ pending          → core pending
 discarded        → no owner
 ```
 
-`already_admitted` is the authority-owned disposition for an incoming matching
-identity. A matching pending identity belongs to `pending`, not to a generic
-duplicate owner. Delivery evidence may distinguish:
+`already_admitted` is the authority-owned terminal category for an incoming
+matching identity. A duplicate of a pending identity is delivery evidence only;
+its final ownership is determined by the actual outcome. Delivery evidence may
+distinguish:
 
 ```text
-already-admitted duplicate  → identity is in already_admitted
-pending duplicate           → identity is in pending
-same-batch duplicate        → occurrence evidence only
+already-admitted duplicate  → duplicate_of_admitted evidence;
+                               terminal identity is already_admitted
+pending duplicate           → duplicate_of_pending evidence only;
+                               terminal identity is committed, pending, or discarded
+same-batch duplicate        → same_batch_duplicate evidence only
 ```
 
-Same-batch duplicate occurrences and retransmission counts are separate
-delivery evidence; they may record coalescing or duplicate provenance but
-never create another identity set in the ownership partition.
+Duplicate occurrence counts and provenance never create another identity set in
+the ownership partition. In particular, a pending duplicate that is awakened
+by a dependency in the same admission is placed in `committed` if it commits,
+in `pending` only if it remains uncommitted, and in `discarded` if rejection
+closure removes it.
 
 `retained`, `staged`, and `discarded` are provenance partitions used to explain
 how an affected identity reached its final category; they must not create a
@@ -352,8 +400,10 @@ second owner. In particular:
 - a committed identity is never also retained or retried;
 - an admitted duplicate is not re-committed and is represented in
   `already_admitted` at most once;
-- a pending duplicate is represented in `pending` at most once, with any
-  duplicate occurrence evidence kept separately;
+- a duplicate of a pending identity is represented in `pending_from_transition`
+  only when it remains pending after the commit attempt; if it commits or is
+  discarded, it appears only in that terminal category, with duplicate
+  provenance kept separately;
 - the partial suffix is the exact uncommitted suffix of
   `PreparedAdmission::operations()` and may contain both retained-pending and
   newly staged provenance;
@@ -416,7 +466,8 @@ plan review before implementation:
    committed, `already_admitted`, `pending_from_transition`, discarded
    provenance, global pending before/after counts, and receipt-owned frontier
    snapshots. No complete global pending identity snapshot or planner-owned
-   view may escape.
+   view may escape. Array order is deterministic but non-contractual unless an
+   accessor explicitly documents otherwise.
 
 No implementation branch should be created until these decisions are accepted.
 
@@ -492,40 +543,50 @@ No implementation branch should be created until these decisions are accepted.
     evidence, `pending_after_count`, owning frontier snapshot, and causal
     cause. Never authorize retry of the committed prefix.
 15. Keep `commit_remote` as a thin compatibility wrapper that maps complete to
-    its existing array result and partial to the existing legacy error shape.
+    its existing array result and translates a typed partial outcome to the
+    existing legacy error shape only after the typed receipt is constructed.
     Do not add a second planner or a second authority commit loop.
-16. Confirm that all semantic decisions, discard closure, pending-limit checks,
+16. Narrow the post-begin commit seam to `CausalGraphError` →
+    `AdmissionOutcome::Partial`. Any other supposedly impossible internal
+    error is an invariant defect, not a recoverable `OpLogError`; add an
+    explicit outcome variant before admitting any real recoverable case.
+17. Confirm that all semantic decisions, discard closure, pending-limit checks,
     and ownership transfers occur before the first authority mutation or are
     deterministic acknowledgements of an already committed prefix.
 
 ### P1.4 — Close exact ownership and lifecycle properties
 
-17. Add complete-admission tests with admitted duplicates, pending duplicates,
+18. Add complete-admission tests with admitted duplicates, pending duplicates,
     retained pending work, staged arrivals, invalid-root discard, and no
-    pending suffix. A pending duplicate must remain a pending no-op rather than
-    being misclassified as an admitted duplicate.
-18. Add partial tests for zero-prefix failure, middle-prefix failure, and
+    pending suffix. Split pending-duplicate coverage into two cases:
+    an unresolved pending duplicate remains pending, while a pending duplicate
+    awakened by a dependency and committed is `committed` with duplicate
+    provenance retained only as delivery evidence. Add the discarded case if
+    rejection closure invalidates the awakened identity.
+19. Add partial tests for zero-prefix failure, middle-prefix failure, and
     n-minus-one-prefix failure. Each test must assert committed operations,
     exact suffix identities, pending-from-transition membership,
     staged/retained provenance, discarded identities, before/after counts,
     required-pending value, and causal cause. White-box assertions may compare the complete
     planner pending maps; the receipt must not copy them.
-19. Add core-owned recovery tests after partial admission. The suffix is
+20. Add core-owned recovery tests after partial admission. The suffix is
     already in core pending: re-plan it with `prepare_remote([])` or with a
     later dependency-bearing batch, and prove that no committed identity is
     attempted twice. Add network-resend idempotence as a separate test; do not
     make reconstructing and resending the receipt suffix the recovery protocol.
-20. Add stale, consumed, invalid, and pending-limit-rejection tests. Each must prove
+21. Add stale, consumed, invalid, and pending-limit-rejection tests. Each must prove
     operation count, frontier, pending membership, generation, required-pending
-    calculation, and receipt state are unchanged.
-21. Add duplicate and conflicting-identity tests that distinguish full payload
+    calculation, and receipt state are unchanged. Exercise the post-begin seam
+    with causal failure and assert that no non-causal recoverable `OpLogError`
+    can escape after `Applied`.
+22. Add duplicate and conflicting-identity tests that distinguish full payload
     equality from identity reuse. A matching duplicate is an admitted no-op;
     a conflicting identity is rejected before mutation.
-22. Add unrelated-retained tests that prove pending work outside the current
+23. Add unrelated-retained tests that prove pending work outside the current
     rejection closure remains intact. Compare planner pending membership in
     white-box tests and assert only the before/after counts appear in the
     production receipt.
-23. Add a property/model test for the ownership partition:
+24. Add a property/model test for the ownership partition:
 
     ```text
     affected identities = committed ∪ already_admitted ∪ pending ∪ discarded
@@ -538,24 +599,24 @@ No implementation branch should be created until these decisions are accepted.
     Track same-batch duplicate occurrences and pending retransmissions only as
     separate delivery evidence; never add them to the ownership partition.
 
-24. Preserve existing planner fixed-point, atomic rejection, alias-mutation,
+25. Preserve existing planner fixed-point, atomic rejection, alias-mutation,
     and ancestry regressions from P0. The new typed receipt must agree with the
     existing planner state and compatibility wrapper.
 
 ### P1.5 — Validate the internal capability without production cutover
 
-25. Run targeted oplog tests and benchmarks, then the full EGW check/test gate.
-26. Run `moon fmt` and `moon info`; inspect every generated interface diff.
+26. Run targeted oplog tests and benchmarks, then the full EGW check/test gate.
+27. Run `moon fmt` and `moon info`; inspect every generated interface diff.
     Accept only the intentional internal oplog typed-capability/limit delta;
     the new error mapping must not widen unrelated public surfaces.
-27. Verify that Branch and Document behavior, SyncSession, wire/archive,
+28. Verify that Branch and Document behavior, SyncSession, wire/archive,
     projection, and the Canopy gitlink are unchanged by the P1 implementation.
     The EGW text error mapping may gain the new pending-limit variant, but no
     text admission behavior or public Canopy API may change.
-28. Open the EGW P1 PR only after local validation. Inspect raw CI with
+29. Open the EGW P1 PR only after local validation. Inspect raw CI with
     `gh pr checks <NUMBER>` and do not merge while any required check is
     pending, failing, or unapproved skipped.
-29. After merge, record the P1 merge SHA and validation evidence in issue
+30. After merge, record the P1 merge SHA and validation evidence in issue
     #1256. Start P2 only from that updated EGW `main`.
 
 ## Acceptance Criteria
@@ -566,11 +627,21 @@ No implementation branch should be created until these decisions are accepted.
       actual transitions; partial carries a common receipt and causal cause as
       a normal value, while receipt status/cause fields cannot contradict the
       enum variant.
+- [ ] Before `begin_admission` succeeds with the internal `Applied` result,
+      `commit_admission` may raise only pre-mutation `OpLogError` variants.
+      After `Applied`, every non-defect exit returns `Complete` or `Partial`;
+      no recoverable `OpLogError` can hide an applied planner transition or a
+      committed prefix.
+- [ ] `pending_from_transition` contains only identities that remain core
+      pending after the actual attempt; pending-duplicate provenance never
+      determines terminal ownership.
 - [ ] `AdmissionReceipt` exposes only transition-local owning evidence:
       committed, `already_admitted`, `pending_from_transition`, discarded
       provenance, unique pending before/after counts, and receipt-owned
       before/after frontier snapshots. It never copies the complete global
-      pending identity set or returns a planner-owned view.
+      pending identity set or returns a planner-owned view. Identity-array
+      order is deterministic but non-contractual unless explicitly documented
+      by an accessor.
 - [ ] The affected identity partition is exactly
       `committed ∪ already_admitted ∪ pending ∪ discarded`; these sets are
       pairwise disjoint, with committed/already-admitted owned by Authority,
@@ -662,6 +733,10 @@ pending, failing, or unapproved skipped.
 - A separate mutable pending-limit state would add invariants without a
   current reentrant admission need. If future execution becomes asynchronous
   or reentrant, revisit this as a new design boundary.
+- A wider post-begin callback error can hide an applied planner transition or
+  committed prefix if it escapes as ordinary `OpLogError`. Narrow the seam to
+  `CausalGraphError`, classify impossible variants as invariant defects, and
+  add an outcome variant before admitting a real recoverable case.
 - A compatibility wrapper can hide receipt information from legacy callers.
   That is intentional through P2, but the typed capability must remain the
   canonical implementation path so P2 does not need to reconstruct history.

--- a/docs/research/2026-08-15-egw-p1-admission-transition-options.md
+++ b/docs/research/2026-08-15-egw-p1-admission-transition-options.md
@@ -3,7 +3,7 @@
 ## Question
 
 Is the draft P1 design — prospective `PreparedAdmission`, actual typed
-`AdmissionOutcome`, and a hard complete/partial pending budget — the best
+`AdmissionOutcome`, and a hard pending-membership precondition — the best
 boundary for EGW, or is a simpler or safer design available?
 
 This note records the investigation before the P1 plan is accepted. It is
@@ -46,7 +46,7 @@ Primary external sources:
 The paper and reference implementation support keeping event-graph admission
 and transient merge/projection state separate: the event graph is immutable,
 and the prepare/effect versions belong to the merge walker rather than to a
-pending-admission receipt. Neither primary source specifies a pending budget,
+pending-admission receipt. Neither primary source specifies a pending limit,
 partial authority-commit result, or Document/Branch compatibility wrapper.
 They therefore validate the phase boundary but do not provide a better P1
 receipt or capacity contract to import.
@@ -71,10 +71,12 @@ P0 also distinguishes duplicate delivery from ownership: a matching admitted
 identity is accepted by `preflight_remote_identities` and is not staged, while a
 matching identity already in planner pending is also skipped by preparation and
 remains canonical pending (`oplog.mbt:310-325`,
-`remote_admission_planner.mbt:996-1025`). A receipt must therefore classify
-incoming occurrences separately from terminal RawVersion ownership.
+`remote_admission_planner.mbt:996-1025`). Same-batch duplicate occurrences are
+a third delivery-level case; they may be coalesced without creating another
+identity owner. A receipt must therefore classify incoming occurrences
+separately from terminal RawVersion ownership.
 
-### The exact worst-case pending peak is larger than the planned count
+### The exact begin-after pending membership is larger than the planned count
 
 At begin, P0 registers every non-discarded staged node, not only operations in
 `plan.planned`. The `ImmediateGeneral` path builds `staged_nodes` from every
@@ -83,56 +85,61 @@ registers every one before the commit loop (`:1320-1390`). The fast path registe
 every planned operation (`:909-968`, `:1250-1290`).
 
 A first-operation causal failure leaves all registered, unacknowledged nodes in
-pending. Consequently, for one generation-bound plan:
+pending. Because retained planned operations already belong to pending, while
+new staged identities exclude existing pending identities, the exact
+begin-after requirement is:
 
 ```text
-peak_pending_before_ack =
-  live_pending_before_begin
-  - discarded_pending_count
-  + new_staged_count
+required_pending = count_unique(
+  (pending_before - discarded_pending)
+  ∪ staged_unique_not_admitted_not_discarded
+)
 ```
 
-Here `new_staged_count` means the unique, non-admitted, non-existing-pending,
-non-discarded staged identities materialized by the prepared storage. It is not
-`planned.length()` in the general path: unresolved staged nodes are registered
-and remain pending even though they are not in the commit order. This formula
-uses live canonical membership (`pending.length()`), not stale queue/waiter
-references; P0 removes canonical nodes immediately and compacts only disposable
-indexes (`remote_admission_planner.mbt:519-537`, `:1443-1520`).
+The equivalent shorthand is
+`live_pending_before - discarded_pending_count + new_staged_count` when the
+sets are normalized as above. `new_staged_count` means the unique,
+non-admitted, non-existing-pending, non-discarded staged identities materialized
+by prepared storage. It is not `planned.length()` in the general path:
+unresolved staged nodes are registered and remain pending even though they are
+not in the commit order. This calculation uses live canonical membership
+(`pending.length()`), not stale queue/waiter references; P0 removes canonical
+nodes immediately and compacts only disposable indexes
+(`remote_admission_planner.mbt:519-537`, `:1443-1520`).
 
 The complete-after membership is different. `remaining_raws` excludes planned
 identities and discarded identities, then includes retained pending and
 unplanned staged identities (`remote_admission_planner.mbt:1557-1590`). P0's
 `max_pending_after_complete` checks this smaller set and explicitly allows a
 partial suffix to exceed it (`oplog.mbt:348-351`,
-`oplog_semantic_parity_wbtest.mbt:475-526`).
+`oplog_semantic_parity_wbtest.mbt:475-526`). P1 should instead check the
+begin-after requirement before authority mutation.
 
-### A separate live reservation counter is not required by the current shell
+### A separate mutable pending-limit state is not required by the current shell
 
-P0 has one synchronous `OpLog` commit shell: begin registers the full
-prospective pending membership, then the commit loop can only remove pending
-nodes through successful acknowledgement. Generation invalidation prevents a
-second prepared admission from using the same planner state
+P0 has one synchronous `OpLog` commit shell: begin applies the full prospective
+pending transition, then the commit loop can only remove pending nodes through
+successful acknowledgement. Generation invalidation prevents a second prepared
+admission from using the same planner state
 (`remote_admission_planner.mbt:590-631`, `:1201-1398`). The production commit
 callback is the local graph/log operation (`oplog.mbt:472-486`); it does not
 re-enter another admission.
 
-Therefore the safest minimal hard-budget implementation is:
+Therefore the safest minimal hard pending-limit implementation is:
 
 1. prepare calculates and stores `required_pending` plus the optional hard
    `max_pending?` policy in the opaque prepared value;
-2. begin revalidates the plan and checks
-   `required_pending <= max_pending?` before any planner mutation;
-3. registering all staged nodes is the reservation itself;
-4. successful acknowledgements monotonically release live pending membership;
-5. complete and partial results need no independent reserved counter.
+2. begin revalidates the plan and checks the exact requirement against the bound
+   before any planner mutation;
+3. after begin, all successful acknowledgements monotonically decrease live
+   pending membership and commit never adds a pending identity;
+4. complete and partial results need no additional mutable pending-limit state.
 
-A mutable planner `reserved` field would add release, compaction, stale-plan,
-and rejection bookkeeping without covering a currently possible interleaving.
-It should be deferred unless a future asynchronous/reentrant admission shell
-requires simultaneous transitions. This keeps the core functional decision
-(`required_pending`) separate from shell state and avoids a new reservation
-leak state.
+A mutable planner budget field would add invariants for compaction, rejection,
+stale plans, and lifecycle changes without covering a currently possible
+interleaving. It should be deferred unless a future asynchronous/reentrant
+admission shell requires simultaneous transitions. This keeps the core
+functional decision (`required_pending`) separate from shell state.
 
 ## Alternatives
 
@@ -174,15 +181,15 @@ parallel `PreMutationError` would duplicate `StaleAdmission`,
 require adapters in every caller. Keep pre-mutation failures as `raise
 OpLogError`; make only partial a normal `AdmissionOutcome` value.
 
-### E. Reserve a mutable planner budget counter — defer
+### E. Add mutable planner pending-limit state — defer
 
-A live `reserved` counter models a future concurrent/reentrant shell, but the
-current synchronous begin/register/acknowledge lifecycle already makes the
-registered pending nodes the reservation. The counter creates new invariants
-for `compact`, `reject_pending_members`, `acknowledge_admitted`, stale plans,
-and partial transfer. It is not justified by current execution semantics.
+A live budget field models a future concurrent/reentrant shell, but the current
+synchronous begin/register/acknowledge lifecycle already proves the bound from
+actual pending membership. The field creates new invariants for `compact`,
+`reject_pending_members`, `acknowledge_admitted`, stale plans, and partial
+transfer. It is not justified by current execution semantics.
 
-### F. Keep P0's forecast API and add a second hard-budget API — reject
+### F. Keep P0's forecast API and add a second hard-limit API — reject
 
 Keeping `max_pending_after_complete?` and adding another optional hard limit
 would preserve compatibility but create two similarly named policies on one
@@ -208,47 +215,57 @@ adapter; do not overload one argument with two meanings.
 ## Recommended P1 boundary
 
 The investigation finds no better overall architecture than Alternative A,
-but it finds two required corrections to the draft Plan:
+but it finds four required corrections to the draft Plan:
 
-1. **Use the exact peak formula.** Capacity must be based on all registered
-   staged nodes, not planned operations. Add a red test with a ready prefix and
+1. **Use the exact begin-after membership formula.** The hard precondition must
+   be based on the normalized set of live pending plus every unique staged
+   identity, not planned operations. Add a red test with a ready prefix and
    unresolved staged suffix where `planned.length() < new_staged_count`.
-2. **Do not add a live reservation counter yet.** Store the prospective
-   `required_pending` in `PreparedAdmission`; at begin, atomically gate and
-   register the complete staged set. The live planner pending map is the
-   reservation for the current synchronous shell.
+2. **Do not add mutable pending-limit state.** Store prospective
+   `required_pending` in `PreparedAdmission`; begin checks it before mutation,
+   and the commit loop proves monotonic non-increase afterward.
+3. **Keep receipts transition-local.** Do not copy the complete global pending
+   identity set. Own defensive snapshots for committed,
+   `already_admitted`, `pending_from_transition`, discarded provenance,
+   before/after counts, and before/after frontiers.
+4. **Make recovery core-owned.** A partial suffix is already pending; recovery
+   re-plans it through the core planner. Network resend idempotence is a
+   separate property, not the normal recovery protocol.
 
-The receipt should be opaque and immutable at the package boundary. It should
-separate incoming-occurrence disposition from canonical ownership:
+The receipt should be opaque and immutable at the package boundary. Its
+identity partition is:
 
 ```text
-incoming disposition (disjoint):
-  NewlyCommitted | DuplicateOfAuthority | Pending | Discarded
-
-canonical ownership (disjoint):
-  Authority | core pending | discarded
-
-provenance (not additional owners):
-  retained pending | staged | discarded-pending | discarded-staged
+affected identities = committed ∪ already_admitted ∪ pending ∪ discarded
+these four sets are pairwise disjoint
 ```
 
-A matching duplicate is already owned by Authority; `DuplicateOfAuthority` is
-non-owning evidence about the incoming occurrence, not a second RawVersion
-owner. The exact field names remain a plan-review decision, but receipt
-construction must be derived from the prepared provenance plus before/after
-planner/frontier snapshots, not from a second planner or a full-history replay.
+Canonical ownership maps committed and already-admitted identities to
+Authority, pending identities to core pending, and discarded identities to no
+owner. A matching duplicate is already owned by Authority; same-batch duplicate
+occurrences and pending retransmissions are auxiliary delivery evidence, not
+identity owners. Retained/staged/discarded categories are provenance axes.
+Receipt arrays must be owning snapshots, with accessors allowed to return
+views over receipt-owned storage only.
 
-### ADR 0008 wording clarification
+### ADR 0008 amendment prerequisite
 
 ADR 0008's accepted P1 sentence says that the "prepared admission" records
 committed, retained, discarded, duplicate, and partial ownership. The P0 code
 and the actual commit boundary prove that a prospective prepared value cannot
-contain a committed prefix. The P1 implementation must therefore add a
-**docs-only clarification to ADR 0008**, not a new ADR: the phrase names the
-complete single-use transition capability (`PreparedAdmission` plus its actual
-`AdmissionOutcome`), while `PreparedAdmission` itself remains prospective and
-`AdmissionOutcome` owns post-commit facts. This resolves the wording without
-changing the accepted P1/P2 sequencing.
+contain a committed prefix. Before creating the P1 implementation branch, a
+separate EGW docs-only amendment must update ADR 0008 to say:
+
+```text
+P1 — typed transition boundary:
+PreparedAdmission records the prospective, generation-bound transition.
+AdmissionOutcome and AdmissionReceipt record the actual complete or partial
+ownership result after the commit attempt.
+The boundary owns the hard pending-limit contract.
+```
+
+This preserves the accepted architecture decision without silently reading new
+meaning into the old wording and does not create a new ADR.
 
 ## Existing API reuse
 
@@ -258,16 +275,18 @@ Source-verified candidates:
   order (`remote_admission_planner.mbt:1541-1545`);
 - `PreparedAdmission::remaining_raws(planner)` for complete-after comparison
   (`:1557-1590`), not as the hard peak formula;
-- `RemoteAdmissionPlanner::pending_raws()` for live pending snapshots
-  (`:1601-1611`);
+- `RemoteAdmissionPlanner::pending_raws()` for white-box before/after
+  assertions (`:1601-1611`), not for copying the complete pending set into a
+  production receipt;
 - `RemoteAdmissionPlanner::begin_with_semantics` as the one validation and
   registration boundary (`:1201-1398`);
 - `acknowledge_admitted` for monotonic pending removal and waiter wake-up
   (`:590-631`);
 - `reject_pending_members` for the existing rejection closure partition
   (`:668-683`);
-- `OpLog::get_frontier_raw()` for before/after frontier evidence
-  (`oplog.mbt:253-267`);
+- `OpLog::get_frontier()` for non-fallible before/after
+  `@core.Frontier` snapshots (`oplog.mbt:253-267`); `get_frontier_raw()` remains
+  available only when a caller explicitly needs raw identities;
 - `ArrayView::to_owned`, `ArrayView::iter`, `HashSet::to_array`, and
   `HashSet::is_disjoint` for immutable receipt construction and property tests.
 
@@ -276,8 +295,9 @@ Checked but not selected:
 - `Result`: not selected as a second public pre-mutation error algebra because
   `OpLogError` already owns the typed raised boundary;
 - `Option`: useful for optional `max_pending?`, but not a transition result;
-- `@core.Frontier`: retained as the authority's internal frontier, while the
-  receipt exposes copied `RawVersion` evidence through existing conversion;
+- `@core.Frontier`: selected for the receipt's non-fallible owning
+  before/after frontier fields; raw-identity conversion must not be a fallible
+  post-mutation receipt step;
 - `@immut/hashset`: not selected for the receipt because an opaque receipt with
   read-only `ArrayView` accessors matches current `PreparedAdmission` and
   preserves deterministic order; use immutable sets only if review finds a
@@ -287,8 +307,10 @@ Checked but not selected:
 ## Conclusion
 
 Alternative A remains the recommendation. The better version is a minimal,
-serialized transition: exact peak requirement in the prepared capability,
-atomic begin-time capacity gate, full staged registration as the reservation,
-monotonic acknowledgement, and a typed immutable actual outcome. This closes
-P1's ownership gap without inventing a second planner, live reservation state,
-parallel error algebra, or premature Document/Canopy migration.
+serialized transition: exact begin-after pending-membership precondition in the
+prepared capability, atomic begin-time validation, monotonic acknowledgement,
+transition-local owning receipt snapshots, and a typed immutable actual outcome.
+Partial recovery remains core-owned, while duplicate occurrence evidence stays
+separate from identity ownership. This closes P1's ownership gap without
+inventing a second planner, mutable pending-limit state, parallel error
+algebra, or premature Document/Canopy migration.

--- a/docs/research/2026-08-15-egw-p1-admission-transition-options.md
+++ b/docs/research/2026-08-15-egw-p1-admission-transition-options.md
@@ -69,12 +69,15 @@ truthful field of the prepared value.
 
 P0 also distinguishes duplicate delivery from ownership: a matching admitted
 identity is accepted by `preflight_remote_identities` and is not staged, while a
-matching identity already in planner pending is also skipped by preparation and
-remains canonical pending (`oplog.mbt:310-325`,
-`remote_admission_planner.mbt:996-1025`). Same-batch duplicate occurrences are
-a third delivery-level case; they may be coalesced without creating another
-identity owner. A receipt must therefore classify incoming occurrences
-separately from terminal RawVersion ownership.
+matching identity already in planner pending is skipped by preparation
+(`oplog.mbt:310-325`, `remote_admission_planner.mbt:996-1025`). The latter is
+only `duplicate_of_pending` delivery evidence. If a dependency in the same
+admission wakes that pending node, the actual commit attempt can place it in
+Authority, leave it in core pending after a partial prefix, or discard it by
+rejection closure. Same-batch duplicate occurrences are a third delivery-level
+case; they may be coalesced without creating another identity owner. A receipt
+must therefore classify incoming occurrences separately from terminal
+RawVersion ownership.
 
 ### The exact begin-after pending membership is larger than the planned count
 
@@ -156,6 +159,14 @@ ownership evidence, keeps partial non-rollback, and does not move Document or
 Branch in P1. It also uses MoonBit's exhaustive enum matching rather than
 encoding complete/partial in nullable fields or strings.
 
+The typed capability must close its post-begin error algebra: lifecycle,
+structure, and pending-limit failures may raise before the internal begin result
+is `Applied`; after `Applied`, the capability returns `Complete` or `Partial`.
+The post-begin commit seam is narrowed to `CausalGraphError`, and any other
+supposedly impossible internal error is an invariant defect rather than an
+ordinary recoverable `OpLogError`. The legacy wrapper may translate a returned
+partial outcome into its historical error after the typed receipt exists.
+
 ### B. Put the committed prefix into `PreparedAdmission` — reject
 
 This is impossible without making preparation a speculative mutable commit or
@@ -228,6 +239,9 @@ but it finds four required corrections to the draft Plan:
    identity set. Own defensive snapshots for committed,
    `already_admitted`, `pending_from_transition`, discarded provenance,
    before/after counts, and before/after frontiers.
+   `pending_from_transition` contains a duplicate-of-pending identity only when
+   it remains pending after the attempt; delivery provenance alone never
+   determines the field.
 4. **Make recovery core-owned.** A partial suffix is already pending; recovery
    re-plans it through the core planner. Network resend idempotence is a
    separate property, not the normal recovery protocol.
@@ -246,7 +260,10 @@ owner. A matching duplicate is already owned by Authority; same-batch duplicate
 occurrences and pending retransmissions are auxiliary delivery evidence, not
 identity owners. Retained/staged/discarded categories are provenance axes.
 Receipt arrays must be owning snapshots, with accessors allowed to return
-views over receipt-owned storage only.
+views over receipt-owned storage only. Their order is deterministic for
+diagnostics but non-contractual; callers treat them as sets unless an accessor
+explicitly documents order. This avoids turning current planner iteration order
+into a P2 compatibility constraint.
 
 ### ADR 0008 amendment prerequisite
 
@@ -300,8 +317,8 @@ Checked but not selected:
   post-mutation receipt step;
 - `@immut/hashset`: not selected for the receipt because an opaque receipt with
   read-only `ArrayView` accessors matches current `PreparedAdmission` and
-  preserves deterministic order; use immutable sets only if review finds a
-  membership-query requirement;
+  provides deterministic diagnostics without making order contractual; use
+  immutable sets only if review finds a membership-query requirement;
 - `@rle.Rle`: not relevant to identity ownership accounting.
 
 ## Conclusion

--- a/docs/research/2026-08-15-egw-p1-admission-transition-options.md
+++ b/docs/research/2026-08-15-egw-p1-admission-transition-options.md
@@ -1,0 +1,270 @@
+# P1 admission-transition alternatives research
+
+## Question
+
+Is the draft P1 design — prospective `PreparedAdmission`, actual typed
+`AdmissionOutcome`, and a hard complete/partial pending budget — the best
+boundary for EGW, or is a simpler or safer design available?
+
+This note records the investigation before the P1 plan is accepted. It is
+research, not an implementation authorization.
+
+## Sources inspected
+
+Primary local sources:
+
+- EGW P0 merge [PR #118](https://github.com/dowdiness/event-graph-walker/pull/118)
+  and merge commit
+  [`99ab590`](https://github.com/dowdiness/event-graph-walker/commit/99ab59012a31abb8454468509dd790be03c3b391).
+- `internal/oplog/remote_admission_planner.mbt`: the P0 planner state,
+  preparation overlay, begin transition, acknowledgement, and remaining
+  membership.
+- `internal/oplog/oplog.mbt`: `prepare_remote`, `begin_admission`, the
+  operation-by-operation commit shell, and `commit_remote`.
+- `internal/oplog/errors.mbt`: P0 lifecycle, forecast, and partial variants.
+- `internal/oplog/remote_admission_oracle_wbtest.mbt`: the fixed-point
+  ownership/order oracle.
+- `internal/oplog/oplog_semantic_parity_wbtest.mbt`: the complete-only P0
+  forecast contract and partial regression.
+- ADR 0003: Recoverable Edit Atomicity versus non-rollback CRDT convergence.
+- ADR 0004: the planner as the sole pending owner and the prepared-capability
+  lifecycle.
+- ADR 0005: full-payload identity conflict handling.
+- ADR 0008: the accepted P0/P1/P2/P3 boundary.
+- MoonBit API inspection from the P0 module: `ArrayView`, mutable and
+  immutable `HashSet`, `Iter`, `Result`, `Option`, and `@core.Frontier`.
+
+Primary external sources:
+
+- [Collaborative Text Editing with Eg-walker: Better, Faster, Smaller](https://arxiv.org/html/2409.14252v1), especially the event-graph and
+  prepare/effect-version separation.
+- [Eg-walker reference implementation](https://github.com/josephg/eg-walker-reference),
+  as linked by the paper.
+
+## Facts that constrain P1
+
+The paper and reference implementation support keeping event-graph admission
+and transient merge/projection state separate: the event graph is immutable,
+and the prepare/effect versions belong to the merge walker rather than to a
+pending-admission receipt. Neither primary source specifies a pending budget,
+partial authority-commit result, or Document/Branch compatibility wrapper.
+They therefore validate the phase boundary but do not provide a better P1
+receipt or capacity contract to import.
+
+### Prepared state and commit state are different facts
+
+P0's `PreparedAdmission` contains `planned`, `storage`, discard roots,
+discarded-pending and discarded-staged sets, `next_arrival`, a generation, and
+single-use state (`remote_admission_planner.mbt:74-83`). It has no committed
+prefix. `prepare_remote` only constructs this value and checks the P0
+complete-transition forecast (`oplog.mbt:348-375`).
+
+`begin_with_semantics` validates generation, single-use, staged payloads,
+waiting metadata, and compatibility order before it removes discarded pending
+nodes or registers staged nodes (`remote_admission_planner.mbt:1201-1398`).
+`commit_remote_with` then acknowledges each identity only after the operation
+commit succeeds and raises `PartialRemoteAdmission` on a later causal-graph
+failure (`oplog.mbt:434-470`). Therefore the committed prefix cannot be a
+truthful field of the prepared value.
+
+### The exact worst-case pending peak is larger than the planned count
+
+At begin, P0 registers every non-discarded staged node, not only operations in
+`plan.planned`. The `ImmediateGeneral` path builds `staged_nodes` from every
+non-discarded overlay node (`remote_admission_planner.mbt:1150-1185`) and
+registers every one before the commit loop (`:1320-1390`). The fast path registers
+every planned operation (`:909-968`, `:1250-1290`).
+
+A first-operation causal failure leaves all registered, unacknowledged nodes in
+pending. Consequently, for one generation-bound plan:
+
+```text
+peak_pending_before_ack =
+  live_pending_before_begin
+  - discarded_pending_count
+  + new_staged_count
+```
+
+Here `new_staged_count` means the unique, non-admitted, non-existing-pending,
+non-discarded staged identities materialized by the prepared storage. It is not
+`planned.length()` in the general path: unresolved staged nodes are registered
+and remain pending even though they are not in the commit order. This formula
+uses live canonical membership (`pending.length()`), not stale queue/waiter
+references; P0 removes canonical nodes immediately and compacts only disposable
+indexes (`remote_admission_planner.mbt:519-537`, `:1443-1520`).
+
+The complete-after membership is different. `remaining_raws` excludes planned
+identities and discarded identities, then includes retained pending and
+unplanned staged identities (`remote_admission_planner.mbt:1557-1590`). P0's
+`max_pending_after_complete` checks this smaller set and explicitly allows a
+partial suffix to exceed it (`oplog.mbt:348-351`,
+`oplog_semantic_parity_wbtest.mbt:475-526`).
+
+### A separate live reservation counter is not required by the current shell
+
+P0 has one synchronous `OpLog` commit shell: begin registers the full
+prospective pending membership, then the commit loop can only remove pending
+nodes through successful acknowledgement. Generation invalidation prevents a
+second prepared admission from using the same planner state
+(`remote_admission_planner.mbt:590-631`, `:1201-1398`). The production commit
+callback is the local graph/log operation (`oplog.mbt:472-486`); it does not
+re-enter another admission.
+
+Therefore the safest minimal hard-budget implementation is:
+
+1. prepare calculates and stores `required_pending` plus the optional hard
+   `max_pending?` policy in the opaque prepared value;
+2. begin revalidates the plan and checks
+   `required_pending <= max_pending?` before any planner mutation;
+3. registering all staged nodes is the reservation itself;
+4. successful acknowledgements monotonically release live pending membership;
+5. complete and partial results need no independent reserved counter.
+
+A mutable planner `reserved` field would add release, compaction, stale-plan,
+and rejection bookkeeping without covering a currently possible interleaving.
+It should be deferred unless a future asynchronous/reentrant admission shell
+requires simultaneous transitions. This keeps the core functional decision
+(`required_pending`) separate from shell state and avoids a new reservation
+leak state.
+
+## Alternatives
+
+### A. Separate prospective capability and actual typed outcome — recommended
+
+`PreparedAdmission` remains opaque, generation-bound, non-mutating, and
+single-use. A new `AdmissionOutcome` distinguishes `Complete(receipt)` from
+`Partial(receipt, causal_error)`. `commit_admission` is the canonical core
+shell; `commit_remote` maps the typed result back to its existing array/error
+contract through P2.
+
+**Why it fits:** it follows the actual P0 mutation boundary, preserves partial
+ownership evidence, keeps partial non-rollback, and does not move Document or
+Branch in P1. It also uses MoonBit's exhaustive enum matching rather than
+encoding complete/partial in nullable fields or strings.
+
+### B. Put the committed prefix into `PreparedAdmission` — reject
+
+This is impossible without making preparation a speculative mutable commit or
+mutating the value after begin. It would make a pre-commit capability carry a
+fact that is determined only by the injected/causal commit failure boundary.
+It also makes a consumed capability's post-commit state observable as mutable
+history rather than an immutable result.
+
+### C. Extend `PartialRemoteAdmission` and keep errors as the only result — reject
+
+This preserves old callers but cannot express a complete receipt, and it makes
+successful authority progress and exceptional control flow share one error
+channel. ADR 0003 distinguishes valid CRDT progress from recoverable local
+failure; P1 needs the same distinction inside the core boundary.
+
+### D. Return `Result[AdmissionOutcome, PreMutationError]` — do not add a second
+error algebra
+
+MoonBit's `Result` exists and is appropriate for pure fallible computations, but
+EGW already has `OpLogError` as the typed integration boundary. Adding a
+parallel `PreMutationError` would duplicate `StaleAdmission`,
+`ConsumedAdmission`, `InvalidAdmission`, and the pending-limit variant, then
+require adapters in every caller. Keep pre-mutation failures as `raise
+OpLogError`; make only partial a normal `AdmissionOutcome` value.
+
+### E. Reserve a mutable planner budget counter — defer
+
+A live `reserved` counter models a future concurrent/reentrant shell, but the
+current synchronous begin/register/acknowledge lifecycle already makes the
+registered pending nodes the reservation. The counter creates new invariants
+for `compact`, `reject_pending_members`, `acknowledge_admitted`, stale plans,
+and partial transfer. It is not justified by current execution semantics.
+
+### F. Keep P0's forecast API and add a second hard-budget API — reject
+
+Keeping `max_pending_after_complete?` and adding another optional hard limit
+would preserve compatibility but create two similarly named policies on one
+preparation function. Adding a second preparation method repeats the API
+proliferation P0 deliberately removed. The in-repository limit callers are
+whitebox tests, and the hard contract is a deliberate P1 semantic replacement.
+
+### G. Rename the optional policy to `max_pending?` and replace the forecast error
+— recommended API migration
+
+P1 should make the optional policy mean the peak pending membership permitted
+for either complete or partial execution. Rename the optional label to
+`max_pending?` and use `PendingLimitExceeded(limit~, required~)`. Update the
+P0 forecast tests and the EGW text error mapping accordingly. The generated
+internal oplog interface change is intentional and must be reviewed; no
+Document/Branch/Canopy production behavior changes.
+
+This is safer than silently keeping a complete-only name for a hard peak
+contract. If compatibility with an external caller is discovered during the
+P1.0 API inventory, retain the old method only as a clearly named compatibility
+adapter; do not overload one argument with two meanings.
+
+## Recommended P1 boundary
+
+The investigation finds no better overall architecture than Alternative A,
+but it finds two required corrections to the draft Plan:
+
+1. **Use the exact peak formula.** Capacity must be based on all registered
+   staged nodes, not planned operations. Add a red test with a ready prefix and
+   unresolved staged suffix where `planned.length() < new_staged_count`.
+2. **Do not add a live reservation counter yet.** Store the prospective
+   `required_pending` in `PreparedAdmission`; at begin, atomically gate and
+   register the complete staged set. The live planner pending map is the
+   reservation for the current synchronous shell.
+
+The receipt should be opaque and immutable at the package boundary. It should
+separate terminal ownership from provenance:
+
+```text
+terminal ownership (disjoint):
+  committed operations | admitted duplicates | pending-after identities | discarded identities
+
+provenance (not additional owners):
+  retained pending | staged | discarded-pending | discarded-staged
+```
+
+The exact field names remain a plan-review decision, but receipt construction
+must be derived from the prepared provenance plus before/after planner/frontier
+snapshots, not from a second planner or a full-history replay.
+
+## Existing API reuse
+
+Source-verified candidates:
+
+- `PreparedAdmission::operations() -> ArrayView[@core.Op]` for compatibility
+  order (`remote_admission_planner.mbt:1541-1545`);
+- `PreparedAdmission::remaining_raws(planner)` for complete-after comparison
+  (`:1557-1590`), not as the hard peak formula;
+- `RemoteAdmissionPlanner::pending_raws()` for live pending snapshots
+  (`:1601-1611`);
+- `RemoteAdmissionPlanner::begin_with_semantics` as the one validation and
+  registration boundary (`:1201-1398`);
+- `acknowledge_admitted` for monotonic pending removal and waiter wake-up
+  (`:590-631`);
+- `reject_pending_members` for the existing rejection closure partition
+  (`:668-683`);
+- `OpLog::get_frontier_raw()` for before/after frontier evidence
+  (`oplog.mbt:253-267`);
+- `ArrayView::to_owned`, `ArrayView::iter`, `HashSet::to_array`, and
+  `HashSet::is_disjoint` for immutable receipt construction and property tests.
+
+Checked but not selected:
+
+- `Result`: not selected as a second public pre-mutation error algebra because
+  `OpLogError` already owns the typed raised boundary;
+- `Option`: useful for optional `max_pending?`, but not a transition result;
+- `@core.Frontier`: retained as the authority's internal frontier, while the
+  receipt exposes copied `RawVersion` evidence through existing conversion;
+- `@immut/hashset`: not selected for the receipt because an opaque receipt with
+  read-only `ArrayView` accessors matches current `PreparedAdmission` and
+  preserves deterministic order; use immutable sets only if review finds a
+  membership-query requirement;
+- `@rle.Rle`: not relevant to identity ownership accounting.
+
+## Conclusion
+
+Alternative A remains the recommendation. The better version is a minimal,
+serialized transition: exact peak requirement in the prepared capability,
+atomic begin-time capacity gate, full staged registration as the reservation,
+monotonic acknowledgement, and a typed immutable actual outcome. This closes
+P1's ownership gap without inventing a second planner, live reservation state,
+parallel error algebra, or premature Document/Canopy migration.

--- a/docs/research/2026-08-15-egw-p1-admission-transition-options.md
+++ b/docs/research/2026-08-15-egw-p1-admission-transition-options.md
@@ -67,6 +67,13 @@ commit succeeds and raises `PartialRemoteAdmission` on a later causal-graph
 failure (`oplog.mbt:434-470`). Therefore the committed prefix cannot be a
 truthful field of the prepared value.
 
+P0 also distinguishes duplicate delivery from ownership: a matching admitted
+identity is accepted by `preflight_remote_identities` and is not staged, while a
+matching identity already in planner pending is also skipped by preparation and
+remains canonical pending (`oplog.mbt:310-325`,
+`remote_admission_planner.mbt:996-1025`). A receipt must therefore classify
+incoming occurrences separately from terminal RawVersion ownership.
+
 ### The exact worst-case pending peak is larger than the planned count
 
 At begin, P0 registers every non-discarded staged node, not only operations in
@@ -212,19 +219,36 @@ but it finds two required corrections to the draft Plan:
    reservation for the current synchronous shell.
 
 The receipt should be opaque and immutable at the package boundary. It should
-separate terminal ownership from provenance:
+separate incoming-occurrence disposition from canonical ownership:
 
 ```text
-terminal ownership (disjoint):
-  committed operations | admitted duplicates | pending-after identities | discarded identities
+incoming disposition (disjoint):
+  NewlyCommitted | DuplicateOfAuthority | Pending | Discarded
+
+canonical ownership (disjoint):
+  Authority | core pending | discarded
 
 provenance (not additional owners):
   retained pending | staged | discarded-pending | discarded-staged
 ```
 
-The exact field names remain a plan-review decision, but receipt construction
-must be derived from the prepared provenance plus before/after planner/frontier
-snapshots, not from a second planner or a full-history replay.
+A matching duplicate is already owned by Authority; `DuplicateOfAuthority` is
+non-owning evidence about the incoming occurrence, not a second RawVersion
+owner. The exact field names remain a plan-review decision, but receipt
+construction must be derived from the prepared provenance plus before/after
+planner/frontier snapshots, not from a second planner or a full-history replay.
+
+### ADR 0008 wording clarification
+
+ADR 0008's accepted P1 sentence says that the "prepared admission" records
+committed, retained, discarded, duplicate, and partial ownership. The P0 code
+and the actual commit boundary prove that a prospective prepared value cannot
+contain a committed prefix. The P1 implementation must therefore add a
+**docs-only clarification to ADR 0008**, not a new ADR: the phrase names the
+complete single-use transition capability (`PreparedAdmission` plus its actual
+`AdmissionOutcome`), while `PreparedAdmission` itself remains prospective and
+`AdmissionOutcome` owns post-commit facts. This resolves the wording without
+changing the accepted P1/P2 sequencing.
 
 ## Existing API reuse
 


### PR DESCRIPTION
## Summary

- Add the P1 implementation plan for typed admission transition over the P0 merged EGW baseline.
- Separate prospective `PreparedAdmission` from actual typed `AdmissionOutcome`/`AdmissionReceipt`.
- Make the hard pending contract a begin-after membership precondition, using:
  `count_unique((pending_before - discarded_pending) ∪ staged_unique_not_admitted_not_discarded)`.
- Keep receipts transition-local with defensive owned arrays, before/after counts, and frontier snapshots; do not copy unrelated global pending identities.
- Separate duplicate delivery provenance from terminal ownership, including pending duplicates that are later awakened and committed, left pending, or discarded.
- Close the post-begin error algebra: after `Applied`, the typed capability returns only `Complete` or `Partial`; non-causal impossible errors are invariant defects, not recoverable `OpLogError` exits.
- Require a separate EGW docs-only ADR 0008 amendment before creating the P1 implementation branch.

## Scope

Docs-only. No MoonBit source, generated interfaces, submodule pointers, wire/archive formats, Canopy production ingress, or ADR changes are made by this Canopy plan PR. The EGW implementation work must start only after the separate ADR 0008 amendment is merged.

## Review gates

The plan must be accepted before creating a fresh P1 EGW implementation branch from current `origin/main`. Exact receipt fields, `max_pending?`/`PendingLimitExceeded(limit~, required~)` vocabulary, the begin-after pending formula, no-stateful-pending-limit choice, duplicate provenance/terminal ownership split, post-begin outcome closure, core-owned retry protocol, capability method spelling, intentional `.mbti` delta, ADR amendment, receipt ordering policy, and compatibility-wrapper lifetime are explicit review decisions in the plan.

Canonical issue: #1256 (this PR does not close it).
