### PR TITLE
fix(canvas): align edge keyboard activation and accessible naming

### DIFF
--- a/apps/canvas/main/edge_render_layer_wbtest.mbt
+++ b/apps/canvas/main/edge_render_layer_wbtest.mbt
@@ -9,7 +9,7 @@ test "edge layer view renders accessible keyed paths and pending path" {
           id: "edge-1",
           path_d: "M 0 0 C 40 0, 40 10, 80 10",
           selected: true,
-          aria_label: "Disconnect source.out → target.in",
+          aria_label: "Connection source.out → target.in",
         },
       ],
       connecting_path_d: Some("M 0 0 C 40 0, 40 10, 80 10"),
@@ -24,7 +24,7 @@ test "edge layer view renders accessible keyed paths and pending path" {
   assert_true(rendered.contains("role=\"button\""))
   assert_true(rendered.contains("tabindex=\"0\""))
   assert_true(
-    rendered.contains("aria-label=\"Disconnect source.out → target.in\""),
+    rendered.contains("aria-label=\"Connection source.out → target.in\""),
   )
   assert_true(rendered.contains("class=\"edge selected\""))
   assert_true(rendered.contains("class=\"edge-pending\""))
@@ -32,7 +32,7 @@ test "edge layer view renders accessible keyed paths and pending path" {
 
 ///|
 test "edge layer update accepts the shared render snapshot shape" {
-  let json = "{\"viewport\":{\"x\":1.0,\"y\":2.0,\"scale\":3.0},\"nodes\":[],\"edges\":[{\"id\":\"edge-1\",\"path_d\":\"M 0 0\",\"selected\":false,\"aria_label\":\"Disconnect source.out → target.in\"}],\"selected_nodes\":[],\"validation\":[],\"action_count\":0,\"connecting\":{\"from\":\"source\",\"from_port\":\"out\",\"cursor_x\":1.0,\"cursor_y\":2.0,\"path_d\":[\"M 0 0\"]}}"
+  let json = "{\"viewport\":{\"x\":1.0,\"y\":2.0,\"scale\":3.0},\"nodes\":[],\"edges\":[{\"id\":\"edge-1\",\"path_d\":\"M 0 0\",\"selected\":false,\"aria_label\":\"Connection source.out → target.in\"}],\"selected_nodes\":[],\"validation\":[],\"action_count\":0,\"connecting\":{\"from\":\"source\",\"from_port\":\"out\",\"cursor_x\":1.0,\"cursor_y\":2.0,\"path_d\":[\"M 0 0\"]}}"
   let parsed_snapshot = parse_canvas_edge_layer_snapshot(json)
   assert_true(parsed_snapshot is Some(_))
   let next = canvas_edge_layer_update(

--- a/apps/canvas/main/edge_render_projection.mbt
+++ b/apps/canvas/main/edge_render_projection.mbt
@@ -125,7 +125,7 @@ fn project_edge_render(
     id: edge.id.to_string(),
     path_d,
     selected: selected_edge == Some(edge.id),
-    aria_label: "Disconnect \{source_id}.\{edge.source_port} → \{target_id}.\{edge.target_port}",
+    aria_label: "Connection \{source_id}.\{edge.source_port} → \{target_id}.\{edge.target_port}",
   })
 }
 

--- a/apps/canvas/main/edge_render_projection_wbtest.mbt
+++ b/apps/canvas/main/edge_render_projection_wbtest.mbt
@@ -94,7 +94,7 @@ test "edge projection derives anchors and exact horizontal cubic paths" {
     project_edge_render(node_index, edge, None),
   )
   assert_eq(projected.path_d, "M 110 60 C 205 60, 205 80, 300 80")
-  assert_eq(projected.aria_label, "Disconnect source.out → target.in")
+  assert_eq(projected.aria_label, "Connection source.out → target.in")
   assert_true(!projected.selected)
 
   let nearby_target = { ..target, x: 130.0 }

--- a/apps/canvas/main/pointer_session.mbt
+++ b/apps/canvas/main/pointer_session.mbt
@@ -608,6 +608,22 @@ fn canvas_pointer_message(
       }
     "click" =>
       Some(Click(canvas_pointer_hit_from_element(event.target().to_element())))
+    "keydown" =>
+      match event.to_keyboard_event() {
+        None => None
+        Some(keyboard) =>
+          match keyboard.key() {
+            "Enter" | " " | "Spacebar" =>
+              match canvas_pointer_hit_from_element(keyboard.target().to_element()) {
+                Edge(edge_id) => {
+                  keyboard.prevent_default()
+                  Some(Click(Edge(edge_id)))
+                }
+                _ => None
+              }
+            _ => None
+          }
+      }
     _ =>
       match event.to_pointer_event() {
         None => None
@@ -689,6 +705,7 @@ fn canvas_pointer_subscriptions(
 ) -> @sub.Sub {
   @sub.batch([
     canvas_pointer_subscription("click", emit),
+    canvas_pointer_subscription("keydown", emit),
     canvas_pointer_subscription("pointerdown", emit),
     canvas_pointer_subscription("pointermove", emit),
     canvas_pointer_subscription("pointerup", emit),

--- a/apps/canvas/web/e2e/canvas-handles.spec.ts
+++ b/apps/canvas/web/e2e/canvas-handles.spec.ts
@@ -273,6 +273,84 @@ test('Rabbita edge paths preserve keyed identity and focus on selection updates'
   expect(identity.edgeId).toBeTruthy();
 });
 
+test('edge keyboard activation selects without actions or Space scrolling', async ({ page }) => {
+  await page.goto('/');
+  await expect(edgePaths(page)).toHaveCount(3);
+  await expect(page.locator('#action-stat')).toHaveText('0 actions logged');
+
+  const backgroundDefaultPrevented = await page.locator('#canvas-root').evaluate((node) => {
+    const event = new KeyboardEvent('keydown', {
+      bubbles: true,
+      cancelable: true,
+      key: 'Enter',
+    });
+    node.dispatchEvent(event);
+    return event.defaultPrevented;
+  });
+  expect(backgroundDefaultPrevented).toBe(false);
+
+  const first = edgePaths(page).first();
+  await first.focus();
+  const unrelatedDefaultPrevented = await first.evaluate((node) => {
+    const event = new KeyboardEvent('keydown', {
+      bubbles: true,
+      cancelable: true,
+      key: 'ArrowRight',
+    });
+    node.dispatchEvent(event);
+    return event.defaultPrevented;
+  });
+  expect(unrelatedDefaultPrevented).toBe(false);
+  await first.evaluate((node) => {
+    (window as typeof window & { __canvasKeyboardEdgeIdentity?: SVGPathElement }).__canvasKeyboardEdgeIdentity =
+      node as SVGPathElement;
+  });
+  await page.keyboard.press('Enter');
+  await expect(first).toHaveClass(/(?:^|\s)selected(?:\s|$)/);
+  await expect(first).toBeFocused();
+  expect(await first.evaluate((node) => {
+    const windowWithIdentity = window as typeof window & {
+      __canvasKeyboardEdgeIdentity?: SVGPathElement;
+    };
+    return windowWithIdentity.__canvasKeyboardEdgeIdentity === node;
+  })).toBe(true);
+  await expect(page.locator('#action-stat')).toHaveText('0 actions logged');
+
+  const second = edgePaths(page).nth(1);
+  await second.focus();
+  const defaultPrevented = await second.evaluate((node) => {
+    const event = new KeyboardEvent('keydown', {
+      bubbles: true,
+      cancelable: true,
+      code: 'Space',
+      key: ' ',
+    });
+    node.dispatchEvent(event);
+    return event.defaultPrevented;
+  });
+  expect(defaultPrevented).toBe(true);
+  await expect(second).toHaveClass(/(?:^|\s)selected(?:\s|$)/);
+  await expect(second).toBeFocused();
+  await expect(page.locator('#action-stat')).toHaveText('0 actions logged');
+
+  const third = edgePaths(page).nth(2);
+  await third.focus();
+  const legacySpaceDefaultPrevented = await third.evaluate((node) => {
+    const event = new KeyboardEvent('keydown', {
+      bubbles: true,
+      cancelable: true,
+      code: 'Space',
+      key: 'Spacebar',
+    });
+    node.dispatchEvent(event);
+    return event.defaultPrevented;
+  });
+  expect(legacySpaceDefaultPrevented).toBe(true);
+  await expect(third).toHaveClass(/(?:^|\s)selected(?:\s|$)/);
+  await expect(third).toBeFocused();
+  await expect(page.locator('#action-stat')).toHaveText('0 actions logged');
+});
+
 test('canvas handles create edges and reject invalid gestures', async ({ page }) => {
   const runtimeErrors: string[] = [];
   page.on('pageerror', (error) => runtimeErrors.push(error.message));
@@ -296,7 +374,7 @@ test('canvas handles create edges and reject invalid gestures', async ({ page })
   await expect(edgePaths(page).first()).toHaveAttribute('role', 'button');
   await expect(edgePaths(page).first()).toHaveAttribute('tabindex', '0');
   await expect(edgePaths(page).first()).toHaveAttribute('data-edge-id');
-  await expect(edgePaths(page).first()).toHaveAttribute('aria-label', /^Disconnect /);
+  await expect(edgePaths(page).first()).toHaveAttribute('aria-label', /^Connection /);
   expect(runtimeErrors).toEqual([]);
 
   const source = outputHandle(page, 1);

--- a/apps/canvas/web/e2e/source-backed.spec.ts
+++ b/apps/canvas/web/e2e/source-backed.spec.ts
@@ -222,7 +222,44 @@ test('source-backed canvas gestures lower into canonical source', async ({ page 
   await expectSource(page, 'osc = sine(freq: 440Hz)\nmeter = scope(input: osc)');
   await expect(page.locator('#edges path.edge')).toHaveCount(1);
   await expect(page.locator('#edges path.edge')).toHaveAttribute('d', /^M /);
-  await expect(page.locator('#edges path.edge')).toHaveAttribute('aria-label', /^Disconnect /);
+  await expect(page.locator('#edges path.edge')).toHaveAttribute('aria-label', /^Connection /);
+  await expect(page.locator('#action-stat')).toHaveText('1 action logged');
+  expect(runtimeErrors).toEqual([]);
+});
+
+test('source-backed edge keyboard activation selects without changing source', async ({ page }) => {
+  const runtimeErrors = collectRuntimeErrors(page);
+
+  await page.goto('/?source=1');
+  await expectSource(page, SAMPLE_SOURCE);
+
+  await dragBetween(page, outputHandle(page, 'osc'), inputHandle(page, 'meter'));
+  await expect(page.locator('#edges path.edge-pending')).toHaveCount(1);
+  await page.mouse.up();
+  await expectSource(page, 'osc = sine(freq: 440Hz)\nmeter = scope(input: osc)');
+  await expect(edgePaths(page)).toHaveCount(1);
+  await expect(page.locator('#action-stat')).toHaveText('1 action logged');
+
+  const edge = edgePaths(page).first();
+  await edge.focus();
+  await page.keyboard.press('Enter');
+  await expect(edge).toHaveClass(/(?:^|\s)selected(?:\s|$)/);
+  await expect(edge).toBeFocused();
+  await expect(page.locator('#action-stat')).toHaveText('1 action logged');
+  await expectSource(page, 'osc = sine(freq: 440Hz)\nmeter = scope(input: osc)');
+
+  const defaultPrevented = await edge.evaluate((node) => {
+    const event = new KeyboardEvent('keydown', {
+      bubbles: true,
+      cancelable: true,
+      code: 'Space',
+      key: ' ',
+    });
+    node.dispatchEvent(event);
+    return event.defaultPrevented;
+  });
+  expect(defaultPrevented).toBe(true);
+  await expect(edge).toHaveClass(/(?:^|\s)selected(?:\s|$)/);
   await expect(page.locator('#action-stat')).toHaveText('1 action logged');
   expect(runtimeErrors).toEqual([]);
 });


### PR DESCRIPTION
## Summary

- Add app-private Canvas-root keyboard activation for focused edge paths: Enter, Space, and legacy Spacebar now select the edge through the existing typed selection owner.
- Prevent Space scrolling only for edge activation, ignore non-edge targets and unrelated keys, and keep selection ephemeral without action-log or source changes.
- Align edge accessible names with pointer semantics: `Connection source.port → target.port` rather than a disconnect command.

## UI and review evidence

- [x] No visible label was removed; the edge accessible name now describes the selectable connection, while `role="button"`, `tabindex="0"`, visible focus, and keyed identity remain intact.
- [x] Rendered Playwright coverage checks Enter, Space, Spacebar, default prevention, non-edge/unrelated-key rejection, focus identity, workflow selection, and source-backed selection.
- [x] The change follows the Canvas ownership boundaries in `AGENTS.md`; ARIA button behavior is applied as accessibility guidance, not claimed as a repository-specific rule.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `canvas_pointer_hit_from_element` | `apps/canvas/main/pointer_session.mbt` | Yes | Reuses the existing bubbling-target classification, including typed `EdgeId` extraction. |
| `canvas_select_edge` | `apps/canvas/main/pointer_session.mbt` | Yes | Keyboard activation maps to the same `Click(Edge(...))` path as pointer activation for workflow and source-backed hosts. |
| `Event::to_keyboard_event` / `KeyboardEvent::key` | `deps/rabbita/rabbita/dom/event.mbt`, `keyboard_event.mbt` | Yes | Uses the existing typed keyboard-event boundary and standard key values. |
| `IsEvent::prevent_default` | `deps/rabbita/rabbita/dom/event.mbt` | Yes | Prevents the browser's Space default only after an edge target is admitted. |
| `Element::closest` / `Element::get_attribute` | `deps/rabbita/rabbita/dom/element.mbt` | Yes | Reused indirectly through the existing edge-hit classifier; no duplicate DOM lookup was added. |
| `Option` | MoonBit core and existing DOM conversion APIs | Yes | Existing optional target/element conversion remains the failure-safe boundary. |
| `String` pattern matching | MoonBit core | Yes | Matches `Enter`, standard Space (`" "`), and legacy `Spacebar` without a new keyboard abstraction. |
| `Map` / `Set` / `Array` data helpers | MoonBit core | No new use | This slice adds no collection or render projection; keyed rendering remains owned by the existing edge layer. |

New helpers added: none. The implementation adds only a `keydown` subscription to the existing app-private Canvas pointer session and reuses the existing `Click(Edge)` message and selection owner. No Rabbita, `@spatial`, generic keyboard framework, or public API changes were introduced.

## Validation scope

Boundary matrix / first failing regression: `/tmp/canopy-edge-keyboard-boundary-matrix.md`

- Before the implementation, the new workflow test failed because Enter left the edge class as `edge`.
- Workflow: Enter, Space, legacy Spacebar, unrelated key, non-edge target, action-log preservation, and keyed focus identity.
- Source-backed: Enter/Space selection, source preservation, action-log preservation, and default prevention.
- Existing Delete/Backspace, context-menu disconnect, stale-edge, and keyed-render tests remain in the suite.
- Projection whitebox tests and rendered E2E assertions cover the corrected `Connection ...` accessible name.

Target packages:

- `apps/canvas/main`

Additional conditional gates:

- MoonBit target tests: **75/75**
- Canvas Playwright E2E: **54/54** (`CHOKIDAR_USEPOLLING=true ./scripts/test-canvas-e2e.sh --workers=1`)
- `bash scripts/run-submodule-reachability.sh HEAD`: passed
- FFI consumer fan-out and production/web builds: passed through the PR-ready validator

## Out of scope

- Node keyboard navigation
- Arrow-key movement
- Delete/Backspace semantics
- Direct keyboard disconnect
- Focus-management redesign
- Rabbita or `@spatial` API changes
- Node renderer or integrated Canvas render-layer migration

## PR-ready evidence

Validated HEAD: `ae9127bcc1651831d696960f1041ba8f19e42f0c`

Validated base: `origin/main@8fe2adcf97772d324426de617d3c33849a385139`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh --target apps/canvas/main
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for the exact HEAD and base above.
- [x] The base was fetched again and `--verify-evidence` passed immediately before opening this PR.
- [x] `moon info` produced no unintended `.mbti` diff; the working tree is clean.
- [x] No submodule pointer changed; recursive submodule reachability passed.
- [x] Validation was rerun after the final commit.
- [x] Independent `moonbit-reviewer` returned PASS; its additional boundary-test suggestion was incorporated.