### PR TITLE
refactor(canvas): render edge layer with Rabbita

### DIFF
--- a/apps/canvas/main/canvas_init.mbt
+++ b/apps/canvas/main/canvas_init.mbt
@@ -93,7 +93,7 @@ struct EdgeJson {
   path_d : String
   selected : Bool
   aria_label : String
-} derive(Eq, ToJson)
+} derive(Eq, ToJson, FromJson)
 
 ///|
 /// Serialized in-flight connection. `from` is the source node id;

--- a/apps/canvas/main/edge_render_layer.mbt
+++ b/apps/canvas/main/edge_render_layer.mbt
@@ -1,0 +1,250 @@
+///|
+const CANVAS_EDGE_LAYER_ID : String = "canvas-edge-layer"
+
+///|
+const CANVAS_RENDER_STATE_EVENT : String = "canopy-canvas-render-state"
+
+///|
+priv struct CanvasEdgeLayerViewport {
+  x : Double
+  y : Double
+  scale : Double
+} derive(Eq, FromJson)
+
+///|
+priv struct CanvasEdgeLayerSnapshot {
+  viewport : CanvasEdgeLayerViewport
+  edges : Array[EdgeJson]
+  connecting_path_d : String?
+} derive(Eq)
+
+///|
+priv struct CanvasEdgeLayerState {
+  snapshot : CanvasEdgeLayerSnapshot?
+} derive(Eq)
+
+///|
+priv enum CanvasEdgeLayerMsg {
+  RenderState(String)
+}
+
+///|
+fn parse_connecting_path_d(fields : Map[String, Json]) -> String? {
+  match fields.get("path_d") {
+    None | Some(Null) => None
+    Some(String(value)) => Some(value)
+    Some(Array([value])) => {
+      let path_d : String = @json.from_json(value) catch { _ => return None }
+      Some(path_d)
+    }
+    Some(_) => None
+  }
+}
+
+///|
+fn parse_canvas_edge_layer_snapshot(
+  json_text : String,
+) -> CanvasEdgeLayerSnapshot? {
+  let json = @json.parse(json_text) catch { _ => return None }
+  match json {
+    Object(fields) => {
+      let viewport_json = match fields.get("viewport") {
+        Some(value) => value
+        None => return None
+      }
+      let edges_json = match fields.get("edges") {
+        Some(value) => value
+        None => return None
+      }
+      let viewport : CanvasEdgeLayerViewport = @json.from_json(viewport_json) catch {
+        _ => return None
+      }
+      let edges : Array[EdgeJson] = @json.from_json(edges_json) catch {
+        _ => return None
+      }
+      let connecting_path_d = match fields.get("connecting") {
+        None | Some(Null) => None
+        Some(Object(connecting)) => parse_connecting_path_d(connecting)
+        Some(Array([Object(connecting)])) => parse_connecting_path_d(connecting)
+        Some(_) => None
+      }
+      Some({ viewport, edges, connecting_path_d })
+    }
+    _ => None
+  }
+}
+
+///|
+fn canvas_edge_layer_update(
+  model : CanvasEdgeLayerState,
+  message : CanvasEdgeLayerMsg,
+) -> CanvasEdgeLayerState {
+  match message {
+    RenderState(json) =>
+      match parse_canvas_edge_layer_snapshot(json) {
+        Some(snapshot) => { snapshot: Some(snapshot) }
+        None => model
+      }
+  }
+}
+
+///|
+fn canvas_edge_layer_transform(viewport : CanvasEdgeLayerViewport) -> String {
+  "translate(\{viewport.x}px, \{viewport.y}px) scale(\{viewport.scale})"
+}
+
+///|
+fn canvas_edge_path_class(edge : EdgeJson) -> String {
+  if edge.selected {
+    "edge selected"
+  } else {
+    "edge"
+  }
+}
+
+///|
+fn canvas_edge_path(edge : EdgeJson) -> @svg.Svg {
+  @svg.path(
+    class=canvas_edge_path_class(edge),
+    d=edge.path_d,
+    attrs=@svg.Attrs::build()
+      .data_set("edge-id", edge.id)
+      .role("button")
+      .tabindex("0")
+      .aria_label(edge.aria_label),
+  )
+}
+
+///|
+fn canvas_edge_layer_view(model : CanvasEdgeLayerState) -> @rabbita.Html {
+  match model.snapshot {
+    None => @html.nothing
+    Some(snapshot) => {
+      let children : Map[String, @svg.Svg] = Map([])
+      for edge in snapshot.edges {
+        children["edge:\{edge.id}"] = canvas_edge_path(edge)
+      }
+      match snapshot.connecting_path_d {
+        None => ()
+        Some(path_d) =>
+          children["pending"] = @svg.path(class="edge-pending", d=path_d)
+      }
+      let attrs = @svg.Attrs::build()
+        .id("edges")
+        .style("transform", canvas_edge_layer_transform(snapshot.viewport))
+      @svg.keyed_node("svg", attrs, children).to_html()
+    }
+  }
+}
+
+///|
+#cfg(target="js")
+priv suberror CanvasEdgeLayerSubscription {
+  RenderState(@rabbita.Emit[CanvasEdgeLayerMsg])
+}
+
+///|
+#cfg(target="js")
+fn canvas_edge_layer_event_target() -> @dom.EventTarget {
+  @dom.document()
+  .get_element_by_id(CANVAS_EDGE_LAYER_ID)
+  .unwrap()
+  .as_event_target()
+}
+
+///|
+#cfg(target="js")
+fn canvas_edge_layer_sub_loader(
+  payload : Error,
+  scheduler : &@cmd.Scheduler,
+) -> @sub.RunningSub? {
+  match payload {
+    CanvasEdgeLayerSubscription::RenderState(emit) => {
+      let tagger = @ref.Ref(emit)
+      let target = canvas_edge_layer_event_target()
+      let listener : @dom.Listener = event => {
+        match event.to_custom_event() {
+          Some(custom) =>
+            scheduler.add(
+              (tagger.val)(
+                CanvasEdgeLayerMsg::RenderState(custom.get_detail().to_string()),
+              ),
+            )
+          None => ()
+        }
+      }
+      target.add_event_listener(CANVAS_RENDER_STATE_EVENT, listener)
+      Some({
+        unload: _ => {
+          target.remove_event_listener(CANVAS_RENDER_STATE_EVENT, listener)
+        },
+        update_tagger: next => {
+          guard next is CanvasEdgeLayerSubscription::RenderState(new_emit) else {
+            return
+          }
+          tagger.val = new_emit
+        },
+      })
+    }
+    _ => None
+  }
+}
+
+///|
+#cfg(target="js")
+fn canvas_edge_layer_subscriptions(
+  _model : CanvasEdgeLayerState,
+  emit : @rabbita.Emit[CanvasEdgeLayerMsg],
+) -> @sub.Sub {
+  @sub.custom_sub(
+    "canvas.edge-render-state",
+    @sub.Scope::Local,
+    CanvasEdgeLayerSubscription::RenderState(emit),
+    canvas_edge_layer_sub_loader,
+  )
+}
+
+///|
+#cfg(target="js")
+pub fn mount_canvas_edge_layer() -> Unit {
+  @rabbita.new(fn() {
+    let (model, _emit) = @rabbita.create_state(
+      { snapshot: None },
+      update=fn(model, message, _emit) {
+        (canvas_edge_layer_update(model, message), @rabbita.none)
+      },
+      subscriptions=canvas_edge_layer_subscriptions,
+    )
+    model.map(canvas_edge_layer_view)
+  }).mount(CANVAS_EDGE_LAYER_ID)
+}
+
+///|
+#cfg(target="js")
+fn dispatch_canvas_render_state(json : String) -> Unit {
+  match @dom.document().get_element_by_id(CANVAS_EDGE_LAYER_ID).to_option() {
+    None => ()
+    Some(target) =>
+      target.dispatch_event(
+        @dom.CustomEvent::new(
+          CANVAS_RENDER_STATE_EVENT,
+          detail=@js.Optional::from_option(Some(@js.Value::cast_from(json))),
+        ).as_event(),
+      )
+  }
+}
+
+///|
+/// Publish one serialized render snapshot to the TypeScript and Rabbita
+/// consumers. The custom event is only an app-private transport seam; the
+/// returned string is the same snapshot consumed by the TypeScript shell.
+#cfg(target="js")
+pub fn publish_render_state(handle : Int, source_backed : Bool) -> String {
+  let json = if source_backed {
+    get_source_graph_render_state(handle)
+  } else {
+    get_render_state(handle)
+  }
+  dispatch_canvas_render_state(json)
+  json
+}

