### PR TITLE
perf(editor): consume authority admission transitions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -126,6 +126,9 @@ Only needed if you are modifying Canopy itself.
 
 **Performance:**
 
+- [Canopy remote-admission authority transition](performance/2026-08-19-canopy-remote-admission-authority-transition.md)
+  — records the #1281 exact-effect cutover, correctness seam, native release
+  history/length matrix, and whole-call control.
 - [Canopy remote-admission phase attribution](performance/2026-08-18-canopy-remote-admission-phase-attribution.md)
   — isolates materialized-text snapshot lifecycle work from authority admission and
   parser/projection reconciliation, with an independent history/length matrix.
@@ -240,6 +243,8 @@ behavior** — check the code before relying on any specific detail.
 - [Causal Authority residency](decisions/2026-08-12-causal-authority-residency.md)
   — preserves one causal authority while choosing warm or cold residency by
   access path; retained state remains a validated accelerator.
+- [Authority-owned remote admission transition](decisions/2026-08-19-authority-owned-remote-admission-transition.md)
+  — consumes one opaque EGW admission transition, reconciles exact effects without a full authority snapshot, and bounds grapheme-safe snapshot fallback.
 - [Private restore coordinator for Loomark cold open](decisions/2026-08-20-loomark-private-restore-coordinator.md)
   — keeps the public cold-open interface unchanged while one private Rabbita
   module owns readiness, generation-gated fallback, and correlated activation.
@@ -266,6 +271,8 @@ behavior** — check the code before relying on any specific detail.
 
 Recently completed (for quick reference):
 
