### PR TITLE
test(gate-r0): measure browser restore lifecycle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1092,6 +1092,10 @@ jobs:
         working-directory: apps/loomark/examples/vanilla
         run: npm ci
 
+      - name: Run Gate R0 browser measurement contract tests
+        working-directory: apps/loomark/examples/vanilla
+        run: npm run measurement:r0:test
+
       - name: Run Gate R0 artifact contract tests
         run: nu scripts/gate-r0/test-artifacts.nu
 

--- a/apps/loomark/examples/vanilla/README.md
+++ b/apps/loomark/examples/vanilla/README.md
@@ -49,9 +49,26 @@ npm run fixtures:r0:test      # catalog, digest, archive, and fail-closed contro
 npm run fixtures:r0:verify    # regenerate in a temporary directory and byte-compare
 ```
 
-The canonical Gate R0 runner owns the fresh-Chromium correctness run. This
-corpus does not provide browser performance evidence; browser measurement
-remains a separate obligation.
+The canonical Gate R0 runner owns both the fresh-Chromium correctness run and
+the fixed browser measurement lane. It builds release JavaScript, assembles the
+production Warren static output, pins Chromium `149.0.7827.55`, warms each
+fixture once, then performs 20 measured reloads. Every measured reload restores
+the fixed full-history archive, appends U+005A as a real browser edit, and waits
+for the resulting complete archive replacement.
+
+Raw samples and nearest-rank summaries are retained for the IndexedDB storage
+read, the black-box interval from storage completion to expected text, total
+restore-to-text observation, first edit to persisted archive, its IndexedDB
+write transaction, and restore plus first edit. The valid fixture corpus has no
+recovery run, so fallback/error timing is explicitly not applicable. Candidate
+A/C browser timing is likewise `not_applicable: product_restore_seam_absent`;
+the lane must not present plain-text import as candidate restore evidence.
+
+Run the fast schema/invariant checks independently with:
+
+```bash
+npm run measurement:r0:test
+```
 
 ## Startup benchmark
 

--- a/apps/loomark/examples/vanilla/browser-restore-oracle.mjs
+++ b/apps/loomark/examples/vanilla/browser-restore-oracle.mjs
@@ -4,6 +4,11 @@ import { dirname } from "node:path"
 import { fileURLToPath } from "node:url"
 import { chromium } from "playwright"
 
+import {
+  buildBrowserMeasurement,
+  buildBrowserTimingNotApplicable,
+} from "./r0-browser-measurement.mjs"
+
 const [archivePath, caseId, expectedCountRaw, distRoot] = process.argv.slice(2)
 if (archivePath == null || caseId == null || expectedCountRaw == null) {
   throw new Error("usage: browser-restore-oracle.mjs ARCHIVE CASE EXPECTED_COUNT [DIST_ROOT]")
@@ -19,6 +24,7 @@ let origin = ""
 const archiveDatabase = "loomark.local-repository"
 const archiveStore = "archives"
 const archiveKey = "loomark.active-document-archive"
+const measuredReloads = 20
 const serverPath = fileURLToPath(new URL("./serve-standalone-dist.mjs", import.meta.url))
 const server = spawn(process.execPath, [serverPath], {
   env: {
@@ -130,6 +136,7 @@ async function seedFromBrowserAsset(page) {
     })
     return {
       fixture,
+      encoded,
       archiveTransportBytes: archiveDigest.bytes,
       catalogTransportBytes: new TextEncoder().encode(catalogText).length,
       archiveSha256: archiveDigest.sha256,
@@ -137,6 +144,29 @@ async function seedFromBrowserAsset(page) {
       historySha256: historyDigest.sha256,
     }
   }, { caseId, archiveDatabase, archiveStore, archiveKey })
+}
+
+async function seedEncodedArchive(page, encoded) {
+  await page.evaluate(async ({ databaseName, storeName, key, value }) => await new Promise((resolve, reject) => {
+    const request = indexedDB.open(databaseName, 1)
+    request.onerror = () => reject(request.error ?? new Error("archive database open failed"))
+    request.onsuccess = () => {
+      const database = request.result
+      const transaction = database.transaction(storeName, "readwrite")
+      transaction.objectStore(storeName).put(value, key)
+      transaction.oncomplete = () => {
+        database.close()
+        resolve()
+      }
+      transaction.onerror = () => reject(transaction.error ?? new Error("archive seed failed"))
+      transaction.onabort = () => reject(transaction.error ?? new Error("archive seed aborted"))
+    }
+  }), {
+    databaseName: archiveDatabase,
+    storeName: archiveStore,
+    key: archiveKey,
+    value: encoded,
+  })
 }
 
 async function readArchive(page) {
@@ -156,6 +186,18 @@ async function readArchive(page) {
   }), { databaseName: archiveDatabase, storeName: archiveStore, key: archiveKey })
 }
 
+async function waitForExpectedText(page, expected, timeout = 30000) {
+  await page.waitForFunction(value => (
+    document.querySelector("#loomark-input")?.value === value
+  ), expected, { timeout })
+  return page.evaluate(value => {
+    if (document.querySelector("#loomark-input")?.value !== value) {
+      throw new Error("expected text changed before observation")
+    }
+    return performance.now()
+  }, expected)
+}
+
 async function waitForArchive(page, matches, timeout = 30000) {
   const deadline = Date.now() + timeout
   while (Date.now() < deadline) {
@@ -164,7 +206,7 @@ async function waitForArchive(page, matches, timeout = 30000) {
       const parsed = JSON.parse(encoded)
       if (matches(parsed, encoded)) return encoded
     }
-    await page.waitForTimeout(100)
+    await page.waitForTimeout(10)
   }
   throw new Error("timed out waiting for IndexedDB archive")
 }
@@ -178,23 +220,63 @@ try {
   const browserVersion = browser.version()
   context = await browser.newContext()
   await context.addInitScript(({ storeName, key }) => {
+    const originalTransaction = IDBDatabase.prototype.transaction
     const originalGet = IDBObjectStore.prototype.get
     const originalOpenCursor = IDBObjectStore.prototype.openCursor
-    globalThis.__loomarkR0ReadAccounting = {
+    const originalPut = IDBObjectStore.prototype.put
+    const transactionRecords = new WeakMap()
+    const measurement = {
       applicationArchiveReads: 0,
       observationArchiveReads: 0,
+      transactions: [],
+    }
+    globalThis.__loomarkR0Measurement = measurement
+
+    IDBDatabase.prototype.transaction = function(storeNames, mode, options) {
+      const transaction = Reflect.apply(originalTransaction, this, [storeNames, mode, options])
+      const names = typeof storeNames === "string" ? [storeNames] : Array.from(storeNames)
+      if (names.includes(storeName)) {
+        const record = {
+          kind: "unclassified",
+          mode,
+          start_ms: performance.now(),
+          end_ms: null,
+          terminal: null,
+        }
+        transactionRecords.set(transaction, record)
+        measurement.transactions.push(record)
+        const finish = terminal => {
+          if (record.end_ms !== null) return
+          record.end_ms = performance.now()
+          record.terminal = terminal
+        }
+        transaction.addEventListener("complete", () => finish("complete"), { once: true })
+        transaction.addEventListener("abort", () => finish("abort"), { once: true })
+        transaction.addEventListener("error", () => finish("error"), { once: true })
+      }
+      return transaction
+    }
+    const classify = (store, kind) => {
+      const record = transactionRecords.get(store.transaction)
+      if (record !== undefined && record.kind === "unclassified") record.kind = kind
     }
     IDBObjectStore.prototype.get = function(nextKey) {
       if (this.name === storeName && nextKey === key) {
-        globalThis.__loomarkR0ReadAccounting.observationArchiveReads += 1
+        measurement.observationArchiveReads += 1
+        classify(this, "observation_read")
       }
       return originalGet.call(this, nextKey)
     }
     IDBObjectStore.prototype.openCursor = function(query, direction) {
       if (this.name === storeName && query === key) {
-        globalThis.__loomarkR0ReadAccounting.applicationArchiveReads += 1
+        measurement.applicationArchiveReads += 1
+        classify(this, "application_read")
       }
       return originalOpenCursor.call(this, query, direction)
+    }
+    IDBObjectStore.prototype.put = function(value, nextKey) {
+      if (this.name === storeName && nextKey === key) classify(this, "application_write")
+      return originalPut.call(this, value, nextKey)
     }
   }, { storeName: archiveStore, key: archiveKey })
   page = await context.newPage()
@@ -203,16 +285,14 @@ try {
     throw new Error("catalog event count differs from runner input")
   }
 
-  await page.goto(`${origin}/`, { waitUntil: "commit" })
   const input = page.locator("#loomark-input")
-  await input.waitFor({ state: "visible", timeout: 30000 })
   const expectedBrowserText = browserText(seeded.fixture.expected_text)
-  await page.waitForFunction(expected => (
-    document.querySelector("#loomark-input")?.value === expected
-  ), expectedBrowserText, { timeout: 30000 })
+  await page.goto(`${origin}/`, { waitUntil: "commit" })
+  await input.waitFor({ state: "visible", timeout: 30000 })
+  await waitForExpectedText(page, expectedBrowserText)
 
   const beforeEditArchive = await readArchive(page)
-  if (beforeEditArchive === null) throw new Error("archive disappeared before first edit")
+  if (beforeEditArchive === null) throw new Error("archive disappeared during warm-up")
   const beforeEdit = await page.evaluate(async ({ encoded, candidateMarkers }) => {
     const archive = JSON.parse(encoded)
     const history = JSON.parse(archive.history)
@@ -236,8 +316,8 @@ try {
       portableText: archive.portable_markdown,
       historySha256,
       historyEvents: history.operations.length,
-      applicationArchiveReads: globalThis.__loomarkR0ReadAccounting.applicationArchiveReads,
-      observationArchiveReads: globalThis.__loomarkR0ReadAccounting.observationArchiveReads,
+      applicationArchiveReads: globalThis.__loomarkR0Measurement.applicationArchiveReads,
+      observationArchiveReads: globalThis.__loomarkR0Measurement.observationArchiveReads,
       candidateBundleMarkerDetected,
       candidateConsumerStarts: candidateBundleMarkerDetected ? 1 : 0,
       candidateEventReads: candidateBundleMarkerDetected ? 1 : 0,
@@ -253,10 +333,9 @@ try {
   ) {
     throw new Error("browser portable text/history mismatch")
   }
-  const applicationArchiveReads = beforeEdit.applicationArchiveReads
-  if (applicationArchiveReads !== 1 || beforeEdit.observationArchiveReads !== 1) {
+  if (beforeEdit.applicationArchiveReads !== 1 || beforeEdit.observationArchiveReads !== 1) {
     throw new Error(`unexpected archive storage read count: ${JSON.stringify({
-      application: applicationArchiveReads,
+      application: beforeEdit.applicationArchiveReads,
       observation: beforeEdit.observationArchiveReads,
     })}`)
   }
@@ -264,26 +343,77 @@ try {
     throw new Error("candidate_consumer_selected")
   }
 
-  await input.focus()
-  await input.evaluate(element => {
-    const length = element.value.length
-    element.setSelectionRange(length, length, "forward")
-  })
-  await page.keyboard.type("Z")
-  const afterEditArchive = await waitForArchive(
-    page,
-    archive => archive.portable_markdown === seeded.fixture.expected_text_after_edit,
-  )
-  const parsedAfterEditArchive = JSON.parse(afterEditArchive)
-  const afterEdit = {
-    portableText: parsedAfterEditArchive.portable_markdown,
-    historyEvents: JSON.parse(parsedAfterEditArchive.history).operations.length,
+  let afterEdit
+  const measurementSamples = []
+  for (let sample = 0; sample < measuredReloads; sample += 1) {
+    await seedEncodedArchive(page, seeded.encoded)
+    await page.reload({ waitUntil: "commit" })
+    await input.waitFor({ state: "visible", timeout: 30000 })
+    const textObservedMs = await waitForExpectedText(page, expectedBrowserText)
+    await input.focus()
+    await input.evaluate(element => {
+      const length = element.value.length
+      element.setSelectionRange(length, length, "forward")
+    })
+    const editStartedMs = await page.evaluate(() => performance.now())
+    await page.keyboard.type("Z")
+    const afterEditArchive = await waitForArchive(
+      page,
+      archive => archive.portable_markdown === seeded.fixture.expected_text_after_edit,
+    )
+    const editObservedMs = await page.evaluate(() => performance.now())
+    const parsedAfterEditArchive = JSON.parse(afterEditArchive)
+    afterEdit = {
+      portableText: parsedAfterEditArchive.portable_markdown,
+      historyEvents: JSON.parse(parsedAfterEditArchive.history).operations.length,
+    }
+    if (
+      afterEdit.portableText !== seeded.fixture.expected_text_after_edit ||
+      afterEdit.historyEvents !== expectedCount + 1
+    ) {
+      throw new Error("exact first edit differs")
+    }
+    const timing = await page.evaluate(({ textObservedMs, editStartedMs, editObservedMs }) => {
+      const completed = globalThis.__loomarkR0Measurement.transactions.filter(
+        transaction => transaction.terminal === "complete" && transaction.end_ms !== null,
+      )
+      const reads = completed.filter(transaction => transaction.kind === "application_read")
+      const writes = completed.filter(
+        transaction => transaction.kind === "application_write" && transaction.start_ms >= editStartedMs,
+      )
+      if (reads.length !== 1) {
+        throw new Error(`measurement_failure: expected one completed application read, found ${reads.length}`)
+      }
+      if (writes.length !== 1) {
+        throw new Error(`measurement_failure: expected one completed first-edit write, found ${writes.length}`)
+      }
+      const read = reads[0]
+      const write = writes[0]
+      const values = {
+        storage_read_ms: read.end_ms - read.start_ms,
+        archive_open_ms: textObservedMs - read.end_ms,
+        restore_to_text_observed_ms: textObservedMs,
+        first_edit_ms: editObservedMs - editStartedMs,
+        first_edit_storage_write_ms: write.end_ms - write.start_ms,
+        restore_plus_first_edit_ms: editObservedMs,
+      }
+      return Object.fromEntries(Object.entries(values).map(([name, value]) => [
+        name,
+        Number(value.toFixed(3)),
+      ]))
+    }, { textObservedMs, editStartedMs, editObservedMs })
+    measurementSamples.push({ sample, ...timing })
   }
-  const firstEditResultEqual = (
-    afterEdit.portableText === seeded.fixture.expected_text_after_edit &&
-    afterEdit.historyEvents === expectedCount + 1
-  )
-  if (!firstEditResultEqual) throw new Error("exact first edit differs")
+  if (afterEdit === undefined) {
+    throw new Error("measurement_failure: browser measurement emitted no observations")
+  }
+  const browserMeasurement = buildBrowserMeasurement({
+    fixtureId: caseId,
+    browserVersion,
+    samples: measurementSamples,
+  })
+  const firstEditResultEqual = true
+  const applicationArchiveReads = beforeEdit.applicationArchiveReads
   const firstEditLocalOperations = afterEdit.historyEvents - beforeEdit.historyEvents
   const browserControlPositionValid = (
     beforeEdit.browserUtf16End === expectedBrowserText.length
@@ -294,10 +424,8 @@ try {
   const adapterMappingProved = firstEditResultEqual && browserControlPositionValid
 
   await page.reload({ waitUntil: "commit" })
-  await page.locator("#loomark-input").waitFor({ state: "visible", timeout: 30000 })
-  await page.waitForFunction(expected => (
-    document.querySelector("#loomark-input")?.value === expected
-  ), browserText(seeded.fixture.expected_text_after_edit), { timeout: 30000 })
+  await input.waitFor({ state: "visible", timeout: 30000 })
+  await waitForExpectedText(page, browserText(seeded.fixture.expected_text_after_edit))
 
   process.stdout.write(`${JSON.stringify({
     schema_version: 1,
@@ -333,6 +461,10 @@ try {
         adapter_mapping_proved: adapterMappingProved,
         result_equal: firstEditResultEqual,
       },
+      browser_measurement: browserMeasurement,
+      candidate_browser_timing: ["A", "C"].map(candidate => (
+        buildBrowserTimingNotApplicable(caseId, candidate)
+      )),
       read_accounting: {
         archive_transport_bytes: seeded.archiveTransportBytes,
         catalog_transport_bytes: seeded.catalogTransportBytes,

--- a/apps/loomark/examples/vanilla/package.json
+++ b/apps/loomark/examples/vanilla/package.json
@@ -10,6 +10,7 @@
     "fixtures:r0:generate": "node ./generate-r0-browser-fixtures.mjs",
     "fixtures:r0:test": "node ./test-r0-browser-fixtures.mjs",
     "fixtures:r0:verify": "node ./verify-r0-browser-fixtures.mjs",
+    "measurement:r0:test": "node --test ./test-r0-browser-measurement.mjs",
     "bench:startup": "node ./bench-startup.mjs",
     "bench:projection": "node ./bench-projection-placement.mjs"
   },

--- a/apps/loomark/examples/vanilla/r0-browser-measurement.mjs
+++ b/apps/loomark/examples/vanilla/r0-browser-measurement.mjs
@@ -1,0 +1,107 @@
+export const BROWSER_MEASUREMENT_INTERVALS = [
+  "storage_read_ms",
+  "archive_open_ms",
+  "restore_to_text_observed_ms",
+  "first_edit_ms",
+  "first_edit_storage_write_ms",
+  "restore_plus_first_edit_ms",
+]
+
+function measurementFailure(message) {
+  throw new Error(`measurement_failure: ${message}`)
+}
+
+function requireMilliseconds(value, label) {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    measurementFailure(`${label} must be a finite non-negative number`)
+  }
+  return value
+}
+
+export function nearestRankSummary(values) {
+  if (!Array.isArray(values) || values.length === 0) {
+    measurementFailure("nearest-rank summary requires samples")
+  }
+  const raw = values.map((value, index) => requireMilliseconds(value, `sample ${index}`))
+  const sorted = [...raw].sort((left, right) => left - right)
+  const selected = percentage => {
+    const rank = Math.ceil((percentage / 100) * sorted.length)
+    return { rank, value_ms: sorted[rank - 1] }
+  }
+  return {
+    n: raw.length,
+    raw_values_ms: raw,
+    p50: selected(50),
+    p95: selected(95),
+    max_ms: sorted.at(-1),
+  }
+}
+
+export function buildBrowserMeasurement({ fixtureId, browserVersion, samples }) {
+  if (typeof fixtureId !== "string" || fixtureId.length === 0) {
+    measurementFailure("fixture id is missing")
+  }
+  if (typeof browserVersion !== "string" || browserVersion.length === 0) {
+    measurementFailure("browser revision is missing")
+  }
+  if (!Array.isArray(samples) || samples.length !== 20) {
+    measurementFailure("expected exactly 20 measured reloads")
+  }
+  for (const [index, sample] of samples.entries()) {
+    if (sample?.sample !== index) {
+      measurementFailure(`sample order mismatch at ${index}`)
+    }
+    for (const interval of BROWSER_MEASUREMENT_INTERVALS) {
+      if (!Object.hasOwn(sample, interval)) {
+        measurementFailure(`missing ${interval} for sample ${index}`)
+      }
+      requireMilliseconds(sample[interval], `${interval} for sample ${index}`)
+    }
+    if (sample.storage_read_ms + sample.archive_open_ms > sample.restore_to_text_observed_ms) {
+      measurementFailure(`restore interval ordering is invalid for sample ${index}`)
+    }
+    if (sample.first_edit_storage_write_ms > sample.first_edit_ms) {
+      measurementFailure(`first-edit interval ordering is invalid for sample ${index}`)
+    }
+    if (
+      sample.restore_to_text_observed_ms + sample.first_edit_ms >
+      sample.restore_plus_first_edit_ms
+    ) {
+      measurementFailure(`restore-plus-first-edit interval ordering is invalid for sample ${index}`)
+    }
+  }
+  return {
+    fixture_id: fixtureId,
+    browser_version: browserVersion,
+    consumer: "full_history_v1",
+    output: "release_warren_static",
+    warmup_navigations: 1,
+    measured_reloads: samples.length,
+    samples,
+    intervals: Object.fromEntries(BROWSER_MEASUREMENT_INTERVALS.map(interval => [
+      interval,
+      nearestRankSummary(samples.map(sample => sample[interval])),
+    ])),
+    fallback_error: {
+      applicability: "not_applicable",
+      reason: "valid_fixture_no_recovery",
+    },
+  }
+}
+
+export function buildBrowserTimingNotApplicable(fixtureId, candidate) {
+  return {
+    schema_version: 1,
+    run_id: "gate-r0-v1",
+    case_id: fixtureId,
+    producer: "runner",
+    status: "pass",
+    payload: {
+      record: "candidate_result",
+      candidate,
+      path: "browser_product_restore",
+      outcome: "not_applicable",
+      reason: "product_restore_seam_absent",
+    },
+  }
+}

--- a/apps/loomark/examples/vanilla/test-r0-browser-measurement.mjs
+++ b/apps/loomark/examples/vanilla/test-r0-browser-measurement.mjs
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  BROWSER_MEASUREMENT_INTERVALS,
+  buildBrowserMeasurement,
+  buildBrowserTimingNotApplicable,
+  nearestRankSummary,
+} from "./r0-browser-measurement.mjs"
+
+test("nearest-rank summary retains raw values and selects ranks 10 and 19 for n=20", () => {
+  const raw = [
+    20, 1, 19, 2, 18, 3, 17, 4, 16, 5,
+    15, 6, 14, 7, 13, 8, 12, 9, 11, 10,
+  ]
+  assert.deepEqual(nearestRankSummary(raw), {
+    n: 20,
+    raw_values_ms: raw,
+    p50: { rank: 10, value_ms: 10 },
+    p95: { rank: 19, value_ms: 19 },
+    max_ms: 20,
+  })
+})
+
+test("browser measurement requires every applicable interval on all 20 reloads", () => {
+  const complete = {
+    storage_read_ms: 1,
+    archive_open_ms: 2,
+    restore_to_text_observed_ms: 10,
+    first_edit_ms: 5,
+    first_edit_storage_write_ms: 2,
+    restore_plus_first_edit_ms: 20,
+  }
+  const samples = Array.from({ length: 20 }, (_, sample) => ({ sample, ...complete }))
+  const result = buildBrowserMeasurement({
+    fixtureId: "S-linear-1000",
+    browserVersion: "149.0.7827.55",
+    samples,
+  })
+  assert.equal(result.warmup_navigations, 1)
+  assert.equal(result.measured_reloads, 20)
+  assert.deepEqual(Object.keys(result.intervals), BROWSER_MEASUREMENT_INTERVALS)
+  assert.equal(result.intervals.storage_read_ms.n, 20)
+  assert.equal(result.intervals.storage_read_ms.p95.rank, 19)
+  assert.deepEqual(result.fallback_error, {
+    applicability: "not_applicable",
+    reason: "valid_fixture_no_recovery",
+  })
+
+  assert.throws(
+    () => buildBrowserMeasurement({
+      fixtureId: "S-linear-1000",
+      browserVersion: "149.0.7827.55",
+      samples: samples.map((row, index) => index === 7
+        ? Object.fromEntries(Object.entries(row).filter(([key]) => key !== "first_edit_ms"))
+        : row),
+    }),
+    /measurement_failure: missing first_edit_ms for sample 7/,
+  )
+  assert.throws(
+    () => buildBrowserMeasurement({
+      fixtureId: "S-linear-1000",
+      browserVersion: "149.0.7827.55",
+      samples: samples.map((row, index) => index === 3
+        ? { ...row, restore_plus_first_edit_ms: 12 }
+        : row),
+    }),
+    /measurement_failure: restore-plus-first-edit interval ordering is invalid for sample 3/,
+  )
+})
+
+test("candidate browser timing is explicitly unavailable without the product seam", () => {
+  assert.deepEqual(buildBrowserTimingNotApplicable("S-linear-1000", "A"), {
+    schema_version: 1,
+    run_id: "gate-r0-v1",
+    case_id: "S-linear-1000",
+    producer: "runner",
+    status: "pass",
+    payload: {
+      record: "candidate_result",
+      candidate: "A",
+      path: "browser_product_restore",
+      outcome: "not_applicable",
+      reason: "product_restore_seam_absent",
+    },
+  })
+})

--- a/docs/evidence/2026-08-22-r0-browser-v1-measurement.md
+++ b/docs/evidence/2026-08-22-r0-browser-v1-measurement.md
@@ -1,0 +1,143 @@
+<!-- textlint-disable slopless/coleman-liau slopless/flesch-kincaid slopless/gunning-fog slopless/paragraph-length slopless/colon-dramatic -->
+
+# Gate R0 browser oracle v1 measurement
+
+> Evidence record. This report characterizes the fixed full-history browser
+> oracle/control lane. It does not establish candidate browser performance,
+> choose a production restore design, or set a performance budget.
+
+## Scope and revisions
+
+The measured code is commit
+`d17da6b4671901171afe56cfb5384c38462bf9e4`, based on
+`main@588ab1beedac892c0bc647fc972e5d11bb0a5f54` after the per-document
+local durability queue in #1337. The checked-out EGW revision is
+`9d71c86699322ca1d365e46f33b3ca71fd209859`.
+
+The browser is pinned to Chromium `149.0.7827.55`. The immutable browser
+fixture catalog SHA-256 is
+`c664b138653cf976482be772458eeff07e8c85d48c7fe57ee841d50ce286dee8`.
+The lane changes no production public API, archive, wire format, or storage
+operation.
+
+## Build and procedure
+
+The canonical runner executes the required release sequence:
+
+```bash
+NEW_MOON_MOD=0 moon build --target js --release
+./scripts/install-local-warren.sh
+(cd apps/loomark && ../../_build/tools/bin/warren build)
+```
+
+The two release Worker entries are staged beside Warren's generated static
+site. For each of the five fixed complete-v1 archives, one navigation warms the
+browser/build cache. Each of 20 measured samples then:
+
+1. restores the original checked and browser-verified archive bytes to the
+   production IndexedDB slot;
+2. reloads the release Warren page and waits for the exact browser-normalized
+   expected text;
+3. appends U+005A at the restored textarea's UTF-16 end;
+4. waits until the production persistence path commits a complete archive with
+   the expected post-edit text and exactly 1,001 operations.
+
+The browser context is fresh per fixture. The archive is reset before every
+measured reload, so an earlier edit cannot grow a later sample's history.
+Raw values are retained in `candidate-results.json`; nearest-rank p50 selects
+rank 10 and p95 rank 19 for `n = 20`.
+
+## Clock boundaries
+
+| Clock | Browser-owned boundary |
+|---|---|
+| `storage_read_ms` | production archive-store readonly transaction creation through transaction completion |
+| `archive_open_ms` | storage-read completion through exact expected-text observation |
+| `restore_to_text_observed_ms` | navigation performance time origin through exact expected-text observation |
+| `first_edit_ms` | immediately before the real keyboard edit through observation of its committed complete archive |
+| `first_edit_storage_write_ms` | first-edit archive readwrite transaction creation through transaction completion |
+| `restore_plus_first_edit_ms` | navigation performance time origin through observation of the committed first edit |
+
+`archive_open_ms` is deliberately a black-box remainder. It includes archive
+decode, full-history admission/materialization, model adoption, and presentation
+to the observed textarea; it does not claim a new public
+`MarkdownEditor::open` lifecycle milestone. Observation-only IndexedDB reads
+are separately classified and excluded from the application read interval.
+
+All five source fixtures are valid archives, so no recovery screen is expected
+and fallback/error timing is recorded as
+`not_applicable: valid_fixture_no_recovery`. A missing applicable clock,
+invalid interval ordering, incomplete read/write transaction, timeout, or
+sample-count mismatch is `measurement_failure` and exits 40.
+
+## Full-history oracle result
+
+Times are milliseconds.
+
+| fixture | storage p50 / p95 | archive-open p50 / p95 | restore-text p50 / p95 | first-edit p50 / p95 | edit-write p50 / p95 | restore+edit p50 / p95 |
+|---|---:|---:|---:|---:|---:|---:|
+| `S-linear-1000` | 2.7 / 6.0 | 151.5 / 242.5 | 229.7 / 320.3 | 143.6 / 176.2 | 5.5 / 22.3 | 395.8 / 495.9 |
+| `S-distributed-1000` | 2.6 / 5.7 | 160.8 / 272.4 | 238.8 / 365.6 | 157.8 / 174.3 | 5.8 / 7.9 | 416.6 / 565.6 |
+| `S-tombstone-1000` | 2.1 / 5.1 | 128.2 / 239.6 | 204.6 / 325.8 | 146.2 / 162.3 | 5.8 / 14.9 | 363.3 / 478.1 |
+| `S-replacement-1000` | 2.3 / 5.7 | 203.2 / 220.6 | 284.2 / 299.9 | 135.0 / 159.5 | 5.7 / 21.7 | 431.4 / 469.3 |
+| `S-unicode-1000` | 2.6 / 4.9 | 152.4 / 243.9 | 226.9 / 326.8 | 144.2 / 152.8 | 5.5 / 7.4 | 408.4 / 487.6 |
+
+IndexedDB transaction time is small relative to the black-box archive-open
+remainder. This measurement therefore remains consistent with the earlier
+finding that full-history decode/admission/materialization, rather than the
+storage read itself, dominates restored readiness. The table is a control
+baseline. It cannot decompose every operation inside `archive_open_ms`.
+
+## Candidate and gate outcome
+
+`candidate-results.json` contains five full-history oracle measurement rows and
+five rows each for Candidate A and Candidate C. A/C rows contain no fabricated
+samples and are explicitly:
+
+```text
+outcome: not_applicable
+reason: product_restore_seam_absent
+```
+
+The run passed with exactly the canonical ten artifacts,
+`implementation_complete: true`, and `blocked_obligations: []`. This completes
+the browser-measurement obligation owned by #1289; it does not make Candidate
+A or C promotable and does not authorize a production restore seam.
+
+Selected local artifact hashes:
+
+| artifact | SHA-256 |
+|---|---|
+| `manifest.json` | `4b6be0dc346445bda7ced3244a61d11c599938b03f55de57949625b0cf2e0e17` |
+| `result.json` | `3d3ce380f6a834f40fff43c570f530f02bf1ee86f798e4b198cac68206a98721` |
+| `candidate-results.json` | `77bcbb02a9228a90b7a797e8092e56e5f82f3ee1a40cef1688b88b6dff3f7859` |
+| `operation-matrix.jsonl` | `5e60d460875b595546aaa066aa3ce55fd875123860de3669cad5401a2e6f48ab` |
+| `validation.log` | `b072b2cb5227c26b81a1812bd53d4d7c963b3c9f2537db22f1c95e22384348e1` |
+
+The targeted clean run completed in 2:19.53 with whole-runner maximum RSS
+976,196 KiB. That process-tree value is supplementary harness evidence and is
+not a candidate consumer `peak_rss_bytes` sample.
+
+## Validation and reuse
+
+- five fixtures × one warm-up + 20 measured restore/edit samples: pass;
+- exact-ten artifact inventory: pass;
+- browser measurement schema and interval-order unit tests: pass;
+- standalone and development-host TypeScript checks: pass;
+- canonical artifact contract tests: pass;
+- Nushell IDE parse check: pass;
+- independent post-#1337 review: pass.
+
+The browser shell reuses the existing production IndexedDB database/store/key,
+Warren build, `performance.now()`, IndexedDB transaction completion, and exact
+archive/text/history verification. No MoonBit definition or generated
+interface changed. Remaining imperative code is limited to browser navigation,
+storage instrumentation, keyboard input, and persistence observation; summary
+validation and nearest-rank selection are deterministic functions with focused
+unit tests.
+
+The repository pre-commit MoonBit check still fails on the existing 22 vendored
+deprecation warnings promoted to errors in `deps/alga`, `deps/loom`, and
+`deps/svg-dsl`; no changed file contributes a MoonBit warning.
+
+<!-- textlint-enable slopless/coleman-liau slopless/flesch-kincaid slopless/gunning-fog slopless/paragraph-length slopless/colon-dramatic -->

--- a/scripts/gate-r0/browser.nu
+++ b/scripts/gate-r0/browser.nu
@@ -6,19 +6,50 @@
 def fail [message: string] { error make { msg: $message } }
 
 def prepare-browser-standalone [root: string output: string] {
-  let build = (^moon -C $root build --quiet --release --target js apps/loomark/main apps/loomark/worker apps/loomark/projection_worker | complete)
-  if $build.exit_code != 0 { fail $"browser standalone build failed: ($build.stderr)" }
-  let dist = ($output | path join ".browser-dist" | path expand)
-  rm -rf $dist
-  mkdir $dist
-  ^cp ($root | path join "apps/loomark/public/styles.css") ($dist | path join "styles.css")
-  ^cp ($root | path join "apps/loomark/public/favicon.svg") ($dist | path join "favicon.svg")
-  ^cp ($root | path join "_build/js/release/build/dowdiness/loomark/main/main.js") ($dist | path join "index.js")
+  let _runner_output = $output
+  let build = (with-env { NEW_MOON_MOD: "0" } {
+    ^moon -C $root build --target js --release | complete
+  })
+  if $build.exit_code != 0 { fail $"browser release JS build failed: ($build.stderr)" }
+  let install = (^bash ($root | path join "scripts/install-local-warren.sh") | complete)
+  if $install.exit_code != 0 { fail $"pinned Warren install failed: ($install.stderr)" }
+  let warren = ($root | path join "_build/tools/bin/warren")
+  let loomark = ($root | path join "apps/loomark")
+  let assembled = (do {
+    cd $loomark
+    ^$warren build | complete
+  })
+  if $assembled.exit_code != 0 { fail $"release Warren build failed: ($assembled.stderr)" }
+  let dist = ($root | path join "apps/loomark/dist" | path expand)
   ^cp ($root | path join "_build/js/release/build/dowdiness/loomark/worker/worker.js") ($dist | path join "capability-worker.js")
   ^cp ($root | path join "_build/js/release/build/dowdiness/loomark/projection_worker/projection_worker.js") ($dist | path join "projection-worker.js")
-  let html = (open --raw ($root | path join "apps/loomark/public/index.html") | str replace "</body>" "    <script type=\"module\" src=\"./index.js\"></script>\n  </body>")
-  $html | save -f ($dist | path join "index.html")
+  for required in [index.html index.js styles.css favicon.svg capability-worker.js projection-worker.js] {
+    if not (($dist | path join $required) | path exists) {
+      fail $"release Warren output missing: ($required)"
+    }
+  }
   $dist
+}
+
+export def browser-result-rows [observations: list<any>] {
+  $observations | each {|row|
+    let measurement = $row.payload.browser_measurement
+    let oracle = {
+      schema_version: 1
+      run_id: "gate-r0-v1"
+      case_id: $row.case_id
+      producer: "loomark_fresh_browser_oracle"
+      status: "pass"
+      payload: {
+        record: "candidate_result"
+        candidate: "full_history_oracle"
+        path: "browser_full_history_v1"
+        outcome: "pass"
+        measurement: $measurement
+      }
+    }
+    [$oracle] | append $row.payload.candidate_browser_timing
+  } | flatten
 }
 
 export def run-browser-catalog [root: string output: string] {
@@ -27,6 +58,8 @@ export def run-browser-catalog [root: string output: string] {
   if not ($catalog_path | path exists) { fail "browser fixture catalog is missing" }
   let integrity = (^node ($root | path join "apps/loomark/examples/vanilla/test-r0-browser-fixtures.mjs") | complete)
   if $integrity.exit_code != 0 { fail $"browser fixture integrity failed: ($integrity.stderr)" }
+  let measurement_contract = (^node --test ($root | path join "apps/loomark/examples/vanilla/test-r0-browser-measurement.mjs") | complete)
+  if $measurement_contract.exit_code != 0 { fail $"browser measurement contract failed: ($measurement_contract.stderr)" }
   let catalog = (open $catalog_path)
   let canonical_catalog = (open ($root | path join "deps/event-graph-walker/internal/restore_feasibility_probe/fixtures/fixture-catalog-v1.json"))
   let expected_ids = [
@@ -57,10 +90,13 @@ export def run-browser-catalog [root: string output: string] {
       fail $"browser fixture catalog mismatch: ($fixture.fixture_id)"
     }
     let result = (^node $oracle $archive_path $fixture.fixture_id ($fixture.event_count | into string) $dist | complete)
-    if $result.exit_code != 0 { fail $"oracle_mismatch: fresh Chromium fixture failed for ($fixture.fixture_id): ($result.stderr)" }
+    if $result.exit_code != 0 {
+      let classification = if ($result.stderr | str contains "measurement_failure") { "measurement_failure" } else { "oracle_mismatch" }
+      fail $"($classification): fresh Chromium fixture failed for ($fixture.fixture_id): ($result.stderr)"
+    }
     let row = ($result.stdout | lines | where {|line| $line | str trim | is-not-empty } | last | from json)
-    if ($row.payload.browser_version | is-empty) {
-      fail $"browser revision missing: ($fixture.fixture_id)"
+    if $row.payload.browser_version != "149.0.7827.55" {
+      fail $"browser revision mismatch: ($fixture.fixture_id)"
     }
     if $row.schema_version != 1 or $row.run_id != "gate-r0-v1" or $row.case_id != $fixture.fixture_id or $row.status != "pass" or $row.payload.record != "browser_oracle_result" or $row.payload.operation_count != 1000 or $row.payload.post_edit_operation_count != 1001 or $row.payload.archive_sha256 != $fixture.archive_sha256 or $row.payload.restored_text_sha256 != $fixture.expected_text_sha256 or $row.payload.restored_history_sha256 != $fixture.history_sha256 or $row.payload.selected_consumer != "full_history_v1" or $row.payload.candidate_consumer_starts != 0 or $row.payload.full_history_consumer_starts != 1 or $row.payload.first_edit.scalar != "U+005A" or $row.payload.first_edit.canonical_utf16_position != $fixture.expected_text_utf16_units or not $row.payload.first_edit.browser_control_position_valid or not $row.payload.first_edit.adapter_mapping_proved or not $row.payload.first_edit.result_equal or not $row.payload.edit_persisted_after_fresh_page {
       fail $"oracle_mismatch: browser fixture result mismatch: ($fixture.fixture_id)"
@@ -68,6 +104,21 @@ export def run-browser-catalog [root: string output: string] {
     let accounting = $row.payload.read_accounting
     if $accounting.archive_transport_bytes != $fixture.archive_bytes or $accounting.archive_decode_read_operations != 1 or $accounting.oracle_full_history_event_reads != 1000 or $accounting.candidate_event_reads != 0 or $accounting.first_edit_local_operations != 1 {
       fail $"oracle_mismatch: browser fixture read accounting mismatch: ($fixture.fixture_id)"
+    }
+    let measurement = $row.payload.browser_measurement
+    let intervals = [storage_read_ms archive_open_ms restore_to_text_observed_ms first_edit_ms first_edit_storage_write_ms restore_plus_first_edit_ms]
+    if $measurement.fixture_id != $fixture.fixture_id or $measurement.browser_version != "149.0.7827.55" or $measurement.consumer != "full_history_v1" or $measurement.output != "release_warren_static" or $measurement.warmup_navigations != 1 or $measurement.measured_reloads != 20 or ($measurement.samples | length) != 20 or ($measurement.intervals | columns) != $intervals or $measurement.fallback_error.applicability != "not_applicable" or $measurement.fallback_error.reason != "valid_fixture_no_recovery" {
+      fail $"measurement_failure: browser measurement envelope mismatch: ($fixture.fixture_id)"
+    }
+    for interval in $intervals {
+      let summary = ($measurement.intervals | get $interval)
+      if $summary.n != 20 or ($summary.raw_values_ms | length) != 20 or $summary.p50.rank != 10 or $summary.p95.rank != 19 or ($summary.raw_values_ms | any {|value| $value < 0 }) {
+        fail $"measurement_failure: browser interval mismatch: ($fixture.fixture_id):($interval)"
+      }
+    }
+    let candidate_timing = $row.payload.candidate_browser_timing
+    if ($candidate_timing | length) != 2 or ($candidate_timing | get payload.candidate) != [A C] or ($candidate_timing | any {|candidate| $candidate.case_id != $fixture.fixture_id or $candidate.status != "pass" or $candidate.payload.record != "candidate_result" or $candidate.payload.path != "browser_product_restore" or $candidate.payload.outcome != "not_applicable" or $candidate.payload.reason != "product_restore_seam_absent" }) {
+      fail $"measurement_failure: candidate browser timing mismatch: ($fixture.fixture_id)"
     }
     $observations = ($observations | append $row)
   }
@@ -78,6 +129,5 @@ export def run-browser-catalog [root: string output: string] {
   if ($browser_revisions | length) != 1 {
     fail "oracle_mismatch: browser revision differs across fixtures"
   }
-  rm -rf $dist
   $observations
 }

--- a/scripts/test-loomark-editable-branch-restore-feasibility.nu
+++ b/scripts/test-loomark-editable-branch-restore-feasibility.nu
@@ -6,7 +6,7 @@ use ./gate-r0/artifacts.nu [
   reset-artifact-output
   write-failure-bundle
 ]
-use ./gate-r0/browser.nu run-browser-catalog
+use ./gate-r0/browser.nu [browser-result-rows run-browser-catalog]
 
 # Gate R0 canonical evidence runner.  Exit codes: 0 pass; 10 preflight; 20
 # toolchain; 21 submodule; 30 harness; 31 oracle; 32 causal; 33 cold read; 34
@@ -418,6 +418,7 @@ def main [
     } else {
       []
     }
+    let browser_results = (browser-result-rows $browser_observations)
     let egw = (run-producer $root "deps/event-graph-walker/internal/restore_feasibility_probe")
     write-jsonl ($output_dir | path join "cold-history.jsonl") $egw
     let required_egw = (["known-positive-provider-read" "strict-forward" "closed-concurrent" "immediate-insert-zero-read" "immediate-delete-zero-read" "immediate-undelete-zero-read"] | append (operation-matrix | get trace))
@@ -549,7 +550,22 @@ def main [
       }
       browser_oracle_correctness: "pass"
       browser_revision: (($browser_observations | first).payload.browser_version)
-      browser_measurement: "not_run"
+      browser_measurement: {
+        status: "pass"
+        output: "release_warren_static"
+        build_commands: [
+          "NEW_MOON_MOD=0 moon build --target js --release"
+          "./scripts/install-local-warren.sh"
+          "(cd apps/loomark && ../../_build/tools/bin/warren build)"
+        ]
+        fixture_count: ($browser_observations | length)
+        warmup_navigations_per_fixture: 1
+        measured_reloads_per_fixture: 20
+        total_measured_reloads: (($browser_observations | length) * 20)
+        required_intervals: [storage_read_ms archive_open_ms restore_to_text_observed_ms first_edit_ms first_edit_storage_write_ms restore_plus_first_edit_ms]
+        fallback_error: "not_applicable: valid_fixture_no_recovery"
+        candidate_timing: "not_applicable: product_restore_seam_absent"
+      }
       preflight: {
         interface_hashes: $preflight_interfaces
         interface_baseline_agrees_after_run: true
@@ -581,18 +597,29 @@ def main [
     write-json ($output_dir | path join "manifest.json") $manifest
     write-json ($output_dir | path join "capability-ledger.json") $ledger
     write-jsonl ($output_dir | path join "candidate-captures.jsonl") $captures
-    write-json ($output_dir | path join "candidate-results.json") { schema_version: 1 candidates: $candidates observations: $candidate_bundle.observations }
+    write-json ($output_dir | path join "candidate-results.json") { schema_version: 1 candidates: $candidates observations: ($candidate_bundle.observations | append $browser_results) }
     write-jsonl ($output_dir | path join "operation-matrix.jsonl") $operation_rows
     write-jsonl ($output_dir | path join "oracle-differential.jsonl") ([{ schema_version: 1 run_id: "gate-r0-v1" oracle: "full-history" status: "pass" serialized_archive_bytes: $archive_producer.payload.archive_bytes observations: $markdown memory: { availability: "not_applicable" calibration: "R0 process oracle does not claim resident-memory measurement" } } ] | append $measurements)
     write-jsonl ($output_dir | path join "cold-history.jsonl") $egw
     write-json ($output_dir | path join "negative-results.json") { schema_version: 1 negatives: $candidates }
-    $"Gate R0 pass\npositive provider control: 1 call\nstrict/closed provider calls: 0\nfresh Chromium fixture correctness: ($browser_observations | length)\nbrowser measurement: not run\n" | save -f ($output_dir | path join "validation.log")
+    let validation_lines = [
+      "Gate R0 pass"
+      "positive provider control: 1 call"
+      "strict/closed provider calls: 0"
+      $"fresh Chromium fixture correctness: ($browser_observations | length)"
+      "browser build: NEW_MOON_MOD=0 moon build --target js --release => pass"
+      "browser build: ./scripts/install-local-warren.sh => pass"
+      "browser build: (cd apps/loomark && ../../_build/tools/bin/warren build) => pass"
+      "browser measurement: 1 warm-up + 20 measured reloads per fixture"
+      "browser candidate timing: not_applicable: product_restore_seam_absent"
+    ]
+    (($validation_lines | str join "\n") + "\n") | save -f ($output_dir | path join "validation.log")
     write-json ($output_dir | path join "result.json") {
       schema_version: 1
       status: "pass"
       failure_class: null
-      implementation_complete: false
-      blocked_obligations: [browser_measurement]
+      implementation_complete: true
+      blocked_obligations: []
       candidate_outcomes: $candidates
       artifact_paths: (artifact-paths)
     }


### PR DESCRIPTION
## Summary

- run the fixed five-fixture Gate R0 browser lane on release Warren/static output with pinned Chromium `149.0.7827.55`
- perform one warm-up plus 20 measured full-history restore/edit reloads per fixture
- retain raw values and nearest-rank p50/p95/max for storage read, black-box archive open, restored-text observation, first edit, first-edit storage write, and restore plus first edit
- record Candidate A/C browser timing as `not_applicable: product_restore_seam_absent`
- mark Gate R0 implementation complete only after the exact-ten evidence bundle contains the browser measurements

## Measurement boundary

Every measured sample restores the immutable complete-v1 archive before reload, waits for exact restored text, appends U+005A through the real browser input path, and waits for the queued complete-archive persistence transaction. `archive_open_ms` is explicitly the black-box remainder from IndexedDB read completion to expected-text observation; it does not introduce or claim a new public lifecycle milestone.

The valid fixed corpus does not exercise recovery, so fallback/error timing is explicitly `not_applicable: valid_fixture_no_recovery`. No candidate browser sample is fabricated while the product restore seam is absent.

## Scope

No production public API, archive, wire format, provider operation, or storage operation changes. The implementation is confined to the test-only browser oracle, deterministic measurement summaries, canonical Gate R0 runner, CI wiring, and evidence documentation.

## Validation

- clean canonical `--suite all`: PASS in 5:10.53
- exact ten artifacts: PASS
- five fixtures × one warm-up + 20 measured restore/edit reloads: PASS
- pinned Chromium `149.0.7827.55`: PASS
- browser measurement unit/invariant tests: PASS
- Gate R0 artifact contract: PASS
- standalone + dev-host TypeScript checks: PASS
- Nushell IDE parse check: PASS
- documentation lifecycle + Slopless: PASS
- independent exact-HEAD review: PASS
- `validate-pr-ready.sh --no-target`: PASS
- `validate-pr-ready.sh --verify-evidence`: PASS

Validated HEAD: `25383a04d168e9b1fb2ec4930b36416aba3c9c01`
Validated base: `588ab1beedac892c0bc647fc972e5d11bb0a5f54`

The repository pre-commit MoonBit check encountered the known vendored deprecation-warning baseline; the PR-ready validator suppressed the same 22 vendored paths and passed. No MoonBit file or generated interface changed.

## Reuse check

Reuses the production IndexedDB database/store/key, Warren release build, exact browser-side archive verification, `performance.now()`, transaction completion events, and the canonical ten-artifact runner. New deterministic helpers are limited to required interval validation and nearest-rank summaries; imperative code remains in the browser/storage shell.

Refs #1289