--- a/apps/canvas/main/edge_render_layer_wbtest.mbt
+++ b/apps/canvas/main/edge_render_layer_wbtest.mbt
@@ -1,0 +1,52 @@
+///|
+#warnings("-alert_unstable")
+test "edge layer view renders accessible keyed paths and pending path" {
+  let model : CanvasEdgeLayerState = {
+    snapshot: Some({
+      viewport: { x: 10.0, y: 20.0, scale: 1.5 },
+      edges: [
+        {
+          id: "edge-1",
+          path_d: "M 0 0 C 40 0, 40 10, 80 10",
+          selected: true,
+          aria_label: "Disconnect source.out → target.in",
+        },
+      ],
+      connecting_path_d: Some("M 0 0 C 40 0, 40 10, 80 10"),
+    }),
+  }
+  let html = canvas_edge_layer_view(model)
+  let rendered = @rabbita.render_to_string(() => @rabbita.Val::constant(html))
+  assert_true(rendered.contains("<svg"))
+  assert_true(rendered.contains("id=\"edges\""))
+  assert_true(rendered.contains("transform:translate(10px, 20px) scale(1.5)"))
+  assert_true(rendered.contains("data-edge-id=\"edge-1\""))
+  assert_true(rendered.contains("role=\"button\""))
+  assert_true(rendered.contains("tabindex=\"0\""))
+  assert_true(
+    rendered.contains("aria-label=\"Disconnect source.out → target.in\""),
+  )
+  assert_true(rendered.contains("class=\"edge selected\""))
+  assert_true(rendered.contains("class=\"edge-pending\""))
+}
+
+///|
+test "edge layer update accepts the shared render snapshot shape" {
+  let json = "{\"viewport\":{\"x\":1.0,\"y\":2.0,\"scale\":3.0},\"nodes\":[],\"edges\":[{\"id\":\"edge-1\",\"path_d\":\"M 0 0\",\"selected\":false,\"aria_label\":\"Disconnect source.out → target.in\"}],\"selected_nodes\":[],\"validation\":[],\"action_count\":0,\"connecting\":{\"from\":\"source\",\"from_port\":\"out\",\"cursor_x\":1.0,\"cursor_y\":2.0,\"path_d\":[\"M 0 0\"]}}"
+  let parsed_snapshot = parse_canvas_edge_layer_snapshot(json)
+  assert_true(parsed_snapshot is Some(_))
+  let next = canvas_edge_layer_update(
+    { snapshot: None },
+    CanvasEdgeLayerMsg::RenderState(json),
+  )
+  match next.snapshot {
+    Some(snapshot) => {
+      assert_eq(snapshot.viewport.x, 1.0)
+      assert_eq(snapshot.viewport.y, 2.0)
+      assert_eq(snapshot.viewport.scale, 3.0)
+      assert_eq(snapshot.edges.length(), 1)
+      assert_eq(snapshot.connecting_path_d, Some("M 0 0"))
+    }
+    None => fail("expected the published render snapshot")
+  }
+}

