### PR TITLE
chore(canvas): synchronize package lock metadata

### DIFF
--- a/apps/canvas/web/package-lock.json
+++ b/apps/canvas/web/package-lock.json
@@ -28,8 +28,7 @@
         "@playwright/test": "1.61.1",
         "@types/node": "^24.13.3",
         "typescript": "^6.0.3",
-        "vite": "^6.0.0",
-        "vitest": "^4.1.10"
+        "vite": "^6.0.0"
       },
       "peerDependencies": {
         "@codemirror/commands": "^6.10.0",


### PR DESCRIPTION
## Summary

- remove stale `vitest` metadata from the Canvas web lockfile's local `adapters/editor` package entry
- synchronize the generated lock metadata with the current `adapters/editor/package.json` manifest

## UI and review evidence

N/A — generated dependency metadata only; no UI or runtime source changed.

## Reuse check

N/A — pure generated lockfile synchronization; no functions, methods, helpers, or types added.

## Validation scope

Boundary matrix / first failing regression:

- `adapters/editor/package.json` does not declare `vitest`.
- Before regeneration, the Canvas lockfile's local adapter metadata still declared `vitest`.
- `npm install --package-lock-only --ignore-scripts` reproduces the committed one-line metadata removal exactly and leaves no diff.
- `npm ci --ignore-scripts` succeeds with the synchronized lockfile.

Target packages:

- `--no-target "generated Canvas package-lock metadata only; no MoonBit package changed"`

Additional conditional gates:

- Independent review: PASS, no blockers or warnings.
- No manifest, resolved-version, submodule, source, or `.mbti` changes.

## PR-ready evidence

Validated HEAD: `7c22b481619e9a0927dc6a9a67b6bf5a50347bfc`

Validated base: `origin/main@5a5f9bc0a62f98a9a3a503e42efa8edaf824eee7`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh \
  --no-target "generated Canvas package-lock metadata only; no MoonBit package changed"
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for the exact HEAD and base above.
- [x] The base was fetched again and `--verify-evidence` passed immediately before this PR was opened.
- [x] No committed `.mbti` files changed.
- [x] No submodule commit changed.
- [x] Validation was rerun after the rebase onto the strict-check fix.
- [x] Independent review completed before publication.
