### PR TITLE
feat(loomark): make standalone LocalText source-only

### DIFF
--- a/apps/loomark/README.md
+++ b/apps/loomark/README.md
@@ -1,8 +1,11 @@
 # Loomark
 
 Loomark is the standalone Rabbita Markdown editor. One Rabbita root owns the
-browser page for its lifetime, and every Raw editor, Block editor, and Preview
-change passes through the same canonical document transaction.
+browser page for its lifetime. The production standalone surface edits Raw
+Markdown directly as LocalText; it does not decode prior history or insert the
+stored source into CRDT state during startup or ordinary local input. The
+shared shell still owns an empty editor session. Block and Preview remain development-host
+surfaces until an explicit collaboration promotion path exists.
 
 ## Development
 
@@ -45,21 +48,23 @@ HTTP server.
 
 ## Local document ownership
 
-The standalone application keeps one active Loomark document in this browser's
-local storage. Each history-changing commit replaces one complete archive that
-contains the document's stable logical identity, portable Markdown, and causal
-history. Reloading continues that document under a fresh writing-instance
-identity.
+The standalone application keeps one active LocalText document in this
+browser's local storage. Each accepted Raw edit replaces a small record
+containing the stable logical document identity and portable Markdown. The
+record contains no causal history.
 
-An applied edit remains visible if local replacement fails, while the previous
-readable archive remains intact. Loomark warns that those changes are not saved
-locally; reloading recovers the last successfully replaced archive. An existing
-archive that cannot be safely opened is preserved behind a non-editable
-recovery screen.
+If LocalText is absent, Loomark reads `document_id` and `portable_markdown` from
+the existing v1 archive without decoding or admitting its history. The v1 bytes
+remain untouched. The first subsequent edit writes the new LocalText slot, so
+reloads prefer the fast source-only path while the old archive remains as a
+backup.
 
-Mode, selection, focus, and undo are Session state rather than document archive
-content. In particular, local undo history ends when the page lifetime ends and
-is not restored after reload.
+An applied edit remains visible if LocalText replacement fails. Loomark warns
+that those changes are not saved locally; reloading recovers the last
+successfully stored LocalText, or the untouched v1 fallback when no LocalText
+has been stored. Invalid and unsupported records remain behind the existing
+non-editable recovery screen. Selection, focus, and browser-local undo remain
+page-lifetime state and are not restored after reload.
 
 ## Browser validation
 

--- a/apps/loomark/examples/vanilla/browser-restore-oracle.mjs
+++ b/apps/loomark/examples/vanilla/browser-restore-oracle.mjs
@@ -24,6 +24,7 @@ let origin = ""
 const archiveDatabase = "loomark.local-repository"
 const archiveStore = "archives"
 const archiveKey = "loomark.active-document-archive"
