### PR TITLE
docs(perf): characterize post-admission version expansion

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -119,6 +119,9 @@ Only needed if you are modifying Canopy itself.
 
 **Performance:**
 
+- [Canopy post-admission version expansion characterization](performance/2026-08-18-canopy-post-admission-version-expansion.md)
+  — attributes the next remote-admission bottleneck to an H-bound maintained-version
+  rebuild after P3 and records the event-graph-walker prototype gate.
 - [Loomark projection placement promotion evidence](performance/2026-08-15-loomark-projection-placement.md)
   — rejects Worker and in-process promotion after release-browser comparison and
   records the presentation stop condition.

--- a/docs/evidence/2026-08-18-canopy-post-admission-version-characterization.json
+++ b/docs/evidence/2026-08-18-canopy-post-admission-version-characterization.json
@@ -1,0 +1,845 @@
+{
+  "schema_version": 1,
+  "date": "2026-08-18",
+  "target": "native-release",
+  "canopy_commit": "2f27a4d4b272423d3df432b744e413c8b12dd290",
+  "event_graph_walker_commit": "9dee515f755a59f76bacab6ff582284ab1fbe7cf",
+  "moon": "0.1.20260713 (75c7e1f 2026-07-13)",
+  "moonc": "v0.10.4+2cc641edf (2026-07-15)",
+  "samples_per_cell": 3,
+  "fixture": {
+    "resident_history_operations": [
+      0,
+      1000,
+      10000,
+      100000
+    ],
+    "incoming_message_operations": [
+      1,
+      10,
+      100
+    ],
+    "materialized_text_code_units": "0 or 1 via alternating insert/delete operations",
+    "cache_precondition": "TextState version cache valid immediately before measured admission",
+    "setup_timing": "fixture construction, history admission, and cache priming excluded from inner clocks",
+    "limits": {
+      "max_encoded_bytes": 268435456,
+      "max_decoded_operations": 300000
+    }
+  },
+  "lanes": {
+    "paired_text_admission": {
+      "description": "separate receivers; sync.apply versus sync.apply followed by version; fixed A-then-B order means paired deltas are supporting evidence only",
+      "summary": [
+        {
+          "history": 0,
+          "message": 1,
+          "apply_median_us": 14.907,
+          "apply_version_median_us": 15.498000000000001,
+          "paired_delta_median_us": 0.5
+        },
+        {
+          "history": 0,
+          "message": 10,
+          "apply_median_us": 77.116,
+          "apply_version_median_us": 77.345,
+          "paired_delta_median_us": 2.423000000000002
+        },
+        {
+          "history": 0,
+          "message": 100,
+          "apply_median_us": 739.291,
+          "apply_version_median_us": 772.0020000000001,
+          "paired_delta_median_us": 26.65700000000004
+        },
+        {
+          "history": 1000,
+          "message": 1,
+          "apply_median_us": 395.954,
+          "apply_version_median_us": 478.671,
+          "paired_delta_median_us": 61.35700000000003
+        },
+        {
+          "history": 1000,
+          "message": 10,
+          "apply_median_us": 594.388,
+          "apply_version_median_us": 547.216,
+          "paired_delta_median_us": -40.38099999999997
+        },
+        {
+          "history": 1000,
+          "message": 100,
+          "apply_median_us": 1251.162,
+          "apply_version_median_us": 1367.5710000000001,
+          "paired_delta_median_us": 116.4090000000001
+        },
+        {
+          "history": 10000,
+          "message": 1,
+          "apply_median_us": 6916.115,
+          "apply_version_median_us": 12648.888,
+          "paired_delta_median_us": 5350.101000000001
+        },
+        {
+          "history": 10000,
+          "message": 10,
+          "apply_median_us": 6529.186,
+          "apply_version_median_us": 12972.562,
+          "paired_delta_median_us": 6313.809
+        },
+        {
+          "history": 10000,
+          "message": 100,
+          "apply_median_us": 8342.033,
+          "apply_version_median_us": 14711.49,
+          "paired_delta_median_us": 6369.457
+        },
+        {
+          "history": 100000,
+          "message": 1,
+          "apply_median_us": 123319.212,
+          "apply_version_median_us": 226709.277,
+          "paired_delta_median_us": 103390.065
+        },
+        {
+          "history": 100000,
+          "message": 10,
+          "apply_median_us": 115881.786,
+          "apply_version_median_us": 216233.56,
+          "paired_delta_median_us": 102446.134
+        },
+        {
+          "history": 100000,
+          "message": 100,
+          "apply_median_us": 116072.983,
+          "apply_version_median_us": 217214.986,
+          "paired_delta_median_us": 99023.147
+        }
+      ],
+      "raw": [
+        {
+          "history": 0,
+          "message": 1,
+          "apply_us": 14.298,
+          "apply_version_us": 14.798,
+          "version_delta_us": 0.5,
+          "rep": 1
+        },
+        {
+          "history": 0,
+          "message": 10,
+          "apply_us": 79.787,
+          "apply_version_us": 106.196,
+          "version_delta_us": 26.408999999999992,
+          "rep": 1
+        },
+        {
+          "history": 0,
+          "message": 100,
+          "apply_us": 719.659,
+          "apply_version_us": 802.945,
+          "version_delta_us": 83.28600000000006,
+          "rep": 1
+        },
+        {
+          "history": 1000,
+          "message": 1,
+          "apply_us": 307.809,
+          "apply_version_us": 487.294,
+          "version_delta_us": 179.48499999999996,
+          "rep": 1
+        },
+        {
+          "history": 1000,
+          "message": 10,
+          "apply_us": 594.388,
+          "apply_version_us": 547.216,
+          "version_delta_us": -47.172000000000025,
+          "rep": 1
+        },
+        {
+          "history": 1000,
+          "message": 100,
+          "apply_us": 1296.303,
+          "apply_version_us": 1326.596,
+          "version_delta_us": 30.292999999999893,
+          "rep": 1
+        },
+        {
+          "history": 10000,
+          "message": 1,
+          "apply_us": 6916.115,
+          "apply_version_us": 15216.083,
+          "version_delta_us": 8299.968,
+          "rep": 1
+        },
+        {
+          "history": 10000,
+          "message": 10,
+          "apply_us": 6397.756,
+          "apply_version_us": 10829.009,
+          "version_delta_us": 4431.253,
+          "rep": 1
+        },
+        {
+          "history": 10000,
+          "message": 100,
+          "apply_us": 7736.387,
+          "apply_version_us": 11862.533,
+          "version_delta_us": 4126.146,
+          "rep": 1
+        },
+        {
+          "history": 0,
+          "message": 1,
+          "apply_us": 26.115000000000002,
+          "apply_version_us": 25.986,
+          "version_delta_us": -0.12900000000000134,
+          "rep": 2
+        },
+        {
+          "history": 0,
+          "message": 10,
+          "apply_us": 77.116,
+          "apply_version_us": 77.345,
+          "version_delta_us": 0.2289999999999992,
+          "rep": 2
+        },
+        {
+          "history": 0,
+          "message": 100,
+          "apply_us": 745.345,
+          "apply_version_us": 772.0020000000001,
+          "version_delta_us": 26.65700000000004,
+          "rep": 2
+        },
+        {
+          "history": 1000,
+          "message": 1,
+          "apply_us": 395.954,
+          "apply_version_us": 457.31100000000004,
+          "version_delta_us": 61.35700000000003,
+          "rep": 2
+        },
+        {
+          "history": 1000,
+          "message": 10,
+          "apply_us": 697.37,
+          "apply_version_us": 656.989,
+          "version_delta_us": -40.38099999999997,
+          "rep": 2
+        },
+        {
+          "history": 1000,
+          "message": 100,
+          "apply_us": 1251.162,
+          "apply_version_us": 1367.5710000000001,
+          "version_delta_us": 116.4090000000001,
+          "rep": 2
+        },
+        {
+          "history": 10000,
+          "message": 1,
+          "apply_us": 6174.6410000000005,
+          "apply_version_us": 11463.506,
+          "version_delta_us": 5288.864999999999,
+          "rep": 2
+        },
+        {
+          "history": 10000,
+          "message": 10,
+          "apply_us": 6658.753,
+          "apply_version_us": 12972.562,
+          "version_delta_us": 6313.809,
+          "rep": 2
+        },
+        {
+          "history": 10000,
+          "message": 100,
+          "apply_us": 8342.033,
+          "apply_version_us": 14711.49,
+          "version_delta_us": 6369.457,
+          "rep": 2
+        },
+        {
+          "history": 0,
+          "message": 1,
+          "apply_us": 14.907,
+          "apply_version_us": 15.498000000000001,
+          "version_delta_us": 0.5910000000000011,
+          "rep": 3
+        },
+        {
+          "history": 0,
+          "message": 10,
+          "apply_us": 74.655,
+          "apply_version_us": 77.078,
+          "version_delta_us": 2.423000000000002,
+          "rep": 3
+        },
+        {
+          "history": 0,
+          "message": 100,
+          "apply_us": 739.291,
+          "apply_version_us": 760.048,
+          "version_delta_us": 20.756999999999948,
+          "rep": 3
+        },
+        {
+          "history": 1000,
+          "message": 1,
+          "apply_us": 457.843,
+          "apply_version_us": 478.671,
+          "version_delta_us": 20.827999999999975,
+          "rep": 3
+        },
+        {
+          "history": 1000,
+          "message": 10,
+          "apply_us": 495.301,
+          "apply_version_us": 520.075,
+          "version_delta_us": 24.774000000000058,
+          "rep": 3
+        },
+        {
+          "history": 1000,
+          "message": 100,
+          "apply_us": 1190.819,
+          "apply_version_us": 1387.332,
+          "version_delta_us": 196.51300000000015,
+          "rep": 3
+        },
+        {
+          "history": 10000,
+          "message": 1,
+          "apply_us": 7298.787,
+          "apply_version_us": 12648.888,
+          "version_delta_us": 5350.101000000001,
+          "rep": 3
+        },
+        {
+          "history": 10000,
+          "message": 10,
+          "apply_us": 6529.186,
+          "apply_version_us": 14034.935,
+          "version_delta_us": 7505.749,
+          "rep": 3
+        },
+        {
+          "history": 10000,
+          "message": 100,
+          "apply_us": 8651.427,
+          "apply_version_us": 17704.527000000002,
+          "version_delta_us": 9053.100000000002,
+          "rep": 3
+        },
+        {
+          "history": 100000,
+          "message": 1,
+          "apply_us": 165281.868,
+          "apply_version_us": 270352.655,
+          "version_delta_us": 105070.787,
+          "rep": 1
+        },
+        {
+          "history": 100000,
+          "message": 10,
+          "apply_us": 119298.697,
+          "apply_version_us": 212367.538,
+          "version_delta_us": 93068.841,
+          "rep": 1
+        },
+        {
+          "history": 100000,
+          "message": 100,
+          "apply_us": 116072.983,
+          "apply_version_us": 208485.693,
+          "version_delta_us": 92412.71,
+          "rep": 1
+        },
+        {
+          "history": 100000,
+          "message": 1,
+          "apply_us": 113974.105,
+          "apply_version_us": 213734.724,
+          "version_delta_us": 99760.619,
+          "rep": 2
+        },
+        {
+          "history": 100000,
+          "message": 10,
+          "apply_us": 113336.791,
+          "apply_version_us": 216233.56,
+          "version_delta_us": 102896.769,
+          "rep": 2
+        },
+        {
+          "history": 100000,
+          "message": 100,
+          "apply_us": 113073.922,
+          "apply_version_us": 219850.213,
+          "version_delta_us": 106776.291,
+          "rep": 2
+        },
+        {
+          "history": 100000,
+          "message": 1,
+          "apply_us": 123319.212,
+          "apply_version_us": 226709.277,
+          "version_delta_us": 103390.065,
+          "rep": 3
+        },
+        {
+          "history": 100000,
+          "message": 10,
+          "apply_us": 115881.786,
+          "apply_version_us": 218327.92,
+          "version_delta_us": 102446.134,
+          "rep": 3
+        },
+        {
+          "history": 100000,
+          "message": 100,
+          "apply_us": 118191.839,
+          "apply_version_us": 217214.986,
+          "version_delta_us": 99023.147,
+          "rep": 3
+        }
+      ]
+    },
+    "isolated_direct_version": {
+      "description": "history-primed receiver admits M outside the clock; only first post-admission TextState.version call is timed",
+      "summary": [
+        {
+          "history": 0,
+          "message": 1,
+          "direct_version_median_us": 5.3420000000000005
+        },
+        {
+          "history": 1000,
+          "message": 1,
+          "direct_version_median_us": 444.308
+        },
+        {
+          "history": 10000,
+          "message": 1,
+          "direct_version_median_us": 10410.789
+        },
+        {
+          "history": 100000,
+          "message": 1,
+          "direct_version_median_us": 211752.999
+        },
+        {
+          "history": 100000,
+          "message": 10,
+          "direct_version_median_us": 205915.902
+        },
+        {
+          "history": 100000,
+          "message": 100,
+          "direct_version_median_us": 199511.731
+        }
+      ],
+      "raw": [
+        {
+          "history": 0,
+          "message": 1,
+          "direct_version_us": 5.313,
+          "rep": 1
+        },
+        {
+          "history": 1000,
+          "message": 1,
+          "direct_version_us": 474.317,
+          "rep": 1
+        },
+        {
+          "history": 10000,
+          "message": 1,
+          "direct_version_us": 11036.414,
+          "rep": 1
+        },
+        {
+          "history": 100000,
+          "message": 1,
+          "direct_version_us": 211752.999,
+          "rep": 1
+        },
+        {
+          "history": 100000,
+          "message": 10,
+          "direct_version_us": 205915.902,
+          "rep": 1
+        },
+        {
+          "history": 100000,
+          "message": 100,
+          "direct_version_us": 200994.64500000002,
+          "rep": 1
+        },
+        {
+          "history": 0,
+          "message": 1,
+          "direct_version_us": 5.3420000000000005,
+          "rep": 2
+        },
+        {
+          "history": 1000,
+          "message": 1,
+          "direct_version_us": 417.80400000000003,
+          "rep": 2
+        },
+        {
+          "history": 10000,
+          "message": 1,
+          "direct_version_us": 10410.789,
+          "rep": 2
+        },
+        {
+          "history": 100000,
+          "message": 1,
+          "direct_version_us": 200327.731,
+          "rep": 2
+        },
+        {
+          "history": 100000,
+          "message": 10,
+          "direct_version_us": 228540.78399999999,
+          "rep": 2
+        },
+        {
+          "history": 100000,
+          "message": 100,
+          "direct_version_us": 199511.731,
+          "rep": 2
+        },
+        {
+          "history": 0,
+          "message": 1,
+          "direct_version_us": 5.438,
+          "rep": 3
+        },
+        {
+          "history": 1000,
+          "message": 1,
+          "direct_version_us": 444.308,
+          "rep": 3
+        },
+        {
+          "history": 10000,
+          "message": 1,
+          "direct_version_us": 6150.876,
+          "rep": 3
+        },
+        {
+          "history": 100000,
+          "message": 1,
+          "direct_version_us": 213651.97699999996,
+          "rep": 3
+        },
+        {
+          "history": 100000,
+          "message": 10,
+          "direct_version_us": 198015.46300000002,
+          "rep": 3
+        },
+        {
+          "history": 100000,
+          "message": 100,
+          "direct_version_us": 196723.494,
+          "rep": 3
+        }
+      ]
+    },
+    "canopy_sync_editor_admission": {
+      "description": "full public SyncEditor.admit_with_limits transition including before/after authority versions and parser reconciliation",
+      "summary": [
+        {
+          "history": 0,
+          "message": 1,
+          "canopy_admission_median_us": 20.342
+        },
+        {
+          "history": 0,
+          "message": 10,
+          "canopy_admission_median_us": 88.141
+        },
+        {
+          "history": 0,
+          "message": 100,
+          "canopy_admission_median_us": 804.354
+        },
+        {
+          "history": 1000,
+          "message": 1,
+          "canopy_admission_median_us": 392.194
+        },
+        {
+          "history": 1000,
+          "message": 10,
+          "canopy_admission_median_us": 448.62600000000003
+        },
+        {
+          "history": 1000,
+          "message": 100,
+          "canopy_admission_median_us": 1304.474
+        },
+        {
+          "history": 10000,
+          "message": 1,
+          "canopy_admission_median_us": 6281.902
+        },
+        {
+          "history": 10000,
+          "message": 10,
+          "canopy_admission_median_us": 6906.3
+        },
+        {
+          "history": 10000,
+          "message": 100,
+          "canopy_admission_median_us": 6667.018
+        },
+        {
+          "history": 100000,
+          "message": 1,
+          "canopy_admission_median_us": 126339.54
+        },
+        {
+          "history": 100000,
+          "message": 10,
+          "canopy_admission_median_us": 125745.747
+        },
+        {
+          "history": 100000,
+          "message": 100,
+          "canopy_admission_median_us": 126656.11600000001
+        }
+      ],
+      "raw": [
+        {
+          "history": 0,
+          "message": 1,
+          "canopy_admission_us": 20.064,
+          "rep": 1
+        },
+        {
+          "history": 0,
+          "message": 10,
+          "canopy_admission_us": 83.904,
+          "rep": 1
+        },
+        {
+          "history": 0,
+          "message": 100,
+          "canopy_admission_us": 804.354,
+          "rep": 1
+        },
+        {
+          "history": 1000,
+          "message": 1,
+          "canopy_admission_us": 385.766,
+          "rep": 1
+        },
+        {
+          "history": 1000,
+          "message": 10,
+          "canopy_admission_us": 475.652,
+          "rep": 1
+        },
+        {
+          "history": 1000,
+          "message": 100,
+          "canopy_admission_us": 1239.644,
+          "rep": 1
+        },
+        {
+          "history": 10000,
+          "message": 1,
+          "canopy_admission_us": 5207.7480000000005,
+          "rep": 1
+        },
+        {
+          "history": 10000,
+          "message": 10,
+          "canopy_admission_us": 5861.438,
+          "rep": 1
+        },
+        {
+          "history": 10000,
+          "message": 100,
+          "canopy_admission_us": 5498.0560000000005,
+          "rep": 1
+        },
+        {
+          "history": 0,
+          "message": 1,
+          "canopy_admission_us": 20.342,
+          "rep": 2
+        },
+        {
+          "history": 0,
+          "message": 10,
+          "canopy_admission_us": 88.141,
+          "rep": 2
+        },
+        {
+          "history": 0,
+          "message": 100,
+          "canopy_admission_us": 842.941,
+          "rep": 2
+        },
+        {
+          "history": 1000,
+          "message": 1,
+          "canopy_admission_us": 563.0070000000001,
+          "rep": 2
+        },
+        {
+          "history": 1000,
+          "message": 10,
+          "canopy_admission_us": 448.62600000000003,
+          "rep": 2
+        },
+        {
+          "history": 1000,
+          "message": 100,
+          "canopy_admission_us": 1366.441,
+          "rep": 2
+        },
+        {
+          "history": 10000,
+          "message": 1,
+          "canopy_admission_us": 6281.902,
+          "rep": 2
+        },
+        {
+          "history": 10000,
+          "message": 10,
+          "canopy_admission_us": 7814.5470000000005,
+          "rep": 2
+        },
+        {
+          "history": 10000,
+          "message": 100,
+          "canopy_admission_us": 6667.018,
+          "rep": 2
+        },
+        {
+          "history": 0,
+          "message": 1,
+          "canopy_admission_us": 26.255,
+          "rep": 3
+        },
+        {
+          "history": 0,
+          "message": 10,
+          "canopy_admission_us": 163.835,
+          "rep": 3
+        },
+        {
+          "history": 0,
+          "message": 100,
+          "canopy_admission_us": 799.985,
+          "rep": 3
+        },
+        {
+          "history": 1000,
+          "message": 1,
+          "canopy_admission_us": 392.194,
+          "rep": 3
+        },
+        {
+          "history": 1000,
+          "message": 10,
+          "canopy_admission_us": 443.72700000000003,
+          "rep": 3
+        },
+        {
+          "history": 1000,
+          "message": 100,
+          "canopy_admission_us": 1304.474,
+          "rep": 3
+        },
+        {
+          "history": 10000,
+          "message": 1,
+          "canopy_admission_us": 7840.45,
+          "rep": 3
+        },
+        {
+          "history": 10000,
+          "message": 10,
+          "canopy_admission_us": 6906.3,
+          "rep": 3
+        },
+        {
+          "history": 10000,
+          "message": 100,
+          "canopy_admission_us": 7310.004,
+          "rep": 3
+        },
+        {
+          "history": 100000,
+          "message": 1,
+          "canopy_admission_us": 126339.54,
+          "rep": 1
+        },
+        {
+          "history": 100000,
+          "message": 10,
+          "canopy_admission_us": 125745.747,
+          "rep": 1
+        },
+        {
+          "history": 100000,
+          "message": 100,
+          "canopy_admission_us": 126656.11600000001,
+          "rep": 1
+        },
+        {
+          "history": 100000,
+          "message": 1,
+          "canopy_admission_us": 124370.56400000001,
+          "rep": 2
+        },
+        {
+          "history": 100000,
+          "message": 10,
+          "canopy_admission_us": 123316.979,
+          "rep": 2
+        },
+        {
+          "history": 100000,
+          "message": 100,
+          "canopy_admission_us": 128063.49300000002,
+          "rep": 2
+        },
+        {
+          "history": 100000,
+          "message": 1,
+          "canopy_admission_us": 127243.049,
+          "rep": 3
+        },
+        {
+          "history": 100000,
+          "message": 10,
+          "canopy_admission_us": 126095.68000000001,
+          "rep": 3
+        },
+        {
+          "history": 100000,
+          "message": 100,
+          "canopy_admission_us": 124358.666,
+          "rep": 3
+        }
+      ]
+    }
+  },
+  "limitations": [
+    "MoonBench exposes no allocator counter; retained allocation is not reported.",
+    "Paired Text lane always runs apply-only before apply-plus-version; use the isolated direct-version lane for mechanism attribution.",
+    "Absolute latency is native-only and not a cross-runtime performance claim.",
+    "Temporary benchmark source is intentionally not retained in the production test suite."
+  ]
+}