--- a/apps/canvas/main/moon.pkg
+++ b/apps/canvas/main/moon.pkg
@@ -15,7 +15,9 @@ import {
   "moonbit-community/rabbita/cmd",
   "moonbit-community/rabbita/dom",
   "moonbit-community/rabbita/html",
+  "moonbit-community/rabbita/js",
   "moonbit-community/rabbita/sub",
+  "moonbit-community/rabbita/svg",
 }
 
 import {
@@ -36,6 +38,8 @@ options(
       "exports": [
         "create_canvas",
         "mount_canvas_pointer_session",
+        "mount_canvas_edge_layer",
+        "publish_render_state",
         "add_node",
         "delete_nodes",
         "clear_selected_edge",

--- a/apps/canvas/main/pkg.generated.mbti
+++ b/apps/canvas/main/pkg.generated.mbti
@@ -48,9 +48,13 @@ pub fn get_workflow_node_catalog() -> String
 
 pub fn mount_canvas_context_menu(Int, Bool, () -> Unit, (String) -> Unit) -> Unit
 
+pub fn mount_canvas_edge_layer() -> Unit
+
 pub fn mount_canvas_pointer_session(Int, Bool, () -> Unit) -> Unit
 
 pub fn mount_source_demo(Int, Bool, () -> Unit) -> Unit
+
+pub fn publish_render_state(Int, Bool) -> String
 
 pub fn sample_graph_dsl_source() -> String
 
@@ -69,7 +73,7 @@ type CanvasFullRenderJson derive(Eq)
 
 type ConnectingJson derive(Eq, ToJson)
 
-type EdgeJson derive(Eq, ToJson)
+type EdgeJson derive(Eq, ToJson, @json.FromJson)
 
 type InspectorNodeJson derive(Eq, ToJson)
 

--- a/apps/canvas/web/e2e/canvas-edge-selection-ownership.spec.ts
+++ b/apps/canvas/web/e2e/canvas-edge-selection-ownership.spec.ts
@@ -8,6 +8,10 @@ function source(name: string): string {
   return readFileSync(resolve(sourceDir, name), 'utf8');
 }
 
+function indexHtml(): string {
+  return readFileSync(resolve(process.cwd(), 'index.html'), 'utf8');
+}
+
 test('workflow edge and context-menu authority is not held by TypeScript', () => {
   const main = source('main.ts');
   const adapter = source('graph-adapter.ts');
@@ -26,22 +30,26 @@ test('workflow edge and context-menu authority is not held by TypeScript', () =>
   expect(main).not.toContain('canopy-canvas-context-menu-show');
   expect(main).not.toContain('canopy-canvas-context-menu-hide');
   expect(main).toContain('mount_canvas_context_menu');
-  expect(main).toContain('edge.path_d');
-  expect(main).not.toContain('function portOffset');
-  expect(main).not.toContain('function inputAnchor');
-  expect(main).not.toContain('function outputAnchor');
-  expect(main).not.toContain('function bezierPath');
-  expect(main).not.toContain('function edgeTitle');
-  expect(main).toContain('path_d');
-  expect(main).toContain('aria_label');
-  expect(main).toContain('pendingPath');
+  expect(main).toContain('adapter.publishRenderState()');
+  expect(main).toContain('mount_canvas_edge_layer');
+  expect(main).not.toContain('SVG_NS');
+  expect(main).not.toContain('edgesSvg');
+  expect(main).not.toContain('edgePaths');
+  expect(main).not.toContain('pendingPath');
+  expect(main).not.toContain('createElementNS');
+  expect(main).not.toContain('edge.path_d');
   expect(main).not.toContain('outputAnchor(');
   expect(main).not.toContain('inputAnchor(');
   expect(main).not.toContain('nodesById');
   expect(main).not.toContain('edge.source_port');
   expect(main).not.toContain('edge.target_port');
+  expect(indexHtml()).toContain('id="canvas-edge-layer"');
+  expect(indexHtml()).not.toContain('<svg id="edges"');
   expect(main).toContain('get_workflow_node_catalog');
   expect(adapter).not.toContain('select_edge');
   expect(adapter).not.toContain('disconnect_ports');
+  expect(adapter).not.toContain('EdgeData');
+  expect(adapter).not.toContain('path_d');
+  expect(adapter).toContain('publish_render_state');
   expect(adapter).toContain('delete_selection');
 });

--- a/apps/canvas/web/e2e/canvas-handles.spec.ts
+++ b/apps/canvas/web/e2e/canvas-handles.spec.ts
@@ -245,6 +245,34 @@ test('canvas wheel normalizes units and rejects no-op or active input', async ({
   expect(runtimeErrors).toEqual([]);
 });
 
+test('Rabbita edge paths preserve keyed identity and focus on selection updates', async ({ page }) => {
+  await page.goto('/');
+  await expect(edgePaths(page)).toHaveCount(3);
+  const edge = edgePaths(page).first();
+  await edge.focus();
+  await expect(edge).toBeFocused();
+  await edge.evaluate((node) => {
+    (window as typeof window & { __canvasEdgeIdentity?: SVGPathElement }).__canvasEdgeIdentity =
+      node as SVGPathElement;
+  });
+
+  await clickEdge(page, 0);
+  await expect(edge).toHaveClass(/(?:^|\s)selected(?:\s|$)/);
+  const identity = await edge.evaluate((node) => {
+    const windowWithIdentity = window as typeof window & {
+      __canvasEdgeIdentity?: SVGPathElement;
+    };
+    return {
+      same: windowWithIdentity.__canvasEdgeIdentity === node,
+      focused: document.activeElement === node,
+      edgeId: node.getAttribute('data-edge-id'),
+    };
+  });
+  expect(identity.same).toBe(true);
+  expect(identity.focused).toBe(true);
+  expect(identity.edgeId).toBeTruthy();
+});
+
 test('canvas handles create edges and reject invalid gestures', async ({ page }) => {
   const runtimeErrors: string[] = [];
   page.on('pageerror', (error) => runtimeErrors.push(error.message));

--- a/apps/canvas/web/e2e/source-backed.spec.ts
+++ b/apps/canvas/web/e2e/source-backed.spec.ts
@@ -446,6 +446,9 @@ test('source-backed connection ignores non-finite preview moves', async ({ page 
   await page.mouse.move(start.x + 40, start.y + 40, { steps: 4 });
   const pending = page.locator('#edges path.edge-pending');
   await expect(pending).toHaveCount(1);
+  await page.evaluate(() => new Promise<void>((resolve) => {
+    requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+  }));
   const before = await pending.getAttribute('d');
 
   await page.evaluate(() => {

--- a/apps/canvas/web/index.html
+++ b/apps/canvas/web/index.html
@@ -656,7 +656,7 @@
     <div id="source-panel-root"></div>
 
     <section id="canvas-root" tabindex="-1" aria-label="Workflow canvas">
-      <svg id="edges" xmlns="http://www.w3.org/2000/svg"></svg>
+      <div id="canvas-edge-layer"></div>
       <div id="world"></div>
     </section>
 

--- a/apps/canvas/web/src/graph-adapter.ts
+++ b/apps/canvas/web/src/graph-adapter.ts
@@ -5,6 +5,8 @@ export type CanvasModule = {
     sourceBacked: boolean,
     onChange: () => undefined,
   ) => undefined;
+  mount_canvas_edge_layer: () => undefined;
+  publish_render_state: (h: number, sourceBacked: boolean) => string;
   add_node: (h: number, kindKey: string, sx: number, sy: number) => void;
   delete_nodes: (h: number, nodeIdsJson: string) => void;
   clear_selected_edge: (h: number) => void;
@@ -115,12 +117,6 @@ export type NodeData = {
   configured: boolean;
   params?: NodeParamData[];
 };
-export type EdgeData = {
-  id: string;
-  path_d: string;
-  selected: boolean;
-  aria_label: string;
-};
 export type PortCompatibility = {
   node_id: string;
   port_id: string;
@@ -131,7 +127,6 @@ export type Connecting = {
   from_port: string;
   cursor_x: number;
   cursor_y: number;
-  path_d?: string;
 };
 export type ValidationMessage = {
   severity: 'error' | 'warning';
@@ -151,13 +146,11 @@ export type InspectorNode = {
 export type RenderState = {
   viewport: ViewportData;
   nodes: NodeData[];
-  edges: EdgeData[];
   selected?: string;
   selected_nodes: string[];
   connecting?: Connecting;
   validation: ValidationMessage[];
   action_count: number;
-  selected_edge?: string;
   inspector?: InspectorNode;
 };
 
@@ -279,6 +272,15 @@ export class GraphAdapter {
       ? this.sourceModule().get_source_graph_render_state(this.handle)
       : this.mb.get_render_state(this.handle);
     const state = JSON.parse(json) as RenderState;
+    this.emitOperationsThrough(state.action_count);
+    return state;
+  }
+
+  publishRenderState(): RenderState {
+    this.assertLive();
+    const state = JSON.parse(
+      this.mb.publish_render_state(this.handle, this.isSourceBacked),
+    ) as RenderState;
     this.emitOperationsThrough(state.action_count);
     return state;
   }

--- a/apps/canvas/web/src/main.ts
+++ b/apps/canvas/web/src/main.ts
@@ -39,22 +39,17 @@ type SourceDemoModule = CanvasModule &
     >
   >;
 
-const SVG_NS = 'http://www.w3.org/2000/svg';
-
 let adapter: GraphAdapter;
 let rafPending = false;
 
 const root       = document.getElementById('canvas-root') as HTMLDivElement;
 const world      = document.getElementById('world') as HTMLDivElement;
-const edgesSvg   = document.getElementById('edges') as unknown as SVGSVGElement;
 const search     = document.getElementById('node-search') as HTMLInputElement;
 const libraryEl  = document.getElementById('node-library') as HTMLDivElement;
 const validation = document.getElementById('validation-list') as HTMLDivElement;
 const inspectorNode = document.getElementById('inspector-node') as HTMLDivElement;
 const actionStat = document.getElementById('action-stat') as HTMLSpanElement;
 const nodeDivs = new Map<string, HTMLDivElement>();
-const edgePaths = new Map<string, SVGPathElement>();
-let pendingPath: SVGPathElement | null = null;
 let libraryCatalog: LibraryItem[] = [];
 
 
@@ -161,12 +156,11 @@ function scheduleRender(): void {
 
 function render(): void {
   rafPending = false;
-  const state = adapter.renderState();
+  const state = adapter.publishRenderState();
 
   const { x, y, scale } = state.viewport;
   const transform = `translate(${x}px, ${y}px) scale(${scale})`;
-  world.style.transform    = transform;
-  edgesSvg.style.transform = transform;
+  world.style.transform = transform;
 
   // Nodes ────────────────────────────────────────────────────────────────────
   const seenNodes = new Set<string>();
@@ -239,41 +233,6 @@ function render(): void {
   }
   for (const [id, div] of nodeDivs) {
     if (!seenNodes.has(id)) { div.remove(); nodeDivs.delete(id); }
-  }
-
-  // Edges ────────────────────────────────────────────────────────────────────
-  const seenEdges = new Set<string>();
-  for (const edge of state.edges) {
-    seenEdges.add(edge.id);
-    let path = edgePaths.get(edge.id);
-    if (!path) {
-      path = document.createElementNS(SVG_NS, 'path');
-      path.setAttribute('class', 'edge');
-      edgesSvg.appendChild(path);
-      edgePaths.set(edge.id, path);
-    }
-    path.setAttribute('d', edge.path_d);
-    path.setAttribute('data-edge-id', String(edge.id));
-    path.classList.toggle('selected', edge.selected);
-    path.setAttribute('role', 'button');
-    path.setAttribute('tabindex', '0');
-    path.setAttribute('aria-label', edge.aria_label);
-  }
-  for (const [id, path] of edgePaths) {
-    if (!seenEdges.has(id)) { path.remove(); edgePaths.delete(id); }
-  }
-
-  // In-flight connection ─────────────────────────────────────────────────────
-  if (connecting?.path_d) {
-    if (!pendingPath) {
-      pendingPath = document.createElementNS(SVG_NS, 'path');
-      pendingPath.setAttribute('class', 'edge-pending');
-      edgesSvg.appendChild(pendingPath);
-    }
-    pendingPath.setAttribute('d', connecting.path_d);
-  } else if (pendingPath) {
-    pendingPath.remove();
-    pendingPath = null;
   }
 
   renderValidation(state);
@@ -658,6 +617,7 @@ async function init(): Promise<void> {
       return undefined;
     },
   );
+  sourceDemoModule.mount_canvas_edge_layer();
   sourceDemoModule.mount_source_demo(adapter.handleId, sourceMode, () => {
     scheduleRender();
     return undefined;

--- a/docs/development/rabbita-fork.md
+++ b/docs/development/rabbita-fork.md
@@ -1,6 +1,6 @@
 # Canopy Rabbita fork
 
-Canopy uses a downstream fork of Rabbita for typed pointer-event, pointer-capture, and coordinate hit-testing DOM boundaries.
+Canopy uses a downstream fork of Rabbita for typed pointer-event, pointer-capture, coordinate hit-testing, and keyed accessible SVG boundaries.
 The fork is an owned dependency line, not an upstream release dependency.
 
 ## Ownership
@@ -8,8 +8,8 @@ The fork is an owned dependency line, not an upstream release dependency.
 - **Fork:** [`dowdiness/rabbita`](https://github.com/dowdiness/rabbita)
 - **Upstream:** [`moonbit-community/rabbita`](https://github.com/moonbit-community/rabbita)
 - **Downstream branch:** `canopy/0.14.x`
-- **Pinned commit:** `938cecdf8967e2ce07880628e4b404f106ca7671`
-- **Baseline tag:** `canopy-rabbita-0.14.2-p3`
+- **Pinned commit:** `5d9c8ae0cb0b582c856cf8b512f14ea2dee94f95`
+- **Baseline tag:** `canopy-rabbita-0.14.2-p4`
 - **Canopy submodule:** `deps/rabbita`
 
 The Canopy `.gitmodules` entry intentionally points at the fork. The
@@ -32,7 +32,11 @@ The pinned fork contains:
 - migration of Rabbita/RUI pointer-capture consumers to the new effect and
   fractional coordinate contract;
 - `Document::element_from_point(Double, Double) -> Element?`, a thin binding
-  for release-position hit-testing.
+  for release-position hit-testing;
+- `svg.Attrs::role` and `svg.Attrs::aria_label` for typed edge-path
+  accessibility attributes;
+- `svg.keyed_node`, which exposes keyed SVG children to Rabbita's keyed VDOM
+  reconciliation so edge-path DOM identity survives reorder.
 
 Canopy needs a MoonBit-typed pointer-capture boundary for its Canvas hosts. This
 patch is intentionally maintained downstream rather than proposed as an

--- a/scripts/install-local-warren.sh
+++ b/scripts/install-local-warren.sh
@@ -5,7 +5,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 RABBITA_ROOT="$PROJECT_ROOT/deps/rabbita"
 RABBITA_REMOTE="$(git -C "$PROJECT_ROOT" config -f .gitmodules --get submodule.rabbita.url)"
-EXPECTED_RABBITA="938cecdf8967e2ce07880628e4b404f106ca7671"
+EXPECTED_RABBITA="5d9c8ae0cb0b582c856cf8b512f14ea2dee94f95"
 BIN_DIR="${1:-$PROJECT_ROOT/_build/tools/bin}"
 
 actual_remote="$(git -C "$RABBITA_ROOT" remote get-url origin)"


### PR DESCRIPTION
## Summary

- Move Canvas edge SVG ownership from TypeScript DOM reconciliation into an app-private Rabbita keyed SVG layer.
- Publish one serialized render snapshot per Canvas render; Rabbita consumes the same snapshot for keyed edge paths and pending connection paths.
- Preserve edge geometry, selection classes, `role="button"`, `tabindex="0"`, ARIA labels, keyed DOM identity/focus, pending-path lifecycle, and stale-path cleanup.
- Keep TypeScript responsible for node/inspector/validation presentation and transport only; keyboard activation remains a deferred follow-up.
- Depends on Rabbita p4 PR [#3](https://github.com/dowdiness/rabbita/pull/3), which adds the keyed SVG and accessibility APIs.

## UI and review evidence

- [x] No visible labels were removed; edge paths retain accessible names, `role="button"`, and visible selection/focus behavior.
- [x] Playwright coverage checks keyed edge identity/focus, ARIA attributes, selection updates, pending paths, stale cleanup, malformed geometry omission, and source-backed rendering.
- [x] The implementation follows the Canopy render-authority boundary in `AGENTS.md`; no external UI recommendation is being treated as a repository rule.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `@rabbita.keyed_node` | `deps/rabbita/rabbita/svg/svg.mbt` | Yes | Preserves keyed SVG child identity during VDOM reconciliation. |
| `@svg.path` / `@svg.Attrs` | `deps/rabbita/rabbita/svg/` | Yes | Builds SVG paths and accessibility attributes without a new Canvas renderer. |
| `Map` | MoonBit core; keyed child map in `edge_render_layer.mbt` | Yes | Provides the keyed SVG child collection expected by Rabbita. |
| `Option` pattern matching | MoonBit core; `edge_render_layer.mbt` | Yes | Represents absent snapshots and pending paths without sentinel values. |
| `@json.parse` / `@json.from_json` | MoonBit core; existing Canvas JSON boundary | Yes | Decodes the existing shared render snapshot at the Rabbita transport boundary. |
| `Buffer` / `StringBuilder` | MoonBit core | No | No new string builder is needed; the layer forwards the existing serialized snapshot and uses attribute interpolation. |

New helpers added:

- `CanvasEdgeLayerState` and `CanvasEdgeLayerMsg` keep the app-private Rabbita layer state and message boundary local to Canvas.
- `mount_canvas_edge_layer` owns the keyed SVG mount and subscription lifecycle.
- `publish_render_state` is the narrow app-private publication seam; it returns the same snapshot consumed by the TypeScript shell.

Remaining imperative code is limited to the DOM custom-event transport/subscription shell and the existing TypeScript presentation reconciliation. Edge geometry, selection presentation, accessibility labels, and keyed SVG structure are owned by MoonBit/Rabbita.

## Validation scope

Boundary coverage includes:

- normal and selected edge paths;
- stable keyed DOM identity and focus across selection changes;
- accessible role, tabindex, and ARIA labels;
- pending connection path creation, updates, and removal;
- stale-path cleanup;
- missing, non-finite, and overflowed geometry omission;
- source-backed snapshots and shared render publication;
- TypeScript ownership/static checks for removed edge DOM state and DTOs.

Target packages:

- `apps/canvas/main`

Additional conditional gates:

- Canvas Playwright E2E: **52/52** (`./scripts/test-canvas-e2e.sh --workers=1`)
- Rabbita p4 JS tests: **399/399**
- FFI consumer fan-out, production builds, and TypeScript checks passed through `validate-pr-ready.sh`.

## PR-ready evidence

Validated HEAD: `83be246f2e2c8135d906a60e373d2475cbf065c1`

Validated base: `origin/main@1c014ee7f91e94d0f8861329d1fbc8cc4100f83e`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh --target apps/canvas/main
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for the exact HEAD and base above.
- [x] The base was fetched again and `--verify-evidence` passed immediately before opening this PR.
- [x] The committed `.mbti` diff against the validated base was reviewed; it only adds the app-private mount/publication bindings and `FromJson` derivation needed by the layer.
- [x] The changed Rabbita commit `5d9c8ae0cb0b582c856cf8b512f14ea2dee94f95` is pushed and reachable from `dowdiness/rabbita`.
- [x] Validation was rerun after the rebase and final test commit.
- [x] Independent implementation review passed; keyboard activation is explicitly deferred rather than silently claimed as complete.