### PR TITLE
feat(canvas): add independent skyline packer and arrange selection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,6 +17,8 @@ apps/loomark/internal/archive_storage/js/pkg.generated.mbti whitespace=-blank-at
 apps/loomark/internal/archive_storage/pkg.generated.mbti whitespace=-blank-at-eof
 apps/loomark/repository/pkg.generated.mbti whitespace=-blank-at-eof
 modules/canvas-graph/spatial/pkg.generated.mbti whitespace=-blank-at-eof
+modules/skyline/pkg.generated.mbti whitespace=-blank-at-eof
+modules/canvas-layout/skyline/pkg.generated.mbti whitespace=-blank-at-eof
 
 # Preserve the existing CRLF line endings in Ideal Playwright specs while
 # treating their line terminators as valid whitespace in diff checks.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,8 @@ jobs:
               - 'apps/canvas/**'
               - 'apps/web/vite-plugin-moonbit.ts'
               - 'modules/canvas-graph/**'
+              - 'modules/skyline/**'
+              - 'modules/canvas-layout/**'
               - '.github/actions/setup-moonbit/**'
               - 'scripts/moon-update.sh'
               - '.github/workflows/ci.yml'

--- a/apps/canvas/main/canvas_runtime.mbt
+++ b/apps/canvas/main/canvas_runtime.mbt
@@ -644,6 +644,45 @@ fn CanvasRuntime::add_node(
 }
 
 ///|
