### PR TITLE
refactor(ideal): render Incr Canvas with keyed Rabbita SVG

### DIFF
--- a/apps/ideal/main/incr_canvas_render.mbt
+++ b/apps/ideal/main/incr_canvas_render.mbt
@@ -1,0 +1,135 @@
+///|
+fn incr_canvas_edge_endpoint_key(
+  edge : @visualizer.RecomputeSnapshotEdge,
+) -> String {
+  "edge:" + incr_canvas_cell_id(edge.from) + "->" + incr_canvas_cell_id(edge.to)
+}
+
+///|
+fn incr_canvas_edge_key(endpoint : String, ordinal : Int) -> String {
+  if ordinal == 0 {
+    endpoint
+  } else {
+    endpoint + "#" + ordinal.to_string()
+  }
+}
+
+///|
+fn incr_canvas_svg_attrs() -> @svg.Attrs {
+  @svg.Attrs::build()
+  .class("incr-canvas-svg")
+  .width("100%")
+  .height("220")
+  .role("img")
+  .aria_label("Interactive Incr dependency graph")
+  .pointer_events("none")
+}
+
+///|
+fn incr_canvas_edge_view(
+  state : IncrCanvasState,
+  edge : @visualizer.RecomputeSnapshotEdge,
+) -> @svg.Svg? {
+  match
+    (
+      incr_canvas_screen_position(state, edge.from),
+      incr_canvas_screen_position(state, edge.to),
+    ) {
+    (Some(from), Some(to)) =>
+      Some(
+        @svg.node(
+          "line",
+          @svg.Attrs::build()
+          .class("incr-canvas-edge")
+          .x1(from.x().to_string())
+          .y1(from.y().to_string())
+          .x2(to.x().to_string())
+          .y2(to.y().to_string()),
+          ([] : Array[@svg.Svg]),
+        ),
+      )
+    _ => None
+  }
+}
+
+///|
+fn incr_canvas_node_view(
+  state : IncrCanvasState,
+  snapshot : @visualizer.RecomputeSnapshot,
+  node : @visualizer.RecomputeSnapshotNode,
+) -> @svg.Svg? {
+  match incr_canvas_screen_position(state, node.id) {
+    Some(center) => {
+      let status = incr_canvas_status(snapshot, node.id)
+      let selected = state.selected.contains(node.id)
+      let stroke = if selected { "#b090e0" } else { status.stroke() }
+      let half_width = INCR_CANVAS_NODE_WIDTH / 2.0
+      let half_height = INCR_CANVAS_NODE_HEIGHT / 2.0
+      let cell_id = incr_canvas_cell_id(node.id)
+      let transform = "translate(" +
+        center.x().to_string() +
+        " " +
+        center.y().to_string() +
+        ")"
+      let rect = @svg.node(
+        "rect",
+        @svg.Attrs::build()
+        .x((0.0 - half_width).to_string())
+        .y((0.0 - half_height).to_string())
+        .width(INCR_CANVAS_NODE_WIDTH.to_string())
+        .height(INCR_CANVAS_NODE_HEIGHT.to_string())
+        .rx("6")
+        .fill(status.fill())
+        .stroke(stroke),
+        ([] : Array[@svg.Svg]),
+      )
+      let text = @svg.node(
+        "text",
+        @svg.Attrs::build().x("0").y("5").text_anchor("middle"),
+        [@svg.text(incr_canvas_node_label(node))],
+      )
+      Some(
+        @svg.node(
+          "g",
+          @svg.Attrs::build()
+          .class("incr-canvas-node")
+          .data_set("cell-id", cell_id)
+          .transform(transform),
+          [rect, text],
+        ),
+      )
+    }
+    None => None
+  }
+}
+
+///|
+/// Render the Ideal-local interactive graph as one keyed Rabbita SVG tree.
+/// Positions remain screen-space projections from the local viewport; node
+/// dimensions remain fixed screen pixels. Invalid projections omit only the
+/// affected edge or node.
+fn incr_canvas_svg_view(
+  state : IncrCanvasState,
+  snapshot : @visualizer.RecomputeSnapshot,
+) -> Html {
+  let children : Map[String, @svg.Svg] = Map([])
+  let edge_ordinals : Map[String, Int] = Map([])
+  for edge in snapshot.edges {
+    match incr_canvas_edge_view(state, edge) {
+      Some(line) => {
+        let endpoint = incr_canvas_edge_endpoint_key(edge)
+        let ordinal = edge_ordinals.get(endpoint).unwrap_or(0)
+        edge_ordinals[endpoint] = ordinal + 1
+        children[incr_canvas_edge_key(endpoint, ordinal)] = line
+      }
+      None => ()
+    }
+  }
+  for node in snapshot.nodes {
+    match incr_canvas_node_view(state, snapshot, node) {
+      Some(group) => children["node:" + incr_canvas_cell_id(node.id)] = group
+      None => ()
+    }
+  }
+  @svg.Svg::to_html(@svg.keyed_node("svg", incr_canvas_svg_attrs(), children))
+}

