### PR TITLE
refactor(gate-r0): deepen runner internals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,7 @@ jobs:
               - '.gitmodules'
               - 'moon.mod.json'
               - 'scripts/test-loomark-editable-branch-restore-feasibility.nu'
+              - 'scripts/gate-r0/**'
               - 'scripts/moon-update.sh'
             run_prove:
               - 'modules/semantic/proof/**'
@@ -1090,6 +1091,9 @@ jobs:
       - name: Install browser oracle dependencies
         working-directory: apps/loomark/examples/vanilla
         run: npm ci
+
+      - name: Run Gate R0 artifact contract tests
+        run: nu scripts/gate-r0/test-artifacts.nu
 
       - name: Run complete Gate R0 evidence harness
         run: >-

--- a/scripts/gate-r0/artifacts.nu
+++ b/scripts/gate-r0/artifacts.nu
@@ -1,0 +1,75 @@
+# Canonical Gate R0 run-bundle ownership. The output directory is runner-owned:
+# every run starts empty, and every classified failure replaces its contents
+# with exactly the ten registered files before returning control.
+
+export def artifact-paths [] {
+  [
+    "manifest.json"
+    "result.json"
+    "capability-ledger.json"
+    "candidate-captures.jsonl"
+    "candidate-results.json"
+    "operation-matrix.jsonl"
+    "oracle-differential.jsonl"
+    "cold-history.jsonl"
+    "negative-results.json"
+    "validation.log"
+  ]
+}
+
+def fail [message: string] { error make { msg: $message } }
+
+def write-json [path: string value: any] {
+  $value | to json -r | save -f $path
+}
+
+def write-jsonl [path: string rows: list<any>] {
+  ($rows | each {|row| $row | to json -r } | str join "\n") + "\n" | save -f $path
+}
+
+export def reset-artifact-output [output: string] {
+  let output_type = ($output | path type)
+  if $output_type == "symlink" {
+    fail $"artifact output directory must not be a symlink: ($output)"
+  }
+  if $output_type != null and $output_type != "dir" {
+    fail $"artifact output path must be a directory: ($output)"
+  }
+  mkdir $output
+  for entry in (ls -a $output) {
+    rm -rf $entry.name
+  }
+}
+
+export def assert-artifact-set [output: string] {
+  let expected = (artifact-paths | sort)
+  let actual = (ls -a $output | get name | each {|path| $path | path basename } | sort)
+  if $actual != $expected {
+    fail $"artifact set differs: expected=($expected | to json -r) actual=($actual | to json -r)"
+  }
+}
+
+export def write-failure-bundle [output: string failure: string candidate_outcomes: list<any>] {
+  reset-artifact-output $output
+  write-json ($output | path join "manifest.json") {
+    schema_version: 1
+    run_id: "gate-r0-v1"
+    status: "fail"
+  }
+  write-json ($output | path join "capability-ledger.json") { schema_version: 1 rows: [] }
+  write-jsonl ($output | path join "candidate-captures.jsonl") []
+  write-json ($output | path join "candidate-results.json") { schema_version: 1 candidates: [] }
+  write-jsonl ($output | path join "operation-matrix.jsonl") []
+  write-jsonl ($output | path join "oracle-differential.jsonl") []
+  write-jsonl ($output | path join "cold-history.jsonl") []
+  write-json ($output | path join "negative-results.json") { schema_version: 1 negatives: [] }
+  $"Gate R0 failure: ($failure)\n" | save -f ($output | path join "validation.log")
+  write-json ($output | path join "result.json") {
+    schema_version: 1
+    status: "fail"
+    failure_class: $failure
+    candidate_outcomes: $candidate_outcomes
+    artifact_paths: (artifact-paths)
+  }
+  assert-artifact-set $output
+}