+- [Completed #1281 authority-transition implementation invariants](archive/completed-phases/2026-08-21-1281-authority-transition-implementation-invariants.md)
+  — records the implemented transition precedence, two-phase prepare/settle contract, Unicode coordinate seam, and compatibility constraints.
 - [Markdown List Payloads](archive/completed-phases/2026-06-20-markdown-list-payloads.md)
 - [Canvas Handles And Edges](archive/completed-phases/2026-05-14-canvas-handles-edges.md)
 - [Lambda Annotation Plumbing — Design](archive/completed-phases/2026-04-18-lambda-annotation-plumbing-design.md)

--- a/docs/archive/completed-phases/2026-08-21-1281-authority-transition-implementation-invariants.md
+++ b/docs/archive/completed-phases/2026-08-21-1281-authority-transition-implementation-invariants.md
@@ -1,5 +1,11 @@
 # #1281 authority-transition implementation invariants
 
+**Status:** Complete.
+
+**Decision record:** [Authority-owned remote admission transition](../../decisions/2026-08-19-authority-owned-remote-admission-transition.md)
+
+**Completion:** Implemented for [issue #1281](https://github.com/dowdiness/canopy/issues/1281). Validation covers the native editor package, the full JavaScript suite, exact/fallback/unavailable transition settlement, Unicode coordinate conversion, and the recorded history/length benchmark matrix.
+
 This implementation note makes the accepted issue specification executable. It
 does not change the governing decisions or authorize a second admission path.
 
@@ -99,6 +105,11 @@ calls `finish()` to surface the recovery error. If replay or seed raises after
 authority commit, Canopy records and propagates the existing parser failure and
 does not call `finish()`; authority remains committed and later `finish()` cannot
 declare the parser synchronized.
+
+Fallback cursor reconciliation preserves separated grapheme edits while its LCS
+matrix fits a 65,536-cell budget. Larger changed middles use one grapheme-aligned
+replacement, intentionally trading interior cursor affinity for bounded settlement
+time and memory.
 
 ## Observation and compatibility
 

--- a/docs/decisions/2026-08-19-authority-owned-remote-admission-transition.md
+++ b/docs/decisions/2026-08-19-authority-owned-remote-admission-transition.md
@@ -1,0 +1,50 @@
+# ADR: Authority-owned remote admission transition
+
+**Date:** 2026-08-19
+
+**Status:** Accepted and implemented.
+
+**Implementation plan:** [#1281 authority-transition implementation invariants](../archive/completed-phases/2026-08-21-1281-authority-transition-implementation-invariants.md)
+
+**Canonical issue:** [Avoid full text snapshots during remote admission (#1281)](https://github.com/dowdiness/canopy/issues/1281)
+
+## Context
+
+Canopy remote admission previously asked event-graph-walker to admit a message and then materialized the complete authority text before reconciling parser, cursor, projection identity, and hint state. The full snapshot made a one-operation admission scale with resident history and obscured whether authority had committed when projection recovery failed.
+
+Event-graph-walker now exposes one opaque admission transition whose exhaustive availability is `Exact`, `SnapshotRequired`, or `Unavailable`. The transition retains the complete report or error until `finish()` and keeps authority mutation, recovery precedence, and effect ownership inside the authority module.
+
+## Decision
+
+`SyncEditor` consumes the authority transition as the sole remote-admission result.
+
+For `Exact`, Canopy prepares the ordered scalar-domain text effects without mutating editor state. Preparation derives one coherent candidate source and converts every affected scalar position to a UTF-16 parser edit. Settlement compares that candidate with parser-held source, then applies cursor, peer-cursor, hint, parser, projection-identity, and observation changes from the same prepared value.
+
+For `SnapshotRequired`, Canopy performs exactly one post-admission authority text read and gives that coherent source to settlement. Peer cursors are reconciled on grapheme boundaries in UTF-16 coordinates before parser seeding. Precise separated edits use a longest-common-subsequence matrix capped at 65,536 cells; larger changed middles use one grapheme-aligned replacement so settlement time and memory remain bounded. The coarse path intentionally collapses cursor affinity inside that changed middle.
+
+For `Unavailable`, Canopy performs no authority text read or parser reconciliation and calls `finish()` to surface the retained recovery error. Authority acceptance is observed before settlement. Parser replay or seed failure after authority commit remains a parser failure and does not let `finish()` declare synchronization.
+
+The existing public Canopy interfaces, sync report, wire data, and archive data remain unchanged. The event-graph-walker transition is the authority interface; Canopy owns only editor-domain adaptation and settlement.
+
+## Consequences
+
+- Warm, exact remote admission no longer materializes the complete authority text.
+- Admission outcome and post-commit failure precedence are explicit and testable through one transition interface.
+- Scalar CRDT effects and UTF-16 editor coordinates meet at one preparation seam.
+- Snapshot fallback performs one full authority read and has bounded diff memory and time.
+- Large unrelated fallback changes preserve source correctness but use coarse interior peer-cursor affinity.
+- Existing callers retain their current Canopy interface and compatibility behavior.
+
+## Alternatives rejected
+
+### Always materialize the authority text
+
+This preserves the old implementation but keeps one-operation cost proportional to resident history and hides exact effects already known by the authority module.
+
+### Reconstruct admission effects in Canopy
+
+This duplicates authority ordering, pending, recovery, and partial-admission semantics across the seam. Divergent reconstruction could reconcile a source different from the committed authority outcome.
+
+### Run an unbounded precise fallback diff
+
+A full longest-common-subsequence matrix preserves interior equal clusters, but unrelated large snapshots require quadratic time and memory before parser recovery. Bounded coarse replacement preserves correctness and availability at the documented cursor-affinity cost.

--- a/docs/evidence/2026-08-19-canopy-remote-admission-authority-transition.json
+++ b/docs/evidence/2026-08-19-canopy-remote-admission-authority-transition.json
@@ -1,0 +1,504 @@
+{
+  "schema": 1,
+  "measured_at": "2026-08-19",
+  "canopy_commit_before_uncommitted_change": "dbff0651bf3004e65dc194a5c37e39558805f835",
+  "event_graph_walker_commit": "31fb57b4dc9e423a94dda15a42bfbdcbd7c103e6",
+  "target": "native release",
+  "independent_processes_per_mode_cell": 3,
+  "units": "microseconds",
+  "fixture": {
+    "history_operations": [
+      0,
+      1000,
+      10000,
+      100000
+    ],
+    "visible_utf16_units_at_history_100000": [
+      0,
+      2000,
+      10000,
+      50000
+    ],
+    "incoming_operations": 1,
+    "history_source": "raw TextState",
+    "initial_target_hydration": "raw authority apply_with_limits followed by coherent parser seed",
+    "measured_ingress": "SyncEditor production admission transition / admit",
+    "setup_limits": {
+      "max_encoded_bytes": 268435456,
+      "max_decoded_operations": "H"
+    }
+  },
+  "phase_definitions": {
+    "transition_us": "AuthorityCore::admit_transition_with_tracking for one incoming message",
+    "preparation_us": "read parser-held source, inspect exact effects, and prepare candidate source plus UTF-16 parser edits",
+    "reconciliation_us": "settle prepared admission and finish the authority transition",
+    "whole_call_us": "SyncEditor::admit around the same one-operation fixture, including method-exit work"
+  },
+  "matrix_medians": [
+    {
+      "H": 0,
+      "L": 0,
+      "transition_us": 34.086,
+      "preparation_us": 3.074,
+      "reconciliation_us": 19.492,
+      "whole_call_us": 72.481,
+      "phase_sum_us": 56.652
+    },
+    {
+      "H": 1000,
+      "L": 0,
+      "transition_us": 49.644,
+      "preparation_us": 6.8340000000000005,
+      "reconciliation_us": 26.284,
+      "whole_call_us": 86.507,
+      "phase_sum_us": 82.762
+    },
+    {
+      "H": 10000,
+      "L": 0,
+      "transition_us": 82.471,
+      "preparation_us": 7.516,
+      "reconciliation_us": 28.337,
+      "whole_call_us": 137.071,
+      "phase_sum_us": 118.32400000000001
+    },
+    {
+      "H": 100000,
+      "L": 0,
+      "transition_us": 125.175,
+      "preparation_us": 7.649,
+      "reconciliation_us": 31.665,
+      "whole_call_us": 159.68800000000002,
+      "phase_sum_us": 164.48899999999998
+    },
+    {
+      "H": 100000,
+      "L": 2000,
+      "transition_us": 1237.82,
+      "preparation_us": 20.813,
+      "reconciliation_us": 36.284,
+      "whole_call_us": 1516.212,
+      "phase_sum_us": 1294.9170000000001
+    },
+    {
+      "H": 100000,
+      "L": 10000,
+      "transition_us": 1775.702,
+      "preparation_us": 18.344,
+      "reconciliation_us": 59.984,
+      "whole_call_us": 1433.209,
+      "phase_sum_us": 1854.03
+    },
+    {
+      "H": 100000,
+      "L": 50000,
+      "transition_us": 820.83,
+      "preparation_us": 45.718,
+      "reconciliation_us": 118.93900000000001,
+      "whole_call_us": 1292.603,
+      "phase_sum_us": 985.487
+    }
+  ],
+  "baseline_comparison_H100000_L0": {
+    "H": 100000,
+    "L": 0,
+    "baseline_direct_public_admission_us": 176264.60699999996,
+    "new_whole_call_us": 159.68800000000002,
+    "native_whole_call_ratio": 1103.8062158709479,
+    "baseline_post_authority_text_snapshot_us": 38311.256,
+    "new_preparation_us": 7.649,
+    "baseline_reconciliation_us": 48.293,
+    "new_reconciliation_us": 31.665
+  },
+  "samples": [
+    {
+      "mode": "whole",
+      "H": 0,
+      "L": 0,
+      "whole_call_us": 72.481,
+      "trial": 1,
+      "index": 0
+    },
+    {
+      "mode": "whole",
+      "H": 1000,
+      "L": 0,
+      "whole_call_us": 86.507,
+      "trial": 1,
+      "index": 1
+    },
+    {
+      "mode": "whole",
+      "H": 10000,
+      "L": 0,
+      "whole_call_us": 137.071,
+      "trial": 1,
+      "index": 2
+    },
+    {
+      "mode": "whole",
+      "H": 100000,
+      "L": 0,
+      "whole_call_us": 187.39600000000002,
+      "trial": 1,
+      "index": 3
+    },
+    {
+      "mode": "whole",
+      "H": 100000,
+      "L": 2000,
+      "whole_call_us": 1761.809,
+      "trial": 1,
+      "index": 4
+    },
+    {
+      "mode": "whole",
+      "H": 100000,
+      "L": 10000,
+      "whole_call_us": 1433.209,
+      "trial": 1,
+      "index": 5
+    },
+    {
+      "mode": "whole",
+      "H": 100000,
+      "L": 50000,
+      "whole_call_us": 1035.82,
+      "trial": 1,
+      "index": 6
+    },
+    {
+      "mode": "phases",
+      "H": 0,
+      "L": 0,
+      "transition_us": 51.958,
+      "preparation_us": 4.172,
+      "reconciliation_us": 27.174,
+      "trial": 1,
+      "index": 7
+    },
+    {
+      "mode": "phases",
+      "H": 1000,
+      "L": 0,
+      "transition_us": 69.563,
+      "preparation_us": 9.041,
+      "reconciliation_us": 31.824,
+      "trial": 1,
+      "index": 8
+    },
+    {
+      "mode": "phases",
+      "H": 10000,
+      "L": 0,
+      "transition_us": 82.471,
+      "preparation_us": 7.516,
+      "reconciliation_us": 27.219,
+      "trial": 1,
+      "index": 9
+    },
+    {
+      "mode": "phases",
+      "H": 100000,
+      "L": 0,
+      "transition_us": 120.157,
+      "preparation_us": 7.167,
+      "reconciliation_us": 31.665,
+      "trial": 1,
+      "index": 10
+    },
+    {
+      "mode": "phases",
+      "H": 100000,
+      "L": 2000,
+      "transition_us": 1517.172,
+      "preparation_us": 23.502,
+      "reconciliation_us": 61.671,
+      "trial": 1,
+      "index": 11
+    },
+    {
+      "mode": "phases",
+      "H": 100000,
+      "L": 10000,
+      "transition_us": 1871.534,
+      "preparation_us": 19.323,
+      "reconciliation_us": 60.639,
+      "trial": 1,
+      "index": 12
+    },
+    {
+      "mode": "phases",
+      "H": 100000,
+      "L": 50000,
+      "transition_us": 832.351,
+      "preparation_us": 45.718,
+      "reconciliation_us": 118.93900000000001,
+      "trial": 1,
+      "index": 13
+    },
+    {
+      "mode": "whole",
+      "H": 0,
+      "L": 0,
+      "whole_call_us": 53.517,
+      "trial": 2,
+      "index": 0
+    },
+    {
+      "mode": "whole",
+      "H": 1000,
+      "L": 0,
+      "whole_call_us": 149.875,
+      "trial": 2,
+      "index": 1
+    },
+    {
+      "mode": "whole",
+      "H": 10000,
+      "L": 0,
+      "whole_call_us": 134.44,
+      "trial": 2,
+      "index": 2
+    },
+    {
+      "mode": "whole",
+      "H": 100000,
+      "L": 0,
+      "whole_call_us": 159.68800000000002,
+      "trial": 2,
+      "index": 3
+    },
+    {
+      "mode": "whole",
+      "H": 100000,
+      "L": 2000,
+      "whole_call_us": 1411.228,
+      "trial": 2,
+      "index": 4
+    },
+    {
+      "mode": "whole",
+      "H": 100000,
+      "L": 10000,
+      "whole_call_us": 1438.1100000000001,
+      "trial": 2,
+      "index": 5
+    },
+    {
+      "mode": "whole",
+      "H": 100000,
+      "L": 50000,
+      "whole_call_us": 1303.684,
+      "trial": 2,
+      "index": 6
+    },
+    {
+      "mode": "phases",
+      "H": 0,
+      "L": 0,
+      "transition_us": 33.88,
+      "preparation_us": 2.657,
+      "reconciliation_us": 19.492,
+      "trial": 2,
+      "index": 7
+    },
+    {
+      "mode": "phases",
+      "H": 1000,
+      "L": 0,
+      "transition_us": 49.644,
+      "preparation_us": 6.732,
+      "reconciliation_us": 26.013,
+      "trial": 2,
+      "index": 8
+    },
+    {
+      "mode": "phases",
+      "H": 10000,
+      "L": 0,
+      "transition_us": 77.63,
+      "preparation_us": 7.122,
+      "reconciliation_us": 28.337,
+      "trial": 2,
+      "index": 9
+    },
+    {
+      "mode": "phases",
+      "H": 100000,
+      "L": 0,
+      "transition_us": 125.175,
+      "preparation_us": 7.649,
+      "reconciliation_us": 30.455000000000002,
+      "trial": 2,
+      "index": 10
+    },
+    {
+      "mode": "phases",
+      "H": 100000,
+      "L": 2000,
+      "transition_us": 1143.873,
+      "preparation_us": 20.813,
+      "reconciliation_us": 34.806,
+      "trial": 2,
+      "index": 11
+    },
+    {
+      "mode": "phases",
+      "H": 100000,
+      "L": 10000,
+      "transition_us": 1475.448,
+      "preparation_us": 15.06,
+      "reconciliation_us": 47.668,
+      "trial": 2,
+      "index": 12
+    },
+    {
+      "mode": "phases",
+      "H": 100000,
+      "L": 50000,
+      "transition_us": 820.83,
+      "preparation_us": 48.946,
+      "reconciliation_us": 134.999,
+      "trial": 2,
+      "index": 13
+    },
+    {
+      "mode": "whole",
+      "H": 0,
+      "L": 0,
+      "whole_call_us": 90.06,
+      "trial": 3,
+      "index": 0
+    },
+    {
+      "mode": "whole",
+      "H": 1000,
+      "L": 0,
+      "whole_call_us": 81.649,
+      "trial": 3,
+      "index": 1
+    },
+    {
+      "mode": "whole",
+      "H": 10000,
+      "L": 0,
+      "whole_call_us": 181.74,
+      "trial": 3,
+      "index": 2
+    },
+    {
+      "mode": "whole",
+      "H": 100000,
+      "L": 0,
+      "whole_call_us": 152.716,
+      "trial": 3,
+      "index": 3
+    },
+    {
+      "mode": "whole",
+      "H": 100000,
+      "L": 2000,
+      "whole_call_us": 1516.212,
+      "trial": 3,
+      "index": 4
+    },
+    {
+      "mode": "whole",
+      "H": 100000,
+      "L": 10000,
+      "whole_call_us": 1308.539,
+      "trial": 3,
+      "index": 5
+    },
+    {
+      "mode": "whole",
+      "H": 100000,
+      "L": 50000,
+      "whole_call_us": 1292.603,
+      "trial": 3,
+      "index": 6
+    },
+    {
+      "mode": "phases",
+      "H": 0,
+      "L": 0,
+      "transition_us": 34.086,
+      "preparation_us": 3.074,
+      "reconciliation_us": 18.138,
+      "trial": 3,
+      "index": 7
+    },
+    {
+      "mode": "phases",
+      "H": 1000,
+      "L": 0,
+      "transition_us": 45.962,
+      "preparation_us": 6.8340000000000005,
+      "reconciliation_us": 26.284,
+      "trial": 3,
+      "index": 8
+    },
+    {
+      "mode": "phases",
+      "H": 10000,
+      "L": 0,
+      "transition_us": 98.39,
+      "preparation_us": 7.8500000000000005,
+      "reconciliation_us": 30.591,
+      "trial": 3,
+      "index": 9
+    },
+    {
+      "mode": "phases",
+      "H": 100000,
+      "L": 0,
+      "transition_us": 148.877,
+      "preparation_us": 10.088000000000001,
+      "reconciliation_us": 37.485,
+      "trial": 3,
+      "index": 10
+    },
+    {
+      "mode": "phases",
+      "H": 100000,
+      "L": 2000,
+      "transition_us": 1237.82,
+      "preparation_us": 18.277,
+      "reconciliation_us": 36.284,
+      "trial": 3,
+      "index": 11
+    },
+    {
+      "mode": "phases",
+      "H": 100000,
+      "L": 10000,
+      "transition_us": 1775.702,
+      "preparation_us": 18.344,
+      "reconciliation_us": 59.984,
+      "trial": 3,
+      "index": 12
+    },
+    {
+      "mode": "phases",
+      "H": 100000,
+      "L": 50000,
+      "transition_us": 788.016,
+      "preparation_us": 44.897,
+      "reconciliation_us": 112.019,
+      "trial": 3,
+      "index": 13
+    }
+  ],
+  "commands": {
+    "check": "rtk moon check modules/canopy/editor",
+    "cell": "rtk moon bench --target native --release -p dowdiness/canopy/editor -f sync_editor_remote_admission_benchmark_wbtest.mbt -i <0..13>"
+  },
+  "limitations": [
+    "Native release only; no cross-runtime or end-user speedup claim is made.",
+    "Each phase and whole-call mode runs in a fresh process because the retained editor/parser runtime graph makes two H=100000 fixtures in one process exceed the benchmark environment resource envelope.",
+    "The initial H-operation hydration bypasses production ingress limits only during unmeasured setup; the measured one-operation message uses the production admission path.",
+    "Whole-call and segmented medians come from equivalent independent fixtures, so their difference is not an allocator or destruction counter.",
+    "MoonBench exposes no allocator counter."
+  ]
+}

--- a/docs/performance/2026-08-19-canopy-remote-admission-authority-transition.md
+++ b/docs/performance/2026-08-19-canopy-remote-admission-authority-transition.md
@@ -1,0 +1,121 @@
+# Canopy remote-admission authority transition
+
+- **Date:** 2026-08-19
+- **Canopy measurement base:** `dbff0651bf3004e65dc194a5c37e39558805f835` plus the uncommitted #1281 Canopy change
+- **event-graph-walker:** `31fb57b4dc9e423a94dda15a42bfbdcbd7c103e6`
+- **Issue:** [Canopy #1281](https://github.com/dowdiness/canopy/issues/1281)
+- **Baseline:** [Remote-admission phase attribution](2026-08-18-canopy-remote-admission-phase-attribution.md)
+
+## Decision
+
+Canopy now consumes the event-graph-walker authority-owned admission transition instead
+of materializing complete authority text before and after ordinary warm remote admission.
+Exact scalar effects are prepared against the parser-held source and committed through the
+existing cursor, parser, projection-identity, hint, and observation machinery. Explicit
+`SnapshotRequired` and `Unavailable` outcomes retain coherent fallback and fail-closed
+behavior.
+
+Decision record:
+
+- No ADR needed: this is the accepted #1281 follow-up under the existing authority and
+  projection-publication decisions; it changes no Canopy public interface, wire format, or
+  archive format.
+
+## Correctness mechanism
+
+The remote admission seam has one outcome-driven flow:
+
+1. event-graph-walker admits the message and returns an opaque transition;
+2. `Exact` effects are applied sequentially to the parser-held source without authority
+   text reads;
+3. Canopy converts scalar positions to UTF-16, then atomically settles cursor, peer cursor,
+   parser, projection identity, and hint state;
+4. `SnapshotRequired` reads one coherent post-admission snapshot;
+5. `Unavailable` reads no snapshot and performs no reconciliation;
+6. `finish()` returns the existing `SyncReport` or surfaces the stored committed error.
+
+Detector-backed tests prove zero authority reads on the ordinary exact path, one read on
+snapshot fallback, and zero reads on unavailable outcomes. End-to-end tests cover exact,
+duplicate-only, pending-only, dependency-drain, source-equal, snapshot-required,
+unavailable, partial-error, parser-failure, UTF-16 cursor, peer-cursor, identity-hint, and
+observation behavior.
+
+## Harness
+
+Native release measurements use three independent processes for every mode and matrix
+cell. Each fixture:
+
+- creates exactly $H=0/1k/10k/100k$ resident operations in a raw `TextState`;
+- independently fixes visible length at $L=0/2k/10k/50k$ UTF-16 units;
+- hydrates the target authority with expanded setup-only limits and coherently seeds its
+  parser outside the clocks;
+- admits one new operation through the production `SyncEditor` path;
+- checks the report count and source convergence after measurement.
+
+Segmented and whole-call modes use equivalent fresh-process fixtures. This avoids retaining
+two $H=100000$ editor/parser graphs in one process. Their medians are therefore controls,
+not additive allocator measurements.
+
+| Clock | Included work |
+|---|---|
+| transition | `AuthorityCore::admit_transition_with_tracking` |
+| preparation | parser-source read, exact-effect application, scalar-to-UTF-16 edit preparation |
+| reconciliation | prepared settlement and transition `finish()` |
+| whole call | `SyncEditor::admit`, including method-exit work |
+
+## Native release matrix
+
+Medians in microseconds.
+
+| H | L | transition | preparation | reconciliation | whole call |
+|---:|---:|---:|---:|---:|---:|
+| 0 | 0 | 34.086 | 3.074 | 19.492 | 72.481 |
+| 1,000 | 0 | 49.644 | 6.834 | 26.284 | 86.507 |
+| 10,000 | 0 | 82.471 | 7.516 | 28.337 | 137.071 |
+| 100,000 | 0 | 125.175 | 7.649 | 31.665 | 159.688 |
+| 100,000 | 2,000 | 1,237.820 | 20.813 | 36.284 | 1,516.212 |
+| 100,000 | 10,000 | 1,775.702 | 18.344 | 59.984 | 1,433.209 |
+| 100,000 | 50,000 | 820.830 | 45.718 | 118.939 | 1,292.603 |
+
+At $L=0$, increasing $H$ from 0 to 100k raises the whole call from 72.481 µs
+to 159.688 µs. The removed post-admission snapshot previously reached 38,311.256 µs
+at $H=100k,L=0$ before method-exit work.
+
+At fixed $H=100k$, preparation remains at or below 45.718 µs and reconciliation remains
+at or below 118.939 µs. Transition production is the largest named phase in the visible-text
+cells. Its non-monotonic values across $L$ do not establish a visible-length complexity law;
+the matrix identifies the remaining phase, not a new optimization target.
+
+## Baseline comparison
+
+For $H=100k,L=0$, medians in microseconds:
+
+| Measurement | Baseline | #1281 |
+|---|---:|---:|
+| direct public whole call | 176,264.607 | 159.688 |
+| post-admission complete snapshot / exact preparation | 38,311.256 | 7.649 |
+| parser/projection reconciliation | 48.293 | 31.665 |
+
+The native whole-call ratio is approximately $1104\times$. This supports the native
+mechanism claim that removing full snapshot construction and lifetime cleanup removes the
+measured history-shaped cost. It is not a cross-runtime or end-user speedup claim: no JS or
+wasm-gc end-to-end matrix was run, and MoonBench exposes no allocator counter.
+
+## Reproduction
+
+```sh
+rtk moon check modules/canopy/editor
+rtk moon bench --target native --release \
+  -p dowdiness/canopy/editor \
+  -f sync_editor_remote_admission_benchmark_wbtest.mbt \
+  -i <0..13>
+```
+
+Run every index in three fresh processes. Indices 0–6 are whole-call controls; indices
+7–13 are segmented phase measurements in the same matrix order.
+
+## Evidence
+
+- [Raw samples, medians, provenance, clock definitions, and limitations](../evidence/2026-08-19-canopy-remote-admission-authority-transition.json)
+- [Baseline report](2026-08-18-canopy-remote-admission-phase-attribution.md)
+- [Baseline raw evidence](../evidence/2026-08-18-canopy-remote-admission-phase-attribution.json)

--- a/docs/plans/2026-08-21-1281-authority-transition-implementation-invariants.md
+++ b/docs/plans/2026-08-21-1281-authority-transition-implementation-invariants.md
@@ -1,0 +1,125 @@
+# #1281 authority-transition implementation invariants
+
+This implementation note makes the accepted issue specification executable. It
+does not change the governing decisions or authorize a second admission path.
+
+## Transition outcome precedence
+
+Admission has one linear precedence order. Validation or recovery failure before
+the first OpLog authority mutation raises immediately and returns no transition.
+After authority mutation, failed projection recovery produces an `Unavailable`
+transition and its recovery error wins over a coincident partial-admission error.
+Successful recovery always produces `SnapshotRequired`, even when no operation
+committed. Without recovery, a provably exact warm small-batch projection produces
+`Exact`; cold, dirty, oversized, or otherwise unprovable projection produces
+`SnapshotRequired`. Duplicate-only and pending-only outcomes produce `Exact([])`
+only when no recovery occurred. `finish()` is the sole report/error settlement:
+it returns the complete `SyncReport`, raises the stored partial error after the
+consumer reconciles the committed prefix, or raises the recovery error for
+`Unavailable`.
+
+## Atomic detached workspace publication
+
+Fallible projection never mutates a published index incrementally. Before
+projection, Document detaches the warm visible index and its same-generation LV
+locator into a private workspace. The canonical slots remain empty while the
+workspace applies the committed operations, records ordered effects, and tracks
+exactness. Exact success publishes the derived visible index, locator, and
+effects as one Document-owned state change. The OpLog authority frontier has
+already committed independently and is never rolled back with derived state.
+The Text facade then
+advances its existing maintained `Version` cache from the committed receipt
+before returning the transition; internal Document neither owns nor duplicates
+that Text cache. Losing exactness discards effects and publishes derived state
+only through the coherent fallback/recovery lifecycle. Projection failure
+discards the entire workspace before recovery, so no prefix index, locator, or
+effect list becomes observable. Text cache readiness follows the existing
+receipt-driven rules for complete, partial, recovery, and failed recovery.
+
+## Sequential effect coordinates
+
+Every `TextEffect` is authority-owned and scalar-indexed. Its position or range
+is interpreted against the visible source produced by every preceding effect in
+the same transition. Insert content is the exact projected scalar content;
+delete ranges name the exact formerly-visible scalar interval. Losing LWW
+operations and other visibility no-ops emit no effect, while their admission
+counts and causal Version advancement remain represented. Canopy never derives
+an effect from the wire operation or raw committed receipt.
+
+## Locator generation and complexity
+
+The LV locator and visible index form one generation. Construction, run
+insertion/removal, split/merge, detach, restore, invalidation, and publication
+must update or replace them together. A locator answer is usable only for the
+workspace generation that owns the corresponding visible index. Warm
+LV-to-visible-position resolution uses indexed prefix information and must not
+scan all visible runs. Missing, stale, or failed lookup marks exactness lost and
+takes `SnapshotRequired`; it never falls back to a hidden linear traversal on
+the ordinary path.
+
+## Partial admission and recovery
+
+A partial admission may have committed authority. Its committed prefix is
+projected and reconciled before the partial error is surfaced. Exact prefix
+projection yields `Exact`; successful recovery yields `SnapshotRequired` and
+one coherent post-admission snapshot; failed recovery yields `Unavailable`, no
+snapshot, and no consumer reconciliation. Recovery precedence is independent of
+committed count, so zero-commit successful recovery still seeds once. Pending
+dependency drain contributes every newly committed operation to the same ordered
+projection/effect sequence. The transition retains the authority outcome until
+`finish()` without exposing a second report accessor.
+
+## Canopy two-phase prepare and commit
+
+Remote ingress does not taint identity hints before outcome classification. For
+`Exact`, preparation is pure: starting from parser-held source, it applies
+the scalar effects sequentially, converts affected scalar offsets to UTF-16,
+and returns one candidate source plus ordered parser edits. Preparation does not
+mutate authority, cursor state, peer cursors, parser, projection identity,
+identity hints, observations, or stored failure state. Commit compares the
+candidate to parser-held source. Source-equal commit advances the document
+Version and emits the existing `ProjectionMirrorSynchronized` observation but
+does no replay, cursor movement, identity work, or hint consumption. A changing
+commit clamps the local cursor to candidate UTF-16 length, transforms peer
+cursors with existing UTF-16 affinity rules, then taints/consumes identity hints,
+replays the prepared edits, and settles projection identity from the same
+candidate/edit sequence. Duplicate, pending, net source-equal, unavailable, and
+pre-commit failure paths leave pending identity hints untainted and unconsumed.
+
+For `SnapshotRequired`, Canopy performs exactly one post-admission authority
+text read and passes ownership of that coherent source into settlement. Peer
+cursors are transformed from parser-held old source to that supplied source
+before parser seeding and the local cursor is clamped against the supplied
+source's UTF-16 length. Every `SnapshotRequired` settlement follows the existing
+seed invalidation policy, including a recovered zero-commit or source-equal
+seed; only `Exact` duplicate, pending, and net source-equal settlement preserves
+hints unchanged. Settlement itself performs no authority read. For
+`Unavailable`, Canopy performs no authority read and no reconciliation, then
+calls `finish()` to surface the recovery error. If replay or seed raises after
+authority commit, Canopy records and propagates the existing parser failure and
+does not call `finish()`; authority remains committed and later `finish()` cannot
+declare the parser synchronized.
+
+## Observation and compatibility
+
+Authority acceptance is observed before transition settlement. Existing sync
+methods delegate to transition-aware methods and immediately finish, preserving
+their signatures, standalone `SyncReport`, `TextError`, wire data, and archive
+data. The opaque transition exposes only versions, exhaustive availability, and
+`finish()`. EGW retains authority, conflict, recovery, and effect ownership;
+Canopy retains scalar-to-UTF-16 adaptation, cursor and parser mutation,
+projection identity, hints, and session observation.
+
+## Reuse check before new definitions
+
+Candidate project APIs are `Document::admit_remote` and its typed
+`DocumentAdmission`, `AdmissionOutcome`/`AdmissionReceipt`, `ProjectionStatus`,
+`IndexedState` cache detach/restore and OrderTree prefix lookup, existing Fugue
+visible-change projection, `TextState::advance_cached_version`, and the current
+`SyncEditor` committed-transition/replay/seed/peer-cursor machinery. Core APIs
+checked are `ArrayView` for zero-copy effect exposure, `StringView` scalar and
+code-unit traversal, `Map`/`Set` for locator ownership, and `Array`/`Iter` for
+ordered transformation. New types are limited to the accepted opaque transition,
+two exhaustive effect enums, and private workspace/locator state whose boundary
+is atomic projection publication. Any further helper must have one deterministic
+transformation or publication responsibility and must be justified at review.

--- a/modules/canopy/editor/edit_bridge_wbtest.mbt
+++ b/modules/canopy/editor/edit_bridge_wbtest.mbt
@@ -146,3 +146,50 @@ test "merge_to_edits - disjoint inserts stay separate" {
   inspect(edits[1].old_len, content="0")
   inspect(edits[1].new_len, content="1")
 }
+
+///|
+test "merge_to_edits - astral prefix keeps UTF-16 edit coordinates" {
+  let edits = merge_to_edits("😀a", "😀b")
+  inspect(edits.length(), content="1")
+  inspect(edits[0].start, content="2")
+  inspect(edits[0].old_len, content="1")
+  inspect(edits[0].new_len, content="1")
+}
+
+///|
+test "merge_to_edits - repeated astral clusters preserve the suffix" {
+  let edits = merge_to_edits("😀x😀", "😀y😀")
+  inspect(edits.length(), content="1")
+  inspect(edits[0].start, content="2")
+  inspect(edits[0].old_len, content="1")
+  inspect(edits[0].new_len, content="1")
+}
+
+///|
+test "merge_to_edits - combining graphemes remain indivisible" {
+  let edits = merge_to_edits("e\u{0301}", "o\u{0301}")
+  inspect(edits.length(), content="1")
+  inspect(edits[0].start, content="0")
+  inspect(edits[0].old_len, content="2")
+  inspect(edits[0].new_len, content="2")
+}
+
+///|
+test "merge_to_edits - CRLF remains one grapheme edit" {
+  let edits = merge_to_edits("a\r\nb", "a\nb")
+  inspect(edits.length(), content="1")
+  inspect(edits[0].start, content="1")
+  inspect(edits[0].old_len, content="2")
+  inspect(edits[0].new_len, content="1")
+}
+
+///|
+test "merge_to_edits - large middles use one bounded replacement" {
+  let old_text = "a".repeat(129) + "X" + "b".repeat(128)
+  let new_text = "c".repeat(129) + "X" + "d".repeat(128)
+  let edits = merge_to_edits(old_text, new_text)
+  inspect(edits.length(), content="1")
+  inspect(edits[0].start, content="0")
+  inspect(edits[0].old_len, content="258")
+  inspect(edits[0].new_len, content="258")
+}

--- a/modules/canopy/editor/editor.mbt
+++ b/modules/canopy/editor/editor.mbt
@@ -6,7 +6,7 @@
 /// Wraps a TextState and maintains cursor position
 pub struct Editor {
   doc : @text.TextState
-  mut cursor : Int // Current cursor position (0-based)
+  mut cursor : Int // Unicode-scalar position, 0-based
 } derive(Debug)
 
 ///|
@@ -41,6 +41,15 @@ pub fn Editor::move_cursor(self : Editor, position : Int) -> Unit {
   }
 }
 
+///|
+fn unicode_scalar_length(text : String) -> Int {
+  let mut length = 0
+  for _ in text {
+    length += 1
+  }
+  length
+}
+
 ///| Insert text at current cursor position
 
 ///|
@@ -49,7 +58,7 @@ pub fn Editor::move_cursor(self : Editor, position : Int) -> Unit {
 /// After insertion, cursor moves to after the inserted text
 pub fn Editor::insert(self : Editor, text : String) -> Unit raise {
   self.doc.insert(@text.Pos::at(self.cursor), text)
-  self.cursor += text.length()
+  self.cursor += unicode_scalar_length(text)
 }
 
 ///| Insert text at a specific position

--- a/modules/canopy/editor/editor_properties_test.mbt
+++ b/modules/canopy/editor/editor_properties_test.mbt
@@ -4,6 +4,15 @@
 // built-in quickcheck for random test generation.
 
 ///|
+fn unicode_scalar_length(text : String) -> Int {
+  let mut length = 0
+  for _ in text {
+    length += 1
+  }
+  length
+}
+
+///|
 /// Property: New editor is always empty
 test "property: new editor is empty" {
   let editor = try! Editor::new("test-agent")
@@ -23,14 +32,14 @@ test "property: insert updates length correctly" {
 }
 
 ///|
-/// Property: Cursor is always within valid bounds [0, text.length()]
+/// Property: Cursor is always within valid Unicode-scalar bounds
 test "property: cursor bounds after insert" {
   let texts : Array[String] = @quickcheck.samples(20)
   for text in texts {
     let editor = try! Editor::new("test-agent")
     try! editor.insert(text)
     let cursor = editor.get_cursor()
-    let len = editor.get_text().length()
+    let len = unicode_scalar_length(editor.get_text())
     assert_true(cursor >= 0)
     assert_true(cursor <= len)
   }
@@ -78,7 +87,7 @@ test "property: insert then delete all gives empty" {
 
     // Delete all characters one by one
     editor.move_cursor(0)
-    for _i = 0; _i < text.length(); _i = _i + 1 {
+    for _i = 0; _i < unicode_scalar_length(text); _i = _i + 1 {
       let _ = editor.delete()
     }
     assert_eq(editor.get_text(), "")
@@ -113,7 +122,7 @@ test "property: cursor move clamps to bounds" {
     try! editor.insert("hello")
     editor.move_cursor(position)
     let cursor = editor.get_cursor()
-    let len = editor.get_text().length()
+    let len = unicode_scalar_length(editor.get_text())
     assert_true(cursor >= 0)
     assert_true(cursor <= len)
   }
@@ -147,9 +156,9 @@ test "property: multiple inserts accumulate length" {
     let mut expected_len = 0
     for text in texts {
       try! editor.insert(text)
-      expected_len = expected_len + text.length()
+      expected_len = expected_len + unicode_scalar_length(text)
     }
-    assert_eq(editor.get_text().length(), expected_len)
+    assert_eq(unicode_scalar_length(editor.get_text()), expected_len)
   }
 }
 
@@ -163,8 +172,8 @@ test "property: cursor advances after insert" {
     try! editor.insert(text)
     let end_pos = editor.get_cursor()
 
-    // Cursor should advance by text length
-    assert_eq(end_pos, start_pos + text.length())
+    // Cursor positions count Unicode scalars.
+    assert_eq(end_pos, start_pos + unicode_scalar_length(text))
   }
 }
 
@@ -178,10 +187,10 @@ test "property: delete reduces length by at most 1" {
     }
     let editor = try! Editor::new("test-agent")
     try! editor.insert(text)
-    let before_len = editor.get_text().length()
+    let before_len = unicode_scalar_length(editor.get_text())
     editor.move_cursor(0)
     let deleted = editor.delete()
-    let after_len = editor.get_text().length()
+    let after_len = unicode_scalar_length(editor.get_text())
     if deleted {
       assert_eq(after_len, before_len - 1)
     } else {
@@ -224,7 +233,7 @@ test "property: sequential operations maintain invariants" {
 
       // Verify invariants hold
       let cursor = editor.get_cursor()
-      let len = editor.get_text().length()
+      let len = unicode_scalar_length(editor.get_text())
       assert_true(cursor >= 0)
       assert_true(cursor <= len)
       assert_true(len >= 0)
@@ -233,7 +242,7 @@ test "property: sequential operations maintain invariants" {
 }
 
 ///|
-/// Property: Cursor never exceeds text length after any operation
+/// Property: Cursor never exceeds the text's Unicode-scalar length
 test "property: cursor invariant holds after operations" {
   let op_sequences : Array[Array[Bool]] = @quickcheck.samples(10)
   for ops in op_sequences {
@@ -246,7 +255,7 @@ test "property: cursor invariant holds after operations" {
         let _ = editor.delete()
       }
       let cursor = editor.get_cursor()
-      let len = editor.get_text().length()
+      let len = unicode_scalar_length(editor.get_text())
       assert_true(cursor <= len)
     }
   }

--- a/modules/canopy/editor/editor_test.mbt
+++ b/modules/canopy/editor/editor_test.mbt
@@ -33,6 +33,19 @@ test "multiple inserts" {
 }
 
 ///|
+test "cursor positions count Unicode scalars across inserts and deletes" {
+  let editor = try! Editor::new("unicode-scalars")
+  try! editor.insert("😀")
+  inspect(editor.get_cursor(), content="1")
+  try! editor.insert("x")
+  inspect(editor.get_text(), content="😀x")
+  inspect(editor.get_cursor(), content="2")
+  editor.move_cursor(0)
+  inspect(editor.delete(), content="true")
+  inspect(editor.get_text(), content="x")
+}
+
+///|
 test "insert at specific position" {
   let editor = try! Editor::new("alice")
   try! editor.insert("Heo")

--- a/modules/canopy/editor/moon.pkg
+++ b/modules/canopy/editor/moon.pkg
@@ -45,7 +45,7 @@ options(
     "sync_editor_perf_probe_native.mbt": [ "not", "js" ],
     "error_path_wbtest.mbt": [ "wasm", "wasm-gc" ],
     "sync_editor_ws_wbtest.mbt": [ "wasm", "wasm-gc" ],
-    "sync_status_wbtest.mbt": [ "wasm", "wasm-gc" ],
+    "sync_status_wbtest.mbt": [ "js", "wasm", "wasm-gc" ],
     "test_ws_helper_js_wbtest.mbt": [ "js" ],
     "test_ws_helper_native_wbtest.mbt": [ "wasm", "wasm-gc" ],
   },

--- a/modules/canopy/editor/moon.pkg
+++ b/modules/canopy/editor/moon.pkg
@@ -17,7 +17,6 @@ import {
   "dowdiness/seam",
   "dowdiness/pretty",
   "dowdiness/canopy/protocol",
-  "moonbitlang/core/bench",
   "moonbitlang/core/debug",
   "moonbitlang/core/quickcheck",
   "moonbitlang/core/buffer",
@@ -34,6 +33,7 @@ import {
 
 import {
   "dowdiness/canopy/workspace/probe",
+  "moonbitlang/core/bench",
 } for "wbtest"
 
 warnings = "-7-29"
@@ -43,9 +43,10 @@ options(
   targets: {
     "sync_editor_perf_probe_js.mbt": [ "js" ],
     "sync_editor_perf_probe_native.mbt": [ "not", "js" ],
-    "error_path_wbtest.mbt": [ "not", "js" ],
-    "sync_editor_ws_wbtest.mbt": [ "not", "js" ],
+    "error_path_wbtest.mbt": [ "wasm", "wasm-gc" ],
+    "sync_editor_ws_wbtest.mbt": [ "wasm", "wasm-gc" ],
+    "sync_status_wbtest.mbt": [ "wasm", "wasm-gc" ],
     "test_ws_helper_js_wbtest.mbt": [ "js" ],
-    "test_ws_helper_native_wbtest.mbt": [ "not", "js" ],
+    "test_ws_helper_native_wbtest.mbt": [ "wasm", "wasm-gc" ],
   },
 )

--- a/modules/canopy/editor/sync_editor.mbt
+++ b/modules/canopy/editor/sync_editor.mbt
@@ -45,22 +45,22 @@ fn AuthorityCore::export_since(
 }
 
 ///|
-fn AuthorityCore::admit_with_tracking(
+fn AuthorityCore::admit_transition_with_tracking(
   self : AuthorityCore,
   msg : @text.SyncMessage,
   limits : @sync.Limits?,
-) -> Result[@text.SyncReport, @text.TextError] {
+) -> Result[@text.TextAdmissionTransition, @text.TextError] {
   self.undo.set_tracking(false)
-  let report_result : Result[@text.SyncReport, @text.TextError] = Ok(
+  let transition_result : Result[@text.TextAdmissionTransition, @text.TextError] = Ok(
     match limits {
-      None => self.doc.sync().apply(msg)
-      Some(limits) => self.doc.sync().apply_with_limits(msg, limits)
+      None => self.doc.sync().apply_transition(msg)
+      Some(limits) => self.doc.sync().apply_transition_with_limits(msg, limits)
     },
   ) catch {
     error => Err(error)
   }
   self.undo.set_tracking(true)
-  report_result
+  transition_result
 }
 
 ///|
@@ -979,7 +979,11 @@ pub fn[T : Eq] SyncEditor::apply_span_edits(
           SnapToGrapheme,
         ) {
         Some(applied_edit) =>
-          replay_spans.push({ edit: applied_edit, inserted: edit.inserted })
+          replay_spans.push({
+            edit: applied_edit,
+            inserted: edit.inserted,
+            source_after: None,
+          })
         None => ()
       }
     }
@@ -1023,46 +1027,55 @@ fn[T] SyncEditor::adjust_cursor(self : SyncEditor[T]) -> Unit {
 }
 
 ///|
-fn[T : Eq] SyncEditor::admit_with_policy(
+fn[T : Eq] SyncEditor::admit_with_policy_using_snapshot_reader(
   self : SyncEditor[T],
   msg : @text.SyncMessage,
   limits : @sync.Limits?,
+  read_snapshot : () -> String,
 ) -> @text.SyncReport raise {
   self.ensure_parser_healthy()
   self.reject_projection_observer_reentry()
-  self.taint_pending_transforms()
-  let before_version = self.authority.doc.version()
-  let old_source = self.authority.doc.text()
-  let report_result = self.authority.admit_with_tracking(msg, limits)
-  let after_version = self.authority.doc.version()
-  if after_version != before_version {
-    self.observe_authority_acceptance()
-  }
-  // Reconcile derived state even when apply reports an error, because the
-  // document may have been partially mutated before the failure surfaced.
-  let new_source = self.authority.doc.text()
-  self.adjust_cursor()
-  if after_version == before_version {
-    self.adjust_peer_cursors_after_text_change(old_source, new_source, None)
-    self.sync_parser_after_text_change(old_source, new_source, None)
-  } else {
-    let continuation = classify_projection_continuation(
-      old_source,
-      new_source,
-      None,
-    )
-    self.settle_committed_text_change(
-      old_source,
-      new_source,
-      before_version,
-      continuation,
-      None,
-    )
-  }
-  let report = match report_result {
-    Ok(report) => report
+  let transition = match
+    self.authority.admit_transition_with_tracking(msg, limits) {
+    Ok(transition) => transition
     Err(error) => raise error
   }
+  let authority_advanced = transition.version_after() !=
+    transition.version_before()
+  if authority_advanced {
+    self.observe_authority_acceptance()
+  }
+  let parser_source = self.projection.parser.source().read_or_abort()
+  match transition.availability() {
+    @text.TextEffectAvailability::Exact(effects) => {
+      let prepared = prepare_text_admission(parser_source, effects)
+      self.settle_prepared_text_admission(
+        parser_source,
+        prepared,
+        transition.version_after(),
+        authority_advanced,
+      )
+    }
+    @text.TextEffectAvailability::SnapshotRequired => {
+      let coherent_source = read_snapshot()
+      if authority_advanced {
+        self.observe_committed_transition_settled()
+      }
+      self.interaction.clamp_cursor_to_length(coherent_source.length())
+      self.adjust_peer_cursors_after_text_change(
+        parser_source,
+        coherent_source,
+        None,
+      )
+      self.taint_pending_transforms()
+      self.sync_parser_from_supplied_seed(coherent_source)
+    }
+    @text.TextEffectAvailability::Unavailable =>
+      if authority_advanced {
+        self.observe_committed_transition_settled()
+      }
+  }
+  let report = transition.finish()
   if report.pending_operations() == 0 {
     // Clear a prior Error status once any sync applies — another peer
     // (via RelayedCrdtOps) having filled the causal gap counts as recovery.
@@ -1070,6 +1083,17 @@ fn[T : Eq] SyncEditor::admit_with_policy(
     self.interaction.note_sync_applied()
   }
   report
+}
+
+///|
+fn[T : Eq] SyncEditor::admit_with_policy(
+  self : SyncEditor[T],
+  msg : @text.SyncMessage,
+  limits : @sync.Limits?,
+) -> @text.SyncReport raise {
+  self.admit_with_policy_using_snapshot_reader(msg, limits, () => {
+    self.authority.doc.text()
+  })
 }
 
 ///|

--- a/modules/canopy/editor/sync_editor_hints_wbtest.mbt
+++ b/modules/canopy/editor/sync_editor_hints_wbtest.mbt
@@ -239,10 +239,9 @@ test "multi-span authority batch replays once and matches fresh parse" {
 
 ///|
 test "multi-span parser failure preserves accepted final causal version" {
-  let source = try! @probe.new_test_editor("multi-span-failure-source")
-  source.set_text("ab")
   let editor = try! @probe.new_parser_failure_test_editor("multi-span-failure")
-  ignore(try! editor.admit(try! source.export_all()))
+  try! editor.authority.doc.insert(@text.Pos::at(0), "ab")
+  editor.sync_parser_from_supplied_seed("ab")
   let before_version = editor.get_version()
   let result : Result[Unit, Error] = Ok(
     editor.apply_span_edits(

--- a/modules/canopy/editor/sync_editor_parser.mbt
+++ b/modules/canopy/editor/sync_editor_parser.mbt
@@ -112,19 +112,27 @@ fn[T : Eq] ProjectionState::set_parser_source(
 }
 
 ///|
-fn[T : Eq] SyncEditor::sync_parser_from_coherent_seed(
+fn[T : Eq] SyncEditor::sync_parser_from_supplied_seed(
   self : SyncEditor[T],
+  seed : String,
 ) -> Unit raise Failure {
   self.projection.ensure_parser_healthy()
   editor_perf_measure("documentVersionUpdate", () => {
     self.projection.set_document_version(self.authority.doc.version())
   })
   editor_perf_measure("parserSeed", () => {
-    let seed = self.authority.doc.text()
     self.projection.set_parser_source(seed)
   })
   self.projection.mark_projection_dirty()
   self.observe_parser_synchronized()
+}
+
+///|
+fn[T : Eq] SyncEditor::sync_parser_from_coherent_seed(
+  self : SyncEditor[T],
+) -> Unit raise Failure {
+  let seed = self.authority.doc.text()
+  self.sync_parser_from_supplied_seed(seed)
 }
 
 ///|
@@ -250,7 +258,106 @@ fn resolve_applied_edit(
 priv struct ProjectionReplaySpan {
   edit : @loom_core.Edit
   inserted : String
+  source_after : String?
 } derive(Eq, Debug)
+
+///|
+priv struct PreparedTextAdmission {
+  source : String
+  replay_spans : Array[ProjectionReplaySpan]
+}
+
+///|
+fn scalar_position_to_utf16_offset(
+  source : String,
+  scalar_position : Int,
+) -> Int raise Failure {
+  guard scalar_position >= 0 else {
+    fail("negative scalar position in authority text effect")
+  }
+  if scalar_position == 0 {
+    return 0
+  }
+  let mut scalar_offset = 0
+  let mut utf16_offset = 0
+  for char in source {
+    scalar_offset += 1
+    utf16_offset += if char.to_int() > 0xFFFF { 2 } else { 1 }
+    if scalar_offset == scalar_position {
+      return utf16_offset
+    }
+  }
+  fail("scalar position exceeds parser-held source")
+}
+
+///|
+fn prepare_text_admission(
+  source : String,
+  effects : ArrayView[@text.TextEffect],
+) -> PreparedTextAdmission raise Failure {
+  let mut candidate = source
+  let replay_spans : Array[ProjectionReplaySpan] = []
+  for effect in effects {
+    match effect {
+      @text.TextEffect::Insert(position, inserted) => {
+        let utf16_start = scalar_position_to_utf16_offset(
+          candidate,
+          position.value(),
+        )
+        let edit = @loom_core.Edit::insert(utf16_start, inserted.length())
+        candidate = candidate[:utf16_start].to_owned() +
+          inserted +
+          candidate[utf16_start:].to_owned()
+        replay_spans.push({ edit, inserted, source_after: Some(candidate) })
+      }
+      @text.TextEffect::Delete(range) => {
+        let utf16_start = scalar_position_to_utf16_offset(
+          candidate,
+          range.start().value(),
+        )
+        let utf16_end = scalar_position_to_utf16_offset(
+          candidate,
+          range.end().value(),
+        )
+        let edit = @loom_core.Edit::delete(utf16_start, utf16_end)
+        candidate = candidate[:utf16_start].to_owned() +
+          candidate[utf16_end:].to_owned()
+        replay_spans.push({ edit, inserted: "", source_after: Some(candidate) })
+      }
+    }
+  }
+  { source: candidate, replay_spans }
+}
+
+///|
+fn[T : Eq] SyncEditor::settle_prepared_text_admission(
+  self : SyncEditor[T],
+  parser_source : String,
+  prepared : PreparedTextAdmission,
+  after_version : @text.Version,
+  authority_advanced : Bool,
+) -> Unit raise Failure {
+  if authority_advanced {
+    self.observe_committed_transition_settled()
+  }
+  if prepared.source == parser_source {
+    if authority_advanced {
+      self.projection.set_document_version(after_version)
+      self.observe_parser_synchronized()
+    }
+    return
+  }
+  self.interaction.clamp_cursor_to_length(prepared.source.length())
+  for span in prepared.replay_spans {
+    self.adjust_peer_cursors_after_text_change(
+      parser_source,
+      prepared.source,
+      Some(span.edit),
+    )
+  }
+  self.taint_pending_transforms()
+  self.sync_parser_from_replay_spans(prepared.replay_spans, prepared.source)
+}
 
 ///|
 priv enum ProjectionReplay {
@@ -317,11 +424,16 @@ fn[T : Eq] ProjectionState::replay_parser_spans(
   let mut source = self.parser.source().read_or_abort()
   try {
     for span in spans {
-      let start = span.edit.start()
-      let old_end = start + span.edit.old_len()
-      let next_source = source[:start].to_owned() +
-        span.inserted +
-        source[old_end:].to_owned()
+      let next_source = match span.source_after {
+        Some(source_after) => source_after
+        None => {
+          let start = span.edit.start()
+          let old_end = start + span.edit.old_len()
+          source[:start].to_owned() +
+          span.inserted +
+          source[old_end:].to_owned()
+        }
+      }
       self.parser.apply_edit(span.edit, next_source)
       source = next_source
     }

--- a/modules/canopy/editor/sync_editor_remote_admission_benchmark_wbtest.mbt
+++ b/modules/canopy/editor/sync_editor_remote_admission_benchmark_wbtest.mbt
@@ -1,0 +1,249 @@
+///|
+struct RemoteAdmissionBenchmarkFixture {
+  source : @text.TextState
+  target : SyncEditor[@probe.TestExpr]
+  incoming : @text.SyncMessage
+}
+
+///|
+fn remote_admission_benchmark_fixture(
+  history_operations : Int,
+  visible_utf16_units : Int,
+  fixture_id : String,
+) -> RemoteAdmissionBenchmarkFixture raise Failure {
+  guard history_operations >= visible_utf16_units else {
+    fail("visible length exceeds resident history")
+  }
+  let hidden_operations = history_operations - visible_utf16_units
+  guard hidden_operations % 2 == 0 else {
+    fail("hidden benchmark history must be insert/delete pairs")
+  }
+  let source = try! @text.TextState::new(fixture_id + "-source")
+  let target = try! @probe.new_test_editor(fixture_id + "-target")
+  if visible_utf16_units > 0 {
+    try! source.insert(@text.Pos::at(0), "x".repeat(visible_utf16_units))
+  }
+  for _ in 0..<(hidden_operations / 2) {
+    try! source.insert(@text.Pos::at(visible_utf16_units), "z")
+    try! source.delete(@text.Pos::at(visible_utf16_units))
+  }
+  let setup_limits = try! @sync.Limits::Limits(
+    max_encoded_bytes=256 * 1024 * 1024,
+    max_decoded_operations=history_operations,
+  )
+  let initial = try! target.authority.doc
+    .sync()
+    .apply_with_limits(try! source.sync().export_all(), setup_limits)
+  guard initial.applied_operations() == history_operations else {
+    fail("benchmark fixture produced the wrong resident history size")
+  }
+  try! target.sync_parser_from_coherent_seed()
+  let target_version = target.get_version()
+  try! source.insert(@text.Pos::at(visible_utf16_units), "q")
+  { source, target, incoming: try! source.sync().export_since(target_version) }
+}
+
+///|
+fn measure_segmented_remote_admission(
+  history_operations : Int,
+  visible_utf16_units : Int,
+  fixture_id : String,
+) -> (Double, Double, Double) raise Failure {
+  let segmented = remote_admission_benchmark_fixture(
+    history_operations, visible_utf16_units, fixture_id,
+  )
+  segmented.target.ensure_parser_healthy()
+  segmented.target.reject_projection_observer_reentry()
+  let transition_start = @bench.monotonic_clock_start()
+  let transition = match
+    segmented.target.authority.admit_transition_with_tracking(
+      segmented.incoming,
+      None,
+    ) {
+    Ok(transition) => transition
+    Err(_) => fail("benchmark transition production failed")
+  }
+  let transition_us = @bench.monotonic_clock_end(transition_start)
+  let authority_advanced = transition.version_after() !=
+    transition.version_before()
+  guard authority_advanced else {
+    fail("benchmark transition did not advance authority")
+  }
+  segmented.target.observe_authority_acceptance()
+  let preparation_start = @bench.monotonic_clock_start()
+  let parser_source = segmented.target.projection.parser
+    .source()
+    .read_or_abort()
+  let prepared = match transition.availability() {
+    @text.TextEffectAvailability::Exact(effects) =>
+      prepare_text_admission(parser_source, effects)
+    @text.TextEffectAvailability::SnapshotRequired =>
+      fail("warm one-operation benchmark required a snapshot")
+    @text.TextEffectAvailability::Unavailable =>
+      fail("warm one-operation benchmark transition was unavailable")
+  }
+  let preparation_us = @bench.monotonic_clock_end(preparation_start)
+  let reconciliation_start = @bench.monotonic_clock_start()
+  segmented.target.settle_prepared_text_admission(
+    parser_source,
+    prepared,
+    transition.version_after(),
+    authority_advanced,
+  )
+  let report = transition.finish() catch {
+    _ => fail("segmented benchmark transition finish failed")
+  }
+  let reconciliation_us = @bench.monotonic_clock_end(reconciliation_start)
+  guard report.applied_operations() == 1 &&
+    segmented.target.get_text() == segmented.source.text() else {
+    fail("segmented benchmark reconciliation did not converge")
+  }
+  (transition_us, preparation_us, reconciliation_us)
+}
+
+///|
+fn measure_whole_remote_admission(
+  history_operations : Int,
+  visible_utf16_units : Int,
+  fixture_id : String,
+) -> Double raise Failure {
+  let whole = remote_admission_benchmark_fixture(
+    history_operations, visible_utf16_units, fixture_id,
+  )
+  let whole_call_start = @bench.monotonic_clock_start()
+  let whole_report = whole.target.admit(whole.incoming) catch {
+    _ => fail("whole-call benchmark admission failed")
+  }
+  let whole_call_us = @bench.monotonic_clock_end(whole_call_start)
+  guard whole_report.applied_operations() == 1 &&
+    whole.target.get_text() == whole.source.text() else {
+    fail("whole-call benchmark reconciliation did not converge")
+  }
+  whole_call_us
+}
+
+///|
+fn benchmark_remote_admission_phase_case(
+  b : @bench.T,
+  history_operations : Int,
+  visible_utf16_units : Int,
+) -> Unit {
+  let label = history_operations.to_string() +
+    "-" +
+    visible_utf16_units.to_string()
+  let (transition_us, preparation_us, reconciliation_us) = try! measure_segmented_remote_admission(
+    history_operations,
+    visible_utf16_units,
+    "remote-admission-segmented-" + label,
+  )
+  b.keep((transition_us, preparation_us, reconciliation_us))
+  println(
+    "{\"mode\":\"phases\",\"H\":" +
+    history_operations.to_string() +
+    ",\"L\":" +
+    visible_utf16_units.to_string() +
+    ",\"transition_us\":" +
+    transition_us.to_string() +
+    ",\"preparation_us\":" +
+    preparation_us.to_string() +
+    ",\"reconciliation_us\":" +
+    reconciliation_us.to_string() +
+    "}",
+  )
+}
+
+///|
+fn benchmark_remote_admission_whole_case(
+  b : @bench.T,
+  history_operations : Int,
+  visible_utf16_units : Int,
+) -> Unit {
+  let label = history_operations.to_string() +
+    "-" +
+    visible_utf16_units.to_string()
+  let whole_call_us = try! measure_whole_remote_admission(
+    history_operations,
+    visible_utf16_units,
+    "remote-admission-whole-" + label,
+  )
+  b.keep(whole_call_us)
+  println(
+    "{\"mode\":\"whole\",\"H\":" +
+    history_operations.to_string() +
+    ",\"L\":" +
+    visible_utf16_units.to_string() +
+    ",\"whole_call_us\":" +
+    whole_call_us.to_string() +
+    "}",
+  )
+}
+
+///|
+test "perf: remote admission whole H=0 L=0" (b : @bench.T) {
+  benchmark_remote_admission_whole_case(b, 0, 0)
+}
+
+///|
+test "perf: remote admission whole H=1000 L=0" (b : @bench.T) {
+  benchmark_remote_admission_whole_case(b, 1000, 0)
+}
+
+///|
+test "perf: remote admission whole H=10000 L=0" (b : @bench.T) {
+  benchmark_remote_admission_whole_case(b, 10000, 0)
+}
+
+///|
+test "perf: remote admission whole H=100000 L=0" (b : @bench.T) {
+  benchmark_remote_admission_whole_case(b, 100000, 0)
+}
+
+///|
+test "perf: remote admission whole H=100000 L=2000" (b : @bench.T) {
+  benchmark_remote_admission_whole_case(b, 100000, 2000)
+}
+
+///|
+test "perf: remote admission whole H=100000 L=10000" (b : @bench.T) {
+  benchmark_remote_admission_whole_case(b, 100000, 10000)
+}
+
+///|
+test "perf: remote admission whole H=100000 L=50000" (b : @bench.T) {
+  benchmark_remote_admission_whole_case(b, 100000, 50000)
+}
+
+///|
+test "perf: remote admission phases H=0 L=0" (b : @bench.T) {
+  benchmark_remote_admission_phase_case(b, 0, 0)
+}
+
+///|
+test "perf: remote admission phases H=1000 L=0" (b : @bench.T) {
+  benchmark_remote_admission_phase_case(b, 1000, 0)
+}
+
+///|
+test "perf: remote admission phases H=10000 L=0" (b : @bench.T) {
+  benchmark_remote_admission_phase_case(b, 10000, 0)
+}
+
+///|
+test "perf: remote admission phases H=100000 L=0" (b : @bench.T) {
+  benchmark_remote_admission_phase_case(b, 100000, 0)
+}
+
+///|
+test "perf: remote admission phases H=100000 L=2000" (b : @bench.T) {
+  benchmark_remote_admission_phase_case(b, 100000, 2000)
+}
+
+///|
+test "perf: remote admission phases H=100000 L=10000" (b : @bench.T) {
+  benchmark_remote_admission_phase_case(b, 100000, 10000)
+}
+
+///|
+test "perf: remote admission phases H=100000 L=50000" (b : @bench.T) {
+  benchmark_remote_admission_phase_case(b, 100000, 50000)
+}

--- a/modules/canopy/editor/sync_editor_text_wbtest.mbt
+++ b/modules/canopy/editor/sync_editor_text_wbtest.mbt
@@ -461,6 +461,116 @@ test "remote admission settles one transition before parser synchronization" {
 }
 
 ///|
+test "remote admission preparation converts sequential scalar effects to UTF-16 edits" {
+  let effects : Array[@text.TextEffect] = [
+    @text.TextEffect::Insert(@text.Pos::at(2), "x"),
+    @text.TextEffect::Delete(try! @text.Range::from_ints(1, 2)),
+  ]
+  let prepared = try! prepare_text_admission("A😀B\r\n", effects[:])
+  assert_eq(prepared.source, "AxB\r\n")
+  assert_eq(prepared.replay_spans, [
+    {
+      edit: @loom_core.Edit::insert(3, 1),
+      inserted: "x",
+      source_after: Some("A😀xB\r\n"),
+    },
+    {
+      edit: @loom_core.Edit::delete(1, 3),
+      inserted: "",
+      source_after: Some("AxB\r\n"),
+    },
+  ])
+}
+
+///|
+test "remote exact delete clamps the local cursor in UTF-16 coordinates" {
+  let source = try! @probe.new_test_editor("remote-utf16-clamp-source")
+  let target = try! @probe.new_test_editor("remote-utf16-clamp-target")
+  source.set_text("😀x")
+  ignore(try! target.admit(try! source.export_all()))
+  let target_version = target.get_version()
+  target.move_cursor(3)
+  source.set_text("😀")
+
+  ignore(try! target.admit(try! source.export_since(target_version)))
+
+  assert_eq(target.get_text(), "😀")
+  assert_eq(target.get_cursor(), 2)
+}
+
+///|
+test "remote admission snapshot detector distinguishes exact and fallback paths" {
+  let exact_source = try! @probe.new_test_editor(
+    "snapshot-detector-exact-source",
+  )
+  let exact_target = try! @probe.new_test_editor(
+    "snapshot-detector-exact-target",
+  )
+  exact_source.set_text("A")
+  let mut exact_reads = 0
+  ignore(
+    try! exact_target.admit_with_policy_using_snapshot_reader(
+      try! exact_source.export_all(),
+      None,
+      () => {
+        exact_reads += 1
+        exact_target.authority.doc.text()
+      },
+    ),
+  )
+  assert_eq(exact_reads, 0)
+
+  let fallback_source = try! @probe.new_test_editor(
+    "snapshot-detector-fallback-source",
+  )
+  let fallback_target = try! @probe.new_test_editor(
+    "snapshot-detector-fallback-target",
+  )
+  fallback_source.set_text("ABCD")
+  let mut fallback_reads = 0
+  ignore(
+    try! fallback_target.admit_with_policy_using_snapshot_reader(
+      try! fallback_source.export_all(),
+      None,
+      () => {
+        fallback_reads += 1
+        fallback_target.authority.doc.text()
+      },
+    ),
+  )
+  assert_eq(fallback_reads, 1)
+}
+
+///|
+test "snapshot fallback adjusts peer cursors after an astral prefix" {
+  let source = try! @probe.new_test_editor("snapshot-unicode-source")
+  let target = try! @probe.new_test_editor("snapshot-unicode-target")
+  source.set_text("😀a")
+  ignore(try! target.admit(try! source.export_all()))
+  let target_version = target.get_version()
+  target.interaction.cursor_view.set_cursor("peer", 3, "Peer", "#000000")
+  source.set_text("😀Xa")
+  source.insert_at(3, "zz", 1001)
+  ignore(try! source.delete_at(3, 1002))
+  ignore(try! source.delete_at(3, 1003))
+  let mut snapshot_reads = 0
+  ignore(
+    try! target.admit_with_policy_using_snapshot_reader(
+      try! source.export_since(target_version),
+      None,
+      () => {
+        snapshot_reads += 1
+        target.authority.doc.text()
+      },
+    ),
+  )
+
+  assert_eq(snapshot_reads, 1)
+  assert_eq(target.get_text(), "😀Xa")
+  assert_eq(target.get_peer_cursors().get("peer").unwrap().adjusted_cursor, 4)
+}
+
+///|
 test "projection continuation classification preserves replay barriers" {
   let edit = @loom_core.Edit::insert(0, 1)
   assert_eq(

--- a/modules/canopy/editor/text_diff.mbt
+++ b/modules/canopy/editor/text_diff.mbt
@@ -17,9 +17,9 @@ pub fn compute_edit(old_text : String, new_text : String) -> @loom_core.Edit {
 
 ///|
 priv enum DiffStep {
-  Equal
-  Insert
-  Delete
+  Equal(Int)
+  Insert(Int)
+  Delete(Int)
 }
 
 ///|
@@ -30,45 +30,65 @@ fn compute_text_edits(
   if old_text == new_text {
     return []
   }
-  let old_chars = old_text.to_array()
-  let new_chars = new_text.to_array()
-  let prefix_len = find_common_prefix(old_text, new_text)
-  let old_suffix_start = prefix_len
-  let new_suffix_start = prefix_len
-  let old_len = old_chars.length()
-  let new_len = new_chars.length()
-  let suffix_len = find_common_suffix_after_prefix(
-    old_text, new_text, old_suffix_start, new_suffix_start, old_len, new_len,
+  let old_boundaries = @moji.grapheme_boundaries(old_text)
+  let new_boundaries = @moji.grapheme_boundaries(new_text)
+  let prefix_count = find_common_prefix_cluster_count(
+    old_text, old_boundaries, new_text, new_boundaries,
   )
-  let old_mid_len = old_len - prefix_len - suffix_len
-  let new_mid_len = new_len - prefix_len - suffix_len
-  if old_mid_len == 0 && new_mid_len == 0 {
-    return []
+  let suffix_count = find_common_suffix_cluster_count(
+    old_text, old_boundaries, new_text, new_boundaries, prefix_count,
+  )
+  let old_cluster_count = old_boundaries.length() - 1
+  let new_cluster_count = new_boundaries.length() - 1
+  let old_mid_count = old_cluster_count - prefix_count - suffix_count
+  let new_mid_count = new_cluster_count - prefix_count - suffix_count
+  let start_offset = old_boundaries[prefix_count]
+  let old_mid_utf16_len = old_boundaries[prefix_count + old_mid_count] -
+    start_offset
+  let new_mid_utf16_len = new_boundaries[prefix_count + new_mid_count] -
+    new_boundaries[prefix_count]
+  let old_cells = old_mid_count + 1
+  let new_cells = new_mid_count + 1
+  // Preserve separated edits only while the LCS matrix stays bounded.
+  // Large changed middles use one grapheme-aligned replacement instead.
+  if old_mid_count == 0 || new_mid_count == 0 || old_cells > 65536 / new_cells {
+    return [
+      @loom_core.Edit::new(start_offset, old_mid_utf16_len, new_mid_utf16_len),
+    ]
   }
-  let old_mid = old_chars[prefix_len:old_len - suffix_len].to_owned()
-  let new_mid = new_chars[prefix_len:new_len - suffix_len].to_owned()
-  let steps = compute_diff_steps(old_mid, new_mid)
-  diff_steps_to_edits(steps, prefix_len)
+  let steps = compute_diff_steps(
+    old_text, old_boundaries, prefix_count, old_mid_count, new_text, new_boundaries,
+    prefix_count, new_mid_count,
+  )
+  diff_steps_to_edits(steps, start_offset)
 }
 
 ///|
 fn compute_diff_steps(
-  old_chars : Array[Char],
-  new_chars : Array[Char],
+  old_text : String,
+  old_boundaries : Array[Int],
+  old_start : Int,
+  old_count : Int,
+  new_text : String,
+  new_boundaries : Array[Int],
+  new_start : Int,
+  new_count : Int,
 ) -> Array[DiffStep] {
-  let old_len = old_chars.length()
-  let new_len = new_chars.length()
   let dp : Array[Array[Int]] = []
-  for i = 0; i <= old_len; i = i + 1 {
+  for i = 0; i <= old_count; i = i + 1 {
     let row : Array[Int] = []
-    for j = 0; j <= new_len; j = j + 1 {
+    for j = 0; j <= new_count; j = j + 1 {
       row.push(0)
     }
     dp.push(row)
   }
-  for i = 1; i <= old_len; i = i + 1 {
-    for j = 1; j <= new_len; j = j + 1 {
-      if old_chars[i - 1] == new_chars[j - 1] {
+  for i = 1; i <= old_count; i = i + 1 {
+    for j = 1; j <= new_count; j = j + 1 {
+      let old_idx = old_start + i - 1
+      let new_idx = new_start + j - 1
+      if cluster_equal_at(
+          old_text, old_boundaries, old_idx, new_text, new_boundaries, new_idx,
+        ) {
         dp[i][j] = dp[i - 1][j - 1] + 1
       } else if dp[i][j - 1] >= dp[i - 1][j] {
         dp[i][j] = dp[i][j - 1]
@@ -78,18 +98,30 @@ fn compute_diff_steps(
     }
   }
   let reversed : Array[DiffStep] = []
-  let mut i = old_len
-  let mut j = new_len
+  let mut i = old_count
+  let mut j = new_count
   while i > 0 || j > 0 {
-    if i > 0 && j > 0 && old_chars[i - 1] == new_chars[j - 1] {
-      reversed.push(Equal)
+    let old_idx = old_start + i - 1
+    let new_idx = new_start + j - 1
+    if i > 0 &&
+      j > 0 &&
+      cluster_equal_at(
+        old_text, old_boundaries, old_idx, new_text, new_boundaries, new_idx,
+      ) {
+      reversed.push(
+        Equal(old_boundaries[old_idx + 1] - old_boundaries[old_idx]),
+      )
       i = i - 1
       j = j - 1
     } else if j > 0 && (i == 0 || dp[i][j - 1] >= dp[i - 1][j]) {
-      reversed.push(Insert)
+      reversed.push(
+        Insert(new_boundaries[new_idx + 1] - new_boundaries[new_idx]),
+      )
       j = j - 1
     } else {
-      reversed.push(Delete)
+      reversed.push(
+        Delete(old_boundaries[old_idx + 1] - old_boundaries[old_idx]),
+      )
       i = i - 1
     }
   }
@@ -132,29 +164,29 @@ fn diff_steps_to_edits(
   // text only (no cursor advance); Insert and Equal advance in new text.
   for step in steps {
     match step {
-      Equal => {
+      Equal(width) => {
         push_pending_edit(
           edits, pending_start, pending_delete_len, pending_insert_len, has_pending,
         )
         has_pending = false
         pending_delete_len = 0
         pending_insert_len = 0
-        cursor = cursor + 1
+        cursor = cursor + width
       }
-      Delete => {
+      Delete(width) => {
         if !has_pending {
           pending_start = cursor
           has_pending = true
         }
-        pending_delete_len = pending_delete_len + 1
+        pending_delete_len = pending_delete_len + width
       }
-      Insert => {
+      Insert(width) => {
         if !has_pending {
           pending_start = cursor
           has_pending = true
         }
-        pending_insert_len = pending_insert_len + 1
-        cursor = cursor + 1
+        pending_insert_len = pending_insert_len + width
+        cursor = cursor + width
       }
     }
   }
@@ -165,75 +197,60 @@ fn diff_steps_to_edits(
 }
 
 ///|
-fn cluster_equal(
+fn cluster_equal_at(
   s1 : String,
-  s1_start : Int,
-  s1_end : Int,
+  s1_boundaries : Array[Int],
+  s1_idx : Int,
   s2 : String,
-  s2_start : Int,
-  s2_end : Int,
+  s2_boundaries : Array[Int],
+  s2_idx : Int,
 ) -> Bool {
-  s1[s1_start:s1_end].to_owned() == s2[s2_start:s2_end].to_owned()
+  s1[s1_boundaries[s1_idx]:s1_boundaries[s1_idx + 1]] ==
+  s2[s2_boundaries[s2_idx]:s2_boundaries[s2_idx + 1]]
 }
 
 ///|
-/// Find the length of the longest common prefix between two strings
-fn find_common_prefix(s1 : String, s2 : String) -> Int {
-  let s1_boundaries = @moji.grapheme_boundaries(s1)
-  let s2_boundaries = @moji.grapheme_boundaries(s2)
-  let mut idx = 0
-  let mut prefix = 0
-  while idx + 1 < s1_boundaries.length() && idx + 1 < s2_boundaries.length() {
-    let s1_start = s1_boundaries[idx]
-    let s1_end = s1_boundaries[idx + 1]
-    let s2_start = s2_boundaries[idx]
-    let s2_end = s2_boundaries[idx + 1]
-    if cluster_equal(s1, s1_start, s1_end, s2, s2_start, s2_end) {
-      prefix = s1_end
-      idx = idx + 1
-    } else {
-      break
-    }
-  }
-  prefix
-}
-
-///|
-/// Find the length of the longest common suffix after a given prefix position
-/// This avoids double-counting characters in both prefix and suffix
-fn find_common_suffix_after_prefix(
+fn find_common_prefix_cluster_count(
   s1 : String,
+  s1_boundaries : Array[Int],
   s2 : String,
-  s1_start : Int,
-  s2_start : Int,
-  s1_len : Int,
-  s2_len : Int,
+  s2_boundaries : Array[Int],
 ) -> Int {
-  let s1_boundaries = @moji.grapheme_boundaries(s1)
-  let s2_boundaries = @moji.grapheme_boundaries(s2)
-  let mut s1_idx = s1_boundaries.length() - 1
-  let mut s2_idx = s2_boundaries.length() - 1
-  let mut suffix_len = 0
-  while s1_idx > 0 && s2_idx > 0 {
-    let s1_cluster_start = s1_boundaries[s1_idx - 1]
-    let s1_cluster_end = s1_boundaries[s1_idx]
-    let s2_cluster_start = s2_boundaries[s2_idx - 1]
-    let s2_cluster_end = s2_boundaries[s2_idx]
-    if s1_cluster_end > s1_len ||
-      s2_cluster_end > s2_len ||
-      s1_cluster_start < s1_start ||
-      s2_cluster_start < s2_start {
-      break
-    }
-    if cluster_equal(
-        s1, s1_cluster_start, s1_cluster_end, s2, s2_cluster_start, s2_cluster_end,
-      ) {
-      suffix_len += s1_cluster_end - s1_cluster_start
-      s1_idx = s1_idx - 1
-      s2_idx = s2_idx - 1
-    } else {
-      break
-    }
+  let s1_count = s1_boundaries.length() - 1
+  let s2_count = s2_boundaries.length() - 1
+  let mut prefix_count = 0
+  while prefix_count < s1_count &&
+        prefix_count < s2_count &&
+        cluster_equal_at(
+          s1, s1_boundaries, prefix_count, s2, s2_boundaries, prefix_count,
+        ) {
+    prefix_count += 1
   }
-  suffix_len
+  prefix_count
+}
+
+///|
+fn find_common_suffix_cluster_count(
+  s1 : String,
+  s1_boundaries : Array[Int],
+  s2 : String,
+  s2_boundaries : Array[Int],
+  prefix_count : Int,
+) -> Int {
+  let s1_count = s1_boundaries.length() - 1
+  let s2_count = s2_boundaries.length() - 1
+  let mut suffix_count = 0
+  while suffix_count < s1_count - prefix_count &&
+        suffix_count < s2_count - prefix_count &&
+        cluster_equal_at(
+          s1,
+          s1_boundaries,
+          s1_count - suffix_count - 1,
+          s2,
+          s2_boundaries,
+          s2_count - suffix_count - 1,
+        ) {
+    suffix_count += 1
+  }
+  suffix_count
 }

--- a/modules/canopy/ephemeral/moon.pkg
+++ b/modules/canopy/ephemeral/moon.pkg
@@ -12,6 +12,7 @@ warnings = "-7-29"
 
 options(
   is_main: false,
+  "native-stub": [ "native_stub.c" ],
   targets: {
     "ephemeral_time_js.mbt": [ "js" ],
     "ephemeral_time_native.mbt": [ "not", "js" ],

--- a/scripts/check-submodule-reachability.nu
+++ b/scripts/check-submodule-reachability.nu
@@ -132,6 +132,10 @@ def check-materialized-commit [root: string, commit: string] {
 }
 
 def main [--commit: string = ""] {
+  # Git exports repository-local variables to hooks. They override every
+  # `git -C` below unless removed, redirecting the isolated checkout back into
+  # the source worktree and corrupting its HEAD and submodule core.worktree.
+  hide-env --ignore-errors GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_CONFIG GIT_CONFIG_PARAMETERS GIT_CONFIG_COUNT GIT_OBJECT_DIRECTORY GIT_DIR GIT_WORK_TREE GIT_IMPLICIT_WORK_TREE GIT_GRAFT_FILE GIT_INDEX_FILE GIT_NO_REPLACE_OBJECTS GIT_REPLACE_REF_BASE GIT_PREFIX GIT_SHALLOW_FILE GIT_COMMON_DIR
   try {
     # FILE_PWD is the directory containing this script, so an absolute
     # invocation from another Git worktree cannot inspect the caller's repo.

--- a/scripts/test-submodule-reachability.sh
+++ b/scripts/test-submodule-reachability.sh
@@ -277,4 +277,49 @@ expect_fail_at nested-unreachable "$parent" "$nested_commit" "submodule commit i
 # the object absent from nested-origin rather than the reachable top-level ref.
 test -n "$nested_bad_sha"
 
+# Commit-mode materialization from a linked worktree must not rewrite the
+# source worktree's shared submodule gitdir or detach its parent HEAD.
+parent="$(setup_fixture linked-worktree-source-isolation)"
+linked="$tmp_dir/linked-worktree-source-isolation/linked"
+git -C "$parent" worktree add --quiet "$linked" -b linked-source
+git -c protocol.file.allow=always -C "$linked" submodule update --quiet --init --recursive
+printf 'linked source head\n' >"$linked/source-head.txt"
+git -C "$linked" add source-head.txt
+git -C "$linked" commit --quiet -m "advance linked source head"
+source_submodule="$linked/deps/test-submodule"
+source_gitdir="$(git -C "$source_submodule" rev-parse --absolute-git-dir)"
+source_parent_gitdir="$(git -C "$linked" rev-parse --absolute-git-dir)"
+before_core_worktree="$(git config --file "$source_gitdir/config" --get core.worktree)"
+before_status="$(git -C "$linked" submodule status --recursive)"
+before_head="$(git -C "$linked" symbolic-ref --quiet HEAD)"
+linked_commit="$(git -C "$linked" rev-parse HEAD^)"
+checker_status=0
+GIT_DIR="$source_parent_gitdir" \
+  GIT_WORK_TREE="$linked" \
+  GIT_INDEX_FILE="$source_parent_gitdir/index" \
+  run_checker_at "$linked" "$linked_commit" \
+    >"$tmp_dir/linked-worktree-source-isolation.out" 2>&1 || checker_status=$?
+if ! after_core_worktree="$(git config --file "$source_gitdir/config" --get core.worktree)"; then
+  fail "commit mode removed the source submodule core.worktree"
+fi
+if [[ "$after_core_worktree" != "$before_core_worktree" ]]; then
+  fail "commit mode rewrote the source submodule core.worktree"
+fi
+if ! after_status="$(git -C "$linked" submodule status --recursive)"; then
+  fail "commit mode left the source submodule unusable"
+fi
+if [[ "$after_status" != "$before_status" ]]; then
+  fail "commit mode changed the source recursive submodule status"
+fi
+if ! after_head="$(git -C "$linked" symbolic-ref --quiet HEAD)"; then
+  fail "commit mode detached the source parent worktree"
+fi
+if [[ "$after_head" != "$before_head" ]]; then
+  fail "commit mode detached the source parent worktree"
+fi
+if ((checker_status != 0)); then
+  cat "$tmp_dir/linked-worktree-source-isolation.out" >&2
+  fail "linked-worktree-source-isolation unexpectedly failed"
+fi
+
 echo "ok: submodule reachability contract cases pass"


### PR DESCRIPTION
## Summary

- consume event-graph-walker's opaque `AdmissionTransition` and handle `Exact`, `SnapshotRequired`, and `Unavailable` without reconstructing authority semantics in Canopy
- prepare exact scalar effects against parser-held source, convert them to UTF-16 edits, then settle cursor, peer-cursor, parser, projection identity, hints, and observation from one coherent candidate
- keep fallback source-correct and bounded: exactly one authority snapshot read, grapheme-aligned diffing, and a 65,536-cell LCS cap with coarse replacement above it
- make basic Editor cursor coordinates Unicode-scalar based so native and JavaScript backends agree
- publish the benchmark matrix, raw evidence, ADR, and archived implementation invariants

## Performance

Recorded native release measurements use three fresh processes per matrix cell. At `H=100,000`, `L=0`, median exact-path phases are:

- transition: `125.175 µs`
- preparation: `7.649 µs`
- reconciliation: `31.665 µs`
- whole call: `159.688 µs`

The retained baseline direct public admission median is `176,264.607 µs`, making the measured whole call about `1,104×` faster for that history-only cell. All 42 measured samples completed without benchmark failure. See `docs/performance/2026-08-19-canopy-remote-admission-authority-transition.md` and its linked JSON evidence.

## Verification

- `moon check` — 0 errors (existing deprecation warnings remain)
- `moon test --target native -p dowdiness/canopy/editor` — 267/267 passed
- `moon test --target js` — 7,671/7,671 passed
- focused editor transition, Unicode cursor, grapheme fallback, and bounded-diff tests passed
- `moon fmt --check modules/canopy/editor modules/canopy/ephemeral`
- independent MoonBit review: PASS after two discovered correctness/performance blockers were fixed; final documentation review: PASS

Closes #1281