### PR TITLE
fix(canvas-graph): use explicit ToJson dispatch

### DIFF
--- a/modules/canvas-graph/graph_model/model.mbt
+++ b/modules/canvas-graph/graph_model/model.mbt
@@ -127,7 +127,7 @@ pub impl ToJson for PortDef with fn to_json(self) {
   let fields : Map[String, Json] = Map([])
   fields["id"] = self.id.to_json()
   fields["label"] = self.label.to_json()
-  fields["port_type"] = self.port_type.to_json()
+  fields["port_type"] = ToJson::to_json(self.port_type)
   if self.allows_fan_in {
     fields["allows_fan_in"] = true.to_json()
   }
@@ -415,16 +415,16 @@ pub impl ToJson for GraphOperation with fn to_json(self) {
     }
     ConnectPorts(source, source_port, target, target_port) => {
       fields["type"] = "ConnectPorts".to_json()
-      fields["source"] = source.to_json()
+      fields["source"] = ToJson::to_json(source)
       fields["source_port"] = source_port.to_json()
-      fields["target"] = target.to_json()
+      fields["target"] = ToJson::to_json(target)
       fields["target_port"] = target_port.to_json()
     }
     DisconnectPorts(source, source_port, target, target_port) => {
       fields["type"] = "DisconnectPorts".to_json()
-      fields["source"] = source.to_json()
+      fields["source"] = ToJson::to_json(source)
       fields["source_port"] = source_port.to_json()
-      fields["target"] = target.to_json()
+      fields["target"] = ToJson::to_json(target)
       fields["target_port"] = target_port.to_json()
     }
     DeleteNodes(nodes) => {
@@ -433,12 +433,12 @@ pub impl ToJson for GraphOperation with fn to_json(self) {
     }
     RenameNode(node_id, name) => {
       fields["type"] = "RenameNode".to_json()
-      fields["node_id"] = node_id.to_json()
+      fields["node_id"] = ToJson::to_json(node_id)
       fields["name"] = name.to_json()
     }
     SetNodeParam(node_id, parameter, value) => {
       fields["type"] = "SetNodeParam".to_json()
-      fields["node_id"] = node_id.to_json()
+      fields["node_id"] = ToJson::to_json(node_id)
       fields["parameter"] = parameter.to_json()
       fields["value"] = value.to_json()
     }


### PR DESCRIPTION
## Summary

- replace seven deprecated implicit `ToJson` trait promotions with explicit `ToJson::to_json` dispatch
- preserve the existing `PortType` and `NodeId` JSON representations without adding helpers or changing the public interface
- restore the non-vendored root strict-check baseline

## UI and review evidence

N/A — no UI or visual behavior changed.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `ToJson::to_json` | MoonBit core JSON trait | Yes | Existing explicit trait dispatch required by the current compiler |
| Existing `ToJson` implementations for `PortType` and `NodeId` | `modules/canvas-graph/graph_model/model.mbt` | Yes | Preserve the current JSON contract |
| `extend ... with ToJson` | MoonBit trait promotion mechanism | No | Seven explicit calls are narrower and do not expand method promotion scope |

New helpers added: none.

## Validation scope

Boundary matrix / first failing regression:

- Before: root `check-strict.sh` reported seven non-vendored deprecated implicit `ToJson` promotions in `graph_model/model.mbt`.
- After: those seven diagnostics are gone; only known vendored diagnostics are suppressed by the existing repository filter.
- `PortDef` continues to encode `PortType` through its existing `ToJson` implementation.
- Connect/disconnect/rename/parameter operations continue to encode `NodeId` through its existing `ToJson` implementation.

Target packages:

- `modules/canvas-graph/graph_model`

Additional conditional gates:

- Target release tests: 49/49 passed.
- Independent MoonBit review: PASS, no blockers or warnings.
- Generated `.mbti` diff: none.

## PR-ready evidence

Validated HEAD: `b42305c5a2870e511d52674243a61442299b2a46`

Validated base: `origin/main@60ef805ca502cc5963e919fce9a263b0587d0f1d`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh \
  --target modules/canvas-graph/graph_model
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for the exact HEAD and base above.
- [x] The base was fetched again and `--verify-evidence` passed immediately before this PR was opened.
- [x] The committed `.mbti` diff against the validated base was reviewed for unintended API or trait-bound changes.
- [x] No submodule commit changed.
- [x] Validation was run after the final commit.
- [x] Independent review findings were resolved before final validation.