--- a/docs/performance/2026-08-18-canopy-post-admission-version-expansion.md
+++ b/docs/performance/2026-08-18-canopy-post-admission-version-expansion.md
@@ -1,0 +1,166 @@
+# Canopy post-admission version expansion characterization
+
+**Date:** 2026-08-18
+**Canopy baseline:** `2f27a4d4b272423d3df432b744e413c8b12dd290`
+**event-graph-walker baseline:** `9dee515f755a59f76bacab6ff582284ab1fbe7cf`
+**Follow-up:** [event-graph-walker #123](https://github.com/dowdiness/event-graph-walker/issues/123)
+
+## Decision
+
+The next remote-admission performance prototype should maintain the Text version
+cache from the committed operation receipt instead of rebuilding it from all
+resident operations after every accepted message.
+
+P3 removed history-dependent work from the message admission core, but Canopy's
+`SyncEditor` immediately reads the authority version before and after admission.
+The post-admission read observes the invalid cache and restores history-dependent
+latency outside the P3 measurement boundary. This is an authority-transition
+problem, not a parser, projection, transport, or incoming-message-size problem.
+
+Keep production behavior unchanged in this characterization change. The prototype
+belongs in event-graph-walker's Text admission ownership, where committed,
+duplicate, pending, partial, and recovery outcomes are known. Do not add a Canopy
+caller-side version prediction.
+
+No ADR needed: this change records native characterization evidence and a prototype
+gate without changing production behavior, public interfaces, or accepted ownership.
+A future receipt or cache-maintenance contract that changes public semantics requires
+its own design review and, if public, an ADR.
+
+## Question
+
+After P3 batch admission, does the first maintained-version read scale with incoming
+message operations $M$ or resident history operations $H$, and does Canopy perform
+that read in its real remote-admission transition?
+
+## Harness
+
+All cells use native release builds and three independent processes. The fixture:
+
+- creates exactly $H=0/1k/10k/100k$ resident Text operations;
+- alternates insert and delete, keeping materialized text at zero or one UTF-16 code
+  unit so document length does not stand in for operation history;
+- primes the maintained version cache after history admission;
+- admits exactly $M=1/10/100$ new operations once;
+- excludes fixture construction, history admission, and cache priming from inner
+  clocks;
+- uses expanded private limits only to admit the 100k-operation fixture.
+
+Three lanes were measured:
+
+1. Text `sync().apply(message)`;
+2. Text `sync().apply(message)` followed by `version()` on a separate receiver;
+3. full Canopy `SyncEditor::admit_with_limits(message)` through the public interface.
+
+A fourth isolated control admits the message outside the clock and times only the
+first invalid-cache `TextState::version()` read. This is the attribution lane. The
+paired Text lane always runs apply-only before apply-plus-version, so its subtraction
+can include GC and order effects and is supporting evidence only.
+
+MoonBench exposes no allocator counter. This report makes no allocation claim and no
+cross-runtime claim.
+
+## Paired Text admission matrix
+
+Medians in milliseconds:
+
+| H | M | apply | apply + version |
+|---:|---:|---:|---:|
+| 0 | 1 | 0.015 | 0.015 |
+| 0 | 10 | 0.077 | 0.077 |
+| 0 | 100 | 0.739 | 0.772 |
+| 1,000 | 1 | 0.396 | 0.479 |
+| 1,000 | 10 | 0.594 | 0.547 |
+| 1,000 | 100 | 1.251 | 1.368 |
+| 10,000 | 1 | 6.916 | 12.649 |
+| 10,000 | 10 | 6.529 | 12.973 |
+| 10,000 | 100 | 8.342 | 14.711 |
+| 100,000 | 1 | 123.319 | 226.709 |
+| 100,000 | 10 | 115.882 | 216.234 |
+| 100,000 | 100 | 116.073 | 217.215 |
+
+At 10k and 100k history, the second lane adds an H-sized cost that changes little
+with M. The 1k cells are within native process and GC noise and are not used for the
+mechanism claim.
+
+## Isolated invalid-cache version control
+
+Medians in milliseconds:
+
+| H | M | first post-admission `version()` |
+|---:|---:|---:|
+| 0 | 1 | 0.005 |
+| 1,000 | 1 | 0.444 |
+| 10,000 | 1 | 10.411 |
+| 100,000 | 1 | 211.753 |
+| 100,000 | 10 | 205.916 |
+| 100,000 | 100 | 199.512 |
+
+Increasing H from 0 to 100k raises the direct version read from 5.3 microseconds to
+211.8 milliseconds. At H=100k, changing M by 100x leaves the median in the
+199.5-211.8 ms band. The invalid-cache expansion is therefore history-bound, not
+message-bound.
+
+## Full Canopy admission
+
+Medians in milliseconds:
+
+| H | M | `SyncEditor::admit_with_limits` |
+|---:|---:|---:|
+| 0 | 1 | 0.020 |
+| 0 | 10 | 0.088 |
+| 0 | 100 | 0.804 |
+| 1,000 | 1 | 0.392 |
+| 1,000 | 10 | 0.449 |
+| 1,000 | 100 | 1.304 |
+| 10,000 | 1 | 6.282 |
+| 10,000 | 10 | 6.906 |
+| 10,000 | 100 | 6.667 |
+| 100,000 | 1 | 126.340 |
+| 100,000 | 10 | 125.746 |
+| 100,000 | 100 | 126.656 |
+
+The real Canopy transition reproduces the same shape: at H=100k the median is
+approximately 126 ms for all three M values. Parser reconciliation operates on at
+most one code unit in this fixture, so it cannot explain the history scaling.
+Absolute values differ between lanes because each exercises a different amount of
+admission, projection, allocation, and GC work; the shared H-scaling and M-invariance
+are the claim.
+
+## Source attribution
+
+`SyncSession::apply_with_limits` invalidates `TextState.cached_version` whenever the
+committed count is non-zero. `TextState::version()` then rebuilds the version from the
+operation log.
+
+Canopy's `SyncEditor::admit_with_policy` performs:
+
+1. pre-admission `doc.version()`;
+2. authority admission;
+3. post-admission `doc.version()`;
+4. authority/projection continuation and parser reconciliation.
+
+The post-admission read is required for the existing transition comparison, so P3's
+fast admission core is followed immediately by the full version expansion.
+
+## Prototype gate
+
+Prototype committed-operation cache maintenance inside event-graph-walker's Text
+admission seam. Acceptance requires:
+
+1. cache state equivalent to a fresh `Version::from_ops` reconstruction after
+   complete, duplicate-only, pending-only, partial, dependency-drain, and recovery
+   outcomes;
+2. no caller prediction and no Canopy-only special case;
+3. unchanged public `SyncReport` behavior unless a separately reviewed receipt
+   contract is necessary;
+4. direct-version and full-Canopy H/M matrices showing the post-admission version
+   read no longer scales with H;
+5. native plus JS or wasm-gc evidence before any cross-runtime or end-user speedup
+   claim.
+
+## Evidence
+
+- [Raw samples, medians, provenance, and limitations](../evidence/2026-08-18-canopy-post-admission-version-characterization.json)
+- [P3 Text admission cutover characterization](../../deps/event-graph-walker/docs/performance/2026-08-17-egw-p3-text-admission-cutover-native-characterization.md)
+- [Version-cache maintenance follow-up](https://github.com/dowdiness/event-graph-walker/issues/123)


### PR DESCRIPTION
## Summary

- retain native-release H/M characterization for Text post-admission version expansion and full Canopy admission
- isolate the first invalid-cache `TextState::version()` read from paired-lane GC/order effects
- attribute the next bottleneck to resident history H, not incoming message size M
- file the implementation gate in dowdiness/event-graph-walker#123

## Result

At M=1, the isolated first post-admission version read scales from 5.3 µs at H=0 to 10.4 ms at H=10k and 211.8 ms at H=100k. At H=100k, M=1/10/100 remains in a 199.5–211.8 ms band.

The full public `SyncEditor::admit_with_limits` transition reproduces the shape: H=100k medians are 126.3/125.7/126.7 ms for M=1/10/100.

Production behavior is unchanged. Temporary benchmark source was removed after retaining raw samples, medians, provenance, and limitations.

## Verification

- 3 independent native-release processes per retained cell
- retained medians reproduced from raw JSON samples
- changed Markdown links resolve; detector calibrated with a known-broken control
- `scripts/test-documentation-lifecycle.sh`
- `scripts/check-documentation-lifecycle.sh`
- `scripts/check-agent-doc-links.sh`
- `jq empty docs/evidence/2026-08-18-canopy-post-admission-version-characterization.json`
- `git diff --check`
- independent `openai-codex/gpt-5.3-codex-spark` review: PASS, no findings

Related: dowdiness/event-graph-walker#123