--- a/apps/ideal/main/incr_canvas_render_wbtest.mbt
+++ b/apps/ideal/main/incr_canvas_render_wbtest.mbt
@@ -1,0 +1,68 @@
+///|
+test "incr canvas render assigns duplicate endpoint ordinals without index-only keys" {
+  let endpoint = "edge:cell_7_1->cell_7_2"
+  assert_eq(incr_canvas_edge_key(endpoint, 0), endpoint)
+  assert_eq(incr_canvas_edge_key(endpoint, 1), endpoint + "#1")
+}
+
+///|
+test "incr runtime snapshot characterizes dependency endpoint uniqueness" {
+  let runtime = @incr.Runtime()
+  let source = @incr.Input(runtime, 1, label="source")
+  let derived = @incr.Derived(
+    runtime,
+    () => source.get() + source.get(),
+    label="derived",
+  )
+  let tap = @visualizer.RecomputeTap::attach(runtime)
+  ignore(derived.read_or_abort())
+  let snapshot = tap.snapshot()
+  let seen : Set[String] = Set([])
+  for edge in snapshot.edges {
+    let key = incr_canvas_edge_endpoint_key(edge)
+    assert_false(seen.contains(key))
+    seen.add(key)
+  }
+  match incr_canvas_status(snapshot, derived.id()) {
+    @visualizer.VisualNodeStatus::Changed => ()
+    _ => fail("expected the derived cell to be changed")
+  }
+  match incr_canvas_status(snapshot, source.id()) {
+    @visualizer.VisualNodeStatus::Neutral => ()
+    _ => fail("expected the source cell to be neutral")
+  }
+  tap.detach()
+}
+
+///|
+test "incr canvas renderer omits only invalid node and edge projections" {
+  let runtime = @incr.Runtime()
+  let source = @incr.Input(runtime, 1, label="source")
+  let derived = @incr.Derived(runtime, () => source.get() + 1, label="derived")
+  let tap = @visualizer.RecomputeTap::attach(runtime)
+  ignore(derived.read_or_abort())
+  let snapshot = tap.snapshot()
+  let state = reconcile_incr_canvas(IncrCanvasState::empty(), snapshot)
+  let invalid = test_world(1.0e308, 0.0)
+  let invalid_positions = state.positions.copy()
+  assert_true(snapshot.nodes.length() > 0)
+  let first = snapshot.nodes[0]
+  invalid_positions[first.id] = invalid
+  let invalid_state = {
+    ..state,
+    viewport: incr_canvas_test_viewport(1.0e308, 0.0, 1.0),
+    positions: invalid_positions,
+  }
+  assert_true(incr_canvas_node_view(invalid_state, snapshot, first) is None)
+  assert_true(snapshot.edges.length() > 0)
+  let edge = snapshot.edges[0]
+  let edge_positions = state.positions.copy()
+  edge_positions[edge.from] = invalid
+  let edge_state = {
+    ..state,
+    viewport: incr_canvas_test_viewport(1.0e308, 0.0, 1.0),
+    positions: edge_positions,
+  }
+  assert_true(incr_canvas_edge_view(edge_state, edge) is None)
+  tap.detach()
+}