+const ARRANGE_GAP : Double = 16.0
+
+///|
+/// Compact the current multi-selection with the canvas-layout Skyline policy.
+/// The generic packer is not imported here; only the adapter is.
+fn CanvasRuntime::arrange_selection(self : CanvasRuntime) -> Unit raise Failure {
+  let state = self.state_peek()
+  let nodes = state.interaction.selected_nodes.filter_map(id => {
+    @graph_model.find_node(state.nodes, id)
+  })
+  if nodes.length() < 2 {
+    return
+  }
+  try {
+    let region_width = @layout.compact_region_width(nodes, gap=ARRANGE_GAP)
+    let plan = @layout.arrange_with_skyline(
+      nodes,
+      region_width~,
+      gap=ARRANGE_GAP,
+    )
+    if plan.positions.length() == 0 {
+      return
+    }
+    self.sync_commit_state(
+      @graph_model.record_action(state, plan.to_move_nodes()),
+    )
+  } catch {
+    @layout.NonFiniteGeometry | @layout.CoordinateOverflow => ()
+    @layout.InvalidRegionWidth(_)
+    | @layout.InvalidGap(_)
+    | @layout.ItemTooWide(..)
+    | @layout.NoPlacement(..) =>
+      fail(
+        "arrange_selection: compact skyline policy could not pack the selection",
+      )
+  }
+}
+
+///|
 fn CanvasRuntime::delete_nodes(
   self : CanvasRuntime,
   nodes : Array[NodeId],

--- a/apps/canvas/main/canvas_runtime_wbtest.mbt
+++ b/apps/canvas/main/canvas_runtime_wbtest.mbt
@@ -224,6 +224,69 @@ test "runtime edge selection is ephemeral and edge-first" {
 }
 
 ///|
+test "runtime arrange_selection packs a multi-selection with MoveNodes" {
+  let runtime = CanvasRuntime::CanvasRuntime()
+  let node1 = NodeId("1")
+  let node2 = NodeId("2")
+  let first = contract_state_node(runtime.state_peek(), node1)
+  let (one_sx, one_sy) = contract_screen_point(
+    runtime.render_state().viewport,
+    first.position().x(),
+    first.position().y(),
+  )
+  ignore(runtime.pointer_down(Some(node1), one_sx, one_sy))
+  runtime.pointer_up("1", "", false)
+  let second = contract_state_node(runtime.state_peek(), node2)
+  let (two_sx, two_sy) = contract_screen_point(
+    runtime.render_state().viewport,
+    second.position().x(),
+    second.position().y(),
+  )
+  ignore(runtime.pointer_down(Some(node2), two_sx, two_sy))
+  runtime.pointer_up("2", "", true)
+
+  runtime.arrange_selection()
+
+  let packed1 = contract_state_node(runtime.state_peek(), node1)
+  let packed2 = contract_state_node(runtime.state_peek(), node2)
+  debug_inspect(packed1.position().x(), content="-520")
+  debug_inspect(packed1.position().y(), content="-190")
+  debug_inspect(packed2.position().x(), content="-260")
+  debug_inspect(packed2.position().y(), content="-190")
+  let actions = runtime.action_log_snapshot()
+  match actions[actions.length() - 1].action() {
+    MoveNodes(positions) => {
+      debug_inspect(positions.length(), content="2")
+      debug_inspect(
+        positions[0].id.to_string(),
+        content=(
+          #|"1"
+        ),
+      )
+      debug_inspect(
+        positions[1].id.to_string(),
+        content=(
+          #|"2"
+        ),
+      )
+    }
+    _ => fail("expected MoveNodes as the last action")
+  }
+}
+
+///|
+test "runtime arrange_selection is a no-op without a multi-selection" {
+  let runtime = CanvasRuntime::CanvasRuntime()
+  let before = contract_state_node(runtime.state_peek(), NodeId("2"))
+  runtime.arrange_selection()
+  let after = contract_state_node(runtime.state_peek(), NodeId("2"))
+  debug_inspect(after.position().x(), content="-190")
+  debug_inspect(after.position().y(), content="-190")
+  @debug.assert_eq(after.position(), before.position())
+  assert_eq(runtime.action_log_snapshot().length(), 0)
+}
+
+///|
 test "runtime sparse inspector follows hover until a node is selected" {
   let runtime = CanvasRuntime::CanvasRuntime()
   runtime.sync_viewport_state({

--- a/apps/canvas/main/context_menu.mbt
+++ b/apps/canvas/main/context_menu.mbt
@@ -27,6 +27,7 @@ priv struct CanvasContextRequest {
 ///|
 priv enum CanvasContextAction {
   AddNode(String)
+  Arrange
   Disconnect
 }
 
@@ -102,14 +103,24 @@ fn canvas_context_menu_items(
   target : CanvasContextTarget,
 ) -> Array[CanvasContextMenuItem] {
   match target {
-    Background(_) =>
-      workflow_node_catalog().map(fn(item) {
+    Background(_) => {
+      let items = workflow_node_catalog().map(fn(item) {
         {
           action: AddNode(item.key),
           label: item.label,
           description: item.description,
         }
       })
+      if !model.source_backed &&
+        _registry[model.handle].peek_selection().selected_nodes.length() >= 2 {
+        items.insert(0, {
+          action: Arrange,
+          label: "Arrange compactly",
+          description: "Pack the selection into a compact strip",
+        })
+      }
+      items
+    }
     Edge(edge_id) =>
       [
         {
@@ -232,6 +243,12 @@ fn canvas_context_apply(
         )
       } else {
         _registry[model.handle].add_node(kind, insert_at.x(), insert_at.y())
+      }
+    (Background(_), Arrange) =>
+      if !model.source_backed {
+        _registry[model.handle].arrange_selection() catch {
+          Failure::Failure(detail) => abort(detail)
+        }
       }
     (Edge(edge_id), Disconnect) =>
       if model.source_backed {

--- a/apps/canvas/main/context_menu.mbt
+++ b/apps/canvas/main/context_menu.mbt
@@ -234,7 +234,7 @@ fn canvas_context_apply(
   model : CanvasContextMenuModel,
   target : CanvasContextTarget,
   action : CanvasContextAction,
-) -> Unit {
+) -> Unit raise Failure {
   match (target, action) {
     (Background(insert_at~), AddNode(kind)) =>
       if model.source_backed {
@@ -246,9 +246,7 @@ fn canvas_context_apply(
       }
     (Background(_), Arrange) =>
       if !model.source_backed {
-        _registry[model.handle].arrange_selection() catch {
-          Failure::Failure(detail) => abort(detail)
-        }
+        _registry[model.handle].arrange_selection()
       }
     (Edge(edge_id), Disconnect) =>
       if model.source_backed {
@@ -281,7 +279,10 @@ fn context_menu_action_cmd(
   match model.target {
     None => @rabbita.none
     Some(target) =>
-      @rabbita.effect(fn() { canvas_context_apply(model, target, item.action) })
+      @rabbita.attempt(
+        _ => @rabbita.none,
+        () => canvas_context_apply(model, target, item.action),
+      )
   }
 }
 

--- a/apps/canvas/main/context_menu_wbtest.mbt
+++ b/apps/canvas/main/context_menu_wbtest.mbt
@@ -1,4 +1,9 @@
 ///|
+fn test_background_target() -> CanvasContextTarget {
+  Background(insert_at=try! ScreenPoint::from_xy(x=0.0, y=0.0))
+}
+
+///|
 test "workflow node catalog derives labels and descriptions from graph nodes" {
   let catalog = workflow_node_catalog()
   assert_eq(catalog.length(), 7)
@@ -21,4 +26,72 @@ test "workflow context disconnect uses the captured edge target" {
   assert_false(runtime.disconnect_edge(edge.id))
   assert_eq(runtime.state_peek().edges.length(), 2)
   assert_eq(runtime.action_log_snapshot().length(), 1)
+}
+
+///|
+test "background menu stays catalog-only without a multi-selection" {
+  let handle = create_canvas()
+  let model = context_menu_model(handle, false, () => (), _s => ())
+  let items = canvas_context_menu_items(model, test_background_target())
+  inspect(items.length(), content="7")
+  inspect(items[0].label, content="Timer trigger")
+}
+
+///|
+test "background menu prepends arrange for a multi-selection" {
+  let handle = create_canvas()
+  let runtime = _registry[handle]
+  let node1 = NodeId("1")
+  let node2 = NodeId("2")
+  let first = contract_state_node(runtime.state_peek(), node1)
+  let (one_sx, one_sy) = contract_screen_point(
+    runtime.render_state().viewport,
+    first.position().x(),
+    first.position().y(),
+  )
+  ignore(runtime.pointer_down(Some(node1), one_sx, one_sy))
+  runtime.pointer_up("1", "", false)
+  let second = contract_state_node(runtime.state_peek(), node2)
+  let (two_sx, two_sy) = contract_screen_point(
+    runtime.render_state().viewport,
+    second.position().x(),
+    second.position().y(),
+  )
+  ignore(runtime.pointer_down(Some(node2), two_sx, two_sy))
+  runtime.pointer_up("2", "", true)
+
+  let model = context_menu_model(handle, false, () => (), _s => ())
+  let items = canvas_context_menu_items(model, test_background_target())
+  inspect(items.length(), content="8")
+  inspect(items[0].label, content="Arrange compactly")
+  inspect(items[1].label, content="Timer trigger")
+}
+
+///|
+test "background menu hides arrange on a source-backed graph" {
+  let handle = create_canvas()
+  let runtime = _registry[handle]
+  let node1 = NodeId("1")
+  let node2 = NodeId("2")
+  let first = contract_state_node(runtime.state_peek(), node1)
+  let (one_sx, one_sy) = contract_screen_point(
+    runtime.render_state().viewport,
+    first.position().x(),
+    first.position().y(),
+  )
+  ignore(runtime.pointer_down(Some(node1), one_sx, one_sy))
+  runtime.pointer_up("1", "", false)
+  let second = contract_state_node(runtime.state_peek(), node2)
+  let (two_sx, two_sy) = contract_screen_point(
+    runtime.render_state().viewport,
+    second.position().x(),
+    second.position().y(),
+  )
+  ignore(runtime.pointer_down(Some(node2), two_sx, two_sy))
+  runtime.pointer_up("2", "", true)
+
+  let model = context_menu_model(handle, true, () => (), _s => ())
+  let items = canvas_context_menu_items(model, test_background_target())
+  inspect(items.length(), content="7")
+  inspect(items[0].label, content="Timer trigger")
 }

--- a/apps/canvas/main/moon.pkg
+++ b/apps/canvas/main/moon.pkg
@@ -5,6 +5,7 @@ import {
   "moonbitlang/core/ref",
   "dowdiness/canopy-canvas-graph/graph_model",
   "dowdiness/canopy-canvas-graph/spatial",
+  "dowdiness/canvas-layout/skyline" @layout,
   "dowdiness/incr",
   "dowdiness/graph-dsl" @graph_dsl,
   "dowdiness/loom/core",

--- a/apps/canvas/moon.mod
+++ b/apps/canvas/moon.mod
@@ -6,6 +6,7 @@ import {
   "dowdiness/graph-dsl@0.1.0",
   "dowdiness/diagnostic@0.1.0",
   "dowdiness/canopy-canvas-graph@0.1.0",
+  "dowdiness/canvas-layout@0.1.0",
   "dowdiness/loom@0.1.0",
   "dowdiness/rabbita_codemirror@0.0.1",
   "dowdiness/incr@0.15.0",

--- a/apps/canvas/moon.work
+++ b/apps/canvas/moon.work
@@ -3,6 +3,8 @@ members = [
   "../../deps/loom/diagnostic",
   "../../deps/loom/examples/graph-dsl",
   "../../modules/canvas-graph",
+  "../../modules/skyline",
+  "../../modules/canvas-layout",
   "../../deps/loom/loom",
   "../../modules/rabbita_codemirror",
   "../../deps/loom/incr/incr",

--- a/apps/canvas/web/e2e/canvas-handles.spec.ts
+++ b/apps/canvas/web/e2e/canvas-handles.spec.ts
@@ -829,6 +829,43 @@ test('canvas context menu adds a node from the MoonBit catalog', async ({ page }
   expect(runtimeErrors).toEqual([]);
 });
 
+test('canvas context menu arranges a multi-selection compactly', async ({ page }) => {
+  const runtimeErrors: string[] = [];
+  page.on('pageerror', (error) => runtimeErrors.push(error.message));
+  page.on('console', (message) => {
+    if (message.type() === 'error') {
+      runtimeErrors.push(message.text());
+    }
+  });
+
+  await page.goto('/');
+  await expect(page.locator('.canvas-node')).toHaveCount(6);
+
+  const first = page.locator('.canvas-node[data-node-id="1"]');
+  const second = page.locator('.canvas-node[data-node-id="2"]');
+  await first.click();
+  await expect(first).toHaveClass(/(?:^|\s)selected(?:\s|$)/);
+  await second.click({ modifiers: ['Shift'] });
+  await expect(second).toHaveClass(/(?:^|\s)selected(?:\s|$)/);
+
+  await openBackgroundContextMenu(page);
+  const items = contextMenuItems(page);
+  await expect(items).toHaveCount(8);
+  await expect(items.first()).toHaveText(/Arrange compactly/);
+  await items.first().click();
+
+  await expect.poll(async () => first.evaluate((element) => (element as HTMLElement).style.left))
+    .toBe('-520px');
+  await expect.poll(async () => first.evaluate((element) => (element as HTMLElement).style.top))
+    .toBe('-190px');
+  await expect.poll(async () => second.evaluate((element) => (element as HTMLElement).style.left))
+    .toBe('-260px');
+  await expect.poll(async () => second.evaluate((element) => (element as HTMLElement).style.top))
+    .toBe('-190px');
+  await expect(page.locator('#action-stat')).toHaveText('3 actions logged');
+  expect(runtimeErrors).toEqual([]);
+});
+
 test('canvas edge context menu disconnects the edge', async ({ page }) => {
   const runtimeErrors: string[] = [];
   page.on('pageerror', (error) => runtimeErrors.push(error.message));

--- a/modules/canvas-layout/README.md
+++ b/modules/canvas-layout/README.md
@@ -1,0 +1,15 @@
+# canvas-layout
+
+Layout policies for Canopy canvas graphs. Each policy computes positions and
+returns a `LayoutPlan`. Applying the plan is the caller's job: lower it to
+`WorkflowAction::MoveNodes` and reuse the existing graph operation log.
+
+`canvas-graph` does not depend on this module. Skyline packing stays a generic
+integer algorithm in `dowdiness/skyline`; this adapter owns quantization from
+world-space `Double` coordinates.
+
+## Skyline
+
+`dowdiness/canvas-layout/skyline` packs selected `CanvasNode` sizes into a
+fixed-width strip and returns node positions. Use it for explicit arrange
+actions, not for free-form collision search.

--- a/modules/canvas-layout/moon.mod
+++ b/modules/canvas-layout/moon.mod
@@ -1,0 +1,22 @@
+name = "dowdiness/canvas-layout"
+
+version = "0.1.0"
+
+import {
+  "dowdiness/skyline@0.1.0",
+  "dowdiness/canopy-canvas-graph@0.1.0",
+}
+
+readme = "README.md"
+
+repository = "https://github.com/dowdiness/canopy"
+
+license = "Apache-2.0"
+
+keywords = [ "canvas", "layout", "skyline", "moonbit" ]
+
+description = "Canvas layout policies that lower to existing graph operations."
+
+preferred_target = "native"
+
+supported_targets = "js+native"

--- a/modules/canvas-layout/skyline/arrange.mbt
+++ b/modules/canvas-layout/skyline/arrange.mbt
@@ -1,0 +1,152 @@
+///|
+using @graph_model {type CanvasNode, type NodePosition, type WorkflowAction}
+
+///|
+using @spatial {type WorldPoint}
+
+///|
+const LAYOUT_QUANTUM : Double = 16.0
+
+///|
+pub(all) suberror LayoutError {
+  InvalidRegionWidth(Double)
+  InvalidGap(Double)
+  NonFiniteGeometry
+  ItemTooWide(item_width~ : Int, bin_width~ : Int)
+  NoPlacement(width~ : Int, height~ : Int)
+  CoordinateOverflow
+} derive(Eq, Debug)
+
+///|
+pub struct LayoutPlan {
+  positions : Array[NodePosition]
+} derive(Eq, Debug)
+
+///|
+fn LayoutPlan::LayoutPlan(positions~ : Array[NodePosition]) -> LayoutPlan {
+  { positions, }
+}
+
+///|
+pub fn LayoutPlan::to_move_nodes(self : LayoutPlan) -> WorkflowAction {
+  MoveNodes(self.positions)
+}
+
+///|
+fn finite_number(value : Double) -> Bool {
+  !value.is_nan() && !value.is_inf()
+}
+
+///|
+fn quantize_length(value : Double) -> Int raise LayoutError {
+  guard finite_number(value) else { raise NonFiniteGeometry }
+  let scaled = (value * LAYOUT_QUANTUM).ceil()
+  guard finite_number(scaled) && scaled <= @int.MAX_VALUE.to_double() else {
+    raise CoordinateOverflow
+  }
+  let n = scaled.to_int()
+  if n <= 0 {
+    1
+  } else {
+    n
+  }
+}
+
+///|
+fn dequantize(offset : Int, origin : Double) -> Double {
+  origin + offset.to_double() / LAYOUT_QUANTUM
+}
+
+///|
+fn translate_pack_error(error : @pack.PackError) -> LayoutError {
+  match error {
+    ItemTooWide(item_width~, bin_width~) => ItemTooWide(item_width~, bin_width~)
+    NoPlacement(width~, height~) => NoPlacement(width~, height~)
+    CoordinateOverflow => CoordinateOverflow
+    InvalidBinWidth(_) | InvalidMaxHeight(_) | InvalidSize(_) =>
+      NonFiniteGeometry
+  }
+}
+
+///|
+fn selection_origin(
+  nodes : ArrayView[CanvasNode],
+) -> WorldPoint raise LayoutError {
+  let first = nodes[0].position()
+  let x = nodes.fold(init=first.x(), (acc, node) => acc.min(node.position().x()))
+  let y = nodes.fold(init=first.y(), (acc, node) => acc.min(node.position().y()))
+  WorldPoint::from_xy(x~, y~) catch {
+    _ => raise NonFiniteGeometry
+  }
+}
+
+///|
+fn packed_size(node : CanvasNode, gap : Double) -> @pack.Size raise LayoutError {
+  let width = quantize_length(node.size().width() + gap)
+  let height = quantize_length(node.size().height() + gap)
+  @pack.Size(width~, height~) catch {
+    error => raise translate_pack_error(error)
+  }
+}
+
+///|
+/// Width that fits about two copies of the widest selected node after the same
+/// quantization `arrange_with_skyline` uses. The packer stays width-agnostic.
+pub fn compact_region_width(
+  nodes : ArrayView[CanvasNode],
+  gap~ : Double,
+) -> Double raise LayoutError {
+  guard !nodes.is_empty() else { raise InvalidRegionWidth(0.0) }
+  guard finite_number(gap) && gap >= 0.0 else { raise InvalidGap(gap) }
+  let widest = nodes.fold(init=1, (acc, node) => {
+    acc.max(packed_size(node, gap).width)
+  })
+  guard widest <= @int.MAX_VALUE / 2 else { raise CoordinateOverflow }
+  dequantize(widest * 2, 0.0)
+}
+
+///|
+/// Pack `nodes` into a fixed-width strip with the Bottom-Left skyline heuristic.
+///
+/// Positions are relative to `origin`, or to the minimum X/Y of the selection
+/// when `origin` is omitted. This function does not mutate canvas state.
+pub fn arrange_with_skyline(
+  nodes : ArrayView[CanvasNode],
+  region_width~ : Double,
+  gap? : Double = 0.0,
+  origin? : WorldPoint,
+) -> LayoutPlan raise LayoutError {
+  guard finite_number(region_width) && region_width > 0.0 else {
+    raise InvalidRegionWidth(region_width)
+  }
+  guard finite_number(gap) && gap >= 0.0 else { raise InvalidGap(gap) }
+  if nodes.is_empty() {
+    LayoutPlan(positions=[])
+  } else {
+    let origin = match origin {
+      Some(point) => point
+      None => selection_origin(nodes)
+    }
+    let bin_width = quantize_length(region_width)
+    let packer = @pack.Packer(width=bin_width) catch {
+      error => raise translate_pack_error(error)
+    }
+    let positions : Array[NodePosition] = []
+    for node in nodes {
+      let size = packed_size(node, gap)
+      let placement = packer.place(size) catch {
+        error => raise translate_pack_error(error)
+      }
+      let point = WorldPoint::from_xy(
+        x=dequantize(placement.x, origin.x()),
+        y=dequantize(placement.y, origin.y()),
+      ) catch {
+        _ => raise NonFiniteGeometry
+      }
+      positions.push(
+        @spatial.ItemPosition::from_id_and_point(id=node.id, point~),
+      )
+    }
+    LayoutPlan(positions~)
+  }
+}

--- a/modules/canvas-layout/skyline/arrange_test.mbt
+++ b/modules/canvas-layout/skyline/arrange_test.mbt
@@ -1,0 +1,195 @@
+///|
+fn node_id(n : Int) -> @graph_model.NodeId {
+  @graph_model.NodeId(n.to_string())
+}
+
+///|
+fn world(x : Double, y : Double) -> @spatial.WorldPoint {
+  try! @spatial.WorldPoint::from_xy(x~, y~)
+}
+
+///|
+fn sized_node(
+  id : Int,
+  x : Double,
+  y : Double,
+  width~ : Double,
+  height~ : Double,
+) -> @graph_model.CanvasNode {
+  let base = @graph_model.make_workflow_node(
+    node_id(id),
+    @graph_model.WorkflowNodeKind::TimerTrigger,
+    world(x, y),
+  )
+  @graph_model.CanvasNode::from_parts(
+    id=base.id,
+    position=base.position(),
+    size=try! @graph_model.NodeSize::from_wh(width~, height~),
+    kind=base.kind,
+    title=base.title,
+    subtitle=base.subtitle,
+    inputs=base.inputs,
+    outputs=base.outputs,
+    configured=base.configured,
+  )
+}
+
+///|
+test "empty selection yields an empty plan" {
+  let plan = try! arrange_with_skyline([], region_width=400.0)
+  debug_inspect(plan.positions.length(), content="0")
+}
+
+///|
+test "packs two nodes on one row when the region is wide enough" {
+  let nodes = [
+    sized_node(1, 100.0, 50.0, width=244.0, height=132.0),
+    sized_node(2, 400.0, 80.0, width=260.0, height=148.0),
+  ]
+  let plan = try! arrange_with_skyline(nodes, region_width=504.0)
+  debug_inspect(plan.positions.length(), content="2")
+  debug_inspect(
+    plan.positions[0].id.to_string(),
+    content=(
+      #|"1"
+    ),
+  )
+  debug_inspect(plan.positions[0].point.x(), content="100")
+  debug_inspect(plan.positions[0].point.y(), content="50")
+  debug_inspect(
+    plan.positions[1].id.to_string(),
+    content=(
+      #|"2"
+    ),
+  )
+  debug_inspect(plan.positions[1].point.x(), content="344")
+  debug_inspect(plan.positions[1].point.y(), content="50")
+}
+
+///|
+test "stacks nodes when the region is only wide enough for one" {
+  let nodes = [
+    sized_node(1, 100.0, 50.0, width=244.0, height=132.0),
+    sized_node(2, 400.0, 80.0, width=260.0, height=148.0),
+  ]
+  let plan = try! arrange_with_skyline(nodes, region_width=300.0)
+  debug_inspect(plan.positions[0].point.x(), content="100")
+  debug_inspect(plan.positions[0].point.y(), content="50")
+  debug_inspect(plan.positions[1].point.x(), content="100")
+  debug_inspect(plan.positions[1].point.y(), content="182")
+}
+
+///|
+test "gap is reserved between packed nodes" {
+  let nodes = [
+    sized_node(1, 0.0, 0.0, width=10.0, height=10.0),
+    sized_node(2, 40.0, 5.0, width=10.0, height=10.0),
+  ]
+  let plan = try! arrange_with_skyline(nodes, region_width=40.0, gap=8.0)
+  debug_inspect(plan.positions[0].point.x(), content="0")
+  debug_inspect(plan.positions[1].point.x(), content="18")
+}
+
+///|
+test "rejects a non-positive region width" {
+  let result : Result[LayoutPlan, LayoutError] = Ok(
+    arrange_with_skyline([], region_width=0.0),
+  ) catch {
+    error => Err(error)
+  }
+  debug_inspect(result, content="Err(InvalidRegionWidth(0))")
+}
+
+///|
+test "lowers to MoveNodes without inventing a new graph operation" {
+  let nodes = [
+    sized_node(1, 20.0, 30.0, width=10.0, height=10.0),
+    sized_node(2, 80.0, 90.0, width=10.0, height=10.0),
+  ]
+  let plan = try! arrange_with_skyline(nodes, region_width=40.0)
+  debug_inspect(
+    plan.to_move_nodes(),
+    content=(
+      #|MoveNodes(
+      #|  [
+      #|    { id: NodeId("1"), point: { x: 20, y: 30 } },
+      #|    { id: NodeId("2"), point: { x: 30, y: 30 } },
+      #|  ],
+      #|)
+    ),
+  )
+}
+
+///|
+test "MoveNodes apply updates canvas positions from a layout plan" {
+  let nodes = [
+    sized_node(1, 20.0, 30.0, width=10.0, height=10.0),
+    sized_node(2, 80.0, 90.0, width=10.0, height=10.0),
+  ]
+  let document : @graph_model.CanvasDocument = {
+    nodes,
+    edges: [],
+    next_node_id: 3,
+  }
+  let state = @graph_model.canvas_state_from_parts(
+    document,
+    @graph_model.default_viewport(),
+    @graph_model.empty_interaction(),
+    [],
+  )
+  let plan = try! arrange_with_skyline(nodes, region_width=40.0)
+  let next = @graph_model.apply_action(state, plan.to_move_nodes())
+  let first = @graph_model.find_node(next.nodes, node_id(1)).unwrap()
+  let second = @graph_model.find_node(next.nodes, node_id(2)).unwrap()
+  debug_inspect(first.position().x(), content="20")
+  debug_inspect(first.position().y(), content="30")
+  debug_inspect(second.position().x(), content="30")
+  debug_inspect(second.position().y(), content="30")
+}
+
+///|
+test "compact region is twice the widest node plus gap" {
+  let nodes = [
+    sized_node(1, 0.0, 0.0, width=244.0, height=132.0),
+    sized_node(2, 0.0, 0.0, width=260.0, height=148.0),
+  ]
+  debug_inspect(try! compact_region_width(nodes, gap=16.0), content="552")
+}
+
+///|
+test "compact region rejects an empty selection" {
+  let result : Result[Double, LayoutError] = Ok(
+    compact_region_width([], gap=16.0),
+  ) catch {
+    error => Err(error)
+  }
+  debug_inspect(result, content="Err(InvalidRegionWidth(0))")
+}
+
+///|
+test "too-wide item reports packed widths" {
+  let nodes = [sized_node(1, 0.0, 0.0, width=100.0, height=10.0)]
+  let result : Result[LayoutPlan, LayoutError] = Ok(
+    arrange_with_skyline(nodes, region_width=10.0),
+  ) catch {
+    error => Err(error)
+  }
+  debug_inspect(
+    result,
+    content="Err(ItemTooWide(item_width=1600, bin_width=160))",
+  )
+}
+
+///|
+test "compact region fits two nodes after length quantization" {
+  let nodes = [
+    sized_node(1, 0.0, 0.0, width=10.1, height=10.0),
+    sized_node(2, 80.0, 0.0, width=10.1, height=10.0),
+  ]
+  let region = try! compact_region_width(nodes, gap=8.0)
+  let plan = try! arrange_with_skyline(nodes, region_width=region, gap=8.0)
+  debug_inspect(plan.positions[0].point.x(), content="0")
+  debug_inspect(plan.positions[0].point.y(), content="0")
+  debug_inspect(plan.positions[1].point.x(), content="18.125")
+  debug_inspect(plan.positions[1].point.y(), content="0")
+}

--- a/modules/canvas-layout/skyline/moon.pkg
+++ b/modules/canvas-layout/skyline/moon.pkg
@@ -1,0 +1,11 @@
+import {
+  "dowdiness/skyline" @pack,
+  "dowdiness/canopy-canvas-graph/graph_model",
+  "dowdiness/canopy-canvas-graph/spatial",
+  "moonbitlang/core/debug",
+  "moonbitlang/core/int",
+}
+
+import {
+  "moonbitlang/core/debug",
+} for "test"

--- a/modules/canvas-layout/skyline/pkg.generated.mbti
+++ b/modules/canvas-layout/skyline/pkg.generated.mbti
@@ -1,0 +1,34 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "dowdiness/canvas-layout/skyline"
+
+import {
+  "dowdiness/canopy-canvas-graph/graph_model",
+  "dowdiness/canopy-canvas-graph/spatial",
+  "moonbitlang/core/debug",
+}
+
+// Values
+pub fn arrange_with_skyline(ArrayView[@graph_model.CanvasNode], region_width~ : Double, gap? : Double, origin? : @spatial.WorldPoint) -> LayoutPlan raise LayoutError
+
+pub fn compact_region_width(ArrayView[@graph_model.CanvasNode], gap~ : Double) -> Double raise LayoutError
+
+// Errors
+pub(all) suberror LayoutError {
+  InvalidRegionWidth(Double)
+  InvalidGap(Double)
+  NonFiniteGeometry
+  ItemTooWide(item_width~ : Int, bin_width~ : Int)
+  NoPlacement(width~ : Int, height~ : Int)
+  CoordinateOverflow
+} derive(Eq, @debug.Debug)
+
+// Types and methods
+pub struct LayoutPlan {
+  positions : Array[@spatial.ItemPosition[@graph_model.NodeId]]
+} derive(Eq, @debug.Debug)
+pub fn LayoutPlan::to_move_nodes(Self) -> @graph_model.WorkflowAction
+
+// Type aliases
+
+// Traits
+

--- a/modules/canvas-layout/skyline/pkg.generated.mbti
+++ b/modules/canvas-layout/skyline/pkg.generated.mbti
@@ -31,4 +31,3 @@ pub fn LayoutPlan::to_move_nodes(Self) -> @graph_model.WorkflowAction
 // Type aliases
 
 // Traits
-

--- a/modules/canvas-layout/skyline/pkg.generated.mbti
+++ b/modules/canvas-layout/skyline/pkg.generated.mbti
@@ -31,3 +31,4 @@ pub fn LayoutPlan::to_move_nodes(Self) -> @graph_model.WorkflowAction
 // Type aliases
 
 // Traits
+

--- a/modules/skyline/README.md
+++ b/modules/skyline/README.md
@@ -1,0 +1,55 @@
+# skyline
+
+Deterministic Bottom-Left skyline packing for a fixed-width strip. The package
+owns only rectangle sizes, placements, and the used height. Item identity,
+images, and DOM stay with the caller.
+
+This is a packing primitive, not a canvas layout engine. Canopy's canvas adapter
+lives in `modules/canvas-layout/skyline` and lowers `Placement` to
+`MoveNodes`.
+
+## Install
+
+Workspace member: `./modules/skyline` in the root `moon.work`.
+
+```
+moon add dowdiness/skyline
+```
+
+## Scope
+
+- Fixed width, unlimited height, or an optional maximum height
+- No rotation
+- Input order is kept
+- Bottom-Left heuristic
+- Non-negative `Int` coordinates
+- Optional explicit X candidates via `place_constrained`
+
+## Skyline invariants
+
+1. The first point is `(0, y)`.
+2. The last point is the sentinel `(bin_width, 0)`.
+3. X coordinates are strictly increasing.
+4. Adjacent non-sentinel segments with the same height are merged.
+5. Point `(xᵢ, yᵢ)` is the height of `[xᵢ, xᵢ₊₁)`.
+
+## Quick start
+
+```moonbit
+let packer = Packer(width=10)
+let first = packer.place(Size(width=6, height=4))
+let second = packer.place(Size(width=4, height=3))
+let third = packer.place(Size(width=7, height=2))
+inspect((first.x, first.y), content="(0, 0)")
+inspect((second.x, second.y), content="(6, 0)")
+inspect((third.x, third.y), content="(0, 4)")
+```
+
+`pack_in_order` is the batch form that preserves input indices. Lookahead
+reordering is intentionally not part of `place`.
+
+## Coordinates
+
+MoonBit `Int` is 32-bit. `place` raises `CoordinateOverflow` when a chosen
+top edge is not representable. Callers that need fractional canvas units should
+quantize before packing; do not put `Double` into this core.

--- a/modules/skyline/moon.mod
+++ b/modules/skyline/moon.mod
@@ -1,0 +1,17 @@
+name = "dowdiness/skyline"
+
+version = "0.1.0"
+
+import {
+  "moonbitlang/quickcheck@0.14.0",
+}
+
+readme = "README.md"
+
+repository = "https://github.com/dowdiness/canopy"
+
+license = "Apache-2.0"
+
+keywords = [ "skyline", "rectangle-packing", "layout", "moonbit" ]
+
+description = "Deterministic skyline rectangle packing for fixed-width strips"

--- a/modules/skyline/moon.pkg
+++ b/modules/skyline/moon.pkg
@@ -1,0 +1,16 @@
+import {
+  "moonbitlang/core/debug",
+  "moonbitlang/core/int",
+}
+
+import {
+  "moonbitlang/core/debug",
+  "moonbitlang/core/int",
+} for "test"
+
+import {
+  "moonbitlang/core/debug",
+  "moonbitlang/core/quickcheck",
+  "moonbitlang/core/quickcheck/splitmix",
+  "moonbitlang/quickcheck" @qc,
+} for "wbtest"

--- a/modules/skyline/packer.mbt
+++ b/modules/skyline/packer.mbt
@@ -1,0 +1,167 @@
+///|
+pub struct Packer {
+  priv width : Int
+  priv max_height : Int?
+  priv mut skyline : Array[Node]
+  priv mut used_height : Int
+} derive(Debug)
+
+///|
+pub fn Packer::Packer(
+  width~ : Int,
+  max_height? : Int,
+) -> Packer raise PackError {
+  guard width > 0 else { raise InvalidBinWidth(width) }
+  match max_height {
+    Some(limit) if limit <= 0 => raise InvalidMaxHeight(limit)
+    _ => ()
+  }
+  { width, max_height, skyline: [Node(0, 0), Node(width, 0)], used_height: 0 }
+}
+
+///|
+pub fn Packer::height(self : Packer) -> Int {
+  self.used_height
+}
+
+///|
+fn Packer::validate_size(self : Packer, size : Size) -> Unit raise PackError {
+  guard size.width <= self.width else {
+    raise ItemTooWide(item_width=size.width, bin_width=self.width)
+  }
+}
+
+///|
+fn Packer::height_at(self : Packer, x : Int) -> Int {
+  if x == self.width {
+    0
+  } else {
+    self.skyline
+    .windows(2)
+    .iter()
+    .find_first(window => window[0].x <= x && x < window[1].x)
+    .map(window => window[0].y)
+    .unwrap_or(0)
+  }
+}
+
+///|
+fn Packer::height_over(self : Packer, left : Int, right : Int) -> Int {
+  self.skyline
+  .windows(2)
+  .iter()
+  .filter(window => {
+    let node = window[0]
+    let segment_right = window[1].x
+    segment_right > left && node.x < right
+  })
+  .map(window => window[0].y)
+  .fold(init=0, Int::max)
+}
+
+///|
+fn Packer::candidate_at(self : Packer, size : Size, x : Int) -> Candidate? {
+  guard x >= 0 && x <= self.width - size.width else { None }
+  let y = self.height_over(x, x + size.width)
+  match self.max_height {
+    Some(limit) if size.height > limit => None
+    Some(limit) if y > limit - size.height => None
+    _ => Some(Candidate(x, y))
+  }
+}
+
+///|
+fn Packer::find_candidate(self : Packer, size : Size) -> Candidate? {
+  self.skyline[:self.skyline.length() - 1].fold(init=None, (best, node) => {
+    match self.candidate_at(size, node.x) {
+      Some(candidate) => choose_candidate(best, candidate)
+      None => best
+    }
+  })
+}
+
+///|
+fn Packer::find_constrained_candidate(
+  self : Packer,
+  size : Size,
+  allowed_x : ArrayView[Int],
+) -> Candidate? {
+  allowed_x.fold(init=None, (best, x) => {
+    match self.candidate_at(size, x) {
+      Some(candidate) => choose_candidate(best, candidate)
+      None => best
+    }
+  })
+}
+
+///|
+fn Packer::commit(
+  self : Packer,
+  size : Size,
+  candidate : Candidate,
+) -> Placement raise PackError {
+  let left = candidate.x
+  let right = left + size.width
+  let top = checked_top(candidate.y, size.height)
+  let old_right_height = self.height_at(right)
+  let next : Array[Node] = []
+  self.skyline
+  .iter()
+  .each(node => if node.x < left { push_normalized(next, node, false) })
+  push_normalized(next, Node(left, top), false)
+  if right < self.width {
+    push_normalized(next, Node(right, old_right_height), false)
+  }
+  self.skyline
+  .iter()
+  .each(node => {
+    if node.x > right && node.x < self.width {
+      push_normalized(next, node, false)
+    }
+  })
+  push_normalized(next, Node(self.width, 0), true)
+  self.skyline = next
+  self.used_height = self.used_height.max(top)
+  Placement(x=left, y=candidate.y, width=size.width, height=size.height)
+}
+
+///|
+pub fn Packer::place(self : Packer, size : Size) -> Placement raise PackError {
+  self.validate_size(size)
+  guard self.find_candidate(size) is Some(candidate) else {
+    raise NoPlacement(width=size.width, height=size.height)
+  }
+  self.commit(size, candidate)
+}
+
+///|
+/// Place a rectangle only at one of the supplied X coordinates.
+///
+/// The candidate array is only observed; probing does not mutate the skyline.
+pub fn Packer::place_constrained(
+  self : Packer,
+  size : Size,
+  allowed_x : ArrayView[Int],
+) -> Placement raise PackError {
+  self.validate_size(size)
+  guard self.find_constrained_candidate(size, allowed_x) is Some(candidate) else {
+    raise NoPlacement(width=size.width, height=size.height)
+  }
+  self.commit(size, candidate)
+}
+
+///|
+/// Pack rectangles without changing their order.
+///
+/// The returned placements have the same indices as the input sizes.
+pub fn pack_in_order(
+  sizes : ArrayView[Size],
+  bin_width~ : Int,
+) -> PackResult raise PackError {
+  let packer = Packer(width=bin_width)
+  let placements : Array[Placement] = []
+  for size in sizes {
+    placements.push(packer.place(size))
+  }
+  PackResult(placements~, height=packer.height())
+}

--- a/modules/skyline/packing_property_wbtest.mbt
+++ b/modules/skyline/packing_property_wbtest.mbt
@@ -1,0 +1,81 @@
+///|
+struct PackCase {
+  bin_width : Int
+  sizes : Array[Size]
+} derive(Debug)
+
+///|
+fn gen_pack_case(rs : @splitmix.RandomState) -> PackCase {
+  let bin_width = 8 + rs.split().next_positive_int() % 24
+  let count = 1 + rs.split().next_positive_int() % 8
+  let sizes : Array[Size] = []
+  for _ in 0..<count {
+    let width = 1 + rs.split().next_positive_int() % bin_width
+    let height = 1 + rs.split().next_positive_int() % 12
+    sizes.push(try! Size(width~, height~))
+  }
+  { bin_width, sizes }
+}
+
+///|
+impl @quickcheck.Arbitrary for PackCase with fn arbitrary(_size, rs) {
+  gen_pack_case(rs)
+}
+
+///|
+impl @qc.Shrink for PackCase
+
+///|
+fn pack_case(case_ : PackCase) -> (Packer, Array[Placement]) {
+  let packer = try! Packer(width=case_.bin_width)
+  let placements : Array[Placement] = []
+  for size in case_.sizes {
+    placements.push(try! packer.place(size))
+  }
+  (packer, placements)
+}
+
+///|
+fn prop_in_bin_and_disjoint(case_ : PackCase) -> Bool {
+  let (packer, placements) = pack_case(case_)
+  try! assert_skyline_invariants(packer)
+  placements_in_bin(placements, case_.bin_width) &&
+  !any_interior_overlap(placements) &&
+  skyline_matches_placements(packer, placements)
+}
+
+///|
+fn prop_deterministic(case_ : PackCase) -> Bool {
+  let first = try! pack_in_order(case_.sizes, bin_width=case_.bin_width)
+  let second = try! pack_in_order(case_.sizes, bin_width=case_.bin_width)
+  first == second
+}
+
+///|
+fn prop_constrained_uses_allowed_x(case_ : PackCase) -> Bool {
+  let packer = try! Packer(width=case_.bin_width)
+  guard case_.sizes.length() > 0 else { true }
+  let size = case_.sizes[0]
+  let allowed = [0, case_.bin_width / 2, packer.width - size.width]
+  match
+    (Ok(packer.place_constrained(size, allowed)) catch { error => Err(error) }) {
+    Err(NoPlacement(_)) => true
+    Err(_) => false
+    Ok(placement) => allowed.contains(placement.x)
+  }
+}
+
+///|
+test "property: packed rectangles stay in-bin, disjoint, and match the skyline" {
+  @qc.quick_check_fn(prop_in_bin_and_disjoint)
+}
+
+///|
+test "property: packing is deterministic" {
+  @qc.quick_check_fn(prop_deterministic)
+}
+
+///|
+test "property: constrained placement stays on allowed x" {
+  @qc.quick_check_fn(prop_constrained_uses_allowed_x)
+}

--- a/modules/skyline/packing_test.mbt
+++ b/modules/skyline/packing_test.mbt
@@ -1,0 +1,191 @@
+///|
+test "uses the lowest then leftmost position" {
+  let packer = try! Packer::Packer(width=10)
+  let first = try! packer.place(Size::Size(width=6, height=4))
+  let second = try! packer.place(Size::Size(width=4, height=3))
+  let third = try! packer.place(Size::Size(width=7, height=2))
+  debug_inspect(
+    first,
+    content=(
+      #|{ x: 0, y: 0, width: 6, height: 4 }
+    ),
+  )
+  debug_inspect(
+    second,
+    content=(
+      #|{ x: 6, y: 0, width: 4, height: 3 }
+    ),
+  )
+  debug_inspect(
+    third,
+    content=(
+      #|{ x: 0, y: 4, width: 7, height: 2 }
+    ),
+  )
+  debug_inspect(packer.height(), content="6")
+}
+
+///|
+test "pack_in_order preserves input indices" {
+  let result = try! pack_in_order(
+    [
+      try! Size::Size(width=6, height=4),
+      try! Size::Size(width=4, height=3),
+      try! Size::Size(width=7, height=2),
+    ],
+    bin_width=10,
+  )
+  debug_inspect(result.placements.length(), content="3")
+  debug_inspect(
+    result.placements[0],
+    content=(
+      #|{ x: 0, y: 0, width: 6, height: 4 }
+    ),
+  )
+  debug_inspect(
+    result.placements[1],
+    content=(
+      #|{ x: 6, y: 0, width: 4, height: 3 }
+    ),
+  )
+  debug_inspect(
+    result.placements[2],
+    content=(
+      #|{ x: 0, y: 4, width: 7, height: 2 }
+    ),
+  )
+  debug_inspect(result.height, content="6")
+}
+
+///|
+test "rejects a bin whose width is not positive" {
+  let result : Result[Packer, PackError] = Ok(Packer::Packer(width=0)) catch {
+    error => Err(error)
+  }
+  debug_inspect(result, content="Err(InvalidBinWidth(0))")
+}
+
+///|
+test "rejects a non-positive max height" {
+  let result : Result[Packer, PackError] = Ok(
+    Packer::Packer(width=10, max_height=-1),
+  ) catch {
+    error => Err(error)
+  }
+  debug_inspect(result, content="Err(InvalidMaxHeight(-1))")
+}
+
+///|
+test "rejects a non-positive size" {
+  let result : Result[Size, PackError] = Ok(Size::Size(width=0, height=2)) catch {
+    error => Err(error)
+  }
+  debug_inspect(result, content="Err(InvalidSize(0, 2))")
+}
+
+///|
+test "rejects an item wider than the bin before searching" {
+  let packer = try! Packer::Packer(width=10)
+  let result : Result[Placement, PackError] = Ok(
+    packer.place(try! Size::Size(width=11, height=1)),
+  ) catch {
+    error => Err(error)
+  }
+  debug_inspect(result, content="Err(ItemTooWide(item_width=11, bin_width=10))")
+}
+
+///|
+test "raises NoPlacement when the item exceeds max_height" {
+  let packer = try! Packer::Packer(width=10, max_height=5)
+  let result : Result[Placement, PackError] = Ok(
+    packer.place(try! Size::Size(width=3, height=6)),
+  ) catch {
+    error => Err(error)
+  }
+  debug_inspect(result, content="Err(NoPlacement(width=3, height=6))")
+}
+
+///|
+test "place_constrained only uses supplied x coordinates" {
+  let packer = try! Packer::Packer(width=10)
+  ignore(try! packer.place(try! Size::Size(width=4, height=2)))
+  let placed = try! packer.place_constrained(
+    try! Size::Size(width=3, height=2),
+    [0, 4],
+  )
+  debug_inspect(
+    placed,
+    content=(
+      #|{ x: 4, y: 0, width: 3, height: 2 }
+    ),
+  )
+}
+
+///|
+test "place_constrained does not insert probe points" {
+  let packer = try! Packer::Packer(width=10)
+  let result : Result[Placement, PackError] = Ok(
+    packer.place_constrained(try! Size::Size(width=3, height=2), [3]),
+  ) catch {
+    error => Err(error)
+  }
+  debug_inspect(
+    result,
+    content=(
+      #|Ok({ x: 3, y: 0, width: 3, height: 2 })
+    ),
+  )
+  let packed = try! packer.place(try! Size::Size(width=3, height=2))
+  debug_inspect(packed.x, content="0")
+  debug_inspect(packed.y, content="0")
+}
+
+///|
+test "place_constrained with no valid x raises NoPlacement" {
+  let packer = try! Packer::Packer(width=10)
+  let result : Result[Placement, PackError] = Ok(
+    packer.place_constrained(try! Size::Size(width=3, height=2), [8, 9]),
+  ) catch {
+    error => Err(error)
+  }
+  debug_inspect(result, content="Err(NoPlacement(width=3, height=2))")
+}
+
+///|
+test "merges a uniform top edge after filling a gap" {
+  let packer = try! Packer::Packer(width=10)
+  ignore(try! packer.place(try! Size::Size(width=6, height=4)))
+  ignore(try! packer.place(try! Size::Size(width=4, height=4)))
+  debug_inspect(packer.height(), content="4")
+  let third = try! packer.place(try! Size::Size(width=10, height=1))
+  debug_inspect(
+    third,
+    content=(
+      #|{ x: 0, y: 4, width: 10, height: 1 }
+    ),
+  )
+}
+
+///|
+test "same inputs produce the same placements" {
+  let sizes = [
+    try! Size::Size(width=5, height=2),
+    try! Size::Size(width=3, height=4),
+    try! Size::Size(width=7, height=1),
+  ]
+  let first = try! pack_in_order(sizes, bin_width=10)
+  let second = try! pack_in_order(sizes, bin_width=10)
+  debug_inspect(first == second, content="true")
+}
+
+///|
+test "overflowing a stacked top raises CoordinateOverflow" {
+  let packer = try! Packer::Packer(width=1)
+  ignore(try! packer.place(try! Size::Size(width=1, height=@int.MAX_VALUE)))
+  let result : Result[Placement, PackError] = Ok(
+    packer.place(try! Size::Size(width=1, height=1)),
+  ) catch {
+    error => Err(error)
+  }
+  debug_inspect(result, content="Err(CoordinateOverflow)")
+}

--- a/modules/skyline/packing_wbtest.mbt
+++ b/modules/skyline/packing_wbtest.mbt
@@ -1,0 +1,135 @@
+///|
+fn skyline_pairs(packer : Packer) -> Array[(Int, Int)] {
+  packer.skyline.map(node => (node.x, node.y))
+}
+
+///|
+fn assert_skyline_invariants(packer : Packer) -> Unit raise {
+  let nodes = packer.skyline
+  guard nodes.length() >= 2 else {
+    fail("skyline must keep a start and sentinel")
+  }
+  @debug.assert_eq(nodes[0].x, 0)
+  let sentinel = nodes[nodes.length() - 1]
+  @debug.assert_eq(sentinel.x, packer.width)
+  @debug.assert_eq(sentinel.y, 0)
+  for window in nodes.windows(2) {
+    guard window[1].x > window[0].x else {
+      fail("skyline x coordinates must be strictly increasing")
+    }
+  }
+  for i in 0..<(nodes.length() - 2) {
+    guard nodes[i].y != nodes[i + 1].y else {
+      fail("adjacent non-sentinel nodes must not share a height")
+    }
+  }
+}
+
+///|
+fn placements_in_bin(
+  placements : ArrayView[Placement],
+  bin_width : Int,
+) -> Bool {
+  placements
+  .iter()
+  .all(placement => {
+    placement.x >= 0 && placement.x <= bin_width - placement.width
+  })
+}
+
+///|
+fn placements_overlap(a : Placement, b : Placement) -> Bool {
+  a.x < b.x + b.width &&
+  b.x < a.x + a.width &&
+  a.y < b.y + b.height &&
+  b.y < a.y + a.height
+}
+
+///|
+fn any_interior_overlap(placements : ArrayView[Placement]) -> Bool {
+  for i in 0..<placements.length() {
+    for j in (i + 1)..<placements.length() {
+      if placements_overlap(placements[i], placements[j]) {
+        return true
+      }
+    }
+  }
+  false
+}
+
+///|
+fn covering_top(
+  placements : ArrayView[Placement],
+  left : Int,
+  right : Int,
+) -> Int {
+  placements.fold(init=0, (acc, placement) => {
+    if placement.x < right && left < placement.x + placement.width {
+      acc.max(placement.y + placement.height)
+    } else {
+      acc
+    }
+  })
+}
+
+///|
+fn skyline_matches_placements(
+  packer : Packer,
+  placements : ArrayView[Placement],
+) -> Bool {
+  packer.skyline
+  .windows(2)
+  .iter()
+  .all(window => {
+    let left = window[0].x
+    let right = window[1].x
+    window[0].y == covering_top(placements, left, right)
+  })
+}
+
+///|
+test "empty packer starts with a flat skyline" {
+  let packer = Packer(width=10)
+  assert_skyline_invariants(packer)
+  debug_inspect(skyline_pairs(packer), content="[(0, 0), (10, 0)]")
+}
+
+///|
+test "placing the article's 7-wide rectangle sits on the covered max" {
+  let packer = Packer(width=10)
+  ignore(packer.place(Size(width=6, height=4)))
+  assert_skyline_invariants(packer)
+  debug_inspect(skyline_pairs(packer), content="[(0, 4), (6, 0), (10, 0)]")
+  let placed = packer.place(Size(width=7, height=2))
+  debug_inspect(
+    placed,
+    content=(
+      #|{ x: 0, y: 4, width: 7, height: 2 }
+    ),
+  )
+  assert_skyline_invariants(packer)
+  debug_inspect(skyline_pairs(packer), content="[(0, 6), (7, 0), (10, 0)]")
+}
+
+///|
+test "right-edge placement does not duplicate the sentinel x" {
+  let packer = Packer(width=10)
+  ignore(packer.place(Size(width=6, height=4)))
+  ignore(packer.place(Size(width=4, height=3)))
+  assert_skyline_invariants(packer)
+  debug_inspect(skyline_pairs(packer), content="[(0, 4), (6, 3), (10, 0)]")
+}
+
+///|
+test "constrained probing leaves the skyline unchanged on failure" {
+  let packer = Packer(width=10)
+  ignore(packer.place(Size(width=6, height=4)))
+  let before = skyline_pairs(packer)
+  let result : Result[Placement, PackError] = Ok(
+    packer.place_constrained(Size(width=5, height=1), [6]),
+  ) catch {
+    error => Err(error)
+  }
+  debug_inspect(result, content="Err(NoPlacement(width=5, height=1))")
+  debug_inspect(skyline_pairs(packer) == before, content="true")
+}

--- a/modules/skyline/pkg.generated.mbti
+++ b/modules/skyline/pkg.generated.mbti
@@ -1,0 +1,51 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "dowdiness/skyline"
+
+import {
+  "moonbitlang/core/debug",
+}
+
+// Values
+pub fn pack_in_order(ArrayView[Size], bin_width~ : Int) -> PackResult raise PackError
+
+// Errors
+pub(all) suberror PackError {
+  InvalidBinWidth(Int)
+  InvalidMaxHeight(Int)
+  InvalidSize(Int, Int)
+  ItemTooWide(item_width~ : Int, bin_width~ : Int)
+  NoPlacement(width~ : Int, height~ : Int)
+  CoordinateOverflow
+} derive(Eq, @debug.Debug)
+
+// Types and methods
+pub struct PackResult {
+  placements : Array[Placement]
+  height : Int
+} derive(Eq, @debug.Debug)
+
+pub struct Packer {
+  // private fields
+} derive(@debug.Debug)
+pub fn Packer::Packer(width~ : Int, max_height? : Int) -> Self raise PackError
+pub fn Packer::height(Self) -> Int
+pub fn Packer::place(Self, Size) -> Placement raise PackError
+pub fn Packer::place_constrained(Self, Size, ArrayView[Int]) -> Placement raise PackError
+
+pub struct Placement {
+  x : Int
+  y : Int
+  width : Int
+  height : Int
+} derive(Eq, @debug.Debug)
+
+pub struct Size {
+  width : Int
+  height : Int
+} derive(Eq, @debug.Debug)
+pub fn Size::Size(width~ : Int, height~ : Int) -> Self raise PackError
+
+// Type aliases
+
+// Traits
+

--- a/modules/skyline/pkg.generated.mbti
+++ b/modules/skyline/pkg.generated.mbti
@@ -48,3 +48,4 @@ pub fn Size::Size(width~ : Int, height~ : Int) -> Self raise PackError
 // Type aliases
 
 // Traits
+

--- a/modules/skyline/pkg.generated.mbti
+++ b/modules/skyline/pkg.generated.mbti
@@ -48,4 +48,3 @@ pub fn Size::Size(width~ : Int, height~ : Int) -> Self raise PackError
 // Type aliases
 
 // Traits
-

--- a/modules/skyline/types.mbt
+++ b/modules/skyline/types.mbt
@@ -1,0 +1,109 @@
+///|
+pub(all) suberror PackError {
+  InvalidBinWidth(Int)
+  InvalidMaxHeight(Int)
+  InvalidSize(Int, Int)
+  ItemTooWide(item_width~ : Int, bin_width~ : Int)
+  NoPlacement(width~ : Int, height~ : Int)
+  CoordinateOverflow
+} derive(Eq, Debug)
+
+///|
+pub struct Size {
+  width : Int
+  height : Int
+} derive(Eq, Debug)
+
+///|
+pub fn Size::Size(width~ : Int, height~ : Int) -> Size raise PackError {
+  guard width > 0 && height > 0 else { raise InvalidSize(width, height) }
+  { width, height }
+}
+
+///|
+pub struct Placement {
+  x : Int
+  y : Int
+  width : Int
+  height : Int
+} derive(Eq, Debug)
+
+///|
+fn Placement::Placement(
+  x~ : Int,
+  y~ : Int,
+  width~ : Int,
+  height~ : Int,
+) -> Placement {
+  { x, y, width, height }
+}
+
+///|
+pub struct PackResult {
+  placements : Array[Placement]
+  height : Int
+} derive(Eq, Debug)
+
+///|
+fn PackResult::PackResult(
+  placements~ : Array[Placement],
+  height~ : Int,
+) -> PackResult {
+  { placements, height }
+}
+
+///|
+/// `Node(x, y)` is the height `y` over the half-open interval `[x, next.x)`.
+priv struct Node {
+  x : Int
+  y : Int
+} derive(Debug)
+
+///|
+fn Node::Node(x : Int, y : Int) -> Node {
+  { x, y }
+}
+
+///|
+priv struct Candidate {
+  x : Int
+  y : Int
+}
+
+///|
+fn Candidate::Candidate(x : Int, y : Int) -> Candidate {
+  { x, y }
+}
+
+///|
+fn choose_candidate(best : Candidate?, candidate : Candidate) -> Candidate? {
+  match best {
+    None => Some(candidate)
+    Some(current) =>
+      if candidate.y < current.y ||
+        (candidate.y == current.y && candidate.x < current.x) {
+        Some(candidate)
+      } else {
+        Some(current)
+      }
+  }
+}
+
+///|
+fn push_normalized(
+  nodes : Array[Node],
+  node : Node,
+  is_sentinel : Bool,
+) -> Unit {
+  if nodes.length() == 0 {
+    nodes.push(node)
+  } else if is_sentinel || nodes[nodes.length() - 1].y != node.y {
+    nodes.push(node)
+  }
+}
+
+///|
+fn checked_top(y : Int, height : Int) -> Int raise PackError {
+  guard y <= @int.MAX_VALUE - height else { raise CoordinateOverflow }
+  y + height
+}

--- a/moon.work
+++ b/moon.work
@@ -29,6 +29,8 @@ members = [
   "./modules/rabbita-menu",
   "./modules/rabbita-context-menu",
   "./modules/canvas-graph",
+  "./modules/skyline",
+  "./modules/canvas-layout",
   "./modules/rabbita-status",
   "./modules/rabbita-tabs",
   "./modules/rabbita-treeview",


### PR DESCRIPTION
## Summary

- Add `dowdiness/skyline`, a generic Bottom-Left integer packer with no Canvas types.
- Add `dowdiness/canvas-layout/skyline` to quantize world geometry and lower a compact pack to existing `MoveNodes`.
- Expose **Arrange compactly** on the hand-built canvas context menu when two or more nodes are selected. Source-backed graphs keep the catalog-only menu because they reject `MoveNodes` lowering.

## UI and review evidence

- [x] Visible-label removal preserves accessible names, visible focus, and the keyboard path
- [x] Interactive bounds, pointer feedback, and viewport reflow were checked in the rendered UI
- [x] Any claimed Canopy rule cites its repository source; external guidance, recommendations, and preferences are labeled as such

The new menu item is a labeled `menuitem` prepended to the existing MoonBit catalog. Background menus without a multi-selection stay at 7 items. Keyboard navigation coverage is unchanged for that catalog-only path. Pixel assertions in Playwright encode the intended packed coordinates (`-520,-190` and `-260,-190`), not incidental layout.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `Array::filter_map` | MoonBit core | yes | Preserve selection order while resolving `NodeId` → `CanvasNode` |
| `find_node` | `canvas-graph/graph_model` | yes | Resolve selected ids against the current node array |
| `ArrayView::fold` / `Int::max` | MoonBit core | yes | Compact region width from quantized packed sizes |
| `packed_size` / `quantize_length` / `dequantize` | `canvas-layout/skyline` | yes | Same quantization as packing, so the strip is wide enough after `ceil` |
| `LayoutPlan::to_move_nodes` | `canvas-layout/skyline` | yes | Lower placements to an existing graph operation |
| `record_action` | `canvas-graph/graph_model` | yes | Commit through the current action log |
| `Array::insert` | MoonBit core | yes | Prepend Arrange onto the catalog-owned menu array |
| New `WorkflowAction` variant | `canvas-graph` | no | Arrange is a UI policy that reuses `MoveNodes` |

New helpers added (if any):

- `dowdiness/skyline` (`Packer`, `pack_in_order`, `Size`, `Placement`): independent packing primitive; Canvas must not import this module.
- `arrange_with_skyline` / `compact_region_width` / `LayoutPlan`: canvas adapter boundary; quantization and graph types stay here.
- `CanvasRuntime::arrange_selection`: thin shell that packs the current selection and records `MoveNodes`.
- `CanvasContextAction::Arrange`: menu action; not a workflow operation.

## Validation scope

Boundary matrix / first failing regression:

- Packer: input order, Bottom-Left, no rotation, width overflow before search, `y + height` overflow vs `@int.MAX_VALUE`, skyline rebuilt on commit.
- Adapter: empty selection → `InvalidRegionWidth(0.0)`; compact width uses quantized packed sizes; `ItemTooWide` / `NoPlacement` payloads preserved.
- Runtime: `< 2` nodes no-op; non-finite / coordinate overflow no-op; compact-policy failures `fail`.
- Menu: catalog-only without multi-selection (7 items); Arrange prepended for 2+ selected hand-built nodes (8 items); hidden on source-backed graphs.
- E2E: Shift-select nodes 1 then 2, Arrange compactly, packed positions and 3 actions logged.

Target packages:

- `modules/skyline`
- `modules/canvas-layout/skyline`
- `apps/canvas/main`

Additional conditional gates:

- Canvas Playwright covers Arrange; CI `run_canvas_e2e` now also watches `modules/skyline/**` and `modules/canvas-layout/**`.

## PR-ready evidence

Validated HEAD: `eb51fcd0446930ff9d64562f788e45ca22f5579a`

Validated base: `origin/main@e6b0285ba0ac5ba38554788d818c021e2ec97373`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh \
  --target modules/skyline \
  --target modules/canvas-layout/skyline \
  --target apps/canvas/main
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for the exact HEAD and base above.
- [x] The base was fetched again and `--verify-evidence` passed immediately
      before this PR was opened, updated, or merged.
- [x] The committed `.mbti` diff against the validated base was reviewed for
      unintended API or trait-bound changes.
- [x] Any changed submodule commit is pushed and reachable from its remote.
- [x] Validation was rerun after every commit, amend, rebase, cherry-pick,
      submodule-pointer, manifest, or generated-interface change.
- [x] Independent review findings were resolved before the final validation.


Made with [Cursor](https://cursor.com)