### PR TITLE
refactor(canvas): unify workflow canvas backing registry

### DIFF
--- a/apps/canvas/main/canvas_backing.mbt
+++ b/apps/canvas/main/canvas_backing.mbt
@@ -1,0 +1,162 @@
+///|
+/// One private handle namespace for workflow and source-backed canvases.
+/// The payload keeps the canonical state owner explicit without making either
+/// backing implement a broad public canvas abstraction.
+priv enum CanvasBacking {
+  Runtime(CanvasRuntime)
+  Source(SourceBackedGraph)
+}
+
+///|
+let canvas_instances : Array[CanvasBacking?] = []
+
+///|
+/// Return the live backing at a handle without conflating an empty slot with a
+/// different backing kind.
+fn canvas_backing(handle : Int) -> CanvasBacking? {
+  canvas_instances.get(handle).bind(backing => backing)
+}
+
+///|
+/// Runtime-only public entry points historically indexed their registry
+/// directly. Keep their out-of-range failure behavior while rejecting a valid
+/// source or destroyed slot instead of interpreting it as a runtime.
+fn canvas_runtime_for_public(handle : Int) -> CanvasRuntime? {
+  match canvas_backing(handle) {
+    Some(Runtime(runtime)) => Some(runtime)
+    Some(Source(_)) => None
+    None => {
+      if handle < 0 || handle >= canvas_instances.length() {
+        ignore(canvas_instances[handle])
+      }
+      None
+    }
+  }
+}
+
+///|
+fn CanvasBacking::state(self : CanvasBacking) -> CanvasState {
+  match self {
+    Runtime(runtime) => runtime.state_peek()
+    Source(graph) => source_graph_base_canvas_state(graph)
+  }
+}
+
+///|
+fn CanvasBacking::select_edge(self : CanvasBacking, edge : EdgeId) -> Unit {
+  match self {
+    Runtime(runtime) => runtime.select_edge(edge)
+    Source(graph) => graph.select_edge(edge)
+  }
+}
+
+///|
+fn CanvasBacking::clear_selected_edge(self : CanvasBacking) -> Unit {
+  match self {
+    Runtime(runtime) => runtime.clear_selected_edge()
+    Source(graph) => graph.clear_selected_edge()
+  }
+}
+
+///|
+fn CanvasBacking::pointer_down_handle(
+  self : CanvasBacking,
+  node_id : NodeId,
+  port_id : String,
+  sx : Double,
+  sy : Double,
+) -> Bool {
+  match self {
+    Runtime(runtime) => runtime.pointer_down_handle(node_id, port_id, sx, sy)
+    Source(graph) => graph.pointer_down_handle(node_id, port_id, sx, sy)
+  }
+}
+
+///|
+fn CanvasBacking::pointer_down(
+  self : CanvasBacking,
+  node_id : NodeId?,
+  sx : Double,
+  sy : Double,
+) -> Bool {
+  match self {
+    Runtime(runtime) => runtime.pointer_down(node_id, sx, sy)
+    Source(graph) => {
+      let source_node_id = match node_id {
+        Some(node_id) => node_id.to_string()
+        None => ""
+      }
+      graph.pointer_down(source_node_id, sx, sy)
+    }
+  }
+}
+
+///|
+fn CanvasBacking::pointer_move(
+  self : CanvasBacking,
+  sx : Double,
+  sy : Double,
+) -> Unit {
+  match self {
+    Runtime(runtime) => runtime.pointer_move(sx, sy)
+    Source(graph) => graph.pointer_move(sx, sy)
+  }
+}
+
+///|
+fn CanvasBacking::pointer_up(
+  self : CanvasBacking,
+  node_id : String,
+  target_port_id : String,
+  additive : Bool,
+) -> Unit {
+  match self {
+    Runtime(runtime) => runtime.pointer_up(node_id, target_port_id, additive)
+    Source(graph) => graph.pointer_up(node_id, target_port_id, additive)
+  }
+}
+
+///|
+fn CanvasBacking::pointer_interrupt(self : CanvasBacking) -> Unit {
+  match self {
+    Runtime(runtime) => runtime.pointer_interrupt()
+    Source(graph) => graph.pointer_interrupt()
+  }
+}
+
+///|
+fn CanvasBacking::zoom(
+  self : CanvasBacking,
+  delta_y : Double,
+  delta_mode : Int,
+  ctrl_key : Bool,
+  cx : Double,
+  cy : Double,
+) -> Unit {
+  match self {
+    Runtime(runtime) => runtime.zoom(delta_y, delta_mode, ctrl_key, cx, cy)
+    Source(graph) => graph.zoom(delta_y, delta_mode, ctrl_key, cx, cy)
+  }
+}
+
+///|
+/// Workflow hover is a runtime-only ephemeral concern. A source-backed graph
+/// deliberately ignores it because its inspector is driven by source-backed
+/// selection and parser state.
+fn CanvasBacking::hover_node(self : CanvasBacking, node_id : String) -> Bool {
+  match self {
+    Runtime(runtime) => {
+      runtime.hover_node(node_id)
+      true
+    }
+    Source(_) => false
+  }
+}
+
+///|
+fn CanvasBacking::render_state_json(self : CanvasBacking) -> String {
+  match self {
+    Runtime(runtime) => runtime.render_state().to_json().stringify()
+    Source(graph) => graph.render_state_json()
+  }
+}