--- a/apps/ideal/main/moon.pkg
+++ b/apps/ideal/main/moon.pkg
@@ -4,6 +4,7 @@ import {
   "moonbit-community/rabbita/sub",
   "moonbit-community/rabbita/dom",
   "moonbit-community/rabbita/js" @js_value,
+  "moonbit-community/rabbita/svg",
   "dowdiness/rabbita_codemirror" @cm,
   "dowdiness/rabbita_codemirror/js" @cm_js,
   "dowdiness/rabbita-menu/menu",

--- a/apps/ideal/main/view_bottom_incr_canvas.mbt
+++ b/apps/ideal/main/view_bottom_incr_canvas.mbt
@@ -51,75 +51,6 @@ fn incr_canvas_status(
 }
 
 ///|
-fn append_incr_canvas_edge(
-  buf : StringBuilder,
-  state : IncrCanvasState,
-  edge : @visualizer.RecomputeSnapshotEdge,
-) -> Unit {
-  match
-    (
-      incr_canvas_screen_position(state, edge.from),
-      incr_canvas_screen_position(state, edge.to),
-    ) {
-    (Some(from), Some(to)) =>
-      buf.write_string(
-        "<line class=\"incr-canvas-edge\" x1=\"\{from.x()}\" y1=\"\{from.y()}\" x2=\"\{to.x()}\" y2=\"\{to.y()}\" />",
-      )
-    _ => ()
-  }
-}
-
-///|
-fn append_incr_canvas_node(
-  buf : StringBuilder,
-  state : IncrCanvasState,
-  snapshot : @visualizer.RecomputeSnapshot,
-  node : @visualizer.RecomputeSnapshotNode,
-) -> Unit {
-  match incr_canvas_screen_position(state, node.id) {
-    Some(center) => {
-      let status = incr_canvas_status(snapshot, node.id)
-      let selected = state.selected.contains(node.id)
-      let stroke = if selected { "#b090e0" } else { status.stroke() }
-      let label = @history_render.escape_html_string(
-        incr_canvas_node_label(node),
-      )
-      let cell_id = @history_render.escape_html_string(
-        incr_canvas_cell_id(node.id),
-      )
-      let half_width = INCR_CANVAS_NODE_WIDTH / 2.0
-      let half_height = INCR_CANVAS_NODE_HEIGHT / 2.0
-      buf.write_string(
-        "<g class=\"incr-canvas-node\" data-cell-id=\"\{cell_id}\" transform=\"translate(\{center.x()} \{center.y()})\"><rect x=\"\{0.0 - half_width}\" y=\"\{0.0 - half_height}\" width=\"\{INCR_CANVAS_NODE_WIDTH}\" height=\"\{INCR_CANVAS_NODE_HEIGHT}\" rx=\"6\" fill=\"\{status.fill()}\" stroke=\"\{stroke}\" /><text x=\"0\" y=\"5\" text-anchor=\"middle\">\{label}</text></g>",
-      )
-    }
-    None => ()
-  }
-}
-
-///|
-/// Render the Ideal-local interactive graph. The SVG is deliberately small
-/// and local: positions belong to `IncrCanvasState`, while nodes and edges are
-/// read directly from the current `RecomputeSnapshot`.
-fn render_incr_canvas_svg(
-  state : IncrCanvasState,
-  snapshot : @visualizer.RecomputeSnapshot,
-) -> String {
-  let buf = StringBuilder::new()
-  buf.write_string(
-    "<svg class=\"incr-canvas-svg\" width=\"100%\" height=\"220\" role=\"img\" aria-label=\"Interactive Incr dependency graph\" style=\"pointer-events:none\">",
-  )
-  for edge in snapshot.edges {
-    append_incr_canvas_edge(buf, state, edge)
-  }
-  for node in snapshot.nodes {
-    append_incr_canvas_node(buf, state, snapshot, node)
-  }
-  buf.write_string("</svg>")
-  buf.to_string()
-}
-
-///|
 const INCR_CANVAS_ACTIVE_POINTER_ATTRIBUTE : String = "data-incr-active-pointer-id"
 
 ///|
@@ -368,17 +299,13 @@ fn incr_canvas_interaction_attrs(
 }
 
 ///|
-#warnings("-alert_xss_vulnerable")
 fn view_incr_canvas_panel(dispatch : Emit[Msg], model : Model) -> Html {
   let snapshot = model.incr_tap.snapshot()
-  let svg = if model.workspace.bottom_visible {
-    render_incr_canvas_svg(model.incr_canvas, snapshot)
+  let svg : Html = if model.workspace.bottom_visible {
+    incr_canvas_svg_view(model.incr_canvas, snapshot)
   } else {
-    ""
+    @html.nothing
   }
-  // Use a distinct outer tag from the raw-innerHTML SVG panels. Rabbita then
-  // replaces the subtree when switching tabs instead of trying to patch a
-  // stale innerHTML property in place.
   @html.div(
     class="bottom-content incr-canvas-content",
     attrs=bottom_panel_attrs(IncrCanvas),
@@ -392,13 +319,7 @@ fn view_incr_canvas_panel(dispatch : Emit[Msg], model : Model) -> Html {
         @html.div(
           class="incr-canvas-interaction",
           attrs=incr_canvas_interaction_attrs(dispatch, model.incr_canvas),
-          [
-            @html.div(
-              class="incr-canvas-svg-host",
-              attrs=@html.Attrs::build().inner_html(svg),
-              ([] : Array[Html]),
-            ),
-          ],
+          [svg],
         ),
       ]),
     ],

--- a/apps/ideal/web/e2e/incr-canvas.spec.ts
+++ b/apps/ideal/web/e2e/incr-canvas.spec.ts
@@ -10,6 +10,48 @@ async function waitForEditorReady(page: import('@playwright/test').Page) {
 }
 
 test.describe('Bottom panel — interactive Incr Canvas', () => {
+  test('renders one keyed SVG tree and preserves node and edge identity across rerenders', async ({
+    page,
+  }) => {
+    await waitForEditorReady(page);
+    await page.getByRole('button', { name: 'Panels' }).click();
+    await page.getByRole('tab', { name: 'Incr Canvas' }).click();
+
+    const panel = page.locator('#canopy-incr-canvas-container');
+    const stage = panel.locator('.incr-canvas-interaction');
+    const svg = stage.locator(':scope > svg.incr-canvas-svg');
+    const node = svg.locator('.incr-canvas-node').first();
+    const edge = svg.locator('.incr-canvas-edge').first();
+    await expect(svg).toHaveCount(1);
+    await expect(svg).toHaveAttribute('role', 'img');
+    await expect(svg).toHaveAttribute('aria-label', 'Interactive Incr dependency graph');
+    expect(await svg.evaluate(element => element.namespaceURI)).toBe(
+      'http://www.w3.org/2000/svg',
+    );
+    await expect(node).toHaveCount(1);
+    await expect(edge).toHaveCount(1);
+    await expect(stage.locator('.incr-canvas-svg-host')).toHaveCount(0);
+
+    await node.evaluate(element => element.setAttribute('data-test-marker', 'node'));
+    await edge.evaluate(element => element.setAttribute('data-test-marker', 'edge'));
+    const before = await node.getAttribute('transform');
+    const box = await stage.boundingBox();
+    expect(box).not.toBeNull();
+    if (!box) return;
+
+    await page.mouse.move(box.x + box.width - 24, box.y + 120);
+    await page.mouse.wheel(0, -50);
+    await expect(node).not.toHaveAttribute('transform', before ?? '');
+    await expect(node).toHaveAttribute('data-test-marker', 'node');
+    await expect(edge).toHaveAttribute('data-test-marker', 'edge');
+
+    const nodeBox = await node.boundingBox();
+    expect(nodeBox).not.toBeNull();
+    if (!nodeBox) return;
+    await page.mouse.click(nodeBox.x + nodeBox.width / 2, nodeBox.y + nodeBox.height / 2);
+    await expect(node.locator('rect')).toHaveAttribute('stroke', '#b090e0');
+  });
+
   test('renders CellId-backed nodes and supports local drag', async ({ page }) => {
     await waitForEditorReady(page);
     await page.getByRole('button', { name: 'Panels' }).click();
@@ -199,7 +241,7 @@ test.describe('Bottom panel — interactive Incr Canvas', () => {
       x: firstBox.x + 20.25,
       y: firstBox.y + 20.75,
     };
-    const child = first.stage.locator('.incr-canvas-svg-host');
+    const child = first.stage.locator('.incr-canvas-svg');
     const beforeChild = await first.node.getAttribute('transform');
     await child.evaluate((element, point) => {
       const event = new WheelEvent('wheel', {

--- a/apps/ideal/web/styles/editor.css
+++ b/apps/ideal/web/styles/editor.css
@@ -813,7 +813,6 @@ canopy-editor {
   cursor: grabbing;
 }
 
-.incr-canvas-svg-host,
 .incr-canvas-svg {
   display: block;
   width: 100%;


### PR DESCRIPTION
## Summary

- Replace Ideal Incr Canvas raw SVG-string / `inner_html` rendering with a single keyed Rabbita SVG tree.
- Key nodes by `CellId` and edges by endpoint identity with an ordinal fallback for duplicate endpoints.
- Preserve screen-space coordinates, fixed node dimensions, interaction semantics, selection/status presentation, and invalid-projection omission.
- Remove Canvas-path manual HTML escaping and `alert_xss_vulnerable` suppression.

## UI and review evidence

- [x] No visible labels were removed; existing SVG accessible name, text content, DOM attributes, and interaction path remain covered.
- [x] Interactive bounds, pointer feedback, keyed DOM identity, and viewport reflow were checked in the rendered UI.
- [x] Canopy repository rules are addressed through the package boundary and validation evidence below; no external guidance is presented as a repository requirement.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `@svg.node`, `@svg.text`, `@svg.keyed_node` | `deps/rabbita/rabbita/svg` | Yes | These are the existing Rabbita SVG constructors and keyed reconciliation boundary. |
| `@incr.RecomputeTap` / `@visualizer.RecomputeSnapshot` | Existing Ideal/visualizer integration | Yes | The renderer consumes the existing snapshot and tap state; no second snapshot or renderer state was introduced. |
| `Map[String, @svg.Svg]` | MoonBit core `Map`; keyed SVG API contract | Yes | Stores keyed children for Rabbita reconciliation; no index-only DOM identity path is used. |
| `Option` pattern matching | MoonBit core `Option` | Yes | Invalid screen projections are omitted without introducing a new error abstraction. |
| `Array` iteration | MoonBit core `Array` | Yes | Snapshot edges and nodes are traversed with existing collection iteration. |

New helpers added (if any):

- `incr_canvas_edge_endpoint_key` and `incr_canvas_edge_key`: private, renderer-specific key construction. They preserve endpoint identity and provide a deterministic duplicate-ordinal fallback; no existing project API owns this Ideal-specific key namespace.
- `incr_canvas_svg_attrs`, `incr_canvas_edge_view`, `incr_canvas_node_view`, and `incr_canvas_svg_view`: private presentation helpers that keep SVG projection and keyed-tree assembly inside the Ideal host.

## Validation scope

Boundary matrix / first failing regression:

- SVG namespace and one-root structure.
- Stable node and edge DOM identity across wheel/state rerenders.
- CellId-backed node attributes and fractional screen-space coordinates.
- Fixed 150px × 44px node dimensions.
- Selection stroke and status fill/stroke presentation.
- Invalid node/edge projection omission.
- Pointer admission, lost capture, capture failure, local drag, background pan, and anchor zoom.
- Wheel normalization, zero-delta suppression, and active-input rejection.
- Clean panel replacement when switching tabs.

Target packages:

- `apps/ideal/main`

Additional conditional gates:

- Ideal Canvas Playwright E2E: 10/10, one worker.
- Ideal production build: passed.
- Independent MoonBit/Rabbita review: PASS; no blocking findings.

## PR-ready evidence

Validated HEAD: `52a68085e9f9f46d356f2f0f6ec7684612c22778`

Validated base: `origin/main@4b16c62a6df46ef16d3b367dc57bfe6b72cb8a0a`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh \
  --target apps/ideal/main
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for the exact HEAD and base above.
- [x] The base was fetched again and `--verify-evidence` passed immediately before this PR was opened.
- [x] The committed `.mbti` diff against the validated base was reviewed; no drift.
- [x] No submodule commit changed; submodule status is clean and reachable.
- [x] Validation was rerun after the only commit; no amend, rebase, or generated-interface change followed.
- [x] Independent review findings were resolved before final validation.

## Out of scope

- Shared Canvas renderer extraction.
- Node or edge keyboard interaction.
- Layout semantics.
- `@spatial` API changes.
- Status computation optimization.
