### PR TITLE
refactor(canvas): move root wheel admission to MoonBit and Rabbita

### DIFF
--- a/apps/canvas/main/canvas_init.mbt
+++ b/apps/canvas/main/canvas_init.mbt
@@ -9,18 +9,6 @@ pub fn create_canvas() -> Int {
 }
 
 ///|
-pub fn zoom(
-  handle : Int,
-  delta_y : Double,
-  delta_mode : Int,
-  ctrl_key : Bool,
-  cx : Double,
-  cy : Double,
-) -> Unit {
-  _registry[handle].zoom(delta_y, delta_mode, ctrl_key, cx, cy)
-}
-
-///|
 /// Add a workflow node from the library/context menu at canvas-local screen
 /// coordinates. `kind_key` is intentionally string-based at the FFI boundary;
 /// MoonBit converts it to an extensible `WorkflowNodeKind` inside the model.

--- a/apps/canvas/main/graph_dsl_adapter.mbt
+++ b/apps/canvas/main/graph_dsl_adapter.mbt
@@ -1354,21 +1354,6 @@ pub fn get_source_graph_input_port_compatibility(
 }
 
 ///|
-pub fn source_graph_zoom(
-  handle : Int,
-  delta_y : Double,
-  delta_mode : Int,
-  ctrl_key : Bool,
-  cx : Double,
-  cy : Double,
-) -> Unit {
-  match source_graph_by_handle(handle) {
-    Some(graph) => graph.zoom(delta_y, delta_mode, ctrl_key, cx, cy)
-    None => ()
-  }
-}
-
-///|
 fn source_render_state_string(
   graph : SourceBackedGraph,
   state : CanvasState,

--- a/apps/canvas/main/moon.pkg
+++ b/apps/canvas/main/moon.pkg
@@ -36,7 +36,6 @@ options(
       "exports": [
         "create_canvas",
         "mount_canvas_pointer_session",
-        "zoom",
         "add_node",
         "delete_nodes",
         "disconnect_ports",
@@ -57,7 +56,6 @@ options(
         "mount_canvas_context_menu",
         "source_graph_insert_unique",
         "get_source_graph_input_port_compatibility",
-        "source_graph_zoom",
       ],
     },
   },

--- a/apps/canvas/main/pkg.generated.mbti
+++ b/apps/canvas/main/pkg.generated.mbti
@@ -50,11 +50,7 @@ pub fn set_source_graph_source_result(Int, String) -> String raise Failure
 
 pub fn source_graph_insert_unique(Int, String, String) -> String raise Failure
 
-pub fn source_graph_zoom(Int, Double, Int, Bool, Double, Double) -> Unit
-
 pub fn try_destroy_source_graph(Int) -> Bool
-
-pub fn zoom(Int, Double, Int, Bool, Double, Double) -> Unit
 
 // Errors
 

--- a/apps/canvas/main/pointer_session.mbt
+++ b/apps/canvas/main/pointer_session.mbt
@@ -43,6 +43,14 @@ priv struct CanvasPointerInput {
 }
 
 ///|
+priv struct CanvasWheelInput {
+  delta_y : Double
+  delta_mode : Int
+  ctrl_key : Bool
+  screen : ScreenPoint?
+}
+
+///|
 priv enum CanvasPointerMsg {
   PointerDown(CanvasPointerInput)
   PointerMove(CanvasPointerInput)
@@ -50,6 +58,7 @@ priv enum CanvasPointerMsg {
   PointerCancel(CanvasPointerInput)
   PointerLeave
   LostPointerCapture(CanvasPointerInput)
+  Wheel(CanvasWheelInput)
 }
 
 ///|
@@ -538,20 +547,53 @@ fn canvas_pointer_message(
   event : @dom.Event,
   root : @dom.Element,
 ) -> CanvasPointerMsg? {
-  match event.to_pointer_event() {
-    None => None
-    Some(pointer) => {
-      let input = canvas_pointer_input(pointer, root)
-      match event_name {
-        "pointerdown" => Some(PointerDown(input))
-        "pointermove" => Some(PointerMove(input))
-        "pointerup" => Some(PointerUp(input))
-        "pointercancel" => Some(PointerCancel(input))
-        "pointerleave" => Some(PointerLeave)
-        "lostpointercapture" => Some(LostPointerCapture(input))
-        _ => None
+  match event_name {
+    "wheel" =>
+      match event.to_wheel_event() {
+        None => None
+        Some(wheel) => {
+          // Consume synchronously before scheduling the message. Keep this
+          // access order for Firefox/macOS wheel-unit compatibility.
+          wheel.prevent_default()
+          let delta_y = wheel.get_delta_y()
+          let delta_mode = wheel.get_delta_mode()
+          let ctrl_key = wheel.get_ctrl_key()
+          let screen : ScreenPoint? = match wheel.current_target().to_option() {
+            None => None
+            Some(target) =>
+              match target.to_element() {
+                None => None
+                Some(root) => {
+                  let rect = root.get_bounding_client_rect()
+                  let point = ScreenPoint::from_xy(
+                    x=wheel.get_client_x() - rect.get_left(),
+                    y=wheel.get_client_y() - rect.get_top(),
+                  ) catch {
+                    @spatial.CoordinateError::NonFinite => return None
+                  }
+                  Some(point)
+                }
+              }
+          }
+          Some(Wheel({ delta_y, delta_mode, ctrl_key, screen }))
+        }
       }
-    }
+    _ =>
+      match event.to_pointer_event() {
+        None => None
+        Some(pointer) => {
+          let input = canvas_pointer_input(pointer, root)
+          match event_name {
+            "pointerdown" => Some(PointerDown(input))
+            "pointermove" => Some(PointerMove(input))
+            "pointerup" => Some(PointerUp(input))
+            "pointercancel" => Some(PointerCancel(input))
+            "pointerleave" => Some(PointerLeave)
+            "lostpointercapture" => Some(LostPointerCapture(input))
+            _ => None
+          }
+        }
+      }
   }
 }
 
@@ -572,7 +614,15 @@ fn canvas_pointer_subscription_loader(
           None => ()
         }
       }
-      target.add_event_listener(event_name, listener)
+      if event_name == "wheel" {
+        target.add_event_listener_with_options(
+          event_name,
+          listener,
+          passive=false,
+        )
+      } else {
+        target.add_event_listener(event_name, listener)
+      }
       Some({
         unload: _ => target.remove_event_listener(event_name, listener),
         update_tagger: next => {
@@ -614,6 +664,7 @@ fn canvas_pointer_subscriptions(
     canvas_pointer_subscription("pointercancel", emit),
     canvas_pointer_subscription("pointerleave", emit),
     canvas_pointer_subscription("lostpointercapture", emit),
+    canvas_pointer_subscription("wheel", emit),
   ])
 }
 
@@ -635,6 +686,33 @@ fn canvas_pointer_update(
     PointerCancel(input) => canvas_pointer_interrupt(model, input, on_change)
     LostPointerCapture(input) =>
       canvas_pointer_interrupt(model, input, on_change)
+    Wheel(input) => {
+      guard model.session is Idle else { return model }
+      guard input.screen is Some(screen) else { return model }
+      if model.source_backed {
+        match source_graph_by_handle(model.handle) {
+          Some(graph) =>
+            graph.zoom(
+              input.delta_y,
+              input.delta_mode,
+              input.ctrl_key,
+              screen.x(),
+              screen.y(),
+            )
+          None => return model
+        }
+      } else {
+        _registry[model.handle].zoom(
+          input.delta_y,
+          input.delta_mode,
+          input.ctrl_key,
+          screen.x(),
+          screen.y(),
+        )
+      }
+      on_change()
+      model
+    }
     PointerLeave => {
       if !model.source_backed {
         _registry[model.handle].hover_node("")

--- a/apps/canvas/web/e2e/canvas-handles.spec.ts
+++ b/apps/canvas/web/e2e/canvas-handles.spec.ts
@@ -147,18 +147,21 @@ test('canvas wheel normalizes units and rejects no-op or active input', async ({
     deltaY: number,
     deltaMode: number,
     ctrlKey = false,
-  ) => {
-    await page.evaluate(({ deltaY, deltaMode, ctrlKey }) => {
+  ): Promise<boolean> => {
+    return page.evaluate(({ deltaY, deltaMode, ctrlKey }) => {
       const root = document.querySelector('#canvas-root') as HTMLDivElement;
       const rect = root.getBoundingClientRect();
-      root.dispatchEvent(new WheelEvent('wheel', {
+      const event = new WheelEvent('wheel', {
         bubbles: true,
+        cancelable: true,
         deltaY,
         deltaMode,
         ctrlKey,
-        clientX: rect.left + 120,
-        clientY: rect.top + 80,
-      }));
+        clientX: rect.left + 120.25,
+        clientY: rect.top + 80.75,
+      });
+      root.dispatchEvent(event);
+      return event.defaultPrevented;
     }, { deltaY, deltaMode, ctrlKey });
   };
 
@@ -167,7 +170,7 @@ test('canvas wheel normalizes units and rejects no-op or active input', async ({
   await expect(page.locator('#action-stat')).toHaveText('0 actions logged');
   const initialTransform = await worldTransform(page);
 
-  await dispatchWheel(0, 0);
+  expect(await dispatchWheel(0, 0)).toBe(true);
   await expect(page.locator('#action-stat')).toHaveText('0 actions logged');
   expect(await worldTransform(page)).toBe(initialTransform);
 
@@ -207,7 +210,7 @@ test('canvas wheel normalizes units and rejects no-op or active input', async ({
   });
   await expect(page.locator('#canvas-root')).toHaveClass(/panning/);
   const activeTransform = await worldTransform(page);
-  await dispatchWheel(-100, 0);
+  expect(await dispatchWheel(-100, 0)).toBe(true);
   await expect(page.locator('#action-stat')).toHaveText('0 actions logged');
   expect(await worldTransform(page)).toBe(activeTransform);
   await page.evaluate(() => {

--- a/apps/canvas/web/e2e/canvas-wheel-ownership.spec.ts
+++ b/apps/canvas/web/e2e/canvas-wheel-ownership.spec.ts
@@ -1,0 +1,21 @@
+import { expect, test } from '@playwright/test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const sourceDir = resolve(process.cwd(), 'src');
+
+function source(name: string): string {
+  return readFileSync(resolve(sourceDir, name), 'utf8');
+}
+
+test('workflow wheel ownership has no TypeScript listener or zoom bridge', () => {
+  const main = source('main.ts');
+  const adapter = source('graph-adapter.ts');
+
+  expect(main).not.toContain("root.addEventListener('wheel'");
+  expect(main).not.toContain('root.addEventListener("wheel"');
+  expect(main).not.toContain('adapter.zoom(');
+  expect(adapter).not.toContain('zoom: (');
+  expect(adapter).not.toContain('source_graph_zoom');
+  expect(adapter).not.toContain('zoom(');
+});

--- a/apps/canvas/web/e2e/source-backed.spec.ts
+++ b/apps/canvas/web/e2e/source-backed.spec.ts
@@ -275,22 +275,28 @@ test('source-backed wheel shares normalized camera semantics', async ({ page }) 
 
   await page.goto('/?source=1');
   await expectSource(page, SAMPLE_SOURCE);
-  const dispatchWheel = async (deltaY: number, deltaMode: number) => {
-    await page.evaluate(({ deltaY, deltaMode }) => {
+  const dispatchWheel = async (
+    deltaY: number,
+    deltaMode: number,
+  ): Promise<boolean> => {
+    return page.evaluate(({ deltaY, deltaMode }) => {
       const root = document.querySelector('#canvas-root') as HTMLDivElement;
       const rect = root.getBoundingClientRect();
-      root.dispatchEvent(new WheelEvent('wheel', {
+      const event = new WheelEvent('wheel', {
         bubbles: true,
+        cancelable: true,
         deltaY,
         deltaMode,
-        clientX: rect.left + 120,
-        clientY: rect.top + 80,
-      }));
+        clientX: rect.left + 120.25,
+        clientY: rect.top + 80.75,
+      });
+      root.dispatchEvent(event);
+      return event.defaultPrevented;
     }, { deltaY, deltaMode });
   };
 
   await expect(page.locator('#action-stat')).toHaveText('0 actions logged');
-  await dispatchWheel(0, 0);
+  expect(await dispatchWheel(0, 0)).toBe(true);
   await expect(page.locator('#action-stat')).toHaveText('0 actions logged');
   await dispatchWheel(-2, 1);
   await expect(page.locator('#action-stat')).toHaveText('1 action logged');
@@ -307,7 +313,7 @@ test('source-backed wheel shares normalized camera semantics', async ({ page }) 
     }));
   });
   await expect(page.locator('#canvas-root')).toHaveClass(/panning/);
-  await dispatchWheel(-100, 0);
+  expect(await dispatchWheel(-100, 0)).toBe(true);
   await expect(page.locator('#action-stat')).toHaveText('1 action logged');
   await page.evaluate(() => {
     const root = document.querySelector('#canvas-root') as HTMLDivElement;
@@ -320,6 +326,41 @@ test('source-backed wheel shares normalized camera semantics', async ({ page }) 
     }));
   });
   await expect(page.locator('#canvas-root')).not.toHaveClass(/panning/);
+  expect(runtimeErrors).toEqual([]);
+});
+
+test('source-backed connection keeps its preview while wheel is consumed', async ({ page }) => {
+  const runtimeErrors = collectRuntimeErrors(page);
+
+  await page.goto('/?source=1');
+  await expectSource(page, SAMPLE_SOURCE);
+
+  const start = await center(outputHandle(page, 'osc'), 'source output handle');
+  await page.mouse.move(start.x, start.y);
+  await page.mouse.down();
+  await page.mouse.move(start.x + 40.25, start.y + 40.75, { steps: 4 });
+  await expect(page.locator('#edges path.edge-pending')).toHaveCount(1);
+
+  const prevented = await page.evaluate(() => {
+    const root = document.querySelector('#canvas-root') as HTMLDivElement;
+    const rect = root.getBoundingClientRect();
+    const event = new WheelEvent('wheel', {
+      bubbles: true,
+      cancelable: true,
+      deltaY: -100,
+      deltaMode: 0,
+      clientX: rect.left + 120.25,
+      clientY: rect.top + 80.75,
+    });
+    root.dispatchEvent(event);
+    return event.defaultPrevented;
+  });
+  expect(prevented).toBe(true);
+  await expect(page.locator('#edges path.edge-pending')).toHaveCount(1);
+  await expect(page.locator('#action-stat')).toHaveText('0 actions logged');
+
+  await page.mouse.up();
+  await expect(page.locator('#edges path.edge-pending')).toHaveCount(0);
   expect(runtimeErrors).toEqual([]);
 });
 

--- a/apps/canvas/web/src/graph-adapter.ts
+++ b/apps/canvas/web/src/graph-adapter.ts
@@ -7,14 +7,6 @@ export type CanvasModule = {
     onHideContextMenu: () => undefined,
     onClearSelectedEdge: () => undefined,
   ) => undefined;
-  zoom: (
-    h: number,
-    deltaY: number,
-    deltaMode: number,
-    ctrlKey: boolean,
-    cx: number,
-    cy: number,
-  ) => void;
   add_node: (h: number, kindKey: string, sx: number, sy: number) => void;
   delete_nodes: (h: number, nodeIdsJson: string) => void;
   disconnect_ports: (
@@ -49,14 +41,6 @@ export type CanvasModule = {
     source: string,
     sourcePort: string,
   ) => string;
-  source_graph_zoom?: (
-    h: number,
-    deltaY: number,
-    deltaMode: number,
-    ctrlKey: boolean,
-    cx: number,
-    cy: number,
-  ) => void;
   sample_graph_dsl_source?: () => string;
   mount_source_demo?: (h: number, enabled: boolean, onChange: () => undefined) => undefined;
   mount_canvas_context_menu?: (
@@ -84,14 +68,6 @@ type SourceCanvasModule = CanvasModule & {
     source: string,
     sourcePort: string,
   ) => string;
-  source_graph_zoom: (
-    h: number,
-    deltaY: number,
-    deltaMode: number,
-    ctrlKey: boolean,
-    cx: number,
-    cy: number,
-  ) => void;
 };
 
 const SOURCE_METHODS = [
@@ -105,7 +81,6 @@ const SOURCE_METHODS = [
   'apply_source_graph_operation',
   'source_graph_insert_unique',
   'get_source_graph_input_port_compatibility',
-  'source_graph_zoom',
 ] as const;
 
 export type Tagged = string | [string, ...unknown[]];
@@ -460,36 +435,6 @@ export class GraphAdapter {
       )
       : this.mb.get_input_port_compatibility(this.handle, sourceNodeId, sourcePortId);
     return JSON.parse(json) as PortCompatibility[];
-  }
-
-  zoom(
-    deltaY: number,
-    deltaMode: number,
-    ctrlKey: boolean,
-    cx: number,
-    cy: number,
-  ): void {
-    this.assertLive();
-    if (this.isSourceBacked) {
-      this.sourceModule().source_graph_zoom(
-        this.handle,
-        deltaY,
-        deltaMode,
-        ctrlKey,
-        cx,
-        cy,
-      );
-    } else {
-      this.mb.zoom(
-        this.handle,
-        deltaY,
-        deltaMode,
-        ctrlKey,
-        cx,
-        cy,
-      );
-    }
-    this.emitLatestOperations();
   }
 
   addNode(kindKey: string, sx: number, sy: number): void {

--- a/apps/canvas/web/src/main.ts
+++ b/apps/canvas/web/src/main.ts
@@ -818,19 +818,6 @@ root.addEventListener('click', (e: MouseEvent) => {
   scheduleRender();
 });
 
-root.addEventListener('wheel', (e: WheelEvent) => {
-  e.preventDefault();
-  // Keep deltaY before deltaMode: Firefox/macOS can expose different
-  // deltaMode semantics based on access order. This matches the d3/xyflow
-  // browser-wheel contract that PR1 preserves for the future Rabbita bridge.
-  const deltaY = e.deltaY;
-  const deltaMode = e.deltaMode;
-  const ctrlKey = e.ctrlKey;
-  const [cx, cy] = localCoords(e);
-  adapter.zoom(deltaY, deltaMode, ctrlKey, cx, cy);
-  scheduleRender();
-}, { passive: false });
-
 root.addEventListener('contextmenu', (e: MouseEvent) => {
   e.preventDefault();
   const point = finiteLocalCoords(e);

--- a/apps/loomark/archive/pkg.generated.mbti
+++ b/apps/loomark/archive/pkg.generated.mbti
@@ -40,16 +40,25 @@ pub fn DecodedLoomarkDocumentArchive::document_id(Self) -> LoomarkDocumentId
 pub fn DecodedLoomarkDocumentArchive::history(Self) -> @markdown.MarkdownDocumentHistory
 pub fn DecodedLoomarkDocumentArchive::portable_markdown(Self) -> String
 
+pub(all) enum LoomarkArchivePreparationPhase {
+  PortableMarkdownCaptured
+  CompleteHistoryCaptured
+  HistoryJsonEncoded
+  ArchiveEnvelopeEncoded
+} derive(Eq, @debug.Debug)
+
 pub struct LoomarkDocumentArchive {
   // private fields
 }
 pub fn LoomarkDocumentArchive::capture(document_id~ : LoomarkDocumentId, editor~ : @markdown.MarkdownEditor) -> Self raise
+pub fn LoomarkDocumentArchive::capture_observing(document_id~ : LoomarkDocumentId, editor~ : @markdown.MarkdownEditor, (LoomarkArchivePreparationPhase) -> Unit) -> Self raise
 pub fn LoomarkDocumentArchive::decode_json_string(String) -> DecodedLoomarkDocumentArchive raise
 pub fn LoomarkDocumentArchive::document_id(Self) -> LoomarkDocumentId
 pub fn LoomarkDocumentArchive::from_json_string(String, validation_agent_id~ : String, open_limits~ : @markdown.MarkdownArchiveOpenLimits) -> Self raise
 pub fn LoomarkDocumentArchive::history(Self) -> @markdown.MarkdownDocumentHistory
 pub fn LoomarkDocumentArchive::portable_markdown(Self) -> String
 pub fn LoomarkDocumentArchive::to_json_string(Self) -> String
+pub fn LoomarkDocumentArchive::to_json_string_observing(Self, (LoomarkArchivePreparationPhase) -> Unit) -> String
 
 pub struct LoomarkDocumentId {
   // private fields

--- a/apps/loomark/repository/pkg.generated.mbti
+++ b/apps/loomark/repository/pkg.generated.mbti
@@ -13,6 +13,8 @@ pub fn history_trigger(@dowdiness/canopy/editor/markdown.MarkdownCommitReceipt) 
 
 pub fn prepare_local_archive(document_id~ : @archive.LoomarkDocumentId, editor~ : @dowdiness/canopy/editor/markdown.MarkdownEditor) -> PreparedLocalArchive raise
 
+pub fn prepare_local_archive_observing(document_id~ : @archive.LoomarkDocumentId, editor~ : @dowdiness/canopy/editor/markdown.MarkdownEditor, (@archive.LoomarkArchivePreparationPhase) -> Unit) -> PreparedLocalArchive raise
+
 pub fn reopen_decoded_local_archive(@archive.DecodedLoomarkDocumentArchive, agent_id~ : String, policy~ : LocalRestorePolicy) -> ReopenedLocalArchive raise
 
 pub fn reopen_local_archive(@archive.LoomarkDocumentArchive, agent_id~ : String, policy~ : LocalRestorePolicy) -> ReopenedLocalArchive raise


### PR DESCRIPTION
## Summary

- Move workflow Canvas root wheel admission into the existing app-private Rabbita pointer island.
- Decode cancelable wheel events synchronously, preserve fractional root-relative coordinates, and gate admission on `CanvasPointerSession::Idle`.
- Delegate accepted wheel input to the existing workflow and source-backed zoom implementations while removing temporary TypeScript/public zoom bridges.

## UI and review evidence

N/A — no visual design, labels, focus, or accessibility copy changed. Canvas interaction behavior was verified with Playwright E2E coverage.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `canvas_pointer_subscription` / `canvas_pointer_subscriptions` | `apps/canvas/main/pointer_session.mbt` | Yes | Reused the existing pointer-island subscription and lifecycle rather than adding a second listener path. |
| `@dom.Event::to_wheel_event` and `@dom.WheelEvent` getters | Rabbita DOM bindings | Yes | Used the typed wheel boundary and existing `deltaY`, `deltaMode`, `ctrlKey`, `clientX`, `clientY`, and `prevent_default` APIs. |
| `@dom.Element::get_bounding_client_rect` / `@dom.DOMRect` | Rabbita DOM bindings | Yes | Used for viewport-to-root coordinate conversion without integer coercion. |
| `@spatial.ScreenPoint::from_xy` | `modules/canvas-graph/spatial` | Yes | Preserved the typed finite-coordinate boundary. |
| `CanvasRuntime::zoom` / `SourceBackedGraph::zoom` | `apps/canvas/main` | Yes | Kept normalization, bounds, anchoring, and action-log semantics in the existing host implementations. |
| `Option` / typed `catch` | MoonBit core and project APIs | Yes | Reused option matching for DOM targets and typed coordinate-construction failure handling. |

New helpers added:

- `CanvasWheelInput`: a private typed snapshot separating raw DOM wheel decoding from the workflow reducer; raw wheel fields do not cross into `graph_model`.
- `CanvasPointerMsg::Wheel`: a private message variant in the existing pointer-session island; no generic camera-input abstraction was introduced.

## Validation scope

Boundary matrix / first failing regression:

- Wheel listener is owned by MoonBit/Rabbita; TypeScript has no root wheel listener or zoom bridge.
- Listener is `passive=false` and calls `preventDefault` synchronously.
- `deltaY → deltaMode → ctrlKey` access order is preserved.
- Client coordinates are converted to fractional root-relative `ScreenPoint` values.
- Pixel/line/page normalization, pinch policy, bounds, anchoring, no-op suppression, and action-log behavior remain covered by the existing wheel tests.
- Wheel input is rejected while `GraphGesture` or `SourceConnection` is active, without disrupting the active preview/gesture.
- Workflow and source-backed canvases delegate accepted input to their existing private zoom paths.

Target packages:

- `apps/canvas/main`

Additional conditional gates:

- `./scripts/test-canvas-e2e.sh` — 42 passed.
- Production JavaScript build and TypeScript/FFI consumer checks passed through the PR-ready validator.

## PR-ready evidence

Validated HEAD: `187575188c9fb5cde98a1ff7fbad5d5f3ff62631`

Validated base: `origin/main@99681b29438185cd8562b373a6ace939348f32f0`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh \
  --target apps/canvas/main
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for the exact HEAD and base above.
- [x] The base was fetched again and `--verify-evidence` passed immediately before this PR was opened.
- [x] The committed `.mbti` diff against the validated base was reviewed; the only generated-interface refresh is the required Loomark drift from the current base, with no unintended Canvas API or trait-bound changes.
- [x] No submodule commit changed.
- [x] Validation was rerun after the generated-interface commit.
- [x] Independent review findings were resolved or documented as pre-existing/out-of-scope before final validation.