--- a/scripts/gate-r0/artifacts.nu
+++ b/scripts/gate-r0/artifacts.nu
@@ -28,14 +28,17 @@ def write-jsonl [path: string rows: list<any>] {
 }
 
 export def reset-artifact-output [output: string] {
-  let output_type = ($output | path type)
-  if $output_type == "symlink" {
+  if ($output | path type) == "symlink" {
     fail $"artifact output directory must not be a symlink: ($output)"
   }
-  if $output_type != null and $output_type != "dir" {
-    fail $"artifact output path must be a directory: ($output)"
+  if ($output | path exists) {
+    let output_type = ($output | path type)
+    if $output_type != "dir" {
+      fail $"artifact output path must be a directory: ($output)"
+    }
+  } else {
+    mkdir $output
   }
-  mkdir $output
   for entry in (ls -a $output) {
     rm -rf $entry.name
   }

--- a/scripts/gate-r0/browser.nu
+++ b/scripts/gate-r0/browser.nu
@@ -1,0 +1,83 @@
+# Browser-owned full-history oracle adapter for Gate R0. This module owns the
+# release-static build, fixed fixture validation, fresh Chromium invocation,
+# and normalization of browser observations. The canonical runner sees only
+# the returned observation rows.
+
+def fail [message: string] { error make { msg: $message } }
+
+def prepare-browser-standalone [root: string output: string] {
+  let build = (^moon -C $root build --quiet --release --target js apps/loomark/main apps/loomark/worker apps/loomark/projection_worker | complete)
+  if $build.exit_code != 0 { fail $"browser standalone build failed: ($build.stderr)" }
+  let dist = ($output | path join ".browser-dist" | path expand)
+  rm -rf $dist
+  mkdir $dist
+  ^cp ($root | path join "apps/loomark/public/styles.css") ($dist | path join "styles.css")
+  ^cp ($root | path join "apps/loomark/public/favicon.svg") ($dist | path join "favicon.svg")
+  ^cp ($root | path join "_build/js/release/build/dowdiness/loomark/main/main.js") ($dist | path join "index.js")
+  ^cp ($root | path join "_build/js/release/build/dowdiness/loomark/worker/worker.js") ($dist | path join "capability-worker.js")
+  ^cp ($root | path join "_build/js/release/build/dowdiness/loomark/projection_worker/projection_worker.js") ($dist | path join "projection-worker.js")
+  let html = (open --raw ($root | path join "apps/loomark/public/index.html") | str replace "</body>" "    <script type=\"module\" src=\"./index.js\"></script>\n  </body>")
+  $html | save -f ($dist | path join "index.html")
+  $dist
+}
+
+export def run-browser-catalog [root: string output: string] {
+  let fixture_root = ($root | path join "apps/loomark/examples/vanilla/fixtures/r0-browser-v1")
+  let catalog_path = ($fixture_root | path join "browser-fixture-catalog-v1.json")
+  if not ($catalog_path | path exists) { fail "browser fixture catalog is missing" }
+  let integrity = (^node ($root | path join "apps/loomark/examples/vanilla/test-r0-browser-fixtures.mjs") | complete)
+  if $integrity.exit_code != 0 { fail $"browser fixture integrity failed: ($integrity.stderr)" }
+  let catalog = (open $catalog_path)
+  let canonical_catalog = (open ($root | path join "deps/event-graph-walker/internal/restore_feasibility_probe/fixtures/fixture-catalog-v1.json"))
+  let expected_ids = [
+    S-linear-1000
+    S-distributed-1000
+    S-tombstone-1000
+    S-replacement-1000
+    S-unicode-1000
+  ]
+  if $catalog.schema_version != 1 or $catalog.fixture_seed != "none" or ($catalog.fixtures | get fixture_id) != $expected_ids {
+    fail "browser fixture catalog schema mismatch"
+  }
+  let dist = (prepare-browser-standalone $root $output)
+  let oracle = ($root | path join "apps/loomark/examples/vanilla/browser-restore-oracle.mjs")
+  mut observations = []
+  for fixture in $catalog.fixtures {
+    let canonical_fixture = ($canonical_catalog.fixtures | where fixture_id == $fixture.fixture_id | first)
+    if $canonical_fixture.canonical_sha256 != $fixture.canonical_fixture_sha256 {
+      fail $"evidence_missing: browser fixture source catalog mismatch: ($fixture.fixture_id)"
+    }
+    let archive_path = ($fixture_root | path join $fixture.archive_path)
+    if not ($archive_path | path exists) { fail $"browser fixture missing: ($fixture.archive_path)" }
+    let archive_hash = (^sha256sum $archive_path | str trim | split row " " | first)
+    let archive_bytes = (^stat -c "%s" $archive_path | str trim | into int)
+    let archive = (open $archive_path)
+    let history = ($archive.history | from json)
+    if $fixture.event_count != 1000 or $archive_hash != $fixture.archive_sha256 or $archive_bytes != $fixture.archive_bytes or $archive.document_id != $"loomark-r0-fixture-($fixture.fixture_id)" or ($history.operations | length) != $fixture.event_count {
+      fail $"browser fixture catalog mismatch: ($fixture.fixture_id)"
+    }
+    let result = (^node $oracle $archive_path $fixture.fixture_id ($fixture.event_count | into string) $dist | complete)
+    if $result.exit_code != 0 { fail $"oracle_mismatch: fresh Chromium fixture failed for ($fixture.fixture_id): ($result.stderr)" }
+    let row = ($result.stdout | lines | where {|line| $line | str trim | is-not-empty } | last | from json)
+    if ($row.payload.browser_version | is-empty) {
+      fail $"browser revision missing: ($fixture.fixture_id)"
+    }
+    if $row.schema_version != 1 or $row.run_id != "gate-r0-v1" or $row.case_id != $fixture.fixture_id or $row.status != "pass" or $row.payload.record != "browser_oracle_result" or $row.payload.operation_count != 1000 or $row.payload.post_edit_operation_count != 1001 or $row.payload.archive_sha256 != $fixture.archive_sha256 or $row.payload.restored_text_sha256 != $fixture.expected_text_sha256 or $row.payload.restored_history_sha256 != $fixture.history_sha256 or $row.payload.selected_consumer != "full_history_v1" or $row.payload.candidate_consumer_starts != 0 or $row.payload.full_history_consumer_starts != 1 or $row.payload.first_edit.scalar != "U+005A" or $row.payload.first_edit.canonical_utf16_position != $fixture.expected_text_utf16_units or not $row.payload.first_edit.browser_control_position_valid or not $row.payload.first_edit.adapter_mapping_proved or not $row.payload.first_edit.result_equal or not $row.payload.edit_persisted_after_fresh_page {
+      fail $"oracle_mismatch: browser fixture result mismatch: ($fixture.fixture_id)"
+    }
+    let accounting = $row.payload.read_accounting
+    if $accounting.archive_transport_bytes != $fixture.archive_bytes or $accounting.archive_decode_read_operations != 1 or $accounting.oracle_full_history_event_reads != 1000 or $accounting.candidate_event_reads != 0 or $accounting.first_edit_local_operations != 1 {
+      fail $"oracle_mismatch: browser fixture read accounting mismatch: ($fixture.fixture_id)"
+    }
+    $observations = ($observations | append $row)
+  }
+  if not ($observations | any {|row| not $row.payload.first_edit.coordinate_positions_equal }) {
+    fail "oracle_mismatch: browser corpus did not exercise CRLF coordinate mapping"
+  }
+  let browser_revisions = ($observations | get payload.browser_version | uniq)
+  if ($browser_revisions | length) != 1 {
+    fail "oracle_mismatch: browser revision differs across fixtures"
+  }
+  rm -rf $dist
+  $observations
+}

--- a/scripts/gate-r0/test-artifacts.nu
+++ b/scripts/gate-r0/test-artifacts.nu
@@ -46,6 +46,11 @@ def main [] {
     { candidate: "C" outcome: "not_applicable" }
   ]
   try {
+    let new_output = ($temp | path join "new-output")
+    reset-artifact-output $new_output
+    expect (($new_output | path type) == "dir") "missing output root was not created"
+    expect ((ls -a $new_output | is-empty)) "new output root was not empty"
+
     mkdir $output
     "stale" | save ($output | path join "stale.txt")
     mkdir ($output | path join "stale-directory")

--- a/scripts/gate-r0/test-artifacts.nu
+++ b/scripts/gate-r0/test-artifacts.nu
@@ -1,0 +1,99 @@
+#!/usr/bin/env nu
+
+use ./artifacts.nu [
+  artifact-paths
+  assert-artifact-set
+  reset-artifact-output
+  write-failure-bundle
+]
+
+def fail [message: string] { error make { msg: $message } }
+
+def expect [condition: bool message: string] {
+  if not $condition { fail $message }
+}
+
+def expect-error [message: string action: closure] {
+  let failed = try {
+    do $action
+    false
+  } catch {
+    true
+  }
+  if not $failed { fail $message }
+}
+
+def main [] {
+  let expected = [
+    "manifest.json"
+    "result.json"
+    "capability-ledger.json"
+    "candidate-captures.jsonl"
+    "candidate-results.json"
+    "operation-matrix.jsonl"
+    "oracle-differential.jsonl"
+    "cold-history.jsonl"
+    "negative-results.json"
+    "validation.log"
+  ]
+  expect ((artifact-paths) == $expected) "canonical artifact paths differ"
+
+  let temp = (^mktemp -d | str trim)
+  let output = ($temp | path join "output")
+  let outcomes = [
+    { candidate: "A" outcome: "not_applicable" }
+    { candidate: "B" outcome: "not_applicable" }
+    { candidate: "C" outcome: "not_applicable" }
+  ]
+  try {
+    mkdir $output
+    "stale" | save ($output | path join "stale.txt")
+    mkdir ($output | path join "stale-directory")
+    "nested" | save ($output | path join "stale-directory/nested.txt")
+    mkdir ($output | path join ".candidate-suite")
+    ^ln -s "stale.txt" ($output | path join "stale-link")
+
+    reset-artifact-output $output
+    expect ((ls -a $output | is-empty)) "reset retained stale output entries"
+
+    let external = ($temp | path join "external")
+    let linked_output = ($temp | path join "linked-output")
+    mkdir $external
+    "retain" | save ($external | path join "sentinel.txt")
+    ^ln -s $external $linked_output
+    expect-error "symlink output root was accepted" {|| reset-artifact-output $linked_output }
+    expect (($external | path join "sentinel.txt" | path exists)) "symlink output root deleted external contents"
+
+    let file_output = ($temp | path join "file-output")
+    "retain" | save $file_output
+    expect-error "regular-file output root was accepted" {|| reset-artifact-output $file_output }
+    expect ((open --raw $file_output) == "retain") "regular-file output root was overwritten"
+
+    mkdir ($output | path join "result.json")
+    ^ln -s "result.json" ($output | path join "manifest.json")
+    write-failure-bundle $output "oracle_mismatch" $outcomes
+    assert-artifact-set $output
+
+    let actual = (ls -a $output | get name | each {|path| $path | path basename } | sort)
+    expect ($actual == ($expected | sort)) "failure bundle does not contain exactly ten artifacts"
+    expect (($output | path join "result.json" | path type) == "file") "result artifact is not a file"
+    expect (($output | path join "manifest.json" | path type) == "file") "manifest artifact is not a file"
+
+    let result = (open ($output | path join "result.json"))
+    expect ($result.status == "fail") "failure bundle status differs"
+    expect ($result.failure_class == "oracle_mismatch") "failure class differs"
+    expect ($result.candidate_outcomes == $outcomes) "candidate outcomes differ"
+    expect ($result.artifact_paths == $expected) "result artifact inventory differs"
+
+    rm ($output | path join "validation.log")
+    expect-error "missing artifact was accepted" {|| assert-artifact-set $output }
+    "extra" | save ($output | path join "validation.log")
+    "extra" | save ($output | path join "extra.txt")
+    expect-error "extra artifact was accepted" {|| assert-artifact-set $output }
+  } catch {|error|
+    rm -rf $temp
+    error make { msg: ($error | get -o msg | default ($error | to json -r)) }
+  }
+  rm -rf $temp
+  print "PASS Gate R0 artifact bundle contract"
+}

--- a/scripts/test-loomark-editable-branch-restore-feasibility.nu
+++ b/scripts/test-loomark-editable-branch-restore-feasibility.nu
@@ -1,5 +1,13 @@
 #!/usr/bin/env nu
 
+use ./gate-r0/artifacts.nu [
+  artifact-paths
+  assert-artifact-set
+  reset-artifact-output
+  write-failure-bundle
+]
+use ./gate-r0/browser.nu run-browser-catalog
+
 # Gate R0 canonical evidence runner.  Exit codes: 0 pass; 10 preflight; 20
 # toolchain; 21 submodule; 30 harness; 31 oracle; 32 causal; 33 cold read; 34
 # evidence; 35 interface; 40 measurement; 50 runner failure.  Candidate
@@ -145,83 +153,6 @@ def run-markdown-oracle [root: string mode: string = "undelete"] {
   [$producer $consumer_row]
 }
 
-def prepare-browser-standalone [root: string output: string] {
-  let build = (^moon -C $root build --quiet --release --target js apps/loomark/main apps/loomark/worker apps/loomark/projection_worker | complete)
-  if $build.exit_code != 0 { fail $"browser standalone build failed: ($build.stderr)" }
-  let dist = ($output | path join ".browser-dist" | path expand)
-  rm -rf $dist
-  mkdir $dist
-  ^cp ($root | path join "apps/loomark/public/styles.css") ($dist | path join "styles.css")
-  ^cp ($root | path join "apps/loomark/public/favicon.svg") ($dist | path join "favicon.svg")
-  ^cp ($root | path join "_build/js/release/build/dowdiness/loomark/main/main.js") ($dist | path join "index.js")
-  ^cp ($root | path join "_build/js/release/build/dowdiness/loomark/worker/worker.js") ($dist | path join "capability-worker.js")
-  ^cp ($root | path join "_build/js/release/build/dowdiness/loomark/projection_worker/projection_worker.js") ($dist | path join "projection-worker.js")
-  let html = (open --raw ($root | path join "apps/loomark/public/index.html") | str replace "</body>" "    <script type=\"module\" src=\"./index.js\"></script>\n  </body>")
-  $html | save -f ($dist | path join "index.html")
-  $dist
-}
-
-def run-browser-catalog [root: string output: string] {
-  let fixture_root = ($root | path join "apps/loomark/examples/vanilla/fixtures/r0-browser-v1")
-  let catalog_path = ($fixture_root | path join "browser-fixture-catalog-v1.json")
-  if not ($catalog_path | path exists) { fail "browser fixture catalog is missing" }
-  let integrity = (^node ($root | path join "apps/loomark/examples/vanilla/test-r0-browser-fixtures.mjs") | complete)
-  if $integrity.exit_code != 0 { fail $"browser fixture integrity failed: ($integrity.stderr)" }
-  let catalog = (open $catalog_path)
-  let canonical_catalog = (open ($root | path join "deps/event-graph-walker/internal/restore_feasibility_probe/fixtures/fixture-catalog-v1.json"))
-  let expected_ids = [
-    S-linear-1000
-    S-distributed-1000
-    S-tombstone-1000
-    S-replacement-1000
-    S-unicode-1000
-  ]
-  if $catalog.schema_version != 1 or $catalog.fixture_seed != "none" or ($catalog.fixtures | get fixture_id) != $expected_ids {
-    fail "browser fixture catalog schema mismatch"
-  }
-  let dist = (prepare-browser-standalone $root $output)
-  let oracle = ($root | path join "apps/loomark/examples/vanilla/browser-restore-oracle.mjs")
-  mut observations = []
-  for fixture in $catalog.fixtures {
-    let canonical_fixture = ($canonical_catalog.fixtures | where fixture_id == $fixture.fixture_id | first)
-    if $canonical_fixture.canonical_sha256 != $fixture.canonical_fixture_sha256 {
-      fail $"evidence_missing: browser fixture source catalog mismatch: ($fixture.fixture_id)"
-    }
-    let archive_path = ($fixture_root | path join $fixture.archive_path)
-    if not ($archive_path | path exists) { fail $"browser fixture missing: ($fixture.archive_path)" }
-    let archive_hash = (^sha256sum $archive_path | str trim | split row " " | first)
-    let archive_bytes = (^stat -c "%s" $archive_path | str trim | into int)
-    let archive = (open $archive_path)
-    let history = ($archive.history | from json)
-    if $fixture.event_count != 1000 or $archive_hash != $fixture.archive_sha256 or $archive_bytes != $fixture.archive_bytes or $archive.document_id != $"loomark-r0-fixture-($fixture.fixture_id)" or ($history.operations | length) != $fixture.event_count {
-      fail $"browser fixture catalog mismatch: ($fixture.fixture_id)"
-    }
-    let result = (^node $oracle $archive_path $fixture.fixture_id ($fixture.event_count | into string) $dist | complete)
-    if $result.exit_code != 0 { fail $"oracle_mismatch: fresh Chromium fixture failed for ($fixture.fixture_id): ($result.stderr)" }
-    let row = ($result.stdout | lines | where {|line| $line | str trim | is-not-empty } | last | from json)
-    if ($row.payload.browser_version | is-empty) {
-      fail $"browser revision missing: ($fixture.fixture_id)"
-    }
-    if $row.schema_version != 1 or $row.run_id != "gate-r0-v1" or $row.case_id != $fixture.fixture_id or $row.status != "pass" or $row.payload.record != "browser_oracle_result" or $row.payload.operation_count != 1000 or $row.payload.post_edit_operation_count != 1001 or $row.payload.archive_sha256 != $fixture.archive_sha256 or $row.payload.restored_text_sha256 != $fixture.expected_text_sha256 or $row.payload.restored_history_sha256 != $fixture.history_sha256 or $row.payload.selected_consumer != "full_history_v1" or $row.payload.candidate_consumer_starts != 0 or $row.payload.full_history_consumer_starts != 1 or $row.payload.first_edit.scalar != "U+005A" or $row.payload.first_edit.canonical_utf16_position != $fixture.expected_text_utf16_units or not $row.payload.first_edit.browser_control_position_valid or not $row.payload.first_edit.adapter_mapping_proved or not $row.payload.first_edit.result_equal or not $row.payload.edit_persisted_after_fresh_page {
-      fail $"oracle_mismatch: browser fixture result mismatch: ($fixture.fixture_id)"
-    }
-    let accounting = $row.payload.read_accounting
-    if $accounting.archive_transport_bytes != $fixture.archive_bytes or $accounting.archive_decode_read_operations != 1 or $accounting.oracle_full_history_event_reads != 1000 or $accounting.candidate_event_reads != 0 or $accounting.first_edit_local_operations != 1 {
-      fail $"oracle_mismatch: browser fixture read accounting mismatch: ($fixture.fixture_id)"
-    }
-    $observations = ($observations | append $row)
-  }
-  if not ($observations | any {|row| not $row.payload.first_edit.coordinate_positions_equal }) {
-    fail "oracle_mismatch: browser corpus did not exercise CRLF coordinate mapping"
-  }
-  let browser_revisions = ($observations | get payload.browser_version | uniq)
-  if ($browser_revisions | length) != 1 {
-    fail "oracle_mismatch: browser revision differs across fixtures"
-  }
-  rm -rf $dist
-  $observations
-}
-
 def operation-matrix [] {
   [
     {trace: "initial-materialization" authority: "exact_frontier" projection: "plain_text" expected: "oracle"}
@@ -258,51 +189,8 @@ def candidate-outcomes [] {
   ]
 }
 
-def artifact-paths [] {
-  [
-    "manifest.json"
-    "result.json"
-    "capability-ledger.json"
-    "candidate-captures.jsonl"
-    "candidate-results.json"
-    "operation-matrix.jsonl"
-    "oracle-differential.jsonl"
-    "cold-history.jsonl"
-    "negative-results.json"
-    "validation.log"
-  ]
-}
-
-# The output directory is runner-owned. Remove every prior entry before a run
-# or failure bundle so stale files, symlinks, and required-name directories
-# cannot survive or replace the classified result.
-def cleanup-runner-internals [output: string] {
-  for entry in (ls -a $output) {
-    rm -rf $entry.name
-  }
-}
-
-def assert-artifact-set [output: string] {
-  let expected = (artifact-paths | sort)
-  let actual = (ls -a $output | get name | each {|path| $path | path basename } | sort)
-  if $actual != $expected {
-    fail $"artifact set differs: expected=($expected | to json -r) actual=($actual | to json -r)"
-  }
-}
-
 def write-failure-artifacts [output: string failure: string] {
-  cleanup-runner-internals $output
-  write-json ($output | path join "manifest.json") { schema_version: 1 run_id: "gate-r0-v1" status: "fail" }
-  write-json ($output | path join "capability-ledger.json") { schema_version: 1 rows: [] }
-  write-jsonl ($output | path join "candidate-captures.jsonl") []
-  write-json ($output | path join "candidate-results.json") { schema_version: 1 candidates: [] }
-  write-jsonl ($output | path join "operation-matrix.jsonl") []
-  write-jsonl ($output | path join "oracle-differential.jsonl") []
-  write-jsonl ($output | path join "cold-history.jsonl") []
-  write-json ($output | path join "negative-results.json") { schema_version: 1 negatives: [] }
-  $"Gate R0 failure: ($failure)\n" | save -f ($output | path join "validation.log")
-  write-json ($output | path join "result.json") { schema_version: 1 status: "fail" failure_class: $failure candidate_outcomes: (candidate-outcomes) artifact_paths: (artifact-paths) }
-  assert-artifact-set $output
+  write-failure-bundle $output $failure (candidate-outcomes)
 }
 
 def candidate-cases [suite: string] {
@@ -453,8 +341,7 @@ def main [
   let root = ([$env.FILE_PWD, ".."] | path join | path expand)
   if $ide_check { print "Gate R0 runner syntax valid"; return }
   if $self_test { runner-self-test $root; return }
-  mkdir $output_dir
-  cleanup-runner-internals $output_dir
+  reset-artifact-output $output_dir
   if not ($suite in ["all" "self-test" "oracle" "ordinary" "concurrency" "legacy"]) {
     write-failure-artifacts $output_dir "preflight_invalid"
     exit 10


### PR DESCRIPTION
## Summary

- move canonical ten-artifact ownership and classified failure-bundle writing behind the test-only `scripts/gate-r0/artifacts.nu` module
- move release-static browser correctness orchestration behind the test-only `scripts/gate-r0/browser.nu` module so the canonical runner remains the thin sequencing shell before browser measurement is added
- add a fast artifact contract test, route `scripts/gate-r0/**` changes through the Gate R0 CI job, and reject symlink/non-directory output roots before destructive cleanup

Refs #1289. This is an internal maintainability slice before browser measurement under #1289; `browser_measurement` remains `not_run` and `implementation_complete` remains `false`.

## Behavior boundary

- runner CLI and exit-code map are unchanged
- success and classified failure outputs remain exactly the canonical ten artifacts
- all ten injected failure classes produced byte-identical bundles and identical exits before/after extraction for ordinary output directories
- the five fixed browser fixtures, Chromium observation schema, read accounting, CRLF adapter proof, production archive path, and candidate/full-history separation are unchanged
- no production MoonBit package, public API, archive/wire format, provider operation, or storage implementation changed

The artifact module now additionally fails closed when the output root itself is a symlink or non-directory, preventing cleanup from following a caller-supplied symlink and deleting external contents.

The first CI run exposed a Nushell `0.114.1` inference difference for a nonexistent output root. A focused regression now covers that exact fresh-directory path under the CI-pinned binary; the runner creates it before writing while preserving the symlink/non-directory rejection.

## Validation

- `nu scripts/gate-r0/test-artifacts.nu`: PASS
- `nu --ide-check 100` for the runner and both new modules: PASS
- ten injected failure classes: identical exit code and byte-for-byte bundle versus merged `main`
- `--suite self-test --allow-dirty`: PASS, exact ten artifacts
- `--suite oracle --allow-dirty`: PASS, five Chromium `149.0.7827.55` rows
- clean exact-HEAD `--suite all` under CI-pinned Nushell `0.114.1`: PASS in 3:07.85, exact ten artifacts, five browser rows
- `actionlint -ignore 'SC2046' .github/workflows/ci.yml`: PASS (`SC2046` is the unchanged workflow baseline)
- documentation lifecycle and `git diff --check`: PASS
- CI-version regression: fresh nonexistent output roots pass under Nushell `0.114.1`; symlink/non-directory roots remain rejected
- independent exact-HEAD review: PASS
- pre-commit and pre-push hooks: PASS

## PR-ready evidence

Validated HEAD: `7a1453a823e0d325ddeb22a73490e87fd8a18659`

Validated base: `origin/main@3e7edd1d47de75a5af86dc3620236ce133b5cfb2`

```bash
./scripts/validate-pr-ready.sh \
  --no-target "Gate R0 Nushell/CI test-harness refactor; no MoonBit package changed"
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] Full validator passed on the exact clean HEAD/base above
- [x] Base was fetched again and evidence verified immediately before opening this PR
- [x] No `.mbti` or submodule pointer changed
- [x] Independent review finding for output-root symlink traversal was fixed and regression-tested

## Reuse check

No MoonBit function, helper, type, package, or interface was added. The refactor reuses the existing runner behavior, Nushell path/JSON/JSONL primitives, existing browser fixture validator, and existing browser oracle without adding a production DTO or seam.

## UI review

N/A — test-harness and CI organization only; no visual or interaction change.


