### PR TITLE
refactor(canvas): keep source operations typed inside MoonBit

### DIFF
--- a/apps/canvas/main/graph_dsl_adapter.mbt
+++ b/apps/canvas/main/graph_dsl_adapter.mbt
@@ -18,7 +18,6 @@ struct SourceNodePosition {
 
 ///|
 struct SourceBackedGraph {
-  handle : Int
   attachment : @graph_dsl.GraphAttachment
   mut parser_failure : Failure?
   mut source : String
@@ -37,12 +36,10 @@ fn source_graph_source_id(handle : Int) -> @core.SourceId {
 
 ///|
 fn SourceBackedGraph::SourceBackedGraph(
-  handle : Int,
   source_id : @core.SourceId,
   source : String,
 ) -> SourceBackedGraph raise Failure {
   {
-    handle,
     attachment: @graph_dsl.GraphAttachment::GraphAttachment(source_id, source),
     parser_failure: None,
     source,
@@ -1075,12 +1072,7 @@ fn SourceBackedGraph::complete_connection(
   self.pointer_interrupt()
   match operation {
     Some(operation) =>
-      ignore(
-        apply_source_graph_operation(
-          self.handle,
-          operation.to_json().stringify(),
-        ),
-      ) catch {
+      ignore(self.apply_operation(operation)) catch {
         Failure::Failure(_) => ()
       }
     None => ()
@@ -1182,27 +1174,7 @@ fn source_graph_insert_unique_result(
   let operation = GraphOperation(
     AddNode(source_graph_node_payload(binding, constructor_name)),
   )
-  let result_json = apply_source_graph_operation(
-    handle,
-    operation.to_json().stringify(),
-  )
-  let json = @json.parse(result_json) catch {
-    _ =>
-      return source_graph_result_json_for_graph(
-        graph,
-        false,
-        Some("source graph operation result JSON parse failed"),
-      )
-  }
-  let result : SourceGraphOperationResultJson = @json.from_json(json) catch {
-    _ =>
-      return source_graph_result_json_for_graph(
-        graph,
-        false,
-        Some("source graph operation result JSON decode failed"),
-      )
-  }
-  result
+  graph.apply_operation(operation)
 }
 
 ///|
@@ -1235,33 +1207,9 @@ fn source_graph_connect_sample_result(
   }
   let source = NodeId(nodes[0].id())
   let target = NodeId(nodes[1].id())
-  let result_json = apply_source_graph_operation(
-    handle,
-    GraphOperation(ConnectPorts(source, "out", target, "input"))
-    .to_json()
-    .stringify(),
+  graph.apply_operation(
+    GraphOperation(ConnectPorts(source, "out", target, "input")),
   )
-  let json = @json.parse(result_json) catch {
-    _ =>
-      return source_graph_operation_result_json(
-        false,
-        "",
-        ["source graph operation result JSON parse failed"],
-        0,
-        Some("source graph operation result JSON parse failed"),
-      )
-  }
-  let result : SourceGraphOperationResultJson = @json.from_json(json) catch {
-    _ =>
-      return source_graph_operation_result_json(
-        false,
-        "",
-        ["source graph operation result JSON decode failed"],
-        0,
-        Some("source graph operation result JSON decode failed"),
-      )
-  }
-  result
 }
 
 ///|
@@ -1284,7 +1232,7 @@ pub fn sample_graph_dsl_source() -> String {
 pub fn create_source_graph(source : String) -> Int raise Failure {
   let handle = _source_registry.length()
   let source_id = source_graph_source_id(handle)
-  _source_registry.push(Some(SourceBackedGraph(handle, source_id, source)))
+  _source_registry.push(Some(SourceBackedGraph(source_id, source)))
   handle
 }
 

--- a/apps/canvas/main/graph_dsl_adapter_wbtest.mbt
+++ b/apps/canvas/main/graph_dsl_adapter_wbtest.mbt
@@ -959,6 +959,45 @@ test "source-backed unique insert chooses a fresh graph-dsl binding" {
 }
 
 ///|
+test "source-backed typed helpers return the applied operation result" {
+  let handle = create_source_graph("osc = sine(freq: 440Hz)\nmeter = scope()")
+  let inserted = source_graph_insert_unique_result(handle, "reverb", "plate")
+  assert_true(inserted.applied)
+  inspect(
+    inserted.source,
+    content="osc = sine(freq: 440Hz)\nmeter = scope()\nreverb = plate()",
+  )
+  let connected = source_graph_connect_sample_result(handle)
+  assert_true(connected.applied)
+  inspect(
+    connected.source,
+    content="osc = sine(freq: 440Hz)\nmeter = scope(input: osc)\nreverb = plate()",
+  )
+  inspect(connected.action_count, content="2")
+  destroy_source_graph(handle)
+}
+
+///|
+test "source-backed complete_connection applies its typed operation" {
+  let handle = create_source_graph("osc = sine(freq: 440Hz)\nmeter = scope()")
+  let graph = match source_graph_by_handle(handle) {
+    Some(graph) => graph
+    None => abort("expected source graph handle")
+  }
+  graph.complete_connection(
+    handle_token(handle, "osc"),
+    "out",
+    Some((handle_token(handle, "meter"), "input")),
+  )
+  inspect(
+    graph.source,
+    content="osc = sine(freq: 440Hz)\nmeter = scope(input: osc)",
+  )
+  inspect(graph.action_log.length(), content="1")
+  destroy_source_graph(handle)
+}
+
+///|
 test "source-backed handle rejects local graph operations without mutating source" {
   let source = "osc = sine(freq: 440Hz)\nmeter = scope()"
   let handle = create_source_graph(source)


### PR DESCRIPTION
## Summary

- Keep source-backed `GraphOperation` values typed while they remain inside MoonBit.
- Remove the redundant internal JSON stringify/parse and registry self-relookup paths.
- Remove the now-unneeded `SourceBackedGraph.handle` field while preserving the public JSON FFI boundary.

This is the first step toward the later single `CanvasBacking` registry. It intentionally does not change the two registries, pointer/context models, `GraphAdapter`, Rabbita UI, `canvas-spatial`, or `CanvasRuntime`.

## UI and review evidence

N/A — no UI, DOM, TypeScript, or rendering behavior changed.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `SourceBackedGraph::apply_operation` | `apps/canvas/main/graph_dsl_adapter.mbt` | Yes | Existing typed source-operation owner; all internal callers now delegate directly to it. |
| `apply_source_graph_operation` | `apps/canvas/main/graph_dsl_adapter.mbt` | Yes, boundary-only | Retained as the public JSON decode/encode FFI boundary for JavaScript callers. |
| `@json.parse` / `@json.from_json` | MoonBit core and adapter boundary | Boundary-only | Removed from internal operation delivery; still used where external JSON enters or leaves. |

New helpers added: none.

## Validation scope

Boundary matrix:

- `SourceBackedGraph::complete_connection`: typed `ConnectPorts` is admitted by `can_commit_edge`, pointer state is interrupted, and the operation is applied directly.
- `source_graph_insert_unique_result`: typed `AddNode` returns the same result DTO without an internal JSON round-trip.
- `source_graph_connect_sample_result`: typed `ConnectPorts` returns the same result DTO without an internal JSON round-trip.
- `apply_source_graph_operation`: public string JSON boundary remains unchanged.

The refactor is behavior-preserving, so the first regression additions are characterization tests rather than a behavior-changing red test. Added coverage is in `apps/canvas/main/graph_dsl_adapter_wbtest.mbt` for the typed helpers and `complete_connection`.

Target package:

- `apps/canvas/main`

Additional gates:

- `moon check`
- `moon test`
- JavaScript build
- TypeScript FFI-consumer checks through the PR-ready validator

## PR-ready evidence

Validated HEAD: `c0785fe338b76620649308f60c59e6647cdd05a2`

Validated base: `origin/main@7ac1fef15639a6d8c845835f1d8a78bb9218f719`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh \
  --target apps/canvas/main
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for the exact HEAD and base above.
- [x] The base was fetched again and `--verify-evidence` passed immediately before opening this PR.
- [x] The committed `.mbti` diff against the validated base was reviewed; no `.mbti` files changed.
- [x] No submodule commit changed.
- [x] Validation was rerun after the final commit.
- [x] Independent parallel review found no blocker or warning introduced by this diff.