--- a/apps/canvas/main/canvas_backing_wbtest.mbt
+++ b/apps/canvas/main/canvas_backing_wbtest.mbt
@@ -1,0 +1,70 @@
+///|
+test "canvas instances allocate one monotonic handle space" {
+  let runtime_handle = create_canvas()
+  let source_handle = create_source_graph("osc = sine(freq: 440Hz)")
+  let next_runtime_handle = create_canvas()
+  inspect(source_handle == runtime_handle + 1, content="true")
+  inspect(next_runtime_handle == source_handle + 1, content="true")
+  match canvas_backing(runtime_handle) {
+    Some(Runtime(_)) => ()
+    _ => abort("expected runtime backing")
+  }
+  match canvas_backing(source_handle) {
+    Some(Source(_)) => ()
+    _ => abort("expected source backing")
+  }
+  match canvas_backing(next_runtime_handle) {
+    Some(Runtime(_)) => ()
+    _ => abort("expected next runtime backing")
+  }
+  destroy_source_graph(source_handle)
+}
+
+///|
+test "source destroy clears only its unified backing slot" {
+  let runtime_handle = create_canvas()
+  let source_handle = create_source_graph("osc = sine(freq: 440Hz)")
+  inspect(try_destroy_source_graph(runtime_handle), content="false")
+  match canvas_backing(runtime_handle) {
+    Some(Runtime(_)) => ()
+    _ => abort("runtime slot was changed by source destroy")
+  }
+  inspect(try_destroy_source_graph(source_handle), content="true")
+  inspect(canvas_backing(source_handle) is None, content="true")
+  match canvas_backing(runtime_handle) {
+    Some(Runtime(_)) => ()
+    _ => abort("runtime slot did not survive source destroy")
+  }
+}
+
+///|
+test "cross-backing operations reject without registry reinterpretation" {
+  let runtime_handle = create_canvas()
+  let source_handle = create_source_graph("osc = sine(freq: 440Hz)")
+  let source_before = get_source_graph_source(source_handle)
+  add_node(source_handle, "timer", 0.0, 0.0)
+  assert_eq(get_source_graph_source(source_handle), source_before)
+  inspect(get_render_state(source_handle), content="")
+  inspect(get_action_log(source_handle), content="[]")
+  inspect(
+    operation_result_applied(apply_source_graph_operation(runtime_handle, "{}")),
+    content="false",
+  )
+  inspect(get_source_graph_source(runtime_handle), content="")
+  inspect(get_source_graph_action_log(runtime_handle), content="[]")
+  destroy_source_graph(source_handle)
+}
+
+///|
+test "source-backed node identity survives other backing allocation" {
+  let source_handle = create_source_graph("osc = sine(freq: 440Hz)")
+  let before = handle_token(source_handle, "osc")
+  let runtime_handle = create_canvas()
+  let after = handle_token(source_handle, "osc")
+  assert_eq(before, after)
+  match canvas_backing(runtime_handle) {
+    Some(Runtime(_)) => ()
+    _ => abort("expected runtime backing")
+  }
+  destroy_source_graph(source_handle)
+}

--- a/apps/canvas/main/canvas_init.mbt
+++ b/apps/canvas/main/canvas_init.mbt
@@ -1,11 +1,8 @@
 ///|
-/// Global handle registry. Index = handle (Int returned by create_canvas).
-let _registry : Array[CanvasRuntime] = []
-
-///|
 pub fn create_canvas() -> Int {
-  _registry.push(CanvasRuntime::CanvasRuntime())
-  _registry.length() - 1
+  let handle = canvas_instances.length()
+  canvas_instances.push(Some(Runtime(CanvasRuntime::CanvasRuntime())))
+  handle
 }
 
 ///|
@@ -18,7 +15,10 @@ pub fn add_node(
   sx : Double,
   sy : Double,
 ) -> Unit {
-  _registry[handle].add_node(kind_key, sx, sy)
+  match canvas_runtime_for_public(handle) {
+    Some(runtime) => runtime.add_node(kind_key, sx, sy)
+    None => ()
+  }
 }
 
 ///|