+const localTextKey = "loomark.active-document-text"
 const measuredReloads = 20
 const serverPath = fileURLToPath(new URL("./serve-standalone-dist.mjs", import.meta.url))
 const server = spawn(process.execPath, [serverPath], {
@@ -59,7 +60,13 @@ function browserText(source) {
 async function seedFromBrowserAsset(page) {
   const catalogUrl = `${origin}/fixtures/r0-browser-v1/browser-fixture-catalog-v1.json`
   await page.goto(catalogUrl, { waitUntil: "commit" })
-  return page.evaluate(async ({ caseId, archiveDatabase, archiveStore, archiveKey }) => {
+  return page.evaluate(async ({
+    caseId,
+    archiveDatabase,
+    archiveStore,
+    archiveKey,
+    localTextKey,
+  }) => {
     const hash = async text => {
       const bytes = new TextEncoder().encode(text)
       const digest = await crypto.subtle.digest("SHA-256", bytes)
@@ -125,7 +132,13 @@ async function seedFromBrowserAsset(page) {
       request.onsuccess = () => {
         const database = request.result
         const transaction = database.transaction(archiveStore, "readwrite")
-        transaction.objectStore(archiveStore).put(encoded, archiveKey)
+        const store = transaction.objectStore(archiveStore)
+        store.put(encoded, archiveKey)
+        store.put(JSON.stringify({
+          format: "loomark-local-text-v1",
+          document_id: "gate-r0-stale-local-text",
+          portable_markdown: "stale LocalText must not shadow the Gate R0 archive",
+        }), localTextKey)
         transaction.oncomplete = () => {
           database.close()
           resolve()
@@ -143,7 +156,7 @@ async function seedFromBrowserAsset(page) {
       textSha256: textDigest.sha256,
       historySha256: historyDigest.sha256,
     }
-  }, { caseId, archiveDatabase, archiveStore, archiveKey })
+  }, { caseId, archiveDatabase, archiveStore, archiveKey, localTextKey })
 }
 
 async function seedEncodedArchive(page, encoded) {
@@ -287,7 +300,7 @@ try {
 
   const input = page.locator("#loomark-input")
   const expectedBrowserText = browserText(seeded.fixture.expected_text)
-  await page.goto(`${origin}/`, { waitUntil: "commit" })
+  await page.goto(`${origin}/?gate-r0-full-history-oracle=1`, { waitUntil: "commit" })
   await input.waitFor({ state: "visible", timeout: 30000 })
   await waitForExpectedText(page, expectedBrowserText)
 

--- a/apps/loomark/examples/vanilla/tests/standalone.spec.ts
+++ b/apps/loomark/examples/vanilla/tests/standalone.spec.ts
@@ -4,6 +4,7 @@ const ARCHIVE_DATABASE_NAME = "loomark.local-repository"
 const ARCHIVE_DATABASE_VERSION = 1
 const ARCHIVE_STORE_NAME = "archives"
 const ARCHIVE_KEY = "loomark.active-document-archive"
+const LOCAL_TEXT_KEY = "loomark.active-document-text"
 
 type ArchiveRecord = {
   exists: boolean
@@ -17,7 +18,10 @@ type ArchiveEnvelope = {
   [key: string]: unknown
 }
 
-async function readArchiveRecord(page: Page): Promise<ArchiveRecord> {
+async function readArchiveRecord(
+  page: Page,
+  key = ARCHIVE_KEY,
+): Promise<ArchiveRecord> {
   return page.evaluate(({ databaseName, storeName, key }) => new Promise<ArchiveRecord>((resolve, reject) => {
     let open: IDBOpenDBRequest
     try {
@@ -82,11 +86,15 @@ async function readArchiveRecord(page: Page): Promise<ArchiveRecord> {
   }), {
     databaseName: ARCHIVE_DATABASE_NAME,
     storeName: ARCHIVE_STORE_NAME,
-    key: ARCHIVE_KEY,
+    key,
   })
 }
 
-async function writeArchiveRecord(page: Page, value: unknown): Promise<void> {
+async function writeArchiveRecord(
+  page: Page,
+  value: unknown,
+  key = ARCHIVE_KEY,
+): Promise<void> {
   await page.evaluate(({ databaseName, databaseVersion, storeName, key, value }) => new Promise<void>((resolve, reject) => {
     const open = indexedDB.open(databaseName, databaseVersion)
     open.onupgradeneeded = () => {
@@ -132,13 +140,34 @@ async function writeArchiveRecord(page: Page, value: unknown): Promise<void> {
     databaseName: ARCHIVE_DATABASE_NAME,
     databaseVersion: ARCHIVE_DATABASE_VERSION,
     storeName: ARCHIVE_STORE_NAME,
-    key: ARCHIVE_KEY,
+    key,
     value,
   })
 }
 
+async function deleteArchiveRecord(page: Page, key: string): Promise<void> {
+  await page.evaluate(({ databaseName, storeName, key }) => new Promise<void>((resolve, reject) => {
+    const open = indexedDB.open(databaseName)
+    open.onerror = () => reject(open.error)
+    open.onsuccess = () => {
+      const database = open.result
+      const transaction = database.transaction(storeName, "readwrite")
+      transaction.onerror = () => reject(transaction.error)
+      transaction.oncomplete = () => {
+        database.close()
+        resolve()
+      }
+      transaction.objectStore(storeName).delete(key)
+    }
+  }), {
+    databaseName: ARCHIVE_DATABASE_NAME,
+    storeName: ARCHIVE_STORE_NAME,
+    key,
+  })
+}
+
 async function readArchiveEnvelope(page: Page): Promise<ArchiveEnvelope | null> {
-  const record = await readArchiveRecord(page)
+  const record = await readArchiveRecord(page, LOCAL_TEXT_KEY)
   if (!record.exists || typeof record.value !== "string") return null
   try {
     const parsed: unknown = JSON.parse(record.value)
@@ -148,8 +177,11 @@ async function readArchiveEnvelope(page: Page): Promise<ArchiveEnvelope | null> 
   }
 }
 
-async function readArchiveRaw(page: Page): Promise<string | null> {
-  const record = await readArchiveRecord(page)
+async function readArchiveRaw(
+  page: Page,
+  key = LOCAL_TEXT_KEY,
+): Promise<string | null> {
+  const record = await readArchiveRecord(page, key)
   return record.exists && typeof record.value === "string" ? record.value : null
 }
 
@@ -214,13 +246,13 @@ async function replaceRawValue(input: Locator, value: string): Promise<void> {
  * | boundary | case | required observation |
  * | production boot | clean Warren static output | exactly one visible Loomark root mounts into the declared host |
  * | production isolation | first load and ordinary interaction | private driver DOM and JavaScript exports are absent |
- * | canonical editing | Raw, Block, Preview, and split Preview | every accepted edit converges on one canonical source |
- * | root ownership | mode, document, and viewport changes | state changes inside the existing root without a second mount |
- * | responsive shell | desktop and narrow viewport | editor chrome remains usable and split Preview stacks when required |
+ * | canonical editing | source-only Raw | every accepted edit replaces the LocalText record |
+ * | root ownership | document changes | state changes inside the existing root without a second mount |
  * | release output | clean rebuild and ordinary static server | page, release JavaScript, and declared public assets load without dev inputs |
  * | page lifetime | reload or close | the page ends ownership without claiming unmount or host reuse |
- * | local baseline | first visit with an empty repository | one complete archive establishes the active document identity |
- * | local durability | accepted edit then reload | the complete archive reopens with stable document identity and durable source |
+ * | local baseline | first visit with an empty repository | one LocalText record establishes the active document identity |
+ * | local durability | accepted edit then reload | LocalText reopens with stable document identity and durable source |
+ * | compatibility | legacy v1 fallback | source opens without history decode and v1 bytes remain untouched |
  * | recovery | corrupt, unsupported, or unreadable record | storage remains unchanged and no editable document mounts |
  * | replacement failure | accepted edit after provider failure | applied source remains visible and reload restores the prior durable archive |
  */
@@ -302,15 +334,16 @@ test("standalone projection Worker passes Gate 0C parity, restart, timeout, and 
   expect(report.promotion_rejection).toBe("release-browser-placement-evidence-required")
 })
 
-test("first standalone visit stores a complete baseline archive", async ({ page }) => {
+test("first standalone visit stores a LocalText baseline", async ({ page }) => {
   await page.goto("/")
 
   await expect(page.locator("#loomark-root")).toBeVisible()
   await waitForBaseline(page)
   const baseline = await readArchiveEnvelope(page)
   expect(baseline?.document_id).toBeTruthy()
+  expect(baseline?.format).toBe("loomark-local-text-v1")
   expect(baseline?.portable_markdown).toBe("")
-  expect(baseline?.history).toBeTruthy()
+  expect(baseline?.history).toBeUndefined()
 })
 
 test("standalone IME commits one non-BMP final value and ignores cancellation", async ({ page }) => {
@@ -373,11 +406,36 @@ test("standalone edit replaces the archive and reload restores the durable sourc
     .toBe(documentId)
 })
 
+test("legacy v1 source opens without history decode and remains untouched", async ({ page }) => {
+  const legacyArchive = JSON.stringify({
+    schema_version: "1",
+    document_id: "legacy-source-document",
+    portable_markdown: "# Legacy source\n",
+    history: "not-decoded",
+    extensions: {},
+  })
+  await page.goto("/")
+  await waitForBaseline(page)
+  await deleteArchiveRecord(page, LOCAL_TEXT_KEY)
+  await writeArchiveRecord(page, legacyArchive, ARCHIVE_KEY)
+
+  await page.reload()
+  const input = page.locator("#loomark-input")
+  await expect(input).toHaveValue("# Legacy source\n")
+  await expect.poll(() => readArchiveRaw(page, ARCHIVE_KEY)).toBe(legacyArchive)
+
+  await replaceRawValue(input, "# Local edit\n")
+  await expect.poll(() => readArchiveEnvelope(page).then(record => record?.portable_markdown))
+    .toBe("# Local edit\n")
+  await expect.poll(() => readArchiveRaw(page, ARCHIVE_KEY)).toBe(legacyArchive)
+})
+
 test("corrupt IDB archives mount a recovery view without an editor", async ({ page }) => {
   const corruptArchive = "not-json"
   await page.goto("/")
   await waitForBaseline(page)
-  await writeArchiveRecord(page, corruptArchive)
+  await deleteArchiveRecord(page, LOCAL_TEXT_KEY)
+  await writeArchiveRecord(page, corruptArchive, ARCHIVE_KEY)
   await page.evaluate(({ key, value }) => localStorage.setItem(key, value), {
     key: ARCHIVE_KEY,
     value: JSON.stringify({ schema_version: "1", document_id: "legacy", portable_markdown: "", history: "", extensions: {} }),
@@ -390,7 +448,7 @@ test("corrupt IDB archives mount a recovery view without an editor", async ({ pa
     "corrupt-archive",
   )
   await expect(page.locator("#loomark-input")).toHaveCount(0)
-  await expect.poll(() => readArchiveRaw(page)).toBe(corruptArchive)
+  await expect.poll(() => readArchiveRaw(page, ARCHIVE_KEY)).toBe(corruptArchive)
 })
 
 test("unsupported IDB archives remain preserved behind recovery", async ({ page }) => {
@@ -403,14 +461,15 @@ test("unsupported IDB archives remain preserved behind recovery", async ({ page 
   })
   await page.goto("/")
   await waitForBaseline(page)
-  await writeArchiveRecord(page, unsupportedArchive)
+  await deleteArchiveRecord(page, LOCAL_TEXT_KEY)
+  await writeArchiveRecord(page, unsupportedArchive, ARCHIVE_KEY)
   await page.reload()
 
   await expect(page.locator("#loomark-recovery-root")).toHaveAttribute(
     "data-loomark-recovery-category",
     "unsupported-archive",
   )
-  await expect.poll(() => readArchiveRaw(page)).toBe(unsupportedArchive)
+  await expect.poll(() => readArchiveRaw(page, ARCHIVE_KEY)).toBe(unsupportedArchive)
   await expect(page.locator("#loomark-input")).toHaveCount(0)
 })
 
@@ -439,8 +498,8 @@ test("a failed replacement keeps the applied source but reload restores the prev
   await expect.poll(() => readArchiveEnvelope(page).then(archive => archive?.portable_markdown))
     .toBe("# Previous\n")
 
-  await page.addInitScript(installArchivePutFailure, ARCHIVE_KEY)
-  await page.evaluate(installArchivePutFailure, ARCHIVE_KEY)
+  await page.addInitScript(installArchivePutFailure, LOCAL_TEXT_KEY)
+  await page.evaluate(installArchivePutFailure, LOCAL_TEXT_KEY)
   await replaceRawValue(page.locator("#loomark-input"), "# Applied\n")
   await expect(page.locator("#loomark-input")).toHaveValue("# Applied\n")
   await expect(page.locator("#loomark-error")).toContainText(
@@ -460,8 +519,8 @@ test("explicit local persistence retry clears the applied-but-unsaved state", as
   await expect.poll(() => readArchiveEnvelope(page).then(archive => archive?.portable_markdown))
     .toBe("# Previous\n")
 
-  await page.addInitScript(installArchivePutFailure, ARCHIVE_KEY)
-  await page.evaluate(installArchivePutFailure, ARCHIVE_KEY)
+  await page.addInitScript(installArchivePutFailure, LOCAL_TEXT_KEY)
+  await page.evaluate(installArchivePutFailure, LOCAL_TEXT_KEY)
   await replaceRawValue(page.locator("#loomark-input"), "# Applied\n")
   await expect(page.locator("#loomark-error")).toContainText(
     "Changes are applied but not saved locally.",
@@ -488,7 +547,7 @@ test("legacy local archives migrate once and remain readable from IDB", async ({
     "data-loomark-recovery-category",
     "corrupt-archive",
   )
-  await expect.poll(() => readArchiveRaw(page)).toBe(legacyArchive)
+  await expect.poll(() => readArchiveRaw(page, ARCHIVE_KEY)).toBe(legacyArchive)
   await expect.poll(() => page.evaluate(key => localStorage.getItem(key), ARCHIVE_KEY)).toBeNull()
 })
 
@@ -519,7 +578,7 @@ test("production output boots one instrumentation-free Loomark root", async ({ p
   expect(pageErrors).toEqual([])
 })
 
-test("Raw, Block, and Preview editing stays inside the original production root", async ({ page }) => {
+test("standalone LocalText exposes only the Raw surface", async ({ page }) => {
   await page.goto("/")
   const root = page.locator("#loomark-root")
   await expect(root).toBeVisible()
@@ -527,217 +586,18 @@ test("Raw, Block, and Preview editing stays inside the original production root"
     "data-loomark-projection-placement",
     "synchronous",
   )
-  await root.evaluate(element => element.setAttribute("data-mount-probe", "original"))
+  await expect(page.getByRole("tab", { name: "Raw Markdown" })).toHaveCount(1)
+  await expect(page.getByRole("tab")).toHaveCount(1)
+  await expect(page.locator("#loomark-mode-block")).toHaveCount(0)
+  await expect(page.locator("#loomark-mode-preview")).toHaveCount(0)
+  await expect(page.locator("#loomark-split-toggle")).toHaveCount(0)
 
-  await replaceRawValue(page.locator("#loomark-input"), "# Before\n\nBody\n")
-  await page.locator("#loomark-mode-block").click()
-  await expect(page.locator("#loomark-block-input")).toHaveValue("Before")
-  await page.locator("#loomark-block-input").fill("After")
-  await expect(page.locator("#loomark-block")).toHaveAttribute(
-    "data-loomark-source",
-    "# After\n\nBody\n",
-  )
+  await replaceRawValue(page.locator("#loomark-input"), "# Raw only\n")
+  await expect.poll(() =>
+    readArchiveEnvelope(page).then(record => record?.portable_markdown),
+  ).toBe("# Raw only\n")
 
-  await page.locator("#loomark-mode-preview").click()
-  await expect(page.locator('#loomark-preview h1[data-slot="typography-h1"]')).toHaveText(
-    "After",
-  )
-  await expect(page.locator("#loomark-preview p")).toHaveText("Body")
-  await expect(root).toHaveAttribute("data-mount-probe", "original")
+  await page.reload()
+  await expect(page.locator("#loomark-input")).toHaveValue("# Raw only\n")
   await expect(root).toHaveCount(1)
-})
-
-for (const placement of ["worker", "in-process", "synchronous"] as const) {
-  test(`${placement} comparison placement preserves canonical Preview`, async ({ page }) => {
-    await page.goto(`/?projection-placement=${placement}`)
-    const root = page.locator("#loomark-root")
-    await expect(root).toHaveAttribute("data-loomark-projection-placement", placement)
-    await replaceRawValue(page.locator("#loomark-input"), "# Placement\n\nBody\n")
-    await page.locator("#loomark-mode-preview").click()
-    await expect(page.locator('#loomark-preview h1[data-slot="typography-h1"]')).toHaveText(
-      "Placement",
-    )
-    await expect(page.locator("#loomark-preview p")).toHaveText("Body")
-    await expect(page.locator("#loomark-preview")).toHaveAttribute(
-      "data-loomark-source",
-      "# Placement\n\nBody\n",
-    )
-  })
-}
-
-test("projection trace is absent by default and records only after explicit opt-in", async ({
-  page,
-}) => {
-  await page.goto("/")
-  await expect(page.locator("#loomark-projection-trace-dump")).toHaveCount(0)
-  await expect(page.locator("html")).not.toHaveAttribute(
-    "data-loomark-projection-trace",
-    /.+/,
-  )
-
-  await page.goto("/?projection-benchmark=1&persistence-trace=1")
-  await replaceRawValue(page.locator("#loomark-input"), "# Trace\n\nBody\n")
-  await page.locator("#loomark-mode-preview").click()
-  await expect(page.locator("#loomark-preview p")).toHaveText("Body")
-  await page.locator("#loomark-projection-trace-dump").dispatchEvent("click")
-  const trace = await page.locator("html").getAttribute("data-loomark-projection-trace")
-  expect(trace).not.toBeNull()
-  const report = JSON.parse(trace ?? "{}") as {
-    enabled?: boolean
-    count?: number
-    dropped_count?: number
-    overflowed?: boolean
-    contract_violated?: boolean
-  }
-  expect(report.enabled).toBe(true)
-  expect(report.count).toBeGreaterThan(0)
-  expect(report.dropped_count).toBe(0)
-  expect(report.overflowed).toBe(false)
-  expect(report.contract_violated).toBe(false)
-})
-
-test("ordinary consecutive Block input preserves both characters and the caret", async ({ page }) => {
-  await page.goto("/")
-  await replaceRawValue(page.locator("#loomark-input"), "x")
-  await page.locator("#loomark-mode-block").click()
-
-  const input = page.locator("#loomark-block-input")
-  const block = page.locator("#loomark-block")
-  await expect(input).toHaveValue("x")
-
-  await input.selectText()
-  await input.pressSequentially("a")
-  await expect(block).toHaveAttribute("data-loomark-source", "a")
-  await expect(input).toHaveValue("a")
-  await expect
-    .poll(() => input.evaluate(element => ({
-      start: (element as HTMLTextAreaElement).selectionStart,
-      end: (element as HTMLTextAreaElement).selectionEnd,
-    })))
-    .toEqual({ start: 1, end: 1 })
-
-  await input.pressSequentially("b")
-  await expect(block).toHaveAttribute("data-loomark-source", "ab")
-  await expect(input).toHaveValue("ab")
-  await expect
-    .poll(() => input.evaluate(element => ({
-      start: (element as HTMLTextAreaElement).selectionStart,
-      end: (element as HTMLTextAreaElement).selectionEnd,
-    })))
-    .toEqual({ start: 2, end: 2 })
-  await expect(page.locator("#loomark-error")).toHaveCount(0)
-})
-
-test("Block input preserves the latest value when two events arrive before redraw", async ({ page }) => {
-  await page.goto("/")
-  await replaceRawValue(page.locator("#loomark-input"), "x")
-  await page.locator("#loomark-mode-block").click()
-  const input = page.locator("#loomark-block-input")
-  const block = page.locator("#loomark-block")
-  await expect(input).toHaveValue("x")
-
-  await input.evaluate(element => {
-    const textarea = element as HTMLTextAreaElement
-    textarea.value = "a"
-    textarea.setSelectionRange(1, 1)
-    textarea.dispatchEvent(new InputEvent("input", {
-      bubbles: true,
-      composed: true,
-      data: "a",
-      inputType: "insertText",
-    }))
-
-    textarea.value = "ab"
-    textarea.setSelectionRange(2, 2)
-    textarea.dispatchEvent(new InputEvent("input", {
-      bubbles: true,
-      composed: true,
-      data: "b",
-      inputType: "insertText",
-    }))
-  })
-
-  await expect(block).toHaveAttribute("data-loomark-source", "ab")
-  await expect(input).toHaveValue("ab")
-  await expect
-    .poll(() => input.evaluate(element => ({
-      start: (element as HTMLTextAreaElement).selectionStart,
-      end: (element as HTMLTextAreaElement).selectionEnd,
-    })))
-    .toEqual({ start: 2, end: 2 })
-  await expect(page.locator("#loomark-error")).toHaveCount(0)
-})
-
-test("Preview wraps long unbreakable content inside the reading frame", async ({ page }) => {
-  await page.goto("/")
-  const longUrl = `https://example.com/${`a`.repeat(200)}`
-  const source =
-    `# Long content\n\nVisit ${longUrl} and read this paragraph.\n\nInline code: \`${`x`.repeat(150)}\`\n`
-  await replaceRawValue(page.locator("#loomark-input"), source)
-  await page.locator("#loomark-mode-preview").click()
-  const preview = page.locator("#loomark-preview")
-  await expect(preview).toHaveAttribute("data-loomark-source", source)
-  // Long URLs and inline code wrap inside the reading frame instead of
-  // stretching the Preview pane into a horizontal scroll.
-  await expect
-    .poll(async () => preview.evaluate(el => el.scrollWidth > el.clientWidth))
-    .toBe(false)
-  await expect
-    .poll(() =>
-      page.evaluate(
-        () => document.documentElement.scrollWidth > window.innerWidth,
-      ),
-    )
-    .toBe(false)
-})
-
-test("frames stay borderless and only the split divider separates panes", async ({ page }) => {
-  await page.goto("/")
-
-  const raw = page.locator("#loomark-input")
-  // Raw keeps RUI's transparent control border; no side rail is drawn.
-  await expect(raw).toHaveCSS("border-left-color", "rgba(0, 0, 0, 0)")
-  await expect(raw).toHaveCSS("border-right-color", "rgba(0, 0, 0, 0)")
-  await expect(raw).toHaveCSS("padding-left", "16px")
-
-  await page.setViewportSize({ width: 640, height: 844 })
-  await replaceRawValue(raw, "# Narrow\n")
-  await page.locator("#loomark-split-toggle").click()
-
-  const split = page.locator("#loomark-split")
-  await expect(split).toHaveAttribute("data-orientation", "vertical")
-  await expect(split.locator('[data-slot="resizable-handle"]')).toHaveAttribute(
-    "aria-orientation",
-    "horizontal",
-  )
-  // The resizable handle line is the only divider between the panes.
-  await expect(
-    split.locator('[data-slot="resizable-handle-line"]'),
-  ).toBeVisible()
-
-  const preview = page.locator("#loomark-preview")
-  await expect(preview).toHaveAttribute("data-loomark-source", "# Narrow\n")
-  // Raw keeps RUI's transparent control border (1px, no visible rail);
-  // Preview carries no side border at all. Neither frame draws a rail.
-  await expect(raw).toHaveCSS("border-left-color", "rgba(0, 0, 0, 0)")
-  await expect(raw).toHaveCSS("border-right-color", "rgba(0, 0, 0, 0)")
-  await expect(preview).toHaveCSS("border-left-width", "0px")
-  await expect(preview).toHaveCSS("border-right-width", "0px")
-  for (const frame of [raw, preview]) {
-    await expect(frame).toHaveCSS("padding-left", "12px")
-    await expect(frame).toHaveCSS("padding-right", "12px")
-    await expect(frame).toHaveCSS("width", "640px")
-  }
-
-  await page.locator("#loomark-mode-block").click()
-  await expect(page.locator("#loomark-block")).toHaveCSS("padding-left", "12px")
-  const blockFrame = page.locator("#loomark-block-frame")
-  await expect(blockFrame).toHaveCSS("border-left-width", "0px")
-  await expect(blockFrame).toHaveCSS("border-right-width", "0px")
-  await expect(blockFrame).toHaveCSS("width", "640px")
-  await expect(page.getByRole("toolbar", { name: "Block formatting" })).toHaveCSS(
-    "padding-left",
-    "12px",
-  )
-  await expect(page.locator("#loomark-root")).toHaveCount(1)
 })

--- a/apps/loomark/internal/archive_storage/pkg.generated.mbti
+++ b/apps/loomark/internal/archive_storage/pkg.generated.mbti
@@ -16,6 +16,8 @@ pub fn fresh_id(String) -> String
 
 pub fn load(result~ : @cmd.Emit[LocalArchiveStorageRead]) -> @cmd.Cmd
 
+pub fn load_legacy_archive(result~ : @cmd.Emit[LocalArchiveStorageRead]) -> @cmd.Cmd
+
 pub fn replace(@repository.LocalArchivePendingWrite, completed~ : @cmd.Emit[LocalArchiveWriteCompletion]) -> @cmd.Cmd
 
 // Errors

--- a/apps/loomark/internal/archive_storage/pkg.generated.mbti
+++ b/apps/loomark/internal/archive_storage/pkg.generated.mbti
@@ -10,6 +10,8 @@ import {
 // Values
 pub const ACTIVE_DOCUMENT_KEY : String = "loomark.active-document-archive"
 
+pub const LOCAL_TEXT_KEY : String = "loomark.active-document-text"
+
 pub fn fresh_id(String) -> String
 
 pub fn load(result~ : @cmd.Emit[LocalArchiveStorageRead]) -> @cmd.Cmd
@@ -21,7 +23,8 @@ pub fn replace(@repository.LocalArchivePendingWrite, completed~ : @cmd.Emit[Loca
 // Types and methods
 pub(all) enum LocalArchiveStorageRead {
   Missing
-  Loaded(String)
+  LocalText(String)
+  LegacyArchive(String)
   Failed(@repository.LocalArchiveStorageReadFailure)
 } derive(Eq, @debug.Debug)
 

--- a/apps/loomark/internal/archive_storage/storage.mbt
+++ b/apps/loomark/internal/archive_storage/storage.mbt
@@ -57,7 +57,9 @@ pub fn LocalArchiveWriteCompletion::result(
 }
 
 ///|
-fn load_legacy_archive(result : @cmd.Emit[LocalArchiveStorageRead]) -> @cmd.Cmd {
+pub fn load_legacy_archive(
+  result~ : @cmd.Emit[LocalArchiveStorageRead],
+) -> @cmd.Cmd {
   @indexed_db.get(
     local_repository_config,
     ACTIVE_DOCUMENT_KEY,
@@ -86,7 +88,7 @@ pub fn load(result~ : @cmd.Emit[LocalArchiveStorageRead]) -> @cmd.Cmd {
     migrate_legacy=false,
     result=stored => {
       match stored {
-        @indexed_db.ReadResult::Missing => load_legacy_archive(result)
+        @indexed_db.ReadResult::Missing => load_legacy_archive(result~)
         @indexed_db.ReadResult::Loaded(value) => result(LocalText(value))
         @indexed_db.ReadResult::Unavailable =>
           result(
@@ -100,12 +102,17 @@ pub fn load(result~ : @cmd.Emit[LocalArchiveStorageRead]) -> @cmd.Cmd {
 }
 
 ///|
-/// Schedule one atomic complete archive replacement.
+/// Schedule one atomic complete replacement in its format-owned slot.
 pub fn replace(
   pending : @repository.LocalArchivePendingWrite,
   completed~ : @cmd.Emit[LocalArchiveWriteCompletion],
 ) -> @cmd.Cmd {
-  @indexed_db.put(local_repository_config, LOCAL_TEXT_KEY, pending.encoded(), result=stored => {
+  let key = if pending.is_source_only() {
+    LOCAL_TEXT_KEY
+  } else {
+    ACTIVE_DOCUMENT_KEY
+  }
+  @indexed_db.put(local_repository_config, key, pending.encoded(), result=stored => {
     let result = match stored {
       @indexed_db.WriteResult::Stored => LocalArchiveStorageWrite::Stored
       @indexed_db.WriteResult::Unavailable =>

--- a/apps/loomark/internal/archive_storage/storage.mbt
+++ b/apps/loomark/internal/archive_storage/storage.mbt
@@ -5,8 +5,13 @@ pub fn fresh_id(prefix : String) -> String {
 }
 
 ///|
-/// The one active-document slot owned by standalone Loomark.
+/// Legacy v1 archive slot. Source-only startup reads it as a fallback and
+/// never overwrites it.
 pub const ACTIVE_DOCUMENT_KEY : String = "loomark.active-document-archive"
+
+///|
+/// Active source-only standalone document.
+pub const LOCAL_TEXT_KEY : String = "loomark.active-document-text"
 
 ///|
 /// The one browser database used by the standalone local archive.
@@ -18,7 +23,8 @@ let local_repository_config : @indexed_db.Config = @indexed_db.Config::Config(
 /// Typed result of one IndexedDB binding read.
 pub(all) enum LocalArchiveStorageRead {
   Missing
-  Loaded(String)
+  LocalText(String)
+  LegacyArchive(String)
   Failed(@repository.LocalArchiveStorageReadFailure)
 } derive(Eq, Debug)
 
@@ -51,8 +57,7 @@ pub fn LocalArchiveWriteCompletion::result(
 }
 
 ///|
-/// Map the IndexedDB binding's result into the repository shell taxonomy.
-pub fn load(result~ : @cmd.Emit[LocalArchiveStorageRead]) -> @cmd.Cmd {
+fn load_legacy_archive(result : @cmd.Emit[LocalArchiveStorageRead]) -> @cmd.Cmd {
   @indexed_db.get(
     local_repository_config,
     ACTIVE_DOCUMENT_KEY,
@@ -61,7 +66,7 @@ pub fn load(result~ : @cmd.Emit[LocalArchiveStorageRead]) -> @cmd.Cmd {
       result(
         match stored {
           @indexed_db.ReadResult::Missing => Missing
-          @indexed_db.ReadResult::Loaded(value) => Loaded(value)
+          @indexed_db.ReadResult::Loaded(value) => LegacyArchive(value)
           @indexed_db.ReadResult::Unavailable =>
             Failed(@repository.LocalArchiveStorageReadFailure::Unavailable)
           @indexed_db.ReadResult::Failed =>
@@ -73,32 +78,49 @@ pub fn load(result~ : @cmd.Emit[LocalArchiveStorageRead]) -> @cmd.Cmd {
 }
 
 ///|
+/// Prefer LocalText, then fall back to the untouched legacy-v1 archive.
+pub fn load(result~ : @cmd.Emit[LocalArchiveStorageRead]) -> @cmd.Cmd {
+  @indexed_db.get(
+    local_repository_config,
+    LOCAL_TEXT_KEY,
+    migrate_legacy=false,
+    result=stored => {
+      match stored {
+        @indexed_db.ReadResult::Missing => load_legacy_archive(result)
+        @indexed_db.ReadResult::Loaded(value) => result(LocalText(value))
+        @indexed_db.ReadResult::Unavailable =>
+          result(
+            Failed(@repository.LocalArchiveStorageReadFailure::Unavailable),
+          )
+        @indexed_db.ReadResult::Failed =>
+          result(Failed(@repository.LocalArchiveStorageReadFailure::Failed))
+      }
+    },
+  )
+}
+
+///|
 /// Schedule one atomic complete archive replacement.
 pub fn replace(
   pending : @repository.LocalArchivePendingWrite,
   completed~ : @cmd.Emit[LocalArchiveWriteCompletion],
 ) -> @cmd.Cmd {
-  @indexed_db.put(
-    local_repository_config,
-    ACTIVE_DOCUMENT_KEY,
-    pending.encoded(),
-    result=stored => {
-      let result = match stored {
-        @indexed_db.WriteResult::Stored => LocalArchiveStorageWrite::Stored
-        @indexed_db.WriteResult::Unavailable =>
-          LocalArchiveStorageWrite::Failed(
-            @repository.LocalArchiveStorageWriteFailure::Unavailable,
-          )
-        @indexed_db.WriteResult::QuotaExceeded =>
-          LocalArchiveStorageWrite::Failed(
-            @repository.LocalArchiveStorageWriteFailure::QuotaExceeded,
-          )
-        @indexed_db.WriteResult::Failed =>
-          LocalArchiveStorageWrite::Failed(
-            @repository.LocalArchiveStorageWriteFailure::Failed,
-          )
-      }
-      completed({ pending, result })
-    },
-  )
+  @indexed_db.put(local_repository_config, LOCAL_TEXT_KEY, pending.encoded(), result=stored => {
+    let result = match stored {
+      @indexed_db.WriteResult::Stored => LocalArchiveStorageWrite::Stored
+      @indexed_db.WriteResult::Unavailable =>
+        LocalArchiveStorageWrite::Failed(
+          @repository.LocalArchiveStorageWriteFailure::Unavailable,
+        )
+      @indexed_db.WriteResult::QuotaExceeded =>
+        LocalArchiveStorageWrite::Failed(
+          @repository.LocalArchiveStorageWriteFailure::QuotaExceeded,
+        )
+      @indexed_db.WriteResult::Failed =>
+        LocalArchiveStorageWrite::Failed(
+          @repository.LocalArchiveStorageWriteFailure::Failed,
+        )
+    }
+    completed({ pending, result })
+  })
 }

--- a/apps/loomark/internal/archive_storage/storage.mbt
+++ b/apps/loomark/internal/archive_storage/storage.mbt
@@ -107,10 +107,9 @@ pub fn replace(
   pending : @repository.LocalArchivePendingWrite,
   completed~ : @cmd.Emit[LocalArchiveWriteCompletion],
 ) -> @cmd.Cmd {
-  let key = if pending.is_source_only() {
-    LOCAL_TEXT_KEY
-  } else {
-    ACTIVE_DOCUMENT_KEY
+  let key = match pending.record_kind() {
+    @repository.LocalArchiveRecordKind::FullHistory => ACTIVE_DOCUMENT_KEY
+    @repository.LocalArchiveRecordKind::LocalText => LOCAL_TEXT_KEY
   }
   @indexed_db.put(local_repository_config, key, pending.encoded(), result=stored => {
     let result = match stored {

--- a/apps/loomark/internal/rabbita/application.mbt
+++ b/apps/loomark/internal/rabbita/application.mbt
@@ -11,10 +11,10 @@ extern "js" fn read_textarea_value(id : String) -> String =
   #| id => document.getElementById(id)?.value ?? ""
 
 ///|
-const HELLO_EXAMPLE_SOURCE : String = "# Hello World\n\nWelcome to the Canopy Markdown editor.\n\nRaw Markdown is saved locally without constructing CRDT history.\n"
+const HELLO_EXAMPLE_SOURCE : String = "# Hello World\n\nWelcome to the Canopy Markdown editor.\n\nThis editor has three modes: raw, block, and preview.\n"
 
 ///|
-const BLOG_EXAMPLE_SOURCE : String = "# Getting Started\n\nCanopy is an incremental projectional editor.\n\n## Features\n\nLoomark keeps standalone Markdown source local and responsive.\n\nCollaboration is activated separately from ordinary local editing."
+const BLOG_EXAMPLE_SOURCE : String = "# Getting Started\n\nCanopy is an incremental projectional editor.\n\n## Features\n\nThe editor supports real-time collaboration via CRDT.\n\nEvery keystroke is incrementally parsed and projected into a structured view."
 
 ///|
 const LIST_EXAMPLE_SOURCE : String = "# Shopping List\n\nThings to pick up:\n\n- Apples\n- Bread\n- Coffee\n- Dark chocolate"
@@ -2648,20 +2648,22 @@ fn update_model(
   emit : @cmd.Emit[DriverEvent],
   projection_session? : @ref.Ref[ProjectionSession?],
   projection_worker? : ProjectionWorkerRuntime,
+  bootstrap_mode? : StandaloneBootstrapMode,
   session_ref? : @ref.Ref[EditorSession],
 ) -> (DriverModel, @cmd.Cmd) raise {
   let (next, command) = match event {
     Bootstrap(loaded) =>
-      match session_ref {
-        Some(session_ref) =>
+      match (session_ref, bootstrap_mode) {
+        (Some(session_ref), Some(mode)) =>
           update_standalone_bootstrap(
             session_ref,
             model,
             loaded,
             model.document.source(),
+            mode,
             emit,
           )
-        None => (model, @rabbita_runtime.none)
+        _ => (model, @rabbita_runtime.none)
       }
     Archive(completion) => update_archive_queue(model, completion, emit)
     _ if model.bootstrap_pending =>
@@ -2952,7 +2954,7 @@ fn build_application(
   attachment : @md_markdown.MarkdownSemanticAttachment,
   initial : DriverModel,
   baseline : @repository.LocalArchivePendingWrite?,
-  bootstrap : Bool,
+  bootstrap_mode : StandaloneBootstrapMode?,
   raw_input_telemetry : RawInputTelemetry?,
   subscriptions : (DriverModel, @cmd.Emit[DriverEvent]) -> @sub.Sub,
   view : (DriverModel, @cmd.Emit[DriverEvent], @rabbita_runtime.Html) -> @rabbita_runtime.Html,
@@ -2999,6 +3001,7 @@ fn build_application(
       emit,
       projection_session?,
       projection_worker?,
+      bootstrap_mode?,
       session_ref=current_session,
     ) catch {
       Failure::Failure(_) as failure => {
@@ -3049,10 +3052,14 @@ fn build_application(
   @rabbita_runtime.new(() => {
     let (model, emit) = @rabbita_runtime.create_state_with_init(
       init=fn(emit) {
-        let bootstrap_command = if bootstrap {
-          @archive_storage.load(result=loaded => emit(Bootstrap(loaded)))
-        } else {
-          @rabbita_runtime.none
+        let bootstrap_command = match bootstrap_mode {
+          Some(LocalTextBootstrap) =>
+            @archive_storage.load(result=loaded => emit(Bootstrap(loaded)))
+          Some(FullHistoryOracleBootstrap) =>
+            @archive_storage.load_legacy_archive(result=loaded => {
+              emit(Bootstrap(loaded))
+            })
+          None => @rabbita_runtime.none
         }
         let persistence_command = local_archive_write_command(baseline, emit)
         let projection_command = match projection_worker {
@@ -3085,13 +3092,14 @@ fn standalone_application(
   attachment : @md_markdown.MarkdownSemanticAttachment,
   initial : DriverModel,
   baseline : @repository.LocalArchivePendingWrite?,
+  bootstrap_mode : StandaloneBootstrapMode,
 ) -> @rabbita_runtime.App {
   build_application(
     editor,
     attachment,
     initial,
     baseline,
-    true,
+    Some(bootstrap_mode),
     None,
     standalone_subscriptions,
     standalone_preview_view,
@@ -3110,7 +3118,7 @@ fn private_dev_host_application(
     attachment,
     initial,
     baseline,
-    false,
+    None,
     Some(RawInputTelemetry::new()),
     private_dev_host_subscriptions,
     private_dev_host_preview_view,
@@ -3233,7 +3241,11 @@ fn mount_application(
 ///|
 /// Mount the standalone shell immediately; its initial archive load is a
 /// Rabbita Cmd and the editor session is adopted when that Cmd completes.
-pub fn mount_standalone(host_id : String, source : String) -> String {
+fn mount_standalone_with_mode(
+  host_id : String,
+  source : String,
+  bootstrap_mode : StandaloneBootstrapMode,
+) -> String {
   if mounted.val {
     return "{\"ok\":false,\"error\":\"host-already-mounted\"}"
   }
@@ -3280,9 +3292,27 @@ pub fn mount_standalone(host_id : String, source : String) -> String {
   }
   detached_focus_token.val = ""
   publish(initial, None, None)
-  let app = standalone_application(editor, attachment, initial, None)
+  let app = standalone_application(
+    editor,
+    attachment,
+    initial,
+    None,
+    bootstrap_mode,
+  )
   app.mount(host_id)
   "{\"ok\":true}"
+}
+
+///|
+/// Mount production standalone in its source-only LocalText lane.
+pub fn mount_standalone(host_id : String, source : String) -> String {
+  mount_standalone_with_mode(host_id, source, LocalTextBootstrap)
+}
+
+///|
+/// Mount the fixed full-history baseline used only by Gate R0's browser oracle.
+pub fn mount_full_history_oracle(host_id : String, source : String) -> String {
+  mount_standalone_with_mode(host_id, source, FullHistoryOracleBootstrap)
 }
 
 ///|

--- a/apps/loomark/internal/rabbita/application.mbt
+++ b/apps/loomark/internal/rabbita/application.mbt
@@ -7,10 +7,14 @@ let mounted : @ref.Ref[Bool] = { val: false }
 let detached_snapshot : @ref.Ref[String] = { val: "{}" }
 
 ///|
-const HELLO_EXAMPLE_SOURCE : String = "# Hello World\n\nWelcome to the Canopy Markdown editor.\n\nThis editor has three modes: raw, block, and preview.\n"
+extern "js" fn read_textarea_value(id : String) -> String =
+  #| id => document.getElementById(id)?.value ?? ""
 
 ///|
-const BLOG_EXAMPLE_SOURCE : String = "# Getting Started\n\nCanopy is an incremental projectional editor.\n\n## Features\n\nThe editor supports real-time collaboration via CRDT.\n\nEvery keystroke is incrementally parsed and projected into a structured view."
+const HELLO_EXAMPLE_SOURCE : String = "# Hello World\n\nWelcome to the Canopy Markdown editor.\n\nRaw Markdown is saved locally without constructing CRDT history.\n"
+
+///|
+const BLOG_EXAMPLE_SOURCE : String = "# Getting Started\n\nCanopy is an incremental projectional editor.\n\n## Features\n\nLoomark keeps standalone Markdown source local and responsive.\n\nCollaboration is activated separately from ordinary local editing."
 
 ///|
 const LIST_EXAMPLE_SOURCE : String = "# Shopping List\n\nThings to pick up:\n\n- Apples\n- Bread\n- Coffee\n- Dark chocolate"
@@ -23,9 +27,8 @@ const CODE_EXAMPLE_SOURCE : String = "# README\n\nA minimal example project.\n\n
 const MARKDOWN_DEMO_SOURCE : String =
   $|# Markdown Feature Tour
   $|
-  $|A long-form tour of the Markdown features this editor renders. Switch
-  $|between the Raw, Block, and Preview tabs to see the same document through
-  $|each lens, and open the split view to edit and preview side by side.
+  $|A long-form tour of Markdown syntax for editing in the Raw source view.
+  $|The standalone document is stored directly as portable Markdown.
   $|
   $|---
   $|
@@ -192,6 +195,7 @@ fn mode_name(mode : @core.ApplicationMode) -> String {
 fn runtime_state_name(state : EditorRuntimeState) -> String {
   match state {
     EditorRuntimeState::Healthy => "healthy"
+    EditorRuntimeState::LocalText(_) => "local-text"
     EditorRuntimeState::Restarting => "restarting"
     EditorRuntimeState::RawRecovery(_) => "raw-recovery"
   }
@@ -200,7 +204,8 @@ fn runtime_state_name(state : EditorRuntimeState) -> String {
 ///|
 fn runtime_source(model : DriverModel) -> String {
   match model.runtime_state {
-    EditorRuntimeState::RawRecovery(source) => source
+    EditorRuntimeState::LocalText(source)
+    | EditorRuntimeState::RawRecovery(source) => source
     _ => model.document.source()
   }
 }
@@ -443,7 +448,12 @@ fn raw_editor_view(
   emit : @cmd.Emit[DriverEvent],
   raw_input_coordinator : RawInputCoordinator,
 ) -> @rabbita_runtime.Html {
-  let source = raw_input_coordinator.display_source(model.document.source())
+  let local_text = model.runtime_state is EditorRuntimeState::LocalText(_)
+  let source = if local_text {
+    runtime_source(model)
+  } else {
+    raw_input_coordinator.display_source(model.document.source())
+  }
   @html.div(
     style=[
       "box-sizing:border-box;width:100%;min-width:0;overflow-y:auto;overflow-x:hidden",
@@ -455,6 +465,9 @@ fn raw_editor_view(
       attrs=@html.Attrs::build()
         .aria_label("Raw Markdown source")
         .on_compositionstart(_ => {
+          if local_text {
+            return @rabbita_runtime.none
+          }
           match read_raw_selection() {
             Some(selection) =>
               ignore(
@@ -467,6 +480,11 @@ fn raw_editor_view(
           @rabbita_runtime.none
         })
         .on_compositionend(_ => {
+          if local_text {
+            return emit(
+              Editing(LocalTextInput(read_textarea_value("loomark-input"))),
+            )
+          }
           @cmd.batch([
             raw_input_coordinator.finish_composition(
               model.document.source(),
@@ -476,9 +494,21 @@ fn raw_editor_view(
           ])
         })
         .on_beforeinput(event => {
-          raw_input_coordinator.capture_native_before_input(model, event)
+          if local_text {
+            @rabbita_runtime.none
+          } else {
+            raw_input_coordinator.capture_native_before_input(model, event)
+          }
         })
         .on_input(event => {
+          if local_text {
+            if raw_input_event_is_composing(event) {
+              return @rabbita_runtime.none
+            }
+            return emit(
+              Editing(LocalTextInput(read_textarea_value("loomark-input"))),
+            )
+          }
           if raw_input_event_is_composing(event) {
             raw_input_coordinator.suppress_composing_input_repair()
           }
@@ -488,6 +518,9 @@ fn raw_editor_view(
         "display:block;min-width:0;min-height:clamp(24rem,70vh,36rem);width:var(--lm-page-width);margin-inline:auto;field-sizing:content;resize:none;overflow:hidden;--rui-control-base-border:transparent;--rui-control-base-shadow:none;background:transparent;padding:1rem var(--lm-page-x-padding);font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,\"Liberation Mono\",\"Courier New\",monospace;font-size:1.125rem;line-height:1.65",
       ],
       on_input=@cmd.Emit(source => {
+        if local_text {
+          return @rabbita_runtime.none
+        }
         match read_raw_selection() {
           Some(selection) =>
             if raw_input_coordinator.update_composition(source, selection) {
@@ -565,6 +598,7 @@ fn preview_view(
   active_view : @rabbita_runtime.Html,
   driver_controls : @rabbita_runtime.Html,
 ) -> @rabbita_runtime.Html {
+  let local_text = model.runtime_state is EditorRuntimeState::LocalText(_)
   let raw_selected = model.state.mode() == @core.Raw
   let block_selected = model.state.mode() == @core.Block
   let preview_selected = model.state.mode() == @core.Preview
@@ -609,23 +643,27 @@ fn preview_view(
   // affordance visible but disabled so the limitation is explicit. The toggle
   // stays enabled while a split is already open (e.g. after switching modes).
   let split_disabled = preview_selected && !model.split_preview_open
-  let split_toggle = @rui.button(
-    id="loomark-split-toggle",
-    variant=@rui.Ghost,
-    size=@rui.IconSm,
-    disabled=split_disabled,
-    attrs=@html.Attrs::build()
-      .aria_label(
-        if model.split_preview_open {
-          "Close split Preview"
-        } else {
-          "Open split Preview"
-        },
-      )
-      .aria_pressed(model.split_preview_open.to_string()),
-    on_click=emit(Navigation(ToggleSplitPreview)),
-    mode_icon("M4 4h6v16H4V4Zm10 0h6v16h-6V4Z"),
-  )
+  let split_toggle = if local_text {
+    @html.nothing
+  } else {
+    @rui.button(
+      id="loomark-split-toggle",
+      variant=@rui.Ghost,
+      size=@rui.IconSm,
+      disabled=split_disabled,
+      attrs=@html.Attrs::build()
+        .aria_label(
+          if model.split_preview_open {
+            "Close split Preview"
+          } else {
+            "Open split Preview"
+          },
+        )
+        .aria_pressed(model.split_preview_open.to_string()),
+      on_click=emit(Navigation(ToggleSplitPreview)),
+      mode_icon("M4 4h6v16H4V4Zm10 0h6v16h-6V4Z"),
+    )
+  }
   let examples = @html.div(
     attrs=@html.Attrs::build().role("toolbar").aria_label("Example documents"),
     style=[
@@ -746,7 +784,11 @@ fn preview_view(
                         aria_label="Editor view",
                         id="loomark-toolbar",
                         style=["min-height:3.25rem;padding:0;overflow:visible"],
-                        [block_button, raw_button, preview_button],
+                        if local_text {
+                          [raw_button]
+                        } else {
+                          [block_button, raw_button, preview_button]
+                        },
                       ),
                       split_toggle,
                     ],
@@ -866,6 +908,7 @@ fn driver_event_name(event : DriverEvent) -> String {
     Editing(edit_event) =>
       match edit_event {
         ReplaceSource(_) => "source"
+        LocalTextInput(_) => "local-text-input"
         RawInput(_, _) => "raw-input"
         RawNativeInput(..) => "raw-native-input"
         RawSelectionEdit(_) => "raw-selection-edit"
@@ -1101,7 +1144,10 @@ fn editing_mode_applicable(
 ) -> String? {
   match event {
     ReplaceSource(_) | ProbeBlockSelection(_) | RawNativeInput(..) => None
-    RawInput(_, _) | RawSelectionEdit(_) | CommitCapturedRawSelection(_) =>
+    LocalTextInput(_)
+    | RawInput(_, _)
+    | RawSelectionEdit(_)
+    | CommitCapturedRawSelection(_) =>
       if mode == @core.Raw || (mode == @core.Preview && split_preview_open) {
         None
       } else {
@@ -1170,6 +1216,40 @@ fn update_editing(
     }
     None =>
       match event {
+        LocalTextInput(source) =>
+          match model.runtime_state {
+            EditorRuntimeState::LocalText(previous) => {
+              raw_input_coordinator.cancel_pending()
+              if source == previous {
+                (model, @rabbita_runtime.none)
+              } else {
+                local_text_replacement(
+                  {
+                    ..model,
+                    runtime_state: EditorRuntimeState::LocalText(source),
+                    source_revision: model.source_revision + 1,
+                    text_input_generation: model.text_input_generation + 1,
+                    committed_change_count: model.committed_change_count + 1,
+                    error: None,
+                    error_code: None,
+                    error_operation: None,
+                  },
+                  source,
+                  emit,
+                )
+              }
+            }
+            _ =>
+              (
+                {
+                  ..model,
+                  rejection: Some(
+                    "operation=local-text-input;reason=local-text-inactive",
+                  ),
+                },
+                @rabbita_runtime.none,
+              )
+          }
         RawNativeInput(token~, candidate~) => {
           raw_input_coordinator.mark_reducer_started(token)
           let request = normalize_raw_input_candidate(model, candidate)
@@ -1303,6 +1383,19 @@ fn update_editing(
           (next, @cmd.batch([persistence_command, selection_command]))
         }
         ReplaceSource(source) | RawInput(source, _) => {
+          if model.runtime_state is EditorRuntimeState::LocalText(_) {
+            return update_editing(
+              editor,
+              attachment,
+              raw_input_coordinator,
+              block_input_coordinator,
+              model,
+              latest_model,
+              LocalTextInput(source),
+              emit,
+              projection_session?,
+            )
+          }
           let raw_input_epoch = raw_input_coordinator.epoch()
           let raw_selection = match event {
             RawInput(_, selection) => selection
@@ -1929,6 +2022,23 @@ fn update_navigation(
   emit : @cmd.Emit[DriverEvent],
   projection_session? : @ref.Ref[ProjectionSession?],
 ) -> (DriverModel, @cmd.Cmd) {
+  if model.runtime_state is EditorRuntimeState::LocalText(_) {
+    match event {
+      SelectBlock
+      | SelectPreview
+      | ToggleSplitPreview
+      | FocusBlock
+      | FocusPreview =>
+        return (
+          {
+            ..model,
+            rejection: Some("operation=navigation;reason=local-text-raw-only"),
+          },
+          @rabbita_runtime.none,
+        )
+      _ => ()
+    }
+  }
   match event {
     SelectRaw | SelectBlock | SelectPreview => {
       // The outer or-pattern already narrowed `event` to the Select*
@@ -3139,6 +3249,8 @@ pub fn mount_standalone(host_id : String, source : String) -> String {
       return "{\"ok\":true}"
     }
   }
+  // The production caller supplies an empty source. This session preserves the
+  // shared shell shape; persisted LocalText is never inserted into it.
   let (editor, attachment) = @markdown.MarkdownEditor::with_semantic_attachment(
     agent_id=replica_id,
     source~,

--- a/apps/loomark/internal/rabbita/document_transaction.mbt
+++ b/apps/loomark/internal/rabbita/document_transaction.mbt
@@ -110,6 +110,27 @@ fn archive_replacement(
 }
 
 ///|
+/// Persist standalone LocalText without consulting or constructing CRDT state.
+fn local_text_replacement(
+  model : DriverModel,
+  source : String,
+  emit : @cmd.Emit[DriverEvent],
+) -> (DriverModel, @cmd.Cmd) {
+  guard model.archive_persistence_enabled else {
+    return (model, @rabbita_runtime.none)
+  }
+  let prepared = @repository.prepare_local_text(
+    document_id=model.document_id,
+    source~,
+  )
+  let (archive_queue, pending) = model.archive_queue.enqueue(
+    document_version=model.document_version,
+    archive=prepared,
+  )
+  ({ ..model, archive_queue, }, local_archive_write_command(pending, emit))
+}
+
+///|
 /// Re-materialize the current accepted archive after an explicit retry.
 fn retry_local_persistence(
   editor : @markdown.MarkdownEditor,
@@ -118,6 +139,20 @@ fn retry_local_persistence(
 ) -> (DriverModel, @cmd.Cmd) raise {
   guard model.archive_persistence_enabled else {
     return (model, @rabbita_runtime.none)
+  }
+  if model.runtime_state is EditorRuntimeState::LocalText(source) {
+    let prepared = @repository.prepare_local_text(
+      document_id=model.document_id,
+      source~,
+    )
+    let (archive_queue, pending) = model.archive_queue.retry(
+      document_version=model.document_version,
+      archive=prepared,
+    )
+    return (
+      { ..model, archive_queue, },
+      local_archive_write_command(pending, emit),
+    )
   }
   let prepared = prepare_traced_local_archive(editor, model) catch {
     Failure::Failure(_) as failure => raise failure

--- a/apps/loomark/internal/rabbita/driver_types.mbt
+++ b/apps/loomark/internal/rabbita/driver_types.mbt
@@ -4,6 +4,7 @@
 /// from the mode gate (driver source replacement works in any mode).
 priv enum EditingEvent {
   ReplaceSource(String)
+  LocalTextInput(String)
   RawInput(String, @dom_boundary.TextSelection?)
   RawNativeInput(token~ : Int, candidate~ : RawNativeInputCandidate)
   RawSelectionEdit(RawSelectionEditRequest)

--- a/apps/loomark/internal/rabbita/pkg.generated.mbti
+++ b/apps/loomark/internal/rabbita/pkg.generated.mbti
@@ -30,6 +30,8 @@ pub fn measure_preview() -> Unit
 
 pub fn mount(String, String) -> String
 
+pub fn mount_full_history_oracle(String, String) -> String
+
 pub fn mount_standalone(String, String) -> String
 
 pub fn new_projection_worker_dispatcher() -> (String) -> String

--- a/apps/loomark/internal/rabbita/recovery_state.mbt
+++ b/apps/loomark/internal/rabbita/recovery_state.mbt
@@ -1,8 +1,10 @@
 ///|
-/// Runtime health of the mutable editor session. RawRecovery is terminal for
-/// this mount: the user must explicitly reload before another editor exists.
+/// Runtime health of the mutable editor session. LocalText owns standalone Raw
+/// editing without constructing CRDT state. RawRecovery is terminal for this
+/// mount: the user must explicitly reload before another editor exists.
 priv enum EditorRuntimeState {
   Healthy
+  LocalText(String)
   Restarting
   RawRecovery(String)
 } derive(Eq)
@@ -43,6 +45,8 @@ fn reduce_editor_runtime(
       )
     (Restarting, EditorRecoveryEvent::Failure) =>
       (EditorRuntimeState::RawRecovery(""), EditorRecoveryDecision::Continue)
+    (LocalText(source), _) =>
+      (EditorRuntimeState::LocalText(source), EditorRecoveryDecision::Reject)
     (RawRecovery(source), _) =>
       (EditorRuntimeState::RawRecovery(source), EditorRecoveryDecision::Reject)
     _ => (state, EditorRecoveryDecision::Reject)

--- a/apps/loomark/internal/rabbita/standalone_bootstrap.mbt
+++ b/apps/loomark/internal/rabbita/standalone_bootstrap.mbt
@@ -1,4 +1,32 @@
 ///|
+priv enum StandaloneBootstrapMode {
+  LocalTextBootstrap
+  FullHistoryOracleBootstrap
+}
+
+///|
+fn recovery_category(
+  failure : @repository.LocalArchiveLoadFailure,
+) -> RecoveryCategory {
+  match failure {
+    @repository.LocalArchiveLoadFailure::UnsupportedNewerVersion(_) =>
+      RecoveryCategory::UnsupportedArchive
+    @repository.LocalArchiveLoadFailure::LimitExceeded(..) =>
+      RecoveryCategory::ArchiveOverLimit
+    @repository.LocalArchiveLoadFailure::IncompleteHistory =>
+      RecoveryCategory::IncompleteArchive
+    @repository.LocalArchiveLoadFailure::InvalidValidationAgentId
+    | @repository.LocalArchiveLoadFailure::WriterCreationFailed(..) =>
+      RecoveryCategory::EditorInitializationFailed
+    @repository.LocalArchiveLoadFailure::MalformedArchive(..)
+    | @repository.LocalArchiveLoadFailure::CorruptArchive(..)
+    | @repository.LocalArchiveLoadFailure::HistoryAdmissionFailed(..)
+    | @repository.LocalArchiveLoadFailure::HistoryExportFailed(..) =>
+      RecoveryCategory::CorruptArchive
+  }
+}
+
+///|
 fn recovery_code(category : RecoveryCategory) -> String {
   match category {
     RecoveryCategory::StorageUnavailable => "storage-unavailable"
@@ -32,6 +60,175 @@ fn bootstrap_rejected(
     },
     @cmd.none,
   )
+}
+
+///|
+fn adopt_full_history_session(
+  session_ref : @ref.Ref[EditorSession],
+  model : DriverModel,
+  editor : @markdown.MarkdownEditor,
+  attachment : @md_markdown.MarkdownSemanticAttachment,
+  document_id : @archive.LoomarkDocumentId,
+  replica_id : String,
+  archive_queue : @repository.LocalArchivePersistenceQueue,
+  command : @cmd.Cmd,
+) -> (DriverModel, @cmd.Cmd) {
+  let document = editor.snapshot() catch {
+    _ => {
+      attachment.dispose()
+      return bootstrap_rejected(
+        session_ref,
+        model,
+        RecoveryCategory::EditorInitializationFailed,
+      )
+    }
+  }
+  session_ref.val.attachment.dispose()
+  session_ref.val = { editor, attachment }
+  (
+    {
+      ..model,
+      state: @core.ApplicationState::ApplicationState(@core.Raw),
+      runtime_state: EditorRuntimeState::Healthy,
+      document,
+      document_version: editor.version(),
+      document_id,
+      raw_selection: None,
+      archive_persistence_enabled: true,
+      bootstrap_pending: false,
+      semantic_document: None,
+      preview_artifact: None,
+      semantic_read_count: 0,
+      split_preview_open: false,
+      active_block_key: None,
+      replica_id,
+      source_revision: 0,
+      text_input_generation: 0,
+      fatal: false,
+      error: None,
+      error_code: None,
+      error_operation: None,
+      error_count: 0,
+      committed_change_count: 0,
+      reconstruction_attempt_count: 0,
+      selection: None,
+      measurement: None,
+      event_detail: None,
+      rejection: None,
+      archive_queue,
+    },
+    command,
+  )
+}
+
+///|
+fn create_full_history_document(
+  session_ref : @ref.Ref[EditorSession],
+  model : DriverModel,
+  source : String,
+  emit : @cmd.Emit[DriverEvent],
+) -> (DriverModel, @cmd.Cmd) {
+  let replica_id = @archive_storage.fresh_id("loomark-r0-oracle-writer-")
+  let document_id = @archive.LoomarkDocumentId::from_string(
+    @archive_storage.fresh_id("loomark-document-"),
+  ) catch {
+    _ =>
+      return bootstrap_rejected(
+        session_ref,
+        model,
+        RecoveryCategory::EditorInitializationFailed,
+      )
+  }
+  let (editor, attachment) = @markdown.MarkdownEditor::with_semantic_attachment(
+    agent_id=replica_id,
+    source~,
+  ) catch {
+    _ =>
+      return bootstrap_rejected(
+        session_ref,
+        model,
+        RecoveryCategory::EditorInitializationFailed,
+      )
+  }
+  let queue = @repository.LocalArchivePersistenceQueue::LocalArchivePersistenceQueue(
+    document_id~,
+    queue_epoch=replica_id,
+    current=editor.version(),
+    durable=None,
+  )
+  let prepared = @repository.prepare_local_archive(document_id~, editor~) catch {
+    _ =>
+      return adopt_full_history_session(
+        session_ref,
+        model,
+        editor,
+        attachment,
+        document_id,
+        replica_id,
+        queue.mark_failed(
+          document_version=editor.version(),
+          error=@repository.LocalArchivePersistenceFailure::PreparationFailed,
+        ),
+        @cmd.none,
+      )
+  }
+  let (archive_queue, pending) = queue.enqueue(
+    document_version=editor.version(),
+    archive=prepared,
+  )
+  adopt_full_history_session(
+    session_ref,
+    model,
+    editor,
+    attachment,
+    document_id,
+    replica_id,
+    archive_queue,
+    local_archive_write_command(pending, emit),
+  )
+}
+
+///|
+fn reopen_full_history_archive(
+  session_ref : @ref.Ref[EditorSession],
+  model : DriverModel,
+  encoded : String,
+) -> (DriverModel, @cmd.Cmd) {
+  let replica_id = @archive_storage.fresh_id("loomark-r0-oracle-writer-")
+  let classified = @repository.classify_local_archive_record(
+    Some(encoded),
+    agent_id=replica_id,
+    policy=@repository.LocalRestorePolicy::trusted(),
+  ) catch {
+    _ =>
+      return bootstrap_rejected(
+        session_ref,
+        model,
+        RecoveryCategory::CorruptArchive,
+      )
+  }
+  match classified {
+    @repository.LocalArchiveLoad::Valid(reopened) =>
+      adopt_full_history_session(
+        session_ref,
+        model,
+        reopened.editor(),
+        reopened.attachment(),
+        reopened.document_id(),
+        replica_id,
+        @repository.LocalArchivePersistenceQueue::LocalArchivePersistenceQueue(
+          document_id=reopened.document_id(),
+          queue_epoch=replica_id,
+          current=reopened.editor().version(),
+          durable=Some(reopened.editor().version()),
+        ),
+        @cmd.none,
+      )
+    @repository.LocalArchiveLoad::Rejected(failure) =>
+      bootstrap_rejected(session_ref, model, recovery_category(failure))
+    @repository.LocalArchiveLoad::Missing =>
+      bootstrap_rejected(session_ref, model, RecoveryCategory::CorruptArchive)
+  }
 }
 
 ///|
@@ -101,9 +298,15 @@ fn create_bootstrap_document(
   session_ref : @ref.Ref[EditorSession],
   model : DriverModel,
   source : String,
+  mode : StandaloneBootstrapMode,
   emit : @cmd.Emit[DriverEvent],
 ) -> (DriverModel, @cmd.Cmd) {
-  create_local_text_document(session_ref, model, source, emit)
+  match mode {
+    LocalTextBootstrap =>
+      create_local_text_document(session_ref, model, source, emit)
+    FullHistoryOracleBootstrap =>
+      create_full_history_document(session_ref, model, source, emit)
+  }
 }
 
 ///|
@@ -113,12 +316,13 @@ fn update_standalone_bootstrap(
   model : DriverModel,
   loaded : @archive_storage.LocalArchiveStorageRead,
   source : String,
+  mode : StandaloneBootstrapMode,
   emit : @cmd.Emit[DriverEvent],
 ) -> (DriverModel, @cmd.Cmd) {
   guard !model.archive_persistence_enabled else { return (model, @cmd.none) }
   match loaded {
     @archive_storage.LocalArchiveStorageRead::Missing =>
-      create_bootstrap_document(session_ref, model, source, emit)
+      create_bootstrap_document(session_ref, model, source, mode, emit)
     @archive_storage.LocalArchiveStorageRead::Failed(
       @repository.LocalArchiveStorageReadFailure::Unavailable
     ) =>
@@ -135,41 +339,65 @@ fn update_standalone_bootstrap(
         model,
         RecoveryCategory::StorageReadFailed,
       )
-    @archive_storage.LocalArchiveStorageRead::LocalText(encoded) => {
-      let replica_id = @archive_storage.fresh_id("loomark-standalone-writer-")
-      match @repository.decode_local_text(encoded) {
-        @repository.LocalTextDecode::Valid(document_id~, source=local_source) =>
-          start_local_text(
-            model, document_id, local_source, replica_id, false, emit,
-          )
-        _ =>
+    @archive_storage.LocalArchiveStorageRead::LocalText(encoded) =>
+      match mode {
+        FullHistoryOracleBootstrap =>
           bootstrap_rejected(
             session_ref,
             model,
             RecoveryCategory::CorruptArchive,
           )
+        LocalTextBootstrap => {
+          let replica_id = @archive_storage.fresh_id(
+            "loomark-standalone-writer-",
+          )
+          match @repository.decode_local_text(encoded) {
+            @repository.LocalTextDecode::Valid(
+              document_id~,
+              source=local_source
+            ) =>
+              start_local_text(
+                model, document_id, local_source, replica_id, false, emit,
+              )
+            _ =>
+              bootstrap_rejected(
+                session_ref,
+                model,
+                RecoveryCategory::CorruptArchive,
+              )
+          }
+        }
       }
-    }
-    @archive_storage.LocalArchiveStorageRead::LegacyArchive(encoded) => {
-      let replica_id = @archive_storage.fresh_id("loomark-standalone-writer-")
-      match @repository.decode_v1_archive_text(encoded) {
-        @repository.LocalTextDecode::Valid(document_id~, source=local_source) =>
-          start_local_text(
-            model, document_id, local_source, replica_id, false, emit,
+    @archive_storage.LocalArchiveStorageRead::LegacyArchive(encoded) =>
+      match mode {
+        FullHistoryOracleBootstrap =>
+          reopen_full_history_archive(session_ref, model, encoded)
+        LocalTextBootstrap => {
+          let replica_id = @archive_storage.fresh_id(
+            "loomark-standalone-writer-",
           )
-        @repository.LocalTextDecode::UnsupportedArchive(_) =>
-          bootstrap_rejected(
-            session_ref,
-            model,
-            RecoveryCategory::UnsupportedArchive,
-          )
-        @repository.LocalTextDecode::Invalid =>
-          bootstrap_rejected(
-            session_ref,
-            model,
-            RecoveryCategory::CorruptArchive,
-          )
+          match @repository.decode_v1_archive_text(encoded) {
+            @repository.LocalTextDecode::Valid(
+              document_id~,
+              source=local_source
+            ) =>
+              start_local_text(
+                model, document_id, local_source, replica_id, false, emit,
+              )
+            @repository.LocalTextDecode::UnsupportedArchive(_) =>
+              bootstrap_rejected(
+                session_ref,
+                model,
+                RecoveryCategory::UnsupportedArchive,
+              )
+            @repository.LocalTextDecode::Invalid =>
+              bootstrap_rejected(
+                session_ref,
+                model,
+                RecoveryCategory::CorruptArchive,
+              )
+          }
+        }
       }
-    }
   }
 }

--- a/apps/loomark/internal/rabbita/standalone_bootstrap.mbt
+++ b/apps/loomark/internal/rabbita/standalone_bootstrap.mbt
@@ -1,27 +1,4 @@
 ///|
-/// Map repository admission failures to stable recovery categories.
-fn recovery_category(
-  failure : @repository.LocalArchiveLoadFailure,
-) -> RecoveryCategory {
-  match failure {
-    @repository.LocalArchiveLoadFailure::UnsupportedNewerVersion(_) =>
-      RecoveryCategory::UnsupportedArchive
-    @repository.LocalArchiveLoadFailure::LimitExceeded(..) =>
-      RecoveryCategory::ArchiveOverLimit
-    @repository.LocalArchiveLoadFailure::IncompleteHistory =>
-      RecoveryCategory::IncompleteArchive
-    @repository.LocalArchiveLoadFailure::InvalidValidationAgentId
-    | @repository.LocalArchiveLoadFailure::WriterCreationFailed(..) =>
-      RecoveryCategory::EditorInitializationFailed
-    @repository.LocalArchiveLoadFailure::MalformedArchive(..)
-    | @repository.LocalArchiveLoadFailure::CorruptArchive(..)
-    | @repository.LocalArchiveLoadFailure::HistoryAdmissionFailed(..)
-    | @repository.LocalArchiveLoadFailure::HistoryExportFailed(..) =>
-      RecoveryCategory::CorruptArchive
-  }
-}
-
-///|
 fn recovery_code(category : RecoveryCategory) -> String {
   match category {
     RecoveryCategory::StorageUnavailable => "storage-unavailable"
@@ -58,58 +35,39 @@ fn bootstrap_rejected(
 }
 
 ///|
-fn adopt_bootstrap_session(
-  session_ref : @ref.Ref[EditorSession],
+/// Enter source-only standalone editing without constructing CRDT state.
+fn start_local_text(
   model : DriverModel,
-  editor : @markdown.MarkdownEditor,
-  attachment : @md_markdown.MarkdownSemanticAttachment,
   document_id : @archive.LoomarkDocumentId,
+  source : String,
   replica_id : String,
-  archive_queue : @repository.LocalArchivePersistenceQueue,
-  command : @cmd.Cmd,
+  persist : Bool,
+  emit : @cmd.Emit[DriverEvent],
 ) -> (DriverModel, @cmd.Cmd) {
-  let document = editor.snapshot() catch {
-    _ => {
-      attachment.dispose()
-      return bootstrap_rejected(
-        session_ref,
-        model,
-        RecoveryCategory::EditorInitializationFailed,
-      )
-    }
+  let queue = @repository.LocalArchivePersistenceQueue::LocalArchivePersistenceQueue(
+    document_id~,
+    queue_epoch=replica_id,
+    current=model.document_version,
+    durable=if persist { None } else { Some(model.document_version) },
+  )
+  let (archive_queue, command) = if persist {
+    let prepared = @repository.prepare_local_text(document_id~, source~)
+    let (queue, pending) = queue.enqueue(
+      document_version=model.document_version,
+      archive=prepared,
+    )
+    (queue, local_archive_write_command(pending, emit))
+  } else {
+    (queue, @cmd.none)
   }
-  session_ref.val.attachment.dispose()
-  session_ref.val = { editor, attachment }
   (
     {
       ..model,
-      state: @core.ApplicationState::ApplicationState(@core.Raw),
-      runtime_state: EditorRuntimeState::Healthy,
-      document,
-      document_version: editor.version(),
+      runtime_state: EditorRuntimeState::LocalText(source),
       document_id,
-      raw_selection: None,
       archive_persistence_enabled: true,
       bootstrap_pending: false,
-      semantic_document: None,
-      preview_artifact: None,
-      semantic_read_count: 0,
-      split_preview_open: false,
-      active_block_key: None,
       replica_id,
-      source_revision: 0,
-      text_input_generation: 0,
-      fatal: false,
-      error: None,
-      error_code: None,
-      error_operation: None,
-      error_count: 0,
-      committed_change_count: 0,
-      reconstruction_attempt_count: 0,
-      selection: None,
-      measurement: None,
-      event_detail: None,
-      rejection: None,
       archive_queue,
     },
     command,
@@ -117,8 +75,7 @@ fn adopt_bootstrap_session(
 }
 
 ///|
-/// Create a fresh local document after an empty archive slot is observed.
-fn create_bootstrap_document(
+fn create_local_text_document(
   session_ref : @ref.Ref[EditorSession],
   model : DriverModel,
   source : String,
@@ -135,48 +92,18 @@ fn create_bootstrap_document(
         RecoveryCategory::EditorInitializationFailed,
       )
   }
-  let (editor, attachment) = @markdown.MarkdownEditor::with_semantic_attachment(
-    agent_id=replica_id,
-    source~,
-  ) catch {
-    _ =>
-      return bootstrap_rejected(
-        session_ref,
-        model,
-        RecoveryCategory::EditorInitializationFailed,
-      )
-  }
-  let archive_queue = @repository.LocalArchivePersistenceQueue::LocalArchivePersistenceQueue(
-    document_id~,
-    queue_epoch=replica_id,
-    current=editor.version(),
-    durable=None,
-  )
-  let prepared = @repository.prepare_local_archive(document_id~, editor~) catch {
-    _ =>
-      return adopt_bootstrap_session(
-        session_ref,
-        model,
-        editor,
-        attachment,
-        document_id,
-        replica_id,
-        archive_queue.mark_failed(
-          document_version=editor.version(),
-          error=@repository.LocalArchivePersistenceFailure::PreparationFailed,
-        ),
-        @cmd.none,
-      )
-  }
-  let (archive_queue, pending) = archive_queue.enqueue(
-    document_version=editor.version(),
-    archive=prepared,
-  )
-  let command = local_archive_write_command(pending, emit)
-  adopt_bootstrap_session(
-    session_ref, model, editor, attachment, document_id, replica_id, archive_queue,
-    command,
-  )
+  start_local_text(model, document_id, source, replica_id, true, emit)
+}
+
+///|
+/// Create a fresh source-only local document after an empty slot is observed.
+fn create_bootstrap_document(
+  session_ref : @ref.Ref[EditorSession],
+  model : DriverModel,
+  source : String,
+  emit : @cmd.Emit[DriverEvent],
+) -> (DriverModel, @cmd.Cmd) {
+  create_local_text_document(session_ref, model, source, emit)
 }
 
 ///|
@@ -208,42 +135,40 @@ fn update_standalone_bootstrap(
         model,
         RecoveryCategory::StorageReadFailed,
       )
-    @archive_storage.LocalArchiveStorageRead::Loaded(encoded) => {
-      let policy = @repository.LocalRestorePolicy::trusted()
+    @archive_storage.LocalArchiveStorageRead::LocalText(encoded) => {
       let replica_id = @archive_storage.fresh_id("loomark-standalone-writer-")
-      let classified = @repository.classify_local_archive_record(
-        Some(encoded),
-        agent_id=replica_id,
-        policy~,
-      ) catch {
+      match @repository.decode_local_text(encoded) {
+        @repository.LocalTextDecode::Valid(document_id~, source=local_source) =>
+          start_local_text(
+            model, document_id, local_source, replica_id, false, emit,
+          )
         _ =>
-          return bootstrap_rejected(
+          bootstrap_rejected(
             session_ref,
             model,
             RecoveryCategory::CorruptArchive,
           )
       }
-      match classified {
-        @repository.LocalArchiveLoad::Valid(reopened) =>
-          adopt_bootstrap_session(
+    }
+    @archive_storage.LocalArchiveStorageRead::LegacyArchive(encoded) => {
+      let replica_id = @archive_storage.fresh_id("loomark-standalone-writer-")
+      match @repository.decode_v1_archive_text(encoded) {
+        @repository.LocalTextDecode::Valid(document_id~, source=local_source) =>
+          start_local_text(
+            model, document_id, local_source, replica_id, false, emit,
+          )
+        @repository.LocalTextDecode::UnsupportedArchive(_) =>
+          bootstrap_rejected(
             session_ref,
             model,
-            reopened.editor(),
-            reopened.attachment(),
-            reopened.document_id(),
-            replica_id,
-            @repository.LocalArchivePersistenceQueue::LocalArchivePersistenceQueue(
-              document_id=reopened.document_id(),
-              queue_epoch=replica_id,
-              current=reopened.editor().version(),
-              durable=Some(reopened.editor().version()),
-            ),
-            @cmd.none,
+            RecoveryCategory::UnsupportedArchive,
           )
-        @repository.LocalArchiveLoad::Rejected(failure) =>
-          bootstrap_rejected(session_ref, model, recovery_category(failure))
-        @repository.LocalArchiveLoad::Missing =>
-          create_bootstrap_document(session_ref, model, source, emit)
+        @repository.LocalTextDecode::Invalid =>
+          bootstrap_rejected(
+            session_ref,
+            model,
+            RecoveryCategory::CorruptArchive,
+          )
       }
     }
   }

--- a/apps/loomark/main/main.mbt
+++ b/apps/loomark/main/main.mbt
@@ -499,9 +499,18 @@ extern "js" fn start_projection_worker_gate(
   #| }
 
 ///|
+extern "js" fn gate_r0_full_history_oracle_enabled() -> Bool =
+  #| () => new URLSearchParams(location.search)
+  #|   .get("gate-r0-full-history-oracle") === "1"
+
+///|
 /// Start the page-owned Loomark application exactly once.
 fn main {
-  ignore(@app.mount_standalone("app", ""))
+  if gate_r0_full_history_oracle_enabled() {
+    ignore(@app.mount_full_history_oracle("app", ""))
+  } else {
+    ignore(@app.mount_standalone("app", ""))
+  }
   start_warren_worker_capability_smoke()
   start_projection_worker_gate(@app.new_projection_worker_dispatcher())
 }

--- a/apps/loomark/main/pkg.generated.mbti
+++ b/apps/loomark/main/pkg.generated.mbti
@@ -10,4 +10,3 @@ package "dowdiness/loomark/main"
 // Type aliases
 
 // Traits
-

--- a/apps/loomark/repository/local_persistence_queue.mbt
+++ b/apps/loomark/repository/local_persistence_queue.mbt
@@ -65,6 +65,12 @@ pub fn LocalArchivePendingWrite::encoded(self : Self) -> String {
 }
 
 ///|
+/// Whether this write targets the source-only LocalText slot.
+pub fn LocalArchivePendingWrite::is_source_only(self : Self) -> Bool {
+  self.archive.is_source_only()
+}
+
+///|
 /// Pure per-document single-flight persistence state.
 ///
 /// Invariants:

--- a/apps/loomark/repository/local_persistence_queue.mbt
+++ b/apps/loomark/repository/local_persistence_queue.mbt
@@ -65,9 +65,11 @@ pub fn LocalArchivePendingWrite::encoded(self : Self) -> String {
 }
 
 ///|
-/// Whether this write targets the source-only LocalText slot.
-pub fn LocalArchivePendingWrite::is_source_only(self : Self) -> Bool {
-  self.archive.is_source_only()
+/// Return the prepared record format for exhaustive storage routing.
+pub fn LocalArchivePendingWrite::record_kind(
+  self : Self,
+) -> LocalArchiveRecordKind {
+  self.archive.record_kind()
 }
 
 ///|

--- a/apps/loomark/repository/local_persistence_queue.mbt
+++ b/apps/loomark/repository/local_persistence_queue.mbt
@@ -135,7 +135,9 @@ pub fn LocalArchivePersistenceQueue::status(
       )
     None =>
       match self.durable {
-        Some(durable) if durable == self.current =>
+        Some(durable) if durable == self.current &&
+          self.in_flight is None &&
+          self.pending_latest is None =>
           LocalArchivePersistenceStatus::DurableLocal(self.current)
         _ =>
           LocalArchivePersistenceStatus::Applied(

--- a/apps/loomark/repository/moon.pkg
+++ b/apps/loomark/repository/moon.pkg
@@ -2,11 +2,8 @@ import {
   "dowdiness/loomark/archive",
   "dowdiness/canopy/editor/markdown",
   "dowdiness/markdown" @md_markdown,
-}
-
-import {
   "moonbitlang/core/json",
-} for "wbtest"
+}
 
 warnings = "-7-29"
 

--- a/apps/loomark/repository/pkg.generated.mbti
+++ b/apps/loomark/repository/pkg.generated.mbti
@@ -55,7 +55,7 @@ pub struct LocalArchivePendingWrite {
   // private fields
 } derive(Eq)
 pub fn LocalArchivePendingWrite::encoded(Self) -> String
-pub fn LocalArchivePendingWrite::is_source_only(Self) -> Bool
+pub fn LocalArchivePendingWrite::record_kind(Self) -> LocalArchiveRecordKind
 
 pub(all) enum LocalArchivePersistenceDecision {
   Replace
@@ -90,6 +90,11 @@ pub(all) enum LocalArchiveQueueCompletion {
   Promoted(LocalArchivePendingWrite)
 } derive(Eq)
 
+pub(all) enum LocalArchiveRecordKind {
+  FullHistory
+  LocalText
+} derive(Eq, @debug.Debug)
+
 pub(all) enum LocalArchiveStorageReadFailure {
   Unavailable
   Failed
@@ -122,7 +127,7 @@ pub struct PreparedLocalArchive {
   // private fields
 } derive(Eq)
 pub fn PreparedLocalArchive::encoded(Self) -> String
-pub fn PreparedLocalArchive::is_source_only(Self) -> Bool
+pub fn PreparedLocalArchive::record_kind(Self) -> LocalArchiveRecordKind
 
 pub struct ReopenedLocalArchive {
   // private fields

--- a/apps/loomark/repository/pkg.generated.mbti
+++ b/apps/loomark/repository/pkg.generated.mbti
@@ -9,11 +9,17 @@ import {
 // Values
 pub fn classify_local_archive_record(String?, agent_id~ : String, policy~ : LocalRestorePolicy) -> LocalArchiveLoad raise
 
+pub fn decode_local_text(String) -> LocalTextDecode
+
+pub fn decode_v1_archive_text(String) -> LocalTextDecode
+
 pub fn history_trigger(@dowdiness/canopy/editor/markdown.MarkdownCommitReceipt) -> LocalArchivePersistenceDecision
 
 pub fn prepare_local_archive(document_id~ : @archive.LoomarkDocumentId, editor~ : @dowdiness/canopy/editor/markdown.MarkdownEditor) -> PreparedLocalArchive raise
 
 pub fn prepare_local_archive_observing(document_id~ : @archive.LoomarkDocumentId, editor~ : @dowdiness/canopy/editor/markdown.MarkdownEditor, (@archive.LoomarkArchivePreparationPhase) -> Unit) -> PreparedLocalArchive raise
+
+pub fn prepare_local_text(document_id~ : @archive.LoomarkDocumentId, source~ : String) -> PreparedLocalArchive
 
 pub fn reopen_decoded_local_archive(@archive.DecodedLoomarkDocumentArchive, agent_id~ : String, policy~ : LocalRestorePolicy) -> ReopenedLocalArchive raise
 
@@ -104,6 +110,12 @@ pub struct LocalRestorePolicy {
 }
 pub fn LocalRestorePolicy::LocalRestorePolicy(@dowdiness/canopy/editor/markdown.MarkdownArchiveOpenLimits) -> Self
 pub fn LocalRestorePolicy::trusted() -> Self
+
+pub(all) enum LocalTextDecode {
+  Valid(document_id~ : @archive.LoomarkDocumentId, source~ : String)
+  UnsupportedArchive(String)
+  Invalid
+} derive(Eq, @debug.Debug)
 
 pub struct PreparedLocalArchive {
   // private fields

--- a/apps/loomark/repository/pkg.generated.mbti
+++ b/apps/loomark/repository/pkg.generated.mbti
@@ -55,6 +55,7 @@ pub struct LocalArchivePendingWrite {
   // private fields
 } derive(Eq)
 pub fn LocalArchivePendingWrite::encoded(Self) -> String
+pub fn LocalArchivePendingWrite::is_source_only(Self) -> Bool
 
 pub(all) enum LocalArchivePersistenceDecision {
   Replace
@@ -121,6 +122,7 @@ pub struct PreparedLocalArchive {
   // private fields
 } derive(Eq)
 pub fn PreparedLocalArchive::encoded(Self) -> String
+pub fn PreparedLocalArchive::is_source_only(Self) -> Bool
 
 pub struct ReopenedLocalArchive {
   // private fields

--- a/apps/loomark/repository/repository.mbt
+++ b/apps/loomark/repository/repository.mbt
@@ -166,10 +166,17 @@ pub(all) suberror LocalArchivePreparationError {
 }
 
 ///|
+/// Persistence format carried by one prepared local replacement.
+pub(all) enum LocalArchiveRecordKind {
+  FullHistory
+  LocalText
+} derive(Eq, Debug)
+
+///|
 /// One immutable complete encoded replacement, ready for a storage shell.
 pub struct PreparedLocalArchive {
   priv encoded : String
-  priv source_only : Bool
+  priv record_kind : LocalArchiveRecordKind
 } derive(Eq)
 
 ///|
@@ -184,7 +191,7 @@ pub fn prepare_local_archive(
       raise LocalArchivePreparationError::HistoryUnavailable(detail~)
     error => raise error
   }
-  { encoded: archive.to_json_string(), source_only: false }
+  { encoded: archive.to_json_string(), record_kind: FullHistory }
 }
 
 ///|
@@ -204,7 +211,10 @@ pub fn prepare_local_archive_observing(
       raise LocalArchivePreparationError::HistoryUnavailable(detail~)
     error => raise error
   }
-  { encoded: archive.to_json_string_observing(observer), source_only: false }
+  {
+    encoded: archive.to_json_string_observing(observer),
+    record_kind: FullHistory,
+  }
 }
 
 ///|
@@ -214,9 +224,9 @@ pub fn PreparedLocalArchive::encoded(self : Self) -> String {
 }
 
 ///|
-/// Whether this replacement belongs in the source-only LocalText slot.
-pub fn PreparedLocalArchive::is_source_only(self : Self) -> Bool {
-  self.source_only
+/// Return the replacement format so the storage shell can select its slot.
+pub fn PreparedLocalArchive::record_kind(self : Self) -> LocalArchiveRecordKind {
+  self.record_kind
 }
 
 ///|
@@ -242,7 +252,7 @@ pub fn prepare_local_text(
       "document_id": Json::string(document_id.value()),
       "portable_markdown": Json::string(source),
     }).stringify(),
-    source_only: true,
+    record_kind: LocalText,
   }
 }
 

--- a/apps/loomark/repository/repository.mbt
+++ b/apps/loomark/repository/repository.mbt
@@ -213,6 +213,89 @@ pub fn PreparedLocalArchive::encoded(self : Self) -> String {
 }
 
 ///|
+/// Source-only decode result used by LocalText and legacy-v1 fallback reads.
+pub(all) enum LocalTextDecode {
+  Valid(document_id~ : @archive.LoomarkDocumentId, source~ : String)
+  UnsupportedArchive(String)
+  Invalid
+} derive(Eq, Debug)
+
+///|
+const LOCAL_TEXT_FORMAT : String = "loomark-local-text-v1"
+
+///|
+/// Prepare the standalone source record without consulting CRDT state.
+pub fn prepare_local_text(
+  document_id~ : @archive.LoomarkDocumentId,
+  source~ : String,
+) -> PreparedLocalArchive {
+  {
+    encoded: Json::object({
+      "format": Json::string(LOCAL_TEXT_FORMAT),
+      "document_id": Json::string(document_id.value()),
+      "portable_markdown": Json::string(source),
+    }).stringify(),
+  }
+}
+
+///|
+fn decode_document_source(
+  fields : Map[String, Json],
+) -> (@archive.LoomarkDocumentId, String)? {
+  let document_id = match fields.get("document_id") {
+    Some(Json::String(value)) =>
+      @archive.LoomarkDocumentId::from_string(value) catch {
+        _ => return None
+      }
+    _ => return None
+  }
+  match fields.get("portable_markdown") {
+    Some(Json::String(source)) => Some((document_id, source))
+    _ => None
+  }
+}
+
+///|
+/// Decode the production LocalText record without creating an editor.
+pub fn decode_local_text(encoded : String) -> LocalTextDecode {
+  let value = @json.parse(encoded) catch {
+    _ => return LocalTextDecode::Invalid
+  }
+  guard value is Json::Object(fields) && fields.length() == 3 else {
+    return LocalTextDecode::Invalid
+  }
+  guard fields.get("format") is Some(Json::String(format)) &&
+    format == LOCAL_TEXT_FORMAT else {
+    return LocalTextDecode::Invalid
+  }
+  match decode_document_source(fields) {
+    Some((document_id, source)) => LocalTextDecode::Valid(document_id~, source~)
+    None => LocalTextDecode::Invalid
+  }
+}
+
+///|
+/// Read only the source fields from a legacy v1 archive. History remains
+/// untouched in storage and is never decoded or admitted on this path.
+pub fn decode_v1_archive_text(encoded : String) -> LocalTextDecode {
+  let value = @json.parse(encoded) catch {
+    _ => return LocalTextDecode::Invalid
+  }
+  guard value is Json::Object(fields) else { return LocalTextDecode::Invalid }
+  let version = match fields.get("schema_version") {
+    Some(Json::String(version)) => version
+    _ => return LocalTextDecode::Invalid
+  }
+  if version != "1" {
+    return LocalTextDecode::UnsupportedArchive(version)
+  }
+  match decode_document_source(fields) {
+    Some((document_id, source)) => LocalTextDecode::Valid(document_id~, source~)
+    None => LocalTextDecode::Invalid
+  }
+}
+
+///|
 /// Whether a commit authorizes a complete archive replacement.
 pub(all) enum LocalArchivePersistenceDecision {
   Replace

--- a/apps/loomark/repository/repository.mbt
+++ b/apps/loomark/repository/repository.mbt
@@ -169,6 +169,7 @@ pub(all) suberror LocalArchivePreparationError {
 /// One immutable complete encoded replacement, ready for a storage shell.
 pub struct PreparedLocalArchive {
   priv encoded : String
+  priv source_only : Bool
 } derive(Eq)
 
 ///|
@@ -183,7 +184,7 @@ pub fn prepare_local_archive(
       raise LocalArchivePreparationError::HistoryUnavailable(detail~)
     error => raise error
   }
-  { encoded: archive.to_json_string() }
+  { encoded: archive.to_json_string(), source_only: false }
 }
 
 ///|
@@ -203,13 +204,19 @@ pub fn prepare_local_archive_observing(
       raise LocalArchivePreparationError::HistoryUnavailable(detail~)
     error => raise error
   }
-  { encoded: archive.to_json_string_observing(observer) }
+  { encoded: archive.to_json_string_observing(observer), source_only: false }
 }
 
 ///|
 /// Return the deterministic encoded replacement payload.
 pub fn PreparedLocalArchive::encoded(self : Self) -> String {
   self.encoded
+}
+
+///|
+/// Whether this replacement belongs in the source-only LocalText slot.
+pub fn PreparedLocalArchive::is_source_only(self : Self) -> Bool {
+  self.source_only
 }
 
 ///|
@@ -235,6 +242,7 @@ pub fn prepare_local_text(
       "document_id": Json::string(document_id.value()),
       "portable_markdown": Json::string(source),
     }).stringify(),
+    source_only: true,
   }
 }
 

--- a/apps/loomark/repository/repository_wbtest.mbt
+++ b/apps/loomark/repository/repository_wbtest.mbt
@@ -195,6 +195,7 @@ test "repository prepares one complete immutable encoded archive" {
   )
   let document_id = try! @archive.LoomarkDocumentId::from_string("doc-prepare")
   let prepared = try! prepare_local_archive(document_id~, editor~)
+  assert_false(prepared.is_source_only())
   let decoded = try! @archive.LoomarkDocumentArchive::from_json_string(
     prepared.encoded(),
     validation_agent_id="repository-prepare-decode",
@@ -796,6 +797,7 @@ test "LocalText decodes source without constructing an editor" {
     _ => abort("test document ID must be valid")
   }
   let prepared = prepare_local_text(document_id~, source="alpha\nβeta 🪶\n")
+  assert_true(prepared.is_source_only())
   assert_eq(
     decode_local_text(prepared.encoded()),
     LocalTextDecode::Valid(document_id~, source="alpha\nβeta 🪶\n"),

--- a/apps/loomark/repository/repository_wbtest.mbt
+++ b/apps/loomark/repository/repository_wbtest.mbt
@@ -273,6 +273,38 @@ test "persistence queue reports applied then durable local" {
 }
 
 ///|
+test "persistence queue waits for the latest same-version source" {
+  let (editor, document_id, version) = queue_document(
+    "repository-same-version", "doc-same-version", "",
+  )
+  let queue = LocalArchivePersistenceQueue::LocalArchivePersistenceQueue(
+    document_id~,
+    queue_epoch="repository-same-version",
+    current=version,
+    durable=None,
+  )
+  let first = prepare_local_text(document_id~, source="one")
+  let second = prepare_local_text(document_id~, source="two")
+  let (queue, first_write) = queue.enqueue(
+    document_version=version,
+    archive=first,
+  )
+  guard first_write is Some(first_write) else { fail("expected first write") }
+  let (queue, _) = queue.enqueue(document_version=version, archive=second)
+  let (queue, completion) = queue.complete(
+    first_write,
+    LocalArchiveWriteOutcome::Stored,
+  )
+  guard completion is LocalArchiveQueueCompletion::Promoted(promoted) else {
+    fail("expected latest source promotion")
+  }
+  assert_true(queue.status() is LocalArchivePersistenceStatus::Applied(..))
+  let (queue, _) = queue.complete(promoted, LocalArchiveWriteOutcome::Stored)
+  assert_true(queue.status() is LocalArchivePersistenceStatus::DurableLocal(_))
+  ignore(editor)
+}
+
+///|
 test "persistence queue coalesces and promotes the latest archive" {
   let (editor, document_id, initial_version) = queue_document(
     "repository-queue-coalesce", "doc-queue-coalesce", "zero",
@@ -754,4 +786,37 @@ test "reopen preserves identity and history for continued convergence" {
   )
   assert_eq(reopened.editor().snapshot().source(), peer.snapshot().source())
   reopened.attachment().dispose()
+}
+
+///|
+test "LocalText decodes source without constructing an editor" {
+  let document_id = @archive.LoomarkDocumentId::from_string(
+    "local-text-source-only-document",
+  ) catch {
+    _ => abort("test document ID must be valid")
+  }
+  let prepared = prepare_local_text(document_id~, source="alpha\nβeta 🪶\n")
+  assert_eq(
+    decode_local_text(prepared.encoded()),
+    LocalTextDecode::Valid(document_id~, source="alpha\nβeta 🪶\n"),
+  )
+}
+
+///|
+test "legacy v1 fallback reads source without decoding history" {
+  let encoded =
+    #|{"schema_version":"1","document_id":"legacy-document","portable_markdown":"# Legacy\n","history":"not-decoded","extensions":{}}
+  match decode_v1_archive_text(encoded) {
+    LocalTextDecode::Valid(document_id~, source~) => {
+      assert_eq(document_id.value(), "legacy-document")
+      assert_eq(source, "# Legacy\n")
+    }
+    _ => fail("expected legacy source fallback")
+  }
+  let unsupported =
+    #|{"schema_version":"2","document_id":"future","portable_markdown":"","history":"","extensions":{}}
+  assert_eq(
+    decode_v1_archive_text(unsupported),
+    LocalTextDecode::UnsupportedArchive("2"),
+  )
 }

--- a/apps/loomark/repository/repository_wbtest.mbt
+++ b/apps/loomark/repository/repository_wbtest.mbt
@@ -195,7 +195,7 @@ test "repository prepares one complete immutable encoded archive" {
   )
   let document_id = try! @archive.LoomarkDocumentId::from_string("doc-prepare")
   let prepared = try! prepare_local_archive(document_id~, editor~)
-  assert_false(prepared.is_source_only())
+  assert_eq(prepared.record_kind(), LocalArchiveRecordKind::FullHistory)
   let decoded = try! @archive.LoomarkDocumentArchive::from_json_string(
     prepared.encoded(),
     validation_agent_id="repository-prepare-decode",
@@ -797,7 +797,7 @@ test "LocalText decodes source without constructing an editor" {
     _ => abort("test document ID must be valid")
   }
   let prepared = prepare_local_text(document_id~, source="alpha\nβeta 🪶\n")
-  assert_true(prepared.is_source_only())
+  assert_eq(prepared.record_kind(), LocalArchiveRecordKind::LocalText)
   assert_eq(
     decode_local_text(prepared.encoded()),
     LocalTextDecode::Valid(document_id~, source="alpha\nβeta 🪶\n"),


### PR DESCRIPTION
## Summary

- Make production standalone Loomark restore and edit source-only LocalText without decoding archive history or inserting persisted source into CRDT state.
- Read the new `loomark.active-document-text` record first, then extract only `document_id` and `portable_markdown` from an existing v1 archive while preserving its original bytes.
- Reuse the Raw input surface and existing IndexedDB latest-write queue; keep standalone Raw-only and omit background hydration or automatic LocalText-to-CRDT promotion.
- Represent persistence format as exhaustive `LocalArchiveRecordKind::{FullHistory, LocalText}` variants instead of a semantic boolean.

The shared application shell still creates an empty editor session. Persisted LocalText is never inserted into that session during startup or ordinary local input.

## UI and review evidence

- [x] N/A — no visible label was removed.
- [x] Raw input, IME commit, recovery, retry, reload, and unavailable Block/Preview behavior were exercised in rendered Playwright tests.
- [x] No new design-rule claims are made; the standalone behavior is documented in `apps/loomark/README.md`.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `LocalPersistenceQueue` | `apps/loomark/repository/local_persistence_queue.mbt` | Yes | Retains latest-write coalescing, in-flight tracking, retry, and durable-state semantics. |
| Raw textarea input and recovery shell | `apps/loomark/internal/rabbita` | Yes | Avoids a second editor surface and preserves existing DOM/IME integration. |
| IndexedDB `load` / `replace` commands | `apps/loomark/internal/archive_storage` | Yes | Extended to use a LocalText-first key and legacy fallback rather than adding another storage adapter. |
| Full v1 archive decoder | `apps/loomark/archive` | No | It decodes/adopts history, which is precisely the startup work this standalone path must avoid; the fallback reads only the existing JSON source fields. |
| MoonBit `Json`, `String`, `Option`, and `Result`/error handling | MoonBit core | Yes | Used for tagged record encoding, field validation, source ownership, fallback selection, and fail-closed decode results. |
| `StringView` / `BytesView`, `Map` / `Set`, `Buffer`, `Array` / `Iter` | MoonBit core | No | Records are small fixed JSON objects with owning source strings; no slicing, keyed collection, builder, or collection traversal is required. |

New helpers added:

- `prepare_local_text` / `decode_local_text`: own the `loomark-local-text-v1` storage codec.
- `decode_v1_archive_text`: extracts only the legacy document id and portable source without history admission.
- `load_legacy_archive`: performs the second storage read only when the LocalText slot is absent.
- `local_text_replacement`, `start_local_text`, and bootstrap constructors: isolate deterministic LocalText state transitions from the IndexedDB/DOM shell.

Remaining imperative code is limited to DOM input/IME handling, application mounting, and IndexedDB command execution.

## Validation scope

Boundary matrix / first failing regression:

- Valid LocalText record restores directly and survives edit/reload.
- Missing LocalText falls back to a valid v1 archive without modifying its bytes.
- Corrupt and unsupported LocalText/legacy records enter recovery instead of silently replacing data.
- IME preedit stays transient; only the committed DOM value is persisted.
- Failed writes remain retryable, and same-version/latest-write durability waits for both in-flight and pending writes to drain.
- Production standalone exposes Raw only; Block and Preview remain unavailable.

Target packages:

- `apps/loomark/repository`
- `apps/loomark/internal/archive_storage`
- `apps/loomark/internal/rabbita`
- `apps/loomark/main`

Additional conditional gates:

- Repository tests: 16/16 passed.
- Loomark Rabbita tests: 212/212 passed.
- Dev Host Playwright E2E: 121/121 passed.
- Gate R0 browser oracle: all 5 canonical fixtures passed, including stale-LocalText shadow protection.
- Standalone Playwright E2E: 14/14 passed.
- TypeScript typecheck and release JavaScript build passed.
- Independent MoonBit and integration review found no critical issues; generated `.mbti` diffs were compared against `origin/main` and preserve existing repository APIs.

## PR-ready evidence

Validated HEAD: `d1404625c288263865318409d820d20267fba82d`

Validated base: `origin/main@0d01be37a7b58bcf76a5e68c0279a1be7f342717`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh \
  --target apps/loomark/repository \
  --target apps/loomark/internal/archive_storage \
  --target apps/loomark/internal/rabbita \
  --target apps/loomark/main
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for the exact HEAD and base above.
- [x] The base was fetched again and `--verify-evidence` passed immediately before this PR was opened.
- [x] The committed `.mbti` diff against the validated base was reviewed for unintended API or trait-bound changes.
- [x] No submodule pointer changed.
- [x] Validation was rerun after the final commit; no amend, rebase, cherry-pick, submodule, manifest, or generated-interface change followed it.
- [x] Independent review findings were resolved before the final validation.