@@ -31,12 +31,18 @@ fn decode_node_ids(json_text : String) -> Array[NodeId] {
 
 ///|
 pub fn clear_selected_edge(handle : Int) -> Unit {
-  _registry[handle].clear_selected_edge()
+  match canvas_runtime_for_public(handle) {
+    Some(runtime) => runtime.clear_selected_edge()
+    None => ()
+  }
 }
 
 ///|
 pub fn delete_selection(handle : Int) -> Bool {
-  _registry[handle].delete_selection()
+  match canvas_runtime_for_public(handle) {
+    Some(runtime) => runtime.delete_selection()
+    None => false
+  }
 }
 
 ///|
@@ -45,7 +51,10 @@ pub fn delete_nodes(handle : Int, node_ids_json : String) -> Unit {
   if node_ids.length() == 0 {
     return
   }
-  _registry[handle].delete_nodes(node_ids)
+  match canvas_runtime_for_public(handle) {
+    Some(runtime) => runtime.delete_nodes(node_ids)
+    None => ()
+  }
 }
 
 ///|
@@ -182,10 +191,16 @@ extend RenderStateJson with ToJson::{to_json}
 
 ///|
 pub fn get_render_state(handle : Int) -> String {
-  _registry[handle].render_state().to_json().stringify()
+  match canvas_runtime_for_public(handle) {
+    Some(runtime) => runtime.render_state().to_json().stringify()
+    None => ""
+  }
 }
 
 ///|
 pub fn get_action_log(handle : Int) -> String {
-  _registry[handle].action_log_json()
+  match canvas_runtime_for_public(handle) {
+    Some(runtime) => runtime.action_log_json()
+    None => ([] : Array[GraphOperation]).to_json().stringify()
+  }
 }

--- a/apps/canvas/main/canvas_render_layer.mbt
+++ b/apps/canvas/main/canvas_render_layer.mbt
@@ -535,11 +535,17 @@ fn dispatch_canvas_render_state(json : String) -> Unit {
 /// consumers. The custom event is only an app-private transport seam; the
 /// returned string is the same snapshot consumed by the TypeScript shell.
 #cfg(target="js")
-pub fn publish_render_state(handle : Int, source_backed : Bool) -> String {
-  let json = if source_backed {
-    get_source_graph_render_state(handle)
-  } else {
-    get_render_state(handle)
+pub fn publish_render_state(handle : Int) -> String {
+  let json = match canvas_backing(handle) {
+    Some(backing) => backing.render_state_json()
+    None => {
+      // Preserve the old workflow registry's out-of-range failure while
+      // retaining the source boundary's error result for an empty slot.
+      if handle < 0 || handle >= canvas_instances.length() {
+        ignore(canvas_instances[handle])
+      }
+      get_source_graph_render_state(handle)
+    }
   }
   dispatch_canvas_render_state(json)
   json

--- a/apps/canvas/main/context_menu.mbt
+++ b/apps/canvas/main/context_menu.mbt
@@ -41,7 +41,6 @@ priv struct CanvasContextMenuItem {
 ///|
 priv struct CanvasContextMenuModel {
   handle : Int
-  source_backed : Bool
   items : Array[CanvasContextMenuItem]
   target : CanvasContextTarget?
   context_menu : @context_menu.Model
@@ -61,26 +60,15 @@ priv enum CanvasContextMenuMsg {
 let context_menu_dismissers : Map[Int, () -> Unit] = Map([])
 
 ///|
-fn canvas_context_pointer_state(
-  handle : Int,
-  source_backed : Bool,
-) -> CanvasPointerState {
-  { handle, source_backed, session: Idle }
+fn canvas_context_pointer_state(handle : Int) -> CanvasPointerState {
+  { handle, session: Idle }
 }
 
 ///|
-fn canvas_context_edge_description(
-  handle : Int,
-  source_backed : Bool,
-  edge_id : EdgeId,
-) -> String {
-  let state = if source_backed {
-    match source_graph_by_handle(handle) {
-      Some(graph) => source_graph_base_canvas_state(graph)
-      None => empty_source_canvas_state()
-    }
-  } else {
-    _registry[handle].state_peek()
+fn canvas_context_edge_description(handle : Int, edge_id : EdgeId) -> String {
+  let state = match canvas_backing(handle) {
+    Some(backing) => backing.state()
+    None => empty_source_canvas_state()
   }
   match state.edges.search_by(fn(edge) { edge.id == edge_id }) {
     Some(index) => {
@@ -111,8 +99,12 @@ fn canvas_context_menu_items(
           description: item.description,
         }
       })
-      if !model.source_backed &&
-        _registry[model.handle].peek_selection().selected_nodes.length() >= 2 {
+      let can_arrange = match canvas_backing(model.handle) {
+        Some(Runtime(runtime)) =>
+          runtime.peek_selection().selected_nodes.length() >= 2
+        _ => false
+      }
+      if can_arrange {
         items.insert(0, {
           action: Arrange,
           label: "Arrange compactly",
@@ -126,11 +118,7 @@ fn canvas_context_menu_items(
         {
           action: Disconnect,
           label: "Disconnect edge",
-          description: canvas_context_edge_description(
-            model.handle,
-            model.source_backed,
-            edge_id,
-          ),
+          description: canvas_context_edge_description(model.handle, edge_id),
         },
       ]
   }
@@ -139,13 +127,11 @@ fn canvas_context_menu_items(
 ///|
 fn context_menu_model(
   handle : Int,
-  source_backed : Bool,
   on_change : () -> Unit,
   on_source_result : (String) -> Unit,
 ) -> CanvasContextMenuModel {
   {
     handle,
-    source_backed,
     items: [],
     target: None,
     context_menu: @context_menu.Model::new(id=CONTEXT_MENU_PANEL_ID).with_close_focus_id(
@@ -163,18 +149,15 @@ fn CanvasContextMenuModel::open_request(
 ) -> CanvasContextMenuModel? {
   match request.target {
     Background(insert_at~) => {
-      let pointer_state = canvas_context_pointer_state(
-        self.handle,
-        self.source_backed,
-      )
-      if !self.source_backed &&
-        canvas_pointer_world_point(pointer_state, insert_at) is None {
-        return None
+      let pointer_state = canvas_context_pointer_state(self.handle)
+      match canvas_backing(self.handle) {
+        Some(Runtime(_)) if canvas_pointer_world_point(pointer_state, insert_at)
+          is None => return None
+        _ => ()
       }
-      canvas_clear_selected_edge(self.handle, self.source_backed)
+      canvas_clear_selected_edge(self.handle)
     }
-    Edge(edge_id) =>
-      canvas_select_edge(self.handle, self.source_backed, edge_id)
+    Edge(edge_id) => canvas_select_edge(self.handle, edge_id)
   }
   let items = canvas_context_menu_items(self, request.target)
   Some({
@@ -237,34 +220,31 @@ fn canvas_context_apply(
 ) -> Unit raise Failure {
   match (target, action) {
     (Background(insert_at~), AddNode(kind)) =>
-      if model.source_backed {
-        (model.on_source_result)(
-          canvas_context_insert_unique(model.handle, kind),
-        )
-      } else {
-        _registry[model.handle].add_node(kind, insert_at.x(), insert_at.y())
+      match canvas_backing(model.handle) {
+        Some(Source(_)) =>
+          (model.on_source_result)(
+            canvas_context_insert_unique(model.handle, kind),
+          )
+        Some(Runtime(runtime)) =>
+          runtime.add_node(kind, insert_at.x(), insert_at.y())
+        None => ()
       }
     (Background(_), Arrange) =>
-      if !model.source_backed {
-        _registry[model.handle].arrange_selection()
+      match canvas_backing(model.handle) {
+        Some(Runtime(runtime)) => runtime.arrange_selection()
+        _ => ()
       }
     (Edge(edge_id), Disconnect) =>
-      if model.source_backed {
-        let result = match source_graph_by_handle(model.handle) {
-          Some(graph) =>
-            graph.disconnect_edge(edge_id) catch {
-              Failure::Failure(detail) =>
-                canvas_context_failure_result(model.handle, detail)
-            }
-          None =>
-            canvas_context_failure_result(
-              model.handle,
-              "source graph handle not found",
-            )
+      match canvas_backing(model.handle) {
+        Some(Source(graph)) => {
+          let result = graph.disconnect_edge(edge_id) catch {
+            Failure::Failure(detail) =>
+              canvas_context_failure_result(model.handle, detail)
+          }
+          (model.on_source_result)(result.to_json().stringify())
         }
-        (model.on_source_result)(result.to_json().stringify())
-      } else {
-        ignore(_registry[model.handle].disconnect_edge(edge_id))
+        Some(Runtime(runtime)) => ignore(runtime.disconnect_edge(edge_id))
+        None => ()
       }
     _ => ()
   }
@@ -519,15 +499,12 @@ pub fn dismiss_canvas_context_menu(handle : Int) -> Unit {
 #cfg(target="js")
 pub fn mount_canvas_context_menu(
   handle : Int,
-  source_backed : Bool,
   on_change : () -> Unit,
   on_source_result : (String) -> Unit,
 ) -> Unit {
   @rabbita.new(
     @rabbita.cell(
-      model=context_menu_model(
-        handle, source_backed, on_change, on_source_result,
-      ),
+      model=context_menu_model(handle, on_change, on_source_result),
       update=context_menu_update,
       view=context_menu_view,
       subscriptions=context_menu_subscriptions,

--- a/apps/canvas/main/context_menu_wbtest.mbt
+++ b/apps/canvas/main/context_menu_wbtest.mbt
@@ -31,7 +31,7 @@ test "workflow context disconnect uses the captured edge target" {
 ///|
 test "background menu stays catalog-only without a multi-selection" {
   let handle = create_canvas()
-  let model = context_menu_model(handle, false, () => (), _s => ())
+  let model = context_menu_model(handle, () => (), _s => ())
   let items = canvas_context_menu_items(model, test_background_target())
   inspect(items.length(), content="7")
   inspect(items[0].label, content="Timer trigger")
@@ -40,7 +40,10 @@ test "background menu stays catalog-only without a multi-selection" {
 ///|
 test "background menu prepends arrange for a multi-selection" {
   let handle = create_canvas()
-  let runtime = _registry[handle]
+  let runtime = match canvas_backing(handle) {
+    Some(Runtime(runtime)) => runtime
+    _ => abort("expected runtime backing")
+  }
   let node1 = NodeId("1")
   let node2 = NodeId("2")
   let first = contract_state_node(runtime.state_peek(), node1)
@@ -60,7 +63,7 @@ test "background menu prepends arrange for a multi-selection" {
   ignore(runtime.pointer_down(Some(node2), two_sx, two_sy))
   runtime.pointer_up("2", "", true)
 
-  let model = context_menu_model(handle, false, () => (), _s => ())
+  let model = context_menu_model(handle, () => (), _s => ())
   let items = canvas_context_menu_items(model, test_background_target())
   inspect(items.length(), content="8")
   inspect(items[0].label, content="Arrange compactly")
@@ -69,29 +72,10 @@ test "background menu prepends arrange for a multi-selection" {
 
 ///|
 test "background menu hides arrange on a source-backed graph" {
-  let handle = create_canvas()
-  let runtime = _registry[handle]
-  let node1 = NodeId("1")
-  let node2 = NodeId("2")
-  let first = contract_state_node(runtime.state_peek(), node1)
-  let (one_sx, one_sy) = contract_screen_point(
-    runtime.render_state().viewport,
-    first.position().x(),
-    first.position().y(),
-  )
-  ignore(runtime.pointer_down(Some(node1), one_sx, one_sy))
-  runtime.pointer_up("1", "", false)
-  let second = contract_state_node(runtime.state_peek(), node2)
-  let (two_sx, two_sy) = contract_screen_point(
-    runtime.render_state().viewport,
-    second.position().x(),
-    second.position().y(),
-  )
-  ignore(runtime.pointer_down(Some(node2), two_sx, two_sy))
-  runtime.pointer_up("2", "", true)
-
-  let model = context_menu_model(handle, true, () => (), _s => ())
+  let handle = create_source_graph("osc = sine(freq: 440Hz)\nmeter = scope()")
+  let model = context_menu_model(handle, () => (), _s => ())
   let items = canvas_context_menu_items(model, test_background_target())
   inspect(items.length(), content="7")
   inspect(items[0].label, content="Timer trigger")
+  destroy_source_graph(handle)
 }

--- a/apps/canvas/main/graph_dsl_adapter.mbt
+++ b/apps/canvas/main/graph_dsl_adapter.mbt
@@ -77,14 +77,10 @@ fn SourceBackedGraph::apply_attachment_mutation(
 }
 
 ///|
-let _source_registry : Array[SourceBackedGraph?] = []
-
-///|
 fn source_graph_by_handle(handle : Int) -> SourceBackedGraph? {
-  if handle < 0 || handle >= _source_registry.length() {
-    None
-  } else {
-    _source_registry[handle]
+  match canvas_backing(handle) {
+    Some(Source(graph)) => Some(graph)
+    _ => None
   }
 }
 
@@ -1230,20 +1226,23 @@ pub fn sample_graph_dsl_source() -> String {
 
 ///|
 pub fn create_source_graph(source : String) -> Int raise Failure {
-  let handle = _source_registry.length()
+  let handle = canvas_instances.length()
   let source_id = source_graph_source_id(handle)
-  _source_registry.push(Some(SourceBackedGraph(source_id, source)))
+  canvas_instances.push(Some(Source(SourceBackedGraph(source_id, source))))
   handle
 }
 
 ///|
 pub fn try_destroy_source_graph(handle : Int) -> Bool {
-  match source_graph_by_handle(handle) {
-    Some(graph) => graph.dispose()
-    None => return true
+  match canvas_backing(handle) {
+    Some(Source(graph)) => {
+      graph.dispose()
+      canvas_instances[handle] = None
+      true
+    }
+    Some(Runtime(_)) => false
+    None => true
   }
-  _source_registry[handle] = None
-  true
 }
 
 ///|
@@ -1429,12 +1428,15 @@ fn source_render_state_string(
 }
 
 ///|
+fn SourceBackedGraph::render_state_json(self : SourceBackedGraph) -> String {
+  let state = source_graph_canvas_state(self)
+  source_render_state_string(self, state, source_graph_validation(self))
+}
+
+///|
 pub fn get_source_graph_render_state(handle : Int) -> String {
   match source_graph_by_handle(handle) {
-    Some(graph) => {
-      let state = source_graph_canvas_state(graph)
-      source_render_state_string(graph, state, source_graph_validation(graph))
-    }
+    Some(graph) => graph.render_state_json()
     None =>
       render_state_string(empty_source_canvas_state(), [
         {

--- a/apps/canvas/main/pkg.generated.mbti
+++ b/apps/canvas/main/pkg.generated.mbti
@@ -42,15 +42,15 @@ pub fn get_source_graph_source(Int) -> String
 
 pub fn get_workflow_node_catalog() -> String
 
-pub fn mount_canvas_context_menu(Int, Bool, () -> Unit, (String) -> Unit) -> Unit
+pub fn mount_canvas_context_menu(Int, () -> Unit, (String) -> Unit) -> Unit
 
-pub fn mount_canvas_pointer_session(Int, Bool, () -> Unit) -> Unit
+pub fn mount_canvas_pointer_session(Int, () -> Unit) -> Unit
 
 pub fn mount_canvas_render_layer() -> Unit
 
 pub fn mount_source_demo(Int, Bool, () -> Unit) -> Unit
 
-pub fn publish_render_state(Int, Bool) -> String
+pub fn publish_render_state(Int) -> String
 
 pub fn sample_graph_dsl_source() -> String
 

--- a/apps/canvas/main/pointer_session.mbt
+++ b/apps/canvas/main/pointer_session.mbt
@@ -16,7 +16,6 @@ priv enum CanvasPointerSession {
 ///|
 priv struct CanvasPointerState {
   handle : Int
-  source_backed : Bool
   session : CanvasPointerSession
 } derive(Eq)
 
@@ -178,13 +177,9 @@ fn canvas_pointer_release_hit(
 
 ///|
 fn canvas_pointer_canvas_state(model : CanvasPointerState) -> CanvasState {
-  if model.source_backed {
-    match source_graph_by_handle(model.handle) {
-      Some(graph) => source_graph_base_canvas_state(graph)
-      None => empty_source_canvas_state()
-    }
-  } else {
-    _registry[model.handle].state_peek()
+  match canvas_backing(model.handle) {
+    Some(backing) => backing.state()
+    None => empty_source_canvas_state()
   }
 }
 
@@ -254,30 +249,18 @@ fn canvas_pointer_source_target(
 }
 
 ///|
-fn canvas_select_edge(
-  handle : Int,
-  source_backed : Bool,
-  edge_id : EdgeId,
-) -> Unit {
-  if source_backed {
-    match source_graph_by_handle(handle) {
-      Some(graph) => graph.select_edge(edge_id)
-      None => ()
-    }
-  } else {
-    _registry[handle].select_edge(edge_id)
+fn canvas_select_edge(handle : Int, edge_id : EdgeId) -> Unit {
+  match canvas_backing(handle) {
+    Some(backing) => backing.select_edge(edge_id)
+    None => ()
   }
 }
 
 ///|
-fn canvas_clear_selected_edge(handle : Int, source_backed : Bool) -> Unit {
-  if source_backed {
-    match source_graph_by_handle(handle) {
-      Some(graph) => graph.clear_selected_edge()
-      None => ()
-    }
-  } else {
-    _registry[handle].clear_selected_edge()
+fn canvas_clear_selected_edge(handle : Int) -> Unit {
+  match canvas_backing(handle) {
+    Some(backing) => backing.clear_selected_edge()
+    None => ()
   }
 }
 
@@ -288,14 +271,14 @@ fn canvas_pointer_complete_source_connection(
   source_port_id : String,
   hit : CanvasPointerHit,
 ) -> Unit {
-  match source_graph_by_handle(model.handle) {
-    Some(graph) =>
+  match canvas_backing(model.handle) {
+    Some(Source(graph)) =>
       graph.complete_connection(
         NodeId(source_node_id),
         source_port_id,
         canvas_pointer_source_target(hit),
       )
-    None => ()
+    _ => ()
   }
 }
 
@@ -322,7 +305,7 @@ fn canvas_pointer_start(
       return model
     }
     Handle(side=Input, ..) => {
-      canvas_clear_selected_edge(model.handle, model.source_backed)
+      canvas_clear_selected_edge(model.handle)
       on_change()
       return model
     }
@@ -336,8 +319,8 @@ fn canvas_pointer_start(
   let additive = event.get_shift_key() ||
     event.get_meta_key() ||
     event.get_ctrl_key()
-  let next_session = match hit {
-    Handle(node_id~, side=Output, port_id~) if model.source_backed =>
+  let next_session = match (canvas_backing(model.handle), hit) {
+    (Some(Source(_)), Handle(node_id~, side=Output, port_id~)) =>
       SourceConnection(
         pointer_id~,
         source_node_id=node_id,
@@ -347,56 +330,34 @@ fn canvas_pointer_start(
           None => return model
         },
       )
-    Node(node_id) if model.source_backed =>
+    (Some(Source(_)), Node(node_id)) =>
       GraphGesture(pointer_id~, down_node_id=node_id, additive~)
-    Background if model.source_backed =>
+    (Some(Source(_)), Background) =>
       GraphGesture(pointer_id~, down_node_id="", additive~)
-    Handle(side=Output, ..) =>
+    (Some(_), Handle(side=Output, ..)) =>
       GraphGesture(pointer_id~, down_node_id="", additive~)
-    Node(node_id) => GraphGesture(pointer_id~, down_node_id=node_id, additive~)
-    Background => GraphGesture(pointer_id~, down_node_id="", additive~)
-    Edge(_) | Handle(side=Input, ..) => return model
+    (Some(_), Node(node_id)) =>
+      GraphGesture(pointer_id~, down_node_id=node_id, additive~)
+    (Some(_), Background) =>
+      GraphGesture(pointer_id~, down_node_id="", additive~)
+    (_, Edge(_) | Handle(side=Input, ..)) => return model
+    (None, _) => return model
   }
   root.set_pointer_capture(pointer_id) catch {
     @dom.DOMExceptionError(..) => return model
   }
-  let admitted = match (model.source_backed, hit) {
-    (true, Handle(node_id~, side=Output, port_id~)) =>
-      match source_graph_by_handle(model.handle) {
-        Some(graph) =>
-          graph.pointer_down_handle(
-            NodeId(node_id),
-            port_id,
-            screen.x(),
-            screen.y(),
-          )
-        None => false
-      }
-    (true, Node(node_id)) =>
-      match source_graph_by_handle(model.handle) {
-        Some(graph) => graph.pointer_down(node_id, screen.x(), screen.y())
-        None => false
-      }
-    (true, Background) =>
-      match source_graph_by_handle(model.handle) {
-        Some(graph) => graph.pointer_down("", screen.x(), screen.y())
-        None => false
-      }
-    (false, Handle(node_id~, side=Output, port_id~)) =>
-      _registry[model.handle].pointer_down_handle(
+  let admitted = match (canvas_backing(model.handle), hit) {
+    (Some(backing), Handle(node_id~, side=Output, port_id~)) =>
+      backing.pointer_down_handle(
         NodeId(node_id),
         port_id,
         screen.x(),
         screen.y(),
       )
-    (false, Node(node_id)) =>
-      _registry[model.handle].pointer_down(
-        Some(NodeId(node_id)),
-        screen.x(),
-        screen.y(),
-      )
-    (false, Background) =>
-      _registry[model.handle].pointer_down(None, screen.x(), screen.y())
+    (Some(backing), Node(node_id)) =>
+      backing.pointer_down(Some(NodeId(node_id)), screen.x(), screen.y())
+    (Some(backing), Background) =>
+      backing.pointer_down(None, screen.x(), screen.y())
     _ => false
   }
   guard admitted else {
@@ -404,7 +365,7 @@ fn canvas_pointer_start(
     return model
   }
   let next = { ..model, session: next_session }
-  canvas_clear_selected_edge(model.handle, model.source_backed)
+  canvas_clear_selected_edge(model.handle)
   match hit {
     Background => canvas_pointer_set_panning(root, true)
     _ => ()
@@ -422,32 +383,29 @@ fn canvas_pointer_move(
   let event = input.event
   match model.session {
     Idle => {
-      if !model.source_backed {
-        let node_id = match input.hit {
-          Node(node_id) | Handle(node_id~, ..) => node_id
-          Background | Edge(_) => ""
-        }
-        _registry[model.handle].hover_node(node_id)
-        on_change()
+      let node_id = match input.hit {
+        Node(node_id) | Handle(node_id~, ..) => node_id
+        Background | Edge(_) => ""
+      }
+      match canvas_backing(model.handle) {
+        Some(backing) => if backing.hover_node(node_id) { on_change() }
+        None => ()
       }
       model
     }
     GraphGesture(pointer_id~, ..) if pointer_id == event.get_pointer_id() =>
       match input.screen {
         None => model
-        Some(screen) => {
-          if model.source_backed {
-            match source_graph_by_handle(model.handle) {
-              Some(graph) => graph.pointer_move(screen.x(), screen.y())
-              None => ()
+        Some(screen) =>
+          match canvas_backing(model.handle) {
+            Some(backing) => {
+              ignore(backing.hover_node(""))
+              backing.pointer_move(screen.x(), screen.y())
+              on_change()
+              model
             }
-          } else {
-            _registry[model.handle].hover_node("")
-            _registry[model.handle].pointer_move(screen.x(), screen.y())
+            None => model
           }
-          on_change()
-          model
-        }
       }
     SourceConnection(pointer_id~, source_node_id~, source_port_id~, ..) if pointer_id ==
       event.get_pointer_id() =>
@@ -457,11 +415,13 @@ fn canvas_pointer_move(
           match canvas_pointer_world_point(model, screen) {
             None => model
             Some(next_cursor) => {
-              match source_graph_by_handle(model.handle) {
-                Some(graph) => graph.pointer_move(screen.x(), screen.y())
+              match canvas_backing(model.handle) {
+                Some(backing) => {
+                  backing.pointer_move(screen.x(), screen.y())
+                  on_change()
+                }
                 None => ()
               }
-              on_change()
               {
                 ..model,
                 session: SourceConnection(
@@ -496,13 +456,9 @@ fn canvas_pointer_finish(
       let next = { ..model, session: Idle }
       let node_id = canvas_pointer_node_id(hit, down_node_id)
       let target_port_id = canvas_pointer_target_port(hit)
-      if model.source_backed {
-        match source_graph_by_handle(model.handle) {
-          Some(graph) => graph.pointer_up(node_id, target_port_id, additive)
-          None => ()
-        }
-      } else {
-        _registry[model.handle].pointer_up(node_id, target_port_id, additive)
+      match canvas_backing(model.handle) {
+        Some(backing) => backing.pointer_up(node_id, target_port_id, additive)
+        None => ()
       }
       canvas_pointer_release_capture(input.root, pointer_id)
       on_change()
@@ -540,13 +496,9 @@ fn canvas_pointer_interrupt(
       }
       canvas_pointer_set_panning(input.root, false)
       let next = { ..model, session: Idle }
-      if model.source_backed {
-        match source_graph_by_handle(model.handle) {
-          Some(graph) => graph.pointer_interrupt()
-          None => ()
-        }
-      } else {
-        _registry[model.handle].pointer_interrupt()
+      match canvas_backing(model.handle) {
+        Some(backing) => backing.pointer_interrupt()
+        None => ()
       }
       canvas_pointer_release_capture(input.root, pointer_id)
       on_change()
@@ -558,8 +510,8 @@ fn canvas_pointer_interrupt(
       }
       canvas_pointer_set_panning(input.root, false)
       let next = { ..model, session: Idle }
-      match source_graph_by_handle(model.handle) {
-        Some(graph) => graph.pointer_interrupt()
+      match canvas_backing(model.handle) {
+        Some(backing) => backing.pointer_interrupt()
         None => ()
       }
       canvas_pointer_release_capture(input.root, pointer_id)
@@ -614,7 +566,8 @@ fn canvas_pointer_message(
         Some(keyboard) =>
           match keyboard.key() {
             "Enter" | " " | "Spacebar" =>
-              match canvas_pointer_hit_from_element(keyboard.target().to_element()) {
+              match
+                canvas_pointer_hit_from_element(keyboard.target().to_element()) {
                 Edge(edge_id) => {
                   keyboard.prevent_default()
                   Some(Click(Edge(edge_id)))
@@ -726,7 +679,7 @@ fn canvas_pointer_update(
     Click(hit) => {
       match hit {
         Edge(edge_id) => {
-          canvas_select_edge(model.handle, model.source_backed, edge_id)
+          canvas_select_edge(model.handle, edge_id)
           on_change()
         }
         _ => ()
@@ -742,34 +695,25 @@ fn canvas_pointer_update(
     Wheel(input) => {
       guard model.session is Idle else { return model }
       guard input.screen is Some(screen) else { return model }
-      if model.source_backed {
-        match source_graph_by_handle(model.handle) {
-          Some(graph) =>
-            graph.zoom(
-              input.delta_y,
-              input.delta_mode,
-              input.ctrl_key,
-              screen.x(),
-              screen.y(),
-            )
-          None => return model
+      match canvas_backing(model.handle) {
+        Some(backing) => {
+          backing.zoom(
+            input.delta_y,
+            input.delta_mode,
+            input.ctrl_key,
+            screen.x(),
+            screen.y(),
+          )
+          on_change()
+          model
         }
-      } else {
-        _registry[model.handle].zoom(
-          input.delta_y,
-          input.delta_mode,
-          input.ctrl_key,
-          screen.x(),
-          screen.y(),
-        )
+        None => model
       }
-      on_change()
-      model
     }
     PointerLeave => {
-      if !model.source_backed {
-        _registry[model.handle].hover_node("")
-        on_change()
+      match canvas_backing(model.handle) {
+        Some(backing) => if backing.hover_node("") { on_change() }
+        None => ()
       }
       model
     }
@@ -785,12 +729,11 @@ fn canvas_pointer_view(_model : CanvasPointerState) -> @rabbita.Html {
 #cfg(target="js")
 pub fn mount_canvas_pointer_session(
   handle : Int,
-  source_backed : Bool,
   on_change : () -> Unit,
 ) -> Unit {
   @rabbita.new(fn() {
     let (model, _emit) = @rabbita.create_state(
-      { handle, source_backed, session: Idle },
+      { handle, session: Idle },
       update=fn(model, message, _emit) {
         (canvas_pointer_update(model, message, on_change), @rabbita.none)
       },

--- a/apps/canvas/web/src/graph-adapter.ts
+++ b/apps/canvas/web/src/graph-adapter.ts
@@ -2,11 +2,10 @@ export type CanvasModule = {
   create_canvas: () => number;
   mount_canvas_pointer_session: (
     h: number,
-    sourceBacked: boolean,
     onChange: () => undefined,
   ) => undefined;
   mount_canvas_render_layer: () => undefined;
-  publish_render_state: (h: number, sourceBacked: boolean) => string;
+  publish_render_state: (h: number) => string;
   add_node: (h: number, kindKey: string, sx: number, sy: number) => void;
   delete_nodes: (h: number, nodeIdsJson: string) => void;
   clear_selected_edge: (h: number) => void;
@@ -33,7 +32,6 @@ export type CanvasModule = {
   get_workflow_node_catalog: () => string;
   mount_canvas_context_menu?: (
     h: number,
-    sourceBacked: boolean,
     onChange: () => undefined,
     onSourceResult: (result: string) => undefined,
   ) => undefined;
@@ -264,7 +262,7 @@ export class GraphAdapter {
   publishRenderState(): RenderState {
     this.assertLive();
     const state = JSON.parse(
-      this.mb.publish_render_state(this.handle, this.isSourceBacked),
+      this.mb.publish_render_state(this.handle),
     ) as RenderState;
     this.emitOperationsThrough(state.action_count);
     return state;

--- a/apps/canvas/web/src/main.ts
+++ b/apps/canvas/web/src/main.ts
@@ -460,7 +460,6 @@ async function init(): Promise<void> {
   ) as LibraryItem[];
   sourceDemoModule.mount_canvas_context_menu(
     adapter.handleId,
-    sourceMode,
     () => {
       scheduleRender();
       return undefined;
@@ -477,7 +476,6 @@ async function init(): Promise<void> {
   });
   sourceDemoModule.mount_canvas_pointer_session(
     adapter.handleId,
-    sourceMode,
     () => {
       scheduleRender();
       return undefined;


### PR DESCRIPTION
## Summary

- Replace the independent workflow and source handle registries with one private `Array[CanvasBacking?]` registry.
- Remove `source_backed` from the common MoonBit pointer/context models and from pointer/context/render publication entry points.
- Route shared state, pointer, selection, zoom, hover, and render dispatch through the closed `CanvasBacking` enum while keeping source-only behavior explicit.
- Preserve `GraphAdapter.mode` for source-specific TypeScript presentation and APIs.

This is intentionally limited to instance identity and common dispatch. It does not change `GraphOperation`, `WorkflowAction`, source lowering, last-good projection, `CanvasHostPolicy`, `canvas-spatial`, or source-only editing APIs.

## Design

```text
priv enum CanvasBacking {
  Runtime(CanvasRuntime)
  Source(SourceBackedGraph)
}

let canvas_instances : Array[CanvasBacking?] = []
```

`create_canvas` and `create_source_graph` now allocate from the same monotonic handle space. Destroying a source disposes and clears only a matching `Source` slot. A valid `Runtime` slot rejects `try_destroy_source_graph` with `false`; empty or unknown source slots retain the existing idempotent `true` result.

`SourceId` continues to derive from the stable handle assigned to the source backing. A characterization test confirms that allocating another backing does not change an existing source graph's node identity.

## Reuse check

- Reused existing `CanvasRuntime` and `SourceBackedGraph` owner methods for all common dispatch; no parallel domain operation implementation was added.
- Reused `Array::length` for dense monotonic allocation and `Array::get` + `Option::bind` for safe private slot lookup. `Array::set` remains the lifecycle mutation for clearing a known slot.
- Checked `Map`/`SortedMap`; neither fits this dense indexed registry because no key ordering or range query is required.
- New `CanvasBacking` and its private methods own only variant dispatch (`state`, pointer lifecycle, selection, zoom, hover, and render snapshot). Source lowering, parser lifecycle, layout, diagnostics, and last-good behavior remain on `SourceBackedGraph`.
- Remaining imperative mutation is limited to registry append/clear and existing mutable backing owners; it is required for lifecycle and stateful canvas behavior.

## Boundary matrix

- `Runtime → Source → Runtime`: handles are unique and consecutive.
- Same numeric handle cannot be interpreted as both backing kinds.
- Runtime-only calls on a source slot do not mutate source state.
- Source-only calls on a runtime slot return the existing source rejection result.
- Source destroy preserves neighboring runtime slots.
- Pointer, context menu, and render publication use only the handle in MoonBit.
- Public source/runtime-specific behavior remains owned by the corresponding entry point.

## Tests and validation

The first red test was added before implementation in `apps/canvas/main/canvas_backing_wbtest.mbt`; it referenced the intended unified backing lookup. The final targeted package result is 89/89 tests passing.

Additional validation:

- Canvas E2E: 56/56 passing
- Canvas web production build: passing
- Canvas web TypeScript check: `npx tsc --noEmit` passing
- Root JS artifact build: passing
- FFI consumer checks: passing
- Independent post-rebase MoonBit review: no blocker after the wrong-backing destroy contract was tightened

## PR-ready evidence

Validated HEAD: `5eb54343231cf8ed774b76f225f8a52eee248cd2`

Validated base: `origin/main@da02ddd9e4f0eb74a32b50e90f71c63cd6979ec2`

```bash
git fetch origin main
NEW_MOON_MOD=0 ./scripts/validate-pr-ready.sh \
  --target apps/canvas/main

git fetch origin main
NEW_MOON_MOD=0 ./scripts/validate-pr-ready.sh --verify-evidence
```

The full PR-ready validator and the immediate pre-publication evidence check passed on the exact HEAD/base above. No submodule pointer changed and no unrelated generated interface changed; the `apps/canvas/main/pkg.generated.mbti` changes are the intentional removal of the three `Bool` parameters.
