### PR TITLE
research(loomark): characterize whole-document input costs

### DIFF
--- a/apps/loomark/examples/vanilla/bench-whole-document-input.mjs
+++ b/apps/loomark/examples/vanilla/bench-whole-document-input.mjs
@@ -1,0 +1,550 @@
+import { execFileSync, spawn } from "node:child_process"
+import { createHash } from "node:crypto"
+import { once } from "node:events"
+import { writeFile } from "node:fs/promises"
+import { cpus, platform, release } from "node:os"
+import { dirname, resolve } from "node:path"
+import { performance as nodePerformance } from "node:perf_hooks"
+import { fileURLToPath } from "node:url"
+import { chromium } from "./node_modules/playwright/index.mjs"
+
+const here = dirname(fileURLToPath(import.meta.url))
+const projectRoot = resolve(here, "../../../..")
+const serverPath = resolve(here, "serve-standalone-dist.mjs")
+const localTextKey = "loomark.active-document-text"
+const databaseName = "loomark.local-repository"
+const storeName = "archives"
+const settleMs = 400
+const sizes = parseSizes(process.env.LOOMARK_WHOLE_DOCUMENT_SIZES ?? "65536,262144,1048576")
+const warmups = parseCount(process.env.LOOMARK_WHOLE_DOCUMENT_WARMUPS ?? "5", "LOOMARK_WHOLE_DOCUMENT_WARMUPS", 0)
+const samples = parseCount(process.env.LOOMARK_WHOLE_DOCUMENT_SAMPLES ?? "30", "LOOMARK_WHOLE_DOCUMENT_SAMPLES", 1)
+const traceSamples = parseCount(
+  process.env.LOOMARK_WHOLE_DOCUMENT_TRACE_SAMPLES ?? "0",
+  "LOOMARK_WHOLE_DOCUMENT_TRACE_SAMPLES",
+  0,
+)
+const requirePersistence = process.env.LOOMARK_WHOLE_DOCUMENT_REQUIRE_PERSISTENCE !== "0"
+const outputPath = process.env.LOOMARK_WHOLE_DOCUMENT_OUTPUT
+
+function parseCount(raw, name, minimum) {
+  const value = Number.parseInt(raw, 10)
+  if (!Number.isSafeInteger(value) || value < minimum) {
+    throw new Error(`${name} must be an integer greater than or equal to ${minimum}`)
+  }
+  return value
+}
+
+function parseSizes(raw) {
+  const values = raw.split(",").map(value => Number.parseInt(value.trim(), 10))
+  if (values.length === 0 || values.some(value => !Number.isSafeInteger(value) || value < 1)) {
+    throw new Error("LOOMARK_WHOLE_DOCUMENT_SIZES must contain positive comma-separated integers")
+  }
+  return [...new Set(values)]
+}
+
+function percentile(values, percentage) {
+  if (values.length === 0) return null
+  const sorted = [...values].sort((left, right) => left - right)
+  const rank = Math.max(0, Math.ceil((percentage / 100) * sorted.length) - 1)
+  return Number(sorted[rank].toFixed(3))
+}
+
+function summarize(values) {
+  return {
+    samples: values.length,
+    p50_ms: percentile(values, 50),
+    p95_ms: percentile(values, 95),
+    maximum_ms: values.length === 0 ? null : Number(Math.max(...values).toFixed(3)),
+  }
+}
+
+function fixture(size) {
+  const line = "paragraph alpha beta gamma delta epsilon\n\n"
+  const source = line.repeat(Math.ceil(size / line.length)).slice(0, size)
+  return {
+    source,
+    utf16_length: source.length,
+    utf8_bytes: Buffer.byteLength(source),
+    sha256: createHash("sha256").update(source).digest("hex"),
+  }
+}
+
+function instrumentPage({ key, traceEnabled }) {
+  const state = {
+    active: null,
+    longTasks: [],
+    sequence: 0,
+  }
+  globalThis.__loomarkWholeDocumentBench = state
+
+  document.addEventListener("beforeinput", event => {
+    if (state.active === null || !(event.target instanceof HTMLTextAreaElement)) return
+    state.active.beforeinput = performance.now()
+    if (traceEnabled) performance.mark("loomark-whole:beforeinput")
+  }, { capture: true })
+
+  document.addEventListener("input", event => {
+    if (state.active === null || !(event.target instanceof HTMLTextAreaElement)) return
+    const active = state.active
+    active.input = performance.now()
+    if (traceEnabled) performance.mark("loomark-whole:input")
+    queueMicrotask(() => {
+      active.microtask = performance.now()
+      if (traceEnabled) performance.mark("loomark-whole:microtask")
+    })
+  }, { capture: true })
+
+  try {
+    new PerformanceObserver(list => {
+      for (const entry of list.getEntries()) {
+        state.longTasks.push({ start: entry.startTime, duration: entry.duration })
+      }
+    }).observe({ type: "longtask", buffered: true })
+  } catch {}
+
+  const originalPut = IDBObjectStore.prototype.put
+  IDBObjectStore.prototype.put = function(value, recordKey) {
+    const request = originalPut.apply(this, arguments)
+    const active = state.active
+    if (active !== null && recordKey === key) {
+      const put = {
+        request: performance.now(),
+        acknowledgment: null,
+        outcome: "pending",
+      }
+      active.puts.push(put)
+      if (traceEnabled) performance.mark("loomark-whole:put-request")
+      request.addEventListener("success", () => {
+        put.acknowledgment = performance.now()
+        put.outcome = "stored"
+      })
+      request.addEventListener("error", () => {
+        put.acknowledgment = performance.now()
+        put.outcome = "failed"
+      })
+    }
+    return request
+  }
+}
+
+async function startServer() {
+  const server = spawn(process.execPath, [serverPath], {
+    env: { ...process.env, LOOMARK_STANDALONE_PORT: "0" },
+    stdio: ["ignore", "pipe", "inherit"],
+  })
+  let output = ""
+  const origin = await new Promise((resolveOrigin, reject) => {
+    const timeout = setTimeout(() => reject(new Error("standalone server did not become ready")), 5_000)
+    server.stdout.setEncoding("utf8")
+    server.stdout.on("data", chunk => {
+      output += chunk
+      const match = output.match(/http:\/\/127\.0\.0\.1:\d+/)
+      if (match !== null) {
+        clearTimeout(timeout)
+        resolveOrigin(match[0])
+      }
+    })
+    server.once("error", error => {
+      clearTimeout(timeout)
+      reject(error)
+    })
+    server.once("close", code => {
+      clearTimeout(timeout)
+      reject(new Error(`standalone server exited before readiness (${code ?? "signal"})`))
+    })
+  })
+  return { server, origin }
+}
+
+async function stopServer(server) {
+  if (server.exitCode !== null) return
+  server.kill("SIGTERM")
+  await Promise.race([once(server, "close"), new Promise(resolveTimeout => setTimeout(resolveTimeout, 1_000))])
+  if (server.exitCode === null) server.kill("SIGKILL")
+}
+
+async function seedLocalText(page, source, documentId) {
+  const encoded = JSON.stringify({
+    format: "loomark-local-text-v1",
+    document_id: documentId,
+    portable_markdown: source,
+  })
+  await page.evaluate(async ({ databaseName, storeName, key, encoded }) => {
+    await new Promise((resolveSeed, reject) => {
+      const open = indexedDB.open(databaseName, 1)
+      open.onupgradeneeded = () => {
+        if (!open.result.objectStoreNames.contains(storeName)) {
+          open.result.createObjectStore(storeName)
+        }
+      }
+      open.onerror = () => reject(open.error ?? new Error("database open failed"))
+      open.onsuccess = () => {
+        const database = open.result
+        const transaction = database.transaction(storeName, "readwrite")
+        transaction.objectStore(storeName).put(encoded, key)
+        transaction.oncomplete = () => {
+          database.close()
+          resolveSeed()
+        }
+        transaction.onerror = () => reject(transaction.error ?? new Error("fixture seed failed"))
+        transaction.onabort = () => reject(transaction.error ?? new Error("fixture seed aborted"))
+      }
+    })
+  }, { databaseName, storeName, key: localTextKey, encoded })
+}
+
+async function beginSample(page) {
+  await page.evaluate(() => {
+    const state = globalThis.__loomarkWholeDocumentBench
+    state.active = {
+      sequence: ++state.sequence,
+      command: performance.now(),
+      beforeinput: null,
+      input: null,
+      microtask: null,
+      puts: [],
+    }
+  })
+}
+
+async function finishSample(page, requirePersistence) {
+  await page.waitForTimeout(settleMs)
+  if (requirePersistence) {
+    await page.waitForFunction(key => {
+      const active = globalThis.__loomarkWholeDocumentBench?.active
+      const matching = active?.puts?.filter(put => put.outcome !== "pending") ?? []
+      return matching.length > 0
+    }, localTextKey, { timeout: 2_000 })
+  }
+  return page.evaluate(({ settleMs, requirePersistence }) => {
+    const state = globalThis.__loomarkWholeDocumentBench
+    const active = state.active
+    if (active?.beforeinput === null || active?.input === null || active?.microtask === null) {
+      throw new Error("input timing marks are incomplete")
+    }
+    const puts = active.puts.filter(put => put.acknowledgment !== null)
+    if (requirePersistence && puts.length === 0) throw new Error("LocalText persistence was not observed")
+    const firstPut = puts[0] ?? null
+    const longTasks = state.longTasks
+      .filter(task => task.start >= active.input && task.start <= active.input + settleMs)
+      .map(task => ({
+        offset_ms: Number((task.start - active.input).toFixed(3)),
+        duration_ms: Number(task.duration.toFixed(3)),
+      }))
+    state.active = null
+    return {
+      native_mutation_ms: Number((active.input - active.beforeinput).toFixed(3)),
+      input_handler_ms: Number((active.microtask - active.input).toFixed(3)),
+      put_request_offset_ms: firstPut === null
+        ? null
+        : Number((firstPut.request - active.input).toFixed(3)),
+      put_acknowledgment_ms: firstPut === null
+        ? null
+        : Number((firstPut.acknowledgment - firstPut.request).toFixed(3)),
+      put_outcome: firstPut?.outcome ?? null,
+      long_tasks: longTasks,
+    }
+  }, { settleMs, requirePersistence })
+}
+
+async function typeSample(page, character, requirePersistence) {
+  await beginSample(page)
+  const started = nodePerformance.now()
+  await page.keyboard.type(character)
+  const commandWallMs = nodePerformance.now() - started
+  const measured = await finishSample(page, requirePersistence)
+  return {
+    ...measured,
+    browser_command_wall_ms: Number(commandWallMs.toFixed(3)),
+  }
+}
+
+async function runNative(browser, source, surface, warmupCount, sampleCount) {
+  const context = await browser.newContext({ viewport: { width: 1280, height: 720 } })
+  await context.addInitScript(instrumentPage, { key: localTextKey, traceEnabled: false })
+  const page = await context.newPage()
+  const nativeStyle = `${surface.style};width:${surface.width}px`
+  const html = `<!doctype html><meta charset="utf-8"><textarea id="native-input" style="${nativeStyle.replaceAll("&", "&amp;").replaceAll('"', "&quot;")}"></textarea>`
+  await page.goto(`data:text/html;charset=utf-8,${encodeURIComponent(html)}`)
+  await page.locator("#native-input").evaluate((textarea, value) => {
+    textarea.value = value
+    textarea.setSelectionRange(value.length, value.length)
+    textarea.focus()
+  }, source)
+  const rows = []
+  for (let index = 0; index < warmupCount + sampleCount; index += 1) {
+    const row = await typeSample(page, index % 2 === 0 ? "x" : "y", false)
+    if (index >= warmupCount) rows.push(row)
+  }
+  await context.close()
+  return rows
+}
+
+async function runLoomark(browser, origin, source, documentId, warmupCount, sampleCount) {
+  const context = await browser.newContext({ viewport: { width: 1280, height: 720 } })
+  await context.addInitScript(instrumentPage, { key: localTextKey, traceEnabled: false })
+  const page = await context.newPage()
+  // Seed from an inert same-origin asset so the application's first-visit
+  // baseline write cannot race and overwrite the benchmark fixture.
+  await page.goto(`${origin}/favicon.svg`, { waitUntil: "load" })
+  await seedLocalText(page, source, documentId)
+  await page.goto(origin, { waitUntil: "load" })
+  const input = page.locator("#loomark-input")
+  await input.waitFor({ state: "visible", timeout: 30_000 })
+  await page.waitForFunction(expected => document.querySelector("#loomark-input")?.value === expected, source, {
+    timeout: 120_000,
+  })
+  const surface = await input.evaluate(textarea => ({
+    style: textarea.getAttribute("style"),
+    width: textarea.getBoundingClientRect().width,
+  }))
+  if (surface.style === null) throw new Error("Loomark textarea has no inline style")
+  await input.evaluate((textarea, offset) => {
+    textarea.setSelectionRange(offset, offset)
+    textarea.focus()
+  }, source.length)
+  const rows = []
+  for (let index = 0; index < warmupCount + sampleCount; index += 1) {
+    const row = await typeSample(page, index % 2 === 0 ? "x" : "y", requirePersistence)
+    if (index >= warmupCount) rows.push(row)
+  }
+  await context.close()
+  return { rows, surface }
+}
+
+async function startTrace(context, page) {
+  const session = await context.newCDPSession(page)
+  const events = []
+  session.on("Tracing.dataCollected", ({ value }) => events.push(...value))
+  await session.send("Tracing.start", {
+    categories: "blink.user_timing,devtools.timeline,v8",
+    options: "sampling-frequency=10000",
+  })
+  return { session, events }
+}
+
+async function stopTrace(trace) {
+  const complete = new Promise(resolveComplete => {
+    trace.session.once("Tracing.tracingComplete", resolveComplete)
+  })
+  await trace.session.send("Tracing.end")
+  await complete
+  await trace.session.detach()
+  return trace.events
+}
+
+function summarizeTrace(events) {
+  const marks = new Map(events
+    .filter(event => event.cat?.includes("blink.user_timing") && event.name.startsWith("loomark-whole:"))
+    .map(event => [event.name, event]))
+  const beforeinput = marks.get("loomark-whole:beforeinput")
+  const input = marks.get("loomark-whole:input")
+  const microtask = marks.get("loomark-whole:microtask")
+  const put = marks.get("loomark-whole:put-request")
+  if (beforeinput === undefined || input === undefined || microtask === undefined || put === undefined) {
+    throw new Error("trace is missing a required benchmark mark")
+  }
+  const windows = [
+    ["w0_immediate", beforeinput.ts, microtask.ts],
+    ["w1_preview", input.ts, input.ts + 100_000],
+    // Start 10 ms before the nominal timer so scheduling jitter cannot hide
+    // the beginning of the 250 ms flush task. This is a probe window, not the
+    // flush duration itself.
+    ["w2_probe_240ms_to_put", input.ts + 240_000, put.ts],
+  ]
+  const names = {
+    function_call_ms: new Set(["FunctionCall"]),
+    run_task_ms: new Set(["RunTask"]),
+    style_layout_ms: new Set(["UpdateLayoutTree", "Layout"]),
+    paint_ms: new Set(["PrePaint", "Paint", "CompositeLayers"]),
+    gc_ms: new Set(["MajorGC", "MinorGC", "V8.GC_MAJOR", "V8.GC_MINOR"]),
+  }
+  return Object.fromEntries(windows.map(([name, start, end]) => {
+    const overlapping = events.filter(event => (
+      event.tid === input.tid &&
+      typeof event.dur === "number" &&
+      event.ts < end &&
+      event.ts + event.dur > start
+    ))
+    const durationFor = selectedNames => overlapping.reduce((sum, event) => {
+      if (!selectedNames.has(event.name)) return sum
+      const overlap = Math.max(0, Math.min(event.ts + event.dur, end) - Math.max(event.ts, start))
+      return sum + overlap
+    }, 0) / 1000
+    return [name, {
+      elapsed_ms: Number(((end - start) / 1000).toFixed(3)),
+      ...Object.fromEntries(Object.entries(names).map(([metric, selectedNames]) => [
+        metric,
+        Number(durationFor(selectedNames).toFixed(3)),
+      ])),
+    }]
+  }))
+}
+
+async function runLoomarkTraces(browser, origin, source, documentId, count) {
+  const context = await browser.newContext({ viewport: { width: 1280, height: 720 } })
+  await context.addInitScript(instrumentPage, { key: localTextKey, traceEnabled: true })
+  const page = await context.newPage()
+  await page.goto(`${origin}/favicon.svg`, { waitUntil: "load" })
+  await seedLocalText(page, source, documentId)
+  await page.goto(origin, { waitUntil: "load" })
+  const input = page.locator("#loomark-input")
+  await input.waitFor({ state: "visible", timeout: 30_000 })
+  await page.waitForFunction(expected => document.querySelector("#loomark-input")?.value === expected, source, {
+    timeout: 120_000,
+  })
+  await input.evaluate((textarea, offset) => {
+    textarea.setSelectionRange(offset, offset)
+    textarea.focus()
+  }, source.length)
+
+  // Keep initialization and first-use compilation outside the representative traces.
+  await typeSample(page, "w", true)
+  const traces = []
+  for (let index = 0; index < count; index += 1) {
+    await page.evaluate(() => performance.clearMarks())
+    const trace = await startTrace(context, page)
+    const measured = await typeSample(page, index % 2 === 0 ? "x" : "y", true)
+    const events = await stopTrace(trace)
+    traces.push({ measured, summary: summarizeTrace(events) })
+  }
+  await context.close()
+  return traces
+}
+
+async function withBrowser(action) {
+  const selected = await chromium.launch({ headless: true })
+  try {
+    return await action(selected)
+  } finally {
+    await selected.close()
+  }
+}
+
+function summarizeRows(rows) {
+  const metrics = [
+    "native_mutation_ms",
+    "input_handler_ms",
+    "put_request_offset_ms",
+    "put_acknowledgment_ms",
+    "browser_command_wall_ms",
+  ]
+  return Object.fromEntries(metrics.map(metric => [
+    metric,
+    summarize(rows.map(row => row[metric]).filter(value => value !== null)),
+  ]).concat([[
+    "long_tasks",
+    {
+      samples_with_long_tasks: rows.filter(row => row.long_tasks.length > 0).length,
+      count: rows.reduce((sum, row) => sum + row.long_tasks.length, 0),
+      maximum_ms: rows.flatMap(row => row.long_tasks.map(task => task.duration_ms)).reduce(
+        (maximum, value) => Math.max(maximum, value),
+        0,
+      ),
+    },
+  ]]))
+}
+
+let server
+let browser
+try {
+  const started = await startServer()
+  server = started.server
+  browser = await chromium.launch({ headless: true })
+  const browserVersion = browser.version()
+  await browser.close()
+  browser = undefined
+  const result = {
+    schema: "loomark-whole-document-input-v1",
+    environment: {
+      commit: execFileSync("git", ["rev-parse", "HEAD"], { cwd: projectRoot, encoding: "utf8" }).trim(),
+      browser: browserVersion,
+      node: process.version,
+      platform: platform(),
+      os_release: release(),
+      architecture: process.arch,
+      cpu: cpus()[0]?.model ?? "unknown",
+      headless: true,
+      viewport: { width: 1280, height: 720 },
+      warmups,
+      samples,
+      trace_samples: traceSamples,
+      settle_ms: settleMs,
+      persistence_required: requirePersistence,
+    },
+    invocation: {
+      sizes,
+      environment: {
+        LOOMARK_WHOLE_DOCUMENT_SIZES: process.env.LOOMARK_WHOLE_DOCUMENT_SIZES ?? null,
+        LOOMARK_WHOLE_DOCUMENT_WARMUPS: process.env.LOOMARK_WHOLE_DOCUMENT_WARMUPS ?? null,
+        LOOMARK_WHOLE_DOCUMENT_SAMPLES: process.env.LOOMARK_WHOLE_DOCUMENT_SAMPLES ?? null,
+        LOOMARK_WHOLE_DOCUMENT_TRACE_SAMPLES:
+          process.env.LOOMARK_WHOLE_DOCUMENT_TRACE_SAMPLES ?? null,
+        LOOMARK_WHOLE_DOCUMENT_REQUIRE_PERSISTENCE:
+          process.env.LOOMARK_WHOLE_DOCUMENT_REQUIRE_PERSISTENCE ?? null,
+      },
+    },
+    fixtures: [],
+    scenarios: [],
+    traces: [],
+  }
+
+  for (const size of sizes) {
+    const generated = fixture(size)
+    result.fixtures.push({
+      requested_utf16: size,
+      utf16_length: generated.utf16_length,
+      utf8_bytes: generated.utf8_bytes,
+      sha256: generated.sha256,
+    })
+    const documentId = `whole-document-input-${size}`
+    const loomark = await withBrowser(selected => runLoomark(
+      selected,
+      started.origin,
+      generated.source,
+      documentId,
+      warmups,
+      samples,
+    ))
+    const nativeRows = await withBrowser(selected => runNative(
+      selected,
+      generated.source,
+      loomark.surface,
+      warmups,
+      samples,
+    ))
+    result.scenarios.push({
+      size_utf16: size,
+      surface: "native_textarea",
+      matched_width_px: loomark.surface.width,
+      summary: summarizeRows(nativeRows),
+      samples: nativeRows,
+    })
+    result.scenarios.push({
+      size_utf16: size,
+      surface: "loomark_production",
+      matched_width_px: loomark.surface.width,
+      summary: summarizeRows(loomark.rows),
+      samples: loomark.rows,
+    })
+  }
+
+  if (traceSamples > 0) {
+    const tracedSize = Math.max(...sizes)
+    const tracedFixture = fixture(tracedSize)
+    result.traces = await withBrowser(selected => runLoomarkTraces(
+      selected,
+      started.origin,
+      tracedFixture.source,
+      `whole-document-trace-${tracedSize}`,
+      traceSamples,
+    ))
+  }
+
+  const encoded = `${JSON.stringify(result, null, 2)}\n`
+  if (outputPath !== undefined) await writeFile(outputPath, encoded)
+  process.stdout.write(encoded)
+} finally {
+  if (browser !== undefined) await browser.close()
+  if (server !== undefined) await stopServer(server)
+}

--- a/apps/loomark/examples/vanilla/package.json
+++ b/apps/loomark/examples/vanilla/package.json
@@ -12,7 +12,8 @@
     "fixtures:r0:verify": "node ./verify-r0-browser-fixtures.mjs",
     "measurement:r0:test": "node --test ./test-r0-browser-measurement.mjs",
     "bench:startup": "node ./bench-startup.mjs",
-    "bench:projection": "node ./bench-projection-placement.mjs"
+    "bench:projection": "node ./bench-projection-placement.mjs",
+    "bench:whole-document-input": "node ./bench-whole-document-input.mjs"
   },
   "devDependencies": {
     "@playwright/test": "1.61.1",

--- a/docs/evidence/2026-08-24-loomark-whole-document-input.json
+++ b/docs/evidence/2026-08-24-loomark-whole-document-input.json
@@ -1,0 +1,3062 @@
+{
+  "schema": "loomark-whole-document-input-evidence-v1",
+  "issue": 1353,
+  "decision": "persistence_first",
+  "production": {
+    "schema": "loomark-whole-document-input-v1",
+    "environment": {
+      "commit": "60ef805ca502cc5963e919fce9a263b0587d0f1d",
+      "browser": "149.0.7827.55",
+      "node": "v24.14.1",
+      "platform": "linux",
+      "os_release": "6.18.33.2-microsoft-standard-WSL2",
+      "architecture": "x64",
+      "cpu": "AMD Ryzen 7 6800H with Radeon Graphics",
+      "headless": true,
+      "viewport": {
+        "width": 1280,
+        "height": 720
+      },
+      "warmups": 5,
+      "samples": 30,
+      "trace_samples": 3,
+      "settle_ms": 400,
+      "persistence_required": true
+    },
+    "invocation": {
+      "sizes": [
+        65536,
+        262144,
+        1048576
+      ],
+      "environment": {
+        "LOOMARK_WHOLE_DOCUMENT_SIZES": null,
+        "LOOMARK_WHOLE_DOCUMENT_WARMUPS": null,
+        "LOOMARK_WHOLE_DOCUMENT_SAMPLES": null,
+        "LOOMARK_WHOLE_DOCUMENT_TRACE_SAMPLES": "3",
+        "LOOMARK_WHOLE_DOCUMENT_REQUIRE_PERSISTENCE": null
+      }
+    },
+    "fixtures": [
+      {
+        "requested_utf16": 65536,
+        "utf16_length": 65536,
+        "utf8_bytes": 65536,
+        "sha256": "e4708b363c3f9a2137896aac85d78146eb50793513794a149c25b866df72d127"
+      },
+      {
+        "requested_utf16": 262144,
+        "utf16_length": 262144,
+        "utf8_bytes": 262144,
+        "sha256": "e44d180d726326b85132ed435e835e334114a0cee226588bffe4044ff5a3fd3f"
+      },
+      {
+        "requested_utf16": 1048576,
+        "utf16_length": 1048576,
+        "utf8_bytes": 1048576,
+        "sha256": "bd2b39512f137e45eb14063920e77769422728321640fc9214787e00a5dd74ae"
+      }
+    ],
+    "scenarios": [
+      {
+        "size_utf16": 65536,
+        "surface": "native_textarea",
+        "matched_width_px": 736,
+        "summary": {
+          "native_mutation_ms": {
+            "samples": 30,
+            "p50_ms": 2.2,
+            "p95_ms": 3.5,
+            "maximum_ms": 3.8
+          },
+          "input_handler_ms": {
+            "samples": 30,
+            "p50_ms": 0,
+            "p95_ms": 0.1,
+            "maximum_ms": 0.1
+          },
+          "put_request_offset_ms": {
+            "samples": 0,
+            "p50_ms": null,
+            "p95_ms": null,
+            "maximum_ms": null
+          },
+          "put_acknowledgment_ms": {
+            "samples": 0,
+            "p50_ms": null,
+            "p95_ms": null,
+            "maximum_ms": null
+          },
+          "browser_command_wall_ms": {
+            "samples": 30,
+            "p50_ms": 4.43,
+            "p95_ms": 6.656,
+            "maximum_ms": 8.944
+          },
+          "long_tasks": {
+            "samples_with_long_tasks": 0,
+            "count": 0,
+            "maximum_ms": 0
+          }
+        },
+        "samples": [
+          {
+            "native_mutation_ms": 2.2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.43
+          },
+          {
+            "native_mutation_ms": 2.5,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.708
+          },
+          {
+            "native_mutation_ms": 2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.012
+          },
+          {
+            "native_mutation_ms": 1.9,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 3.749
+          },
+          {
+            "native_mutation_ms": 2.2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.367
+          },
+          {
+            "native_mutation_ms": 2.2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.629
+          },
+          {
+            "native_mutation_ms": 2.3,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.718
+          },
+          {
+            "native_mutation_ms": 3.8,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 6.378
+          },
+          {
+            "native_mutation_ms": 2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.178
+          },
+          {
+            "native_mutation_ms": 2.2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 5.11
+          },
+          {
+            "native_mutation_ms": 2.2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.32
+          },
+          {
+            "native_mutation_ms": 2.5,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 5.038
+          },
+          {
+            "native_mutation_ms": 1.9,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.024
+          },
+          {
+            "native_mutation_ms": 2.2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.495
+          },
+          {
+            "native_mutation_ms": 2.1,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.063
+          },
+          {
+            "native_mutation_ms": 2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.481
+          },
+          {
+            "native_mutation_ms": 2,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 3.997
+          },
+          {
+            "native_mutation_ms": 2.2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.312
+          },
+          {
+            "native_mutation_ms": 2.3,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.742
+          },
+          {
+            "native_mutation_ms": 2.1,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.173
+          },
+          {
+            "native_mutation_ms": 2.4,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.656
+          },
+          {
+            "native_mutation_ms": 2.3,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.906
+          },
+          {
+            "native_mutation_ms": 2.2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.144
+          },
+          {
+            "native_mutation_ms": 2.1,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.396
+          },
+          {
+            "native_mutation_ms": 2.3,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.613
+          },
+          {
+            "native_mutation_ms": 2.5,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.716
+          },
+          {
+            "native_mutation_ms": 3.4,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 8.944
+          },
+          {
+            "native_mutation_ms": 2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.094
+          },
+          {
+            "native_mutation_ms": 3.5,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 6.656
+          },
+          {
+            "native_mutation_ms": 2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.101
+          }
+        ]
+      },
+      {
+        "size_utf16": 65536,
+        "surface": "loomark_production",
+        "matched_width_px": 736,
+        "summary": {
+          "native_mutation_ms": {
+            "samples": 30,
+            "p50_ms": 3.3,
+            "p95_ms": 13,
+            "maximum_ms": 13.3
+          },
+          "input_handler_ms": {
+            "samples": 30,
+            "p50_ms": 0,
+            "p95_ms": 0,
+            "maximum_ms": 0.1
+          },
+          "put_request_offset_ms": {
+            "samples": 30,
+            "p50_ms": 253.4,
+            "p95_ms": 262,
+            "maximum_ms": 266
+          },
+          "put_acknowledgment_ms": {
+            "samples": 30,
+            "p50_ms": 2.4,
+            "p95_ms": 9.5,
+            "maximum_ms": 11.2
+          },
+          "browser_command_wall_ms": {
+            "samples": 30,
+            "p50_ms": 10.478,
+            "p95_ms": 25.796,
+            "maximum_ms": 26.229
+          },
+          "long_tasks": {
+            "samples_with_long_tasks": 0,
+            "count": 0,
+            "maximum_ms": 0
+          }
+        },
+        "samples": [
+          {
+            "native_mutation_ms": 2.3,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 252.2,
+            "put_acknowledgment_ms": 0.2,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.968
+          },
+          {
+            "native_mutation_ms": 2.1,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 252.6,
+            "put_acknowledgment_ms": 3.2,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.515
+          },
+          {
+            "native_mutation_ms": 3.4,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 253.5,
+            "put_acknowledgment_ms": 2.2,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 6.294
+          },
+          {
+            "native_mutation_ms": 2.1,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 252.9,
+            "put_acknowledgment_ms": 0.2,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.32
+          },
+          {
+            "native_mutation_ms": 2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 253.7,
+            "put_acknowledgment_ms": 2.2,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.387
+          },
+          {
+            "native_mutation_ms": 2.2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 252.3,
+            "put_acknowledgment_ms": 0.2,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.517
+          },
+          {
+            "native_mutation_ms": 2.1,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 252.2,
+            "put_acknowledgment_ms": 2.2,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.107
+          },
+          {
+            "native_mutation_ms": 2.2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 251.8,
+            "put_acknowledgment_ms": 0.2,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.371
+          },
+          {
+            "native_mutation_ms": 2.1,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 252.8,
+            "put_acknowledgment_ms": 1.9,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.451
+          },
+          {
+            "native_mutation_ms": 1.9,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 252.2,
+            "put_acknowledgment_ms": 7.3,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.162
+          },
+          {
+            "native_mutation_ms": 2.9,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 253.3,
+            "put_acknowledgment_ms": 7.8,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 18.952
+          },
+          {
+            "native_mutation_ms": 4.2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 255.5,
+            "put_acknowledgment_ms": 1.6,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 6.462
+          },
+          {
+            "native_mutation_ms": 13,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 262,
+            "put_acknowledgment_ms": 2.4,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 25.796
+          },
+          {
+            "native_mutation_ms": 8.6,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 252.4,
+            "put_acknowledgment_ms": 4.1,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 21.591
+          },
+          {
+            "native_mutation_ms": 2.3,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 253.3,
+            "put_acknowledgment_ms": 8.7,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 14.495
+          },
+          {
+            "native_mutation_ms": 2.5,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 256.5,
+            "put_acknowledgment_ms": 5.4,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 9.356
+          },
+          {
+            "native_mutation_ms": 11.6,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 254.3,
+            "put_acknowledgment_ms": 2.6,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 24.63
+          },
+          {
+            "native_mutation_ms": 2.9,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 261,
+            "put_acknowledgment_ms": 0.4,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 9.848
+          },
+          {
+            "native_mutation_ms": 8.4,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 253.5,
+            "put_acknowledgment_ms": 8.4,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 10.966
+          },
+          {
+            "native_mutation_ms": 7.8,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 256,
+            "put_acknowledgment_ms": 0.1,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 20.471
+          },
+          {
+            "native_mutation_ms": 3.3,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 254.5,
+            "put_acknowledgment_ms": 9.5,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 14.102
+          },
+          {
+            "native_mutation_ms": 3.9,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 262,
+            "put_acknowledgment_ms": 0.8,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 11.017
+          },
+          {
+            "native_mutation_ms": 9.7,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 252.6,
+            "put_acknowledgment_ms": 8.5,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 16.989
+          },
+          {
+            "native_mutation_ms": 12.5,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 260.6,
+            "put_acknowledgment_ms": 2.6,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 23.965
+          },
+          {
+            "native_mutation_ms": 13.3,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 252.2,
+            "put_acknowledgment_ms": 11.2,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 23.662
+          },
+          {
+            "native_mutation_ms": 6.3,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 253,
+            "put_acknowledgment_ms": 4.4,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 26.229
+          },
+          {
+            "native_mutation_ms": 3.2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 266,
+            "put_acknowledgment_ms": 2.9,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 9.713
+          },
+          {
+            "native_mutation_ms": 8.6,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 253.4,
+            "put_acknowledgment_ms": 7.2,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 21.546
+          },
+          {
+            "native_mutation_ms": 8,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 257.2,
+            "put_acknowledgment_ms": 2.4,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 10.478
+          },
+          {
+            "native_mutation_ms": 4.2,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": 260.1,
+            "put_acknowledgment_ms": 0.1,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 11.4
+          }
+        ]
+      },
+      {
+        "size_utf16": 262144,
+        "surface": "native_textarea",
+        "matched_width_px": 736,
+        "summary": {
+          "native_mutation_ms": {
+            "samples": 30,
+            "p50_ms": 8.7,
+            "p95_ms": 10,
+            "maximum_ms": 15.2
+          },
+          "input_handler_ms": {
+            "samples": 30,
+            "p50_ms": 0,
+            "p95_ms": 0.1,
+            "maximum_ms": 0.1
+          },
+          "put_request_offset_ms": {
+            "samples": 0,
+            "p50_ms": null,
+            "p95_ms": null,
+            "maximum_ms": null
+          },
+          "put_acknowledgment_ms": {
+            "samples": 0,
+            "p50_ms": null,
+            "p95_ms": null,
+            "maximum_ms": null
+          },
+          "browser_command_wall_ms": {
+            "samples": 30,
+            "p50_ms": 16.699,
+            "p95_ms": 21.094,
+            "maximum_ms": 25.515
+          },
+          "long_tasks": {
+            "samples_with_long_tasks": 0,
+            "count": 0,
+            "maximum_ms": 0
+          }
+        },
+        "samples": [
+          {
+            "native_mutation_ms": 8.9,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 17.971
+          },
+          {
+            "native_mutation_ms": 10,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 20.009
+          },
+          {
+            "native_mutation_ms": 9.6,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 17.052
+          },
+          {
+            "native_mutation_ms": 8.3,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 19.341
+          },
+          {
+            "native_mutation_ms": 8,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 14.263
+          },
+          {
+            "native_mutation_ms": 8.7,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 16.549
+          },
+          {
+            "native_mutation_ms": 9.3,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 17.558
+          },
+          {
+            "native_mutation_ms": 8.9,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 15.415
+          },
+          {
+            "native_mutation_ms": 9.2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 16.699
+          },
+          {
+            "native_mutation_ms": 8.7,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 18.271
+          },
+          {
+            "native_mutation_ms": 8.3,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 15.223
+          },
+          {
+            "native_mutation_ms": 9.8,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 21.094
+          },
+          {
+            "native_mutation_ms": 8.5,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 16.562
+          },
+          {
+            "native_mutation_ms": 9,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 16.947
+          },
+          {
+            "native_mutation_ms": 9,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 19.294
+          },
+          {
+            "native_mutation_ms": 8.5,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 14.62
+          },
+          {
+            "native_mutation_ms": 8.2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 16.691
+          },
+          {
+            "native_mutation_ms": 8.8,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 15.612
+          },
+          {
+            "native_mutation_ms": 15.2,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 25.515
+          },
+          {
+            "native_mutation_ms": 8.2,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 17.775
+          },
+          {
+            "native_mutation_ms": 8.5,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 16.242
+          },
+          {
+            "native_mutation_ms": 8.5,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 16.294
+          },
+          {
+            "native_mutation_ms": 9.8,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 18.892
+          },
+          {
+            "native_mutation_ms": 8.2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 16.738
+          },
+          {
+            "native_mutation_ms": 9.4,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 18.936
+          },
+          {
+            "native_mutation_ms": 7.9,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 13.498
+          },
+          {
+            "native_mutation_ms": 8.8,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 16.55
+          },
+          {
+            "native_mutation_ms": 8.4,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 16.865
+          },
+          {
+            "native_mutation_ms": 9.1,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 16.093
+          },
+          {
+            "native_mutation_ms": 8.2,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 14.656
+          }
+        ]
+      },
+      {
+        "size_utf16": 262144,
+        "surface": "loomark_production",
+        "matched_width_px": 736,
+        "summary": {
+          "native_mutation_ms": {
+            "samples": 30,
+            "p50_ms": 22.4,
+            "p95_ms": 39.5,
+            "maximum_ms": 39.9
+          },
+          "input_handler_ms": {
+            "samples": 30,
+            "p50_ms": 0,
+            "p95_ms": 0.1,
+            "maximum_ms": 1.2
+          },
+          "put_request_offset_ms": {
+            "samples": 30,
+            "p50_ms": 264.1,
+            "p95_ms": 283.7,
+            "maximum_ms": 309.9
+          },
+          "put_acknowledgment_ms": {
+            "samples": 30,
+            "p50_ms": 6.7,
+            "p95_ms": 16,
+            "maximum_ms": 17.2
+          },
+          "browser_command_wall_ms": {
+            "samples": 30,
+            "p50_ms": 43.098,
+            "p95_ms": 75.622,
+            "maximum_ms": 76.633
+          },
+          "long_tasks": {
+            "samples_with_long_tasks": 1,
+            "count": 1,
+            "maximum_ms": 56
+          }
+        },
+        "samples": [
+          {
+            "native_mutation_ms": 8.6,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 256.6,
+            "put_acknowledgment_ms": 6.4,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 22.266
+          },
+          {
+            "native_mutation_ms": 8.2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 256.7,
+            "put_acknowledgment_ms": 5.9,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 15.897
+          },
+          {
+            "native_mutation_ms": 7.2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 257,
+            "put_acknowledgment_ms": 8.2,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 15.291
+          },
+          {
+            "native_mutation_ms": 8.1,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 256.7,
+            "put_acknowledgment_ms": 9.8,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 15.173
+          },
+          {
+            "native_mutation_ms": 8.4,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 256.8,
+            "put_acknowledgment_ms": 6.7,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 15.233
+          },
+          {
+            "native_mutation_ms": 9.7,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 256.3,
+            "put_acknowledgment_ms": 5.7,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 19.556
+          },
+          {
+            "native_mutation_ms": 8.7,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 257.2,
+            "put_acknowledgment_ms": 7.9,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 19.412
+          },
+          {
+            "native_mutation_ms": 11,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 256.5,
+            "put_acknowledgment_ms": 8,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 25.059
+          },
+          {
+            "native_mutation_ms": 10.1,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 256.3,
+            "put_acknowledgment_ms": 5.7,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 22.014
+          },
+          {
+            "native_mutation_ms": 8.2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 268.3,
+            "put_acknowledgment_ms": 16,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 15.757
+          },
+          {
+            "native_mutation_ms": 34.1,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 271.4,
+            "put_acknowledgment_ms": 0.1,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 76.633
+          },
+          {
+            "native_mutation_ms": 31.9,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": 262.9,
+            "put_acknowledgment_ms": 2.5,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 75.622
+          },
+          {
+            "native_mutation_ms": 11.2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 265.1,
+            "put_acknowledgment_ms": 9.1,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 28.372
+          },
+          {
+            "native_mutation_ms": 26.6,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 276.4,
+            "put_acknowledgment_ms": 12.1,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 67.485
+          },
+          {
+            "native_mutation_ms": 34.9,
+            "input_handler_ms": 1.2,
+            "put_request_offset_ms": 261.4,
+            "put_acknowledgment_ms": 17.2,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 72.116
+          },
+          {
+            "native_mutation_ms": 25.8,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 270,
+            "put_acknowledgment_ms": 14.5,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 57.164
+          },
+          {
+            "native_mutation_ms": 22.2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 274.1,
+            "put_acknowledgment_ms": 0.2,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 70.8
+          },
+          {
+            "native_mutation_ms": 39.9,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 261.2,
+            "put_acknowledgment_ms": 10,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 60.972
+          },
+          {
+            "native_mutation_ms": 22.6,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 268.7,
+            "put_acknowledgment_ms": 0.1,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 48.204
+          },
+          {
+            "native_mutation_ms": 34.8,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 265.2,
+            "put_acknowledgment_ms": 0.2,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 74.975
+          },
+          {
+            "native_mutation_ms": 27.2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 265.8,
+            "put_acknowledgment_ms": 14,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 63.054
+          },
+          {
+            "native_mutation_ms": 21.8,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 264.1,
+            "put_acknowledgment_ms": 6.8,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 55.146
+          },
+          {
+            "native_mutation_ms": 26.1,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 309.9,
+            "put_acknowledgment_ms": 0.3,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 254,
+                "duration_ms": 56
+              }
+            ],
+            "browser_command_wall_ms": 54.232
+          },
+          {
+            "native_mutation_ms": 26,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 283.7,
+            "put_acknowledgment_ms": 10.9,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 34.749
+          },
+          {
+            "native_mutation_ms": 33.7,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 281,
+            "put_acknowledgment_ms": 12.5,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 71.981
+          },
+          {
+            "native_mutation_ms": 39.5,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 279.3,
+            "put_acknowledgment_ms": 6.2,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 52.09
+          },
+          {
+            "native_mutation_ms": 30.3,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 257.5,
+            "put_acknowledgment_ms": 3.7,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 33.795
+          },
+          {
+            "native_mutation_ms": 22.4,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": 283.3,
+            "put_acknowledgment_ms": 15.8,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 43.098
+          },
+          {
+            "native_mutation_ms": 26.7,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": 273.9,
+            "put_acknowledgment_ms": 0.8,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 65.696
+          },
+          {
+            "native_mutation_ms": 16.2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 263.2,
+            "put_acknowledgment_ms": 0.5,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 18.35
+          }
+        ]
+      },
+      {
+        "size_utf16": 1048576,
+        "surface": "native_textarea",
+        "matched_width_px": 736,
+        "summary": {
+          "native_mutation_ms": {
+            "samples": 30,
+            "p50_ms": 37,
+            "p95_ms": 45.5,
+            "maximum_ms": 58.9
+          },
+          "input_handler_ms": {
+            "samples": 30,
+            "p50_ms": 0,
+            "p95_ms": 0.1,
+            "maximum_ms": 0.1
+          },
+          "put_request_offset_ms": {
+            "samples": 0,
+            "p50_ms": null,
+            "p95_ms": null,
+            "maximum_ms": null
+          },
+          "put_acknowledgment_ms": {
+            "samples": 0,
+            "p50_ms": null,
+            "p95_ms": null,
+            "maximum_ms": null
+          },
+          "browser_command_wall_ms": {
+            "samples": 30,
+            "p50_ms": 69.655,
+            "p95_ms": 86.143,
+            "maximum_ms": 102.688
+          },
+          "long_tasks": {
+            "samples_with_long_tasks": 0,
+            "count": 0,
+            "maximum_ms": 0
+          }
+        },
+        "samples": [
+          {
+            "native_mutation_ms": 38,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 69.777
+          },
+          {
+            "native_mutation_ms": 36.7,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 67.098
+          },
+          {
+            "native_mutation_ms": 35.4,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 68.433
+          },
+          {
+            "native_mutation_ms": 40.9,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 71.898
+          },
+          {
+            "native_mutation_ms": 45.5,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 79.859
+          },
+          {
+            "native_mutation_ms": 36.2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 70.708
+          },
+          {
+            "native_mutation_ms": 35.2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 66.122
+          },
+          {
+            "native_mutation_ms": 36.3,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 65.949
+          },
+          {
+            "native_mutation_ms": 39.2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 72.457
+          },
+          {
+            "native_mutation_ms": 37.9,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 70.26
+          },
+          {
+            "native_mutation_ms": 36.4,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 68.709
+          },
+          {
+            "native_mutation_ms": 35.9,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 69.143
+          },
+          {
+            "native_mutation_ms": 36,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 66.654
+          },
+          {
+            "native_mutation_ms": 36.5,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 69.191
+          },
+          {
+            "native_mutation_ms": 35.4,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 69.655
+          },
+          {
+            "native_mutation_ms": 40.4,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 75.21
+          },
+          {
+            "native_mutation_ms": 36.7,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 67.129
+          },
+          {
+            "native_mutation_ms": 38.3,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 69.169
+          },
+          {
+            "native_mutation_ms": 39.9,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 86.143
+          },
+          {
+            "native_mutation_ms": 39.9,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 71.871
+          },
+          {
+            "native_mutation_ms": 43.8,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 76.81
+          },
+          {
+            "native_mutation_ms": 58.9,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 102.688
+          },
+          {
+            "native_mutation_ms": 43,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 79.68
+          },
+          {
+            "native_mutation_ms": 36.3,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 69.977
+          },
+          {
+            "native_mutation_ms": 35.5,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 69.585
+          },
+          {
+            "native_mutation_ms": 38.3,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 69.607
+          },
+          {
+            "native_mutation_ms": 36.7,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 66.534
+          },
+          {
+            "native_mutation_ms": 38.8,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 73.176
+          },
+          {
+            "native_mutation_ms": 37,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 68.582
+          },
+          {
+            "native_mutation_ms": 38.4,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 69.899
+          }
+        ]
+      },
+      {
+        "size_utf16": 1048576,
+        "surface": "loomark_production",
+        "matched_width_px": 736,
+        "summary": {
+          "native_mutation_ms": {
+            "samples": 30,
+            "p50_ms": 36,
+            "p95_ms": 57.4,
+            "maximum_ms": 58.7
+          },
+          "input_handler_ms": {
+            "samples": 30,
+            "p50_ms": 0,
+            "p95_ms": 0.1,
+            "maximum_ms": 0.1
+          },
+          "put_request_offset_ms": {
+            "samples": 30,
+            "p50_ms": 316.6,
+            "p95_ms": 344.4,
+            "maximum_ms": 378
+          },
+          "put_acknowledgment_ms": {
+            "samples": 30,
+            "p50_ms": 0.5,
+            "p95_ms": 38,
+            "maximum_ms": 45
+          },
+          "browser_command_wall_ms": {
+            "samples": 30,
+            "p50_ms": 72.526,
+            "p95_ms": 98.326,
+            "maximum_ms": 99.559
+          },
+          "long_tasks": {
+            "samples_with_long_tasks": 30,
+            "count": 45,
+            "maximum_ms": 127
+          }
+        },
+        "samples": [
+          {
+            "native_mutation_ms": 37.3,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": 314.8,
+            "put_acknowledgment_ms": 0.2,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 34.1,
+                "duration_ms": 57
+              },
+              {
+                "offset_ms": 250.4,
+                "duration_ms": 64
+              },
+              {
+                "offset_ms": 321.5,
+                "duration_ms": 52
+              }
+            ],
+            "browser_command_wall_ms": 72.431
+          },
+          {
+            "native_mutation_ms": 36.5,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 317,
+            "put_acknowledgment_ms": 0.3,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.5,
+                "duration_ms": 66
+              }
+            ],
+            "browser_command_wall_ms": 72.526
+          },
+          {
+            "native_mutation_ms": 38.4,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": 332.4,
+            "put_acknowledgment_ms": 0.4,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.4,
+                "duration_ms": 82
+              }
+            ],
+            "browser_command_wall_ms": 74.548
+          },
+          {
+            "native_mutation_ms": 36,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": 308.9,
+            "put_acknowledgment_ms": 0.3,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.5,
+                "duration_ms": 58
+              }
+            ],
+            "browser_command_wall_ms": 71.827
+          },
+          {
+            "native_mutation_ms": 57.4,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 311.1,
+            "put_acknowledgment_ms": 0.2,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.5,
+                "duration_ms": 60
+              }
+            ],
+            "browser_command_wall_ms": 99.559
+          },
+          {
+            "native_mutation_ms": 35,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 326.4,
+            "put_acknowledgment_ms": 0.4,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.2,
+                "duration_ms": 76
+              },
+              {
+                "offset_ms": 333.2,
+                "duration_ms": 67
+              }
+            ],
+            "browser_command_wall_ms": 70.368
+          },
+          {
+            "native_mutation_ms": 35.2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 315.2,
+            "put_acknowledgment_ms": 32.7,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.3,
+                "duration_ms": 65
+              }
+            ],
+            "browser_command_wall_ms": 79.561
+          },
+          {
+            "native_mutation_ms": 52.6,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 378,
+            "put_acknowledgment_ms": 0.3,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.4,
+                "duration_ms": 127
+              }
+            ],
+            "browser_command_wall_ms": 91.708
+          },
+          {
+            "native_mutation_ms": 37,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 316.6,
+            "put_acknowledgment_ms": 21.3,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.3,
+                "duration_ms": 66
+              },
+              {
+                "offset_ms": 340.7,
+                "duration_ms": 51
+              }
+            ],
+            "browser_command_wall_ms": 82.708
+          },
+          {
+            "native_mutation_ms": 38.2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 326.6,
+            "put_acknowledgment_ms": 45,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.3,
+                "duration_ms": 76
+              }
+            ],
+            "browser_command_wall_ms": 73.375
+          },
+          {
+            "native_mutation_ms": 35.3,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 316.5,
+            "put_acknowledgment_ms": 0.2,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 33.8,
+                "duration_ms": 54
+              },
+              {
+                "offset_ms": 250.3,
+                "duration_ms": 66
+              }
+            ],
+            "browser_command_wall_ms": 70.043
+          },
+          {
+            "native_mutation_ms": 39.6,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": 326.6,
+            "put_acknowledgment_ms": 0.2,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.5,
+                "duration_ms": 76
+              }
+            ],
+            "browser_command_wall_ms": 75.519
+          },
+          {
+            "native_mutation_ms": 58.7,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": 341.2,
+            "put_acknowledgment_ms": 0.2,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 38.5,
+                "duration_ms": 53
+              },
+              {
+                "offset_ms": 250.4,
+                "duration_ms": 90
+              }
+            ],
+            "browser_command_wall_ms": 98.326
+          },
+          {
+            "native_mutation_ms": 38.1,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 329.8,
+            "put_acknowledgment_ms": 11.1,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.6,
+                "duration_ms": 79
+              },
+              {
+                "offset_ms": 349,
+                "duration_ms": 68
+              }
+            ],
+            "browser_command_wall_ms": 76.944
+          },
+          {
+            "native_mutation_ms": 36.1,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 310.1,
+            "put_acknowledgment_ms": 36.9,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.4,
+                "duration_ms": 59
+              }
+            ],
+            "browser_command_wall_ms": 70.662
+          },
+          {
+            "native_mutation_ms": 37.8,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": 313.8,
+            "put_acknowledgment_ms": 0.3,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 34.8,
+                "duration_ms": 53
+              },
+              {
+                "offset_ms": 250.3,
+                "duration_ms": 63
+              },
+              {
+                "offset_ms": 320.3,
+                "duration_ms": 53
+              }
+            ],
+            "browser_command_wall_ms": 73.746
+          },
+          {
+            "native_mutation_ms": 40.2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 316.5,
+            "put_acknowledgment_ms": 31.8,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.4,
+                "duration_ms": 66
+              }
+            ],
+            "browser_command_wall_ms": 77.892
+          },
+          {
+            "native_mutation_ms": 36,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 344.4,
+            "put_acknowledgment_ms": 0.5,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 41.1,
+                "duration_ms": 73
+              },
+              {
+                "offset_ms": 250.2,
+                "duration_ms": 94
+              }
+            ],
+            "browser_command_wall_ms": 78.138
+          },
+          {
+            "native_mutation_ms": 35,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 322.3,
+            "put_acknowledgment_ms": 17.1,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.2,
+                "duration_ms": 72
+              },
+              {
+                "offset_ms": 339.9,
+                "duration_ms": 56
+              }
+            ],
+            "browser_command_wall_ms": 68.522
+          },
+          {
+            "native_mutation_ms": 36.9,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": 336.8,
+            "put_acknowledgment_ms": 0.3,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.4,
+                "duration_ms": 86
+              }
+            ],
+            "browser_command_wall_ms": 71.741
+          },
+          {
+            "native_mutation_ms": 34.7,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": 332.2,
+            "put_acknowledgment_ms": 22,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.4,
+                "duration_ms": 81
+              }
+            ],
+            "browser_command_wall_ms": 69.903
+          },
+          {
+            "native_mutation_ms": 34.6,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": 310.8,
+            "put_acknowledgment_ms": 31.8,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.4,
+                "duration_ms": 60
+              }
+            ],
+            "browser_command_wall_ms": 70.427
+          },
+          {
+            "native_mutation_ms": 34.4,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 333.8,
+            "put_acknowledgment_ms": 14.5,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.3,
+                "duration_ms": 83
+              }
+            ],
+            "browser_command_wall_ms": 68.816
+          },
+          {
+            "native_mutation_ms": 35.4,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": 307.8,
+            "put_acknowledgment_ms": 15.4,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.5,
+                "duration_ms": 57
+              }
+            ],
+            "browser_command_wall_ms": 75.125
+          },
+          {
+            "native_mutation_ms": 34.8,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 310,
+            "put_acknowledgment_ms": 0.3,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.4,
+                "duration_ms": 59
+              }
+            ],
+            "browser_command_wall_ms": 75.643
+          },
+          {
+            "native_mutation_ms": 35.3,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 314.3,
+            "put_acknowledgment_ms": 6.4,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 33.1,
+                "duration_ms": 52
+              },
+              {
+                "offset_ms": 250.3,
+                "duration_ms": 64
+              },
+              {
+                "offset_ms": 321.1,
+                "duration_ms": 60
+              }
+            ],
+            "browser_command_wall_ms": 69.323
+          },
+          {
+            "native_mutation_ms": 34.7,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 330.8,
+            "put_acknowledgment_ms": 38,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.4,
+                "duration_ms": 80
+              }
+            ],
+            "browser_command_wall_ms": 70.156
+          },
+          {
+            "native_mutation_ms": 34.3,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 331.3,
+            "put_acknowledgment_ms": 0.3,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.3,
+                "duration_ms": 81
+              }
+            ],
+            "browser_command_wall_ms": 68.858
+          },
+          {
+            "native_mutation_ms": 34.7,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": 309.1,
+            "put_acknowledgment_ms": 13.3,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.4,
+                "duration_ms": 58
+              }
+            ],
+            "browser_command_wall_ms": 70.217
+          },
+          {
+            "native_mutation_ms": 36.2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 312.7,
+            "put_acknowledgment_ms": 6,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 41.7,
+                "duration_ms": 54
+              },
+              {
+                "offset_ms": 250.3,
+                "duration_ms": 62
+              },
+              {
+                "offset_ms": 319.3,
+                "duration_ms": 53
+              }
+            ],
+            "browser_command_wall_ms": 78.947
+          }
+        ]
+      }
+    ],
+    "traces": [
+      {
+        "measured": {
+          "native_mutation_ms": 45.6,
+          "input_handler_ms": 0,
+          "put_request_offset_ms": 328.1,
+          "put_acknowledgment_ms": 23.2,
+          "put_outcome": "stored",
+          "long_tasks": [
+            {
+              "offset_ms": 250.6,
+              "duration_ms": 77
+            },
+            {
+              "offset_ms": 351.6,
+              "duration_ms": 68
+            }
+          ],
+          "browser_command_wall_ms": 87.494
+        },
+        "summary": {
+          "w0_immediate": {
+            "elapsed_ms": 45.628,
+            "function_call_ms": 1.154,
+            "run_task_ms": 0,
+            "style_layout_ms": 23.348,
+            "paint_ms": 0,
+            "gc_ms": 0
+          },
+          "w1_preview": {
+            "elapsed_ms": 100,
+            "function_call_ms": 45.402,
+            "run_task_ms": 0,
+            "style_layout_ms": 0,
+            "paint_ms": 64.308,
+            "gc_ms": 32.958
+          },
+          "w2_probe_240ms_to_put": {
+            "elapsed_ms": 88.174,
+            "function_call_ms": 77.395,
+            "run_task_ms": 0,
+            "style_layout_ms": 0,
+            "paint_ms": 0,
+            "gc_ms": 48.214
+          }
+        }
+      },
+      {
+        "measured": {
+          "native_mutation_ms": 37,
+          "input_handler_ms": 0,
+          "put_request_offset_ms": 331.9,
+          "put_acknowledgment_ms": 37.4,
+          "put_outcome": "stored",
+          "long_tasks": [
+            {
+              "offset_ms": 250.4,
+              "duration_ms": 81
+            }
+          ],
+          "browser_command_wall_ms": 75.293
+        },
+        "summary": {
+          "w0_immediate": {
+            "elapsed_ms": 36.966,
+            "function_call_ms": 0.148,
+            "run_task_ms": 0,
+            "style_layout_ms": 20.087,
+            "paint_ms": 0,
+            "gc_ms": 0
+          },
+          "w1_preview": {
+            "elapsed_ms": 100,
+            "function_call_ms": 9.8,
+            "run_task_ms": 0,
+            "style_layout_ms": 0,
+            "paint_ms": 60.093,
+            "gc_ms": 0
+          },
+          "w2_probe_240ms_to_put": {
+            "elapsed_ms": 91.868,
+            "function_call_ms": 81.167,
+            "run_task_ms": 0,
+            "style_layout_ms": 0,
+            "paint_ms": 0,
+            "gc_ms": 53.769
+          }
+        }
+      },
+      {
+        "measured": {
+          "native_mutation_ms": 35.8,
+          "input_handler_ms": 0,
+          "put_request_offset_ms": 322,
+          "put_acknowledgment_ms": 21.4,
+          "put_outcome": "stored",
+          "long_tasks": [
+            {
+              "offset_ms": 35.4,
+              "duration_ms": 53
+            },
+            {
+              "offset_ms": 250.3,
+              "duration_ms": 71
+            }
+          ],
+          "browser_command_wall_ms": 72.055
+        },
+        "summary": {
+          "w0_immediate": {
+            "elapsed_ms": 35.731,
+            "function_call_ms": 0.129,
+            "run_task_ms": 0,
+            "style_layout_ms": 20.248,
+            "paint_ms": 0,
+            "gc_ms": 0
+          },
+          "w1_preview": {
+            "elapsed_ms": 100,
+            "function_call_ms": 54.039,
+            "run_task_ms": 0,
+            "style_layout_ms": 0,
+            "paint_ms": 58.4,
+            "gc_ms": 42.445
+          },
+          "w2_probe_240ms_to_put": {
+            "elapsed_ms": 82.081,
+            "function_call_ms": 71.555,
+            "run_task_ms": 0,
+            "style_layout_ms": 0,
+            "paint_ms": 0,
+            "gc_ms": 43.727
+          }
+        }
+      }
+    ]
+  },
+  "counterfactual": {
+    "name": "persistence_disabled_before_materialization",
+    "temporary_source_change": {
+      "file": "apps/loomark/internal/rabbita/document_transaction.mbt",
+      "function": "local_text_replacement",
+      "replacement": "guard model.archive_persistence_enabled else -> guard false else",
+      "retained_in_candidate": false,
+      "base_commit": "60ef805ca502cc5963e919fce9a263b0587d0f1d",
+      "working_tree_dirty": true,
+      "patch_description_sha256": "c0b873688f2ba9f5c2334eeea8f25687caf26fff998601bc488dd022525535c2"
+    },
+    "runner_environment": {
+      "LOOMARK_WHOLE_DOCUMENT_SIZES": "1048576",
+      "LOOMARK_WHOLE_DOCUMENT_REQUIRE_PERSISTENCE": "0"
+    },
+    "result": {
+      "schema": "loomark-whole-document-input-v1",
+      "environment": {
+        "commit": "60ef805ca502cc5963e919fce9a263b0587d0f1d",
+        "browser": "149.0.7827.55",
+        "node": "v24.14.1",
+        "platform": "linux",
+        "os_release": "6.18.33.2-microsoft-standard-WSL2",
+        "architecture": "x64",
+        "cpu": "AMD Ryzen 7 6800H with Radeon Graphics",
+        "headless": true,
+        "viewport": {
+          "width": 1280,
+          "height": 720
+        },
+        "warmups": 5,
+        "samples": 30,
+        "trace_samples": 0,
+        "settle_ms": 400,
+        "persistence_required": false,
+        "working_tree_dirty": true,
+        "temporary_patch_description_sha256": "c0b873688f2ba9f5c2334eeea8f25687caf26fff998601bc488dd022525535c2"
+      },
+      "invocation": {
+        "sizes": [
+          1048576
+        ],
+        "environment": {
+          "LOOMARK_WHOLE_DOCUMENT_SIZES": "1048576",
+          "LOOMARK_WHOLE_DOCUMENT_WARMUPS": null,
+          "LOOMARK_WHOLE_DOCUMENT_SAMPLES": null,
+          "LOOMARK_WHOLE_DOCUMENT_TRACE_SAMPLES": null,
+          "LOOMARK_WHOLE_DOCUMENT_REQUIRE_PERSISTENCE": "0"
+        }
+      },
+      "fixtures": [
+        {
+          "requested_utf16": 1048576,
+          "utf16_length": 1048576,
+          "utf8_bytes": 1048576,
+          "sha256": "bd2b39512f137e45eb14063920e77769422728321640fc9214787e00a5dd74ae"
+        }
+      ],
+      "scenarios": [
+        {
+          "size_utf16": 1048576,
+          "surface": "native_textarea",
+          "matched_width_px": 736,
+          "summary": {
+            "native_mutation_ms": {
+              "samples": 30,
+              "p50_ms": 62.1,
+              "p95_ms": 109.5,
+              "maximum_ms": 110.8
+            },
+            "input_handler_ms": {
+              "samples": 30,
+              "p50_ms": 0,
+              "p95_ms": 0.1,
+              "maximum_ms": 0.1
+            },
+            "put_request_offset_ms": {
+              "samples": 0,
+              "p50_ms": null,
+              "p95_ms": null,
+              "maximum_ms": null
+            },
+            "put_acknowledgment_ms": {
+              "samples": 0,
+              "p50_ms": null,
+              "p95_ms": null,
+              "maximum_ms": null
+            },
+            "browser_command_wall_ms": {
+              "samples": 30,
+              "p50_ms": 101.533,
+              "p95_ms": 174.54,
+              "maximum_ms": 178.098
+            },
+            "long_tasks": {
+              "samples_with_long_tasks": 0,
+              "count": 0,
+              "maximum_ms": 0
+            }
+          },
+          "samples": [
+            {
+              "native_mutation_ms": 35.5,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 65.444
+            },
+            {
+              "native_mutation_ms": 35.6,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 64.937
+            },
+            {
+              "native_mutation_ms": 33.4,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 66.468
+            },
+            {
+              "native_mutation_ms": 37.1,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 67.482
+            },
+            {
+              "native_mutation_ms": 35.9,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 67.834
+            },
+            {
+              "native_mutation_ms": 37.9,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 72.091
+            },
+            {
+              "native_mutation_ms": 35.5,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 66.976
+            },
+            {
+              "native_mutation_ms": 35.7,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 65.008
+            },
+            {
+              "native_mutation_ms": 34.7,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 68.177
+            },
+            {
+              "native_mutation_ms": 35.2,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 65.147
+            },
+            {
+              "native_mutation_ms": 71.8,
+              "input_handler_ms": 0.1,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 120.659
+            },
+            {
+              "native_mutation_ms": 91.4,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 133.141
+            },
+            {
+              "native_mutation_ms": 64.2,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 103.558
+            },
+            {
+              "native_mutation_ms": 63.4,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 129.745
+            },
+            {
+              "native_mutation_ms": 56.9,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 58.527
+            },
+            {
+              "native_mutation_ms": 68.7,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 111.012
+            },
+            {
+              "native_mutation_ms": 89,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 133.31
+            },
+            {
+              "native_mutation_ms": 108.5,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 168.337
+            },
+            {
+              "native_mutation_ms": 94.8,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 174.54
+            },
+            {
+              "native_mutation_ms": 60.2,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 100.093
+            },
+            {
+              "native_mutation_ms": 69.1,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 125.351
+            },
+            {
+              "native_mutation_ms": 47.2,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 48.994
+            },
+            {
+              "native_mutation_ms": 97.4,
+              "input_handler_ms": 0.1,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 101.533
+            },
+            {
+              "native_mutation_ms": 82.4,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 125.47
+            },
+            {
+              "native_mutation_ms": 110.8,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 178.098
+            },
+            {
+              "native_mutation_ms": 62.1,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 105.533
+            },
+            {
+              "native_mutation_ms": 70.2,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 150.13
+            },
+            {
+              "native_mutation_ms": 63.2,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 115.631
+            },
+            {
+              "native_mutation_ms": 52.8,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 97.849
+            },
+            {
+              "native_mutation_ms": 109.5,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 146.994
+            }
+          ]
+        },
+        {
+          "size_utf16": 1048576,
+          "surface": "loomark_production",
+          "matched_width_px": 736,
+          "summary": {
+            "native_mutation_ms": {
+              "samples": 30,
+              "p50_ms": 34.1,
+              "p95_ms": 36.8,
+              "maximum_ms": 37.6
+            },
+            "input_handler_ms": {
+              "samples": 30,
+              "p50_ms": 0,
+              "p95_ms": 0.1,
+              "maximum_ms": 0.1
+            },
+            "put_request_offset_ms": {
+              "samples": 0,
+              "p50_ms": null,
+              "p95_ms": null,
+              "maximum_ms": null
+            },
+            "put_acknowledgment_ms": {
+              "samples": 0,
+              "p50_ms": null,
+              "p95_ms": null,
+              "maximum_ms": null
+            },
+            "browser_command_wall_ms": {
+              "samples": 30,
+              "p50_ms": 70.116,
+              "p95_ms": 77.909,
+              "maximum_ms": 79.806
+            },
+            "long_tasks": {
+              "samples_with_long_tasks": 9,
+              "count": 9,
+              "maximum_ms": 52
+            }
+          },
+          "samples": [
+            {
+              "native_mutation_ms": 33.5,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [
+                {
+                  "offset_ms": 250.3,
+                  "duration_ms": 52
+                }
+              ],
+              "browser_command_wall_ms": 75.94
+            },
+            {
+              "native_mutation_ms": 32.3,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 69.094
+            },
+            {
+              "native_mutation_ms": 37.6,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 75.184
+            },
+            {
+              "native_mutation_ms": 35.7,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 72.09
+            },
+            {
+              "native_mutation_ms": 33.9,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 68.963
+            },
+            {
+              "native_mutation_ms": 36,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [
+                {
+                  "offset_ms": 250.2,
+                  "duration_ms": 51
+                }
+              ],
+              "browser_command_wall_ms": 77.909
+            },
+            {
+              "native_mutation_ms": 33,
+              "input_handler_ms": 0.1,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 69.857
+            },
+            {
+              "native_mutation_ms": 33.9,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 68.954
+            },
+            {
+              "native_mutation_ms": 34.1,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 69.12
+            },
+            {
+              "native_mutation_ms": 33.7,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [
+                {
+                  "offset_ms": 34.8,
+                  "duration_ms": 51
+                }
+              ],
+              "browser_command_wall_ms": 69.436
+            },
+            {
+              "native_mutation_ms": 34.2,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 75.803
+            },
+            {
+              "native_mutation_ms": 34.2,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 72.286
+            },
+            {
+              "native_mutation_ms": 36.7,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 72.075
+            },
+            {
+              "native_mutation_ms": 34.2,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [
+                {
+                  "offset_ms": 33.9,
+                  "duration_ms": 50
+                }
+              ],
+              "browser_command_wall_ms": 68.944
+            },
+            {
+              "native_mutation_ms": 32.7,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 69.23
+            },
+            {
+              "native_mutation_ms": 34.1,
+              "input_handler_ms": 0.1,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 79.806
+            },
+            {
+              "native_mutation_ms": 35.5,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [
+                {
+                  "offset_ms": 250.4,
+                  "duration_ms": 52
+                }
+              ],
+              "browser_command_wall_ms": 74.39
+            },
+            {
+              "native_mutation_ms": 32.7,
+              "input_handler_ms": 0.1,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 69.458
+            },
+            {
+              "native_mutation_ms": 34.1,
+              "input_handler_ms": 0.1,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 70.116
+            },
+            {
+              "native_mutation_ms": 34.2,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 69.82
+            },
+            {
+              "native_mutation_ms": 33.3,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [
+                {
+                  "offset_ms": 250.3,
+                  "duration_ms": 51
+                }
+              ],
+              "browser_command_wall_ms": 75.865
+            },
+            {
+              "native_mutation_ms": 33.8,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 69.386
+            },
+            {
+              "native_mutation_ms": 32.8,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 68.528
+            },
+            {
+              "native_mutation_ms": 35.2,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [
+                {
+                  "offset_ms": 34.1,
+                  "duration_ms": 50
+                }
+              ],
+              "browser_command_wall_ms": 70.291
+            },
+            {
+              "native_mutation_ms": 36.4,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 73.117
+            },
+            {
+              "native_mutation_ms": 33.8,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [
+                {
+                  "offset_ms": 250.2,
+                  "duration_ms": 51
+                }
+              ],
+              "browser_command_wall_ms": 75.669
+            },
+            {
+              "native_mutation_ms": 36.8,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 72.474
+            },
+            {
+              "native_mutation_ms": 34,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 69.599
+            },
+            {
+              "native_mutation_ms": 35.2,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [
+                {
+                  "offset_ms": 35.1,
+                  "duration_ms": 52
+                }
+              ],
+              "browser_command_wall_ms": 71.264
+            },
+            {
+              "native_mutation_ms": 33.1,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 69.956
+            }
+          ]
+        }
+      ],
+      "traces": []
+    }
+  },
+  "comparison": {
+    "target_metric": "maximum W2 long-task duration per sample, 200-400 ms after input",
+    "production": {
+      "samples_with_w2_long_task": 30,
+      "p50_ms": 66,
+      "p95_ms": 94,
+      "maximum_ms": 127
+    },
+    "counterfactual": {
+      "samples_with_w2_long_task": 5,
+      "p50_ms": 0,
+      "p95_ms": 52,
+      "maximum_ms": 52
+    },
+    "p95_ratio": 0.553191,
+    "maximum_ratio": 0.409449,
+    "non_targeted_immediate_native_mutation_p95": {
+      "production_ms": 57.4,
+      "counterfactual_ms": 36.8,
+      "ratio": 0.641115
+    }
+  },
+  "limitations": [
+    "Headless Chromium on one Linux WSL2 host; absolute timings are environment-specific.",
+    "The matched native textarea control showed cross-process variance and was not used to select an editing-surface migration.",
+    "Chrome trace category durations can overlap and must not be added together.",
+    "The counterfactual disables all LocalText persistence and is causal evidence only, not a production design."
+  ]
+}

--- a/docs/evidence/2026-08-24-loomark-whole-document-input.md
+++ b/docs/evidence/2026-08-24-loomark-whole-document-input.md
@@ -1,0 +1,185 @@
+# Loomark whole-document input characterization
+
+- **Issue:** [#1353](https://github.com/dowdiness/canopy/issues/1353)
+- **Baseline:** `60ef805ca502cc5963e919fce9a263b0587d0f1d`
+- **Decision:** `persistence_first`
+
+## Result
+
+At 1 MiB, the production 250 ms flush window produced a long task in every
+measured sample. The per-sample maximum W2 long-task duration was 66 ms at p50,
+94 ms at p95, and 127 ms maximum. A one-line throwaway counterfactual that
+returned before `prepare_local_text` reduced W2 long-task incidence from 30/30
+to 5/30 and reduced p95 to 52 ms (`0.553×`). The immediate native-mutation p95
+did not regress.
+
+This satisfies the project material-win threshold for the targeted boundary.
+The first production slice should therefore coalesce revision-bound persistence
+intents before complete-source materialization and encoding. The
+counterfactual itself is not a production design: it disabled durability and
+was removed after measurement.
+
+## Production path
+
+The measured path has three observable windows:
+
+```text
+W0  textarea mutation and immediate input dispatch
+W1  0 ms RawFastPreview / publication / reconciliation
+W2  250 ms RawFastFlush / LocalText preparation / IndexedDB request
+```
+
+Source locations:
+
+- Rabbita reads the text control value in
+  `deps/rabbita/rabbita/html/html_utils.mbt:397-440`.
+- Loomark installs the browser draft and schedules preview and flush in
+  `apps/loomark/internal/rabbita/application.mbt:521-550`.
+- The delays are 0 ms and 250 ms in
+  `apps/loomark/internal/rabbita/text_control_repair.mbt:48-52`.
+- `RawFastFlush` reaches LocalText replacement in
+  `apps/loomark/internal/rabbita/application.mbt:1171-1234`.
+- `local_text_replacement` prepares the complete record before enqueueing it
+  in `apps/loomark/internal/rabbita/document_transaction.mbt:114-130`.
+- `prepare_local_text` constructs and stringifies the complete Source record
+  in `apps/loomark/repository/repository.mbt:245-255`.
+- Publication is rebuilt in
+  `apps/loomark/internal/rabbita/application.mbt:325-400`.
+- The current Rabbita textarea uses `field-sizing:content` in
+  `deps/rabbita/rui/textarea.mbt:2`.
+
+## Method
+
+The release Warren build ran in headless Chromium 149.0.7827.55 on Linux WSL2
+with an AMD Ryzen 7 6800H. Each size and surface used a fresh browser process,
+a 1280×720 viewport, five warmups, and thirty real-keyboard samples. Fixtures
+were deterministic ASCII Markdown with recorded SHA-256 hashes.
+
+The native control reused the production textarea's inline style and measured
+736 px width. The runner recorded:
+
+- `beforeinput` to `input`;
+- `input` to the event-loop microtask;
+- `input` to IndexedDB `put` request;
+- request to acknowledgment; and
+- long-task offsets and durations during the following 400 ms.
+
+Three representative 1 MiB traces were recorded separately from the
+distribution run. Trace category durations can overlap and are not additive.
+
+## Scaling baseline
+
+| Source | Surface | Native mutation p50 / p95 | IDB request offset p50 / p95 | Samples with long task |
+|---:|---|---:|---:|---:|
+| 64 KiB | matched native textarea | 2.2 / 3.5 ms | n/a | 0/30 |
+| 64 KiB | Loomark production | 3.3 / 13.0 ms | 253.4 / 262.0 ms | 0/30 |
+| 256 KiB | matched native textarea | 8.7 / 10.0 ms | n/a | 0/30 |
+| 256 KiB | Loomark production | 22.4 / 39.5 ms | 264.1 / 283.7 ms | 1/30 |
+| 1 MiB | matched native textarea | 37.0 / 45.5 ms | n/a | 0/30 |
+| 1 MiB | Loomark production | 36.0 / 57.4 ms | 316.6 / 344.4 ms | 30/30 |
+
+The 1 MiB IndexedDB acknowledgment itself was 0.5 ms at p50 and 38.0 ms at
+p95. More importantly, the request did not begin until 66.6–94.4 ms after the
+nominal 250 ms flush boundary at p50/p95.
+
+## Representative trace
+
+Across the three 1 MiB traces:
+
+- W0 lasted 35.7–45.6 ms and included 20.1–23.3 ms of style/layout;
+- the 240 ms guard-band probe through the IndexedDB request lasted
+  82.1–91.9 ms;
+- that probe contained 71.6–81.2 ms of traced `FunctionCall` overlap; and
+- each trace observed a 71–81 ms long task beginning near the actual 250 ms
+  flush boundary.
+
+The trace probe starts 10 ms before the nominal timer so scheduling jitter
+cannot hide the task start. Its elapsed value is not presented as the exact
+flush duration; the independently observed long tasks begin at approximately
+250 ms.
+
+W1 also contained substantial paint and occasional GC or script work. It
+remains a measured follow-up concern, but it was not larger than W2 and was not
+needed to select the first cut.
+
+## Counterfactual
+
+The only throwaway application change was based on
+`60ef805ca502cc5963e919fce9a263b0587d0f1d` with a dirty working tree:
+
+```diff
+- guard model.archive_persistence_enabled else {
++ guard false else {
+```
+
+in `local_text_replacement`, before `prepare_local_text`. The runner used:
+
+```text
+LOOMARK_WHOLE_DOCUMENT_SIZES=1048576
+LOOMARK_WHOLE_DOCUMENT_REQUIRE_PERSISTENCE=0
+```
+
+| 1 MiB W2 metric | Production | Persistence disabled | Ratio |
+|---|---:|---:|---:|
+| Samples with W2 long task | 30/30 | 5/30 | 0.167× incidence |
+| Per-sample maximum W2 long task p50 | 66 ms | 0 ms | 0× |
+| Per-sample maximum W2 long task p95 | 94 ms | 52 ms | **0.553×** |
+| Per-sample maximum W2 long task maximum | 127 ms | 52 ms | **0.409×** |
+| Immediate native-mutation p95 | 57.4 ms | 36.8 ms | 0.641× |
+
+The machine-readable evidence marks the counterfactual as dirty and records a
+digest of the patch description; it does not identify the modified build as an
+exact checkout of the baseline commit.
+
+The counterfactual proves that persistence work before or around record
+materialization is a material W2 contributor. It does not by itself distinguish
+JSON construction, stringify, queue construction, command scheduling, or the
+memory pressure those operations create. The production child should move the
+materialization boundary rather than add a permanent persistence-disable mode.
+
+## Reproduction
+
+Build the release standalone output and install browser dependencies:
+
+```bash
+./scripts/test-loomark-standalone-e2e.sh --list
+```
+
+Run the production baseline and representative traces:
+
+```bash
+cd apps/loomark/examples/vanilla
+LOOMARK_WHOLE_DOCUMENT_TRACE_SAMPLES=3 \
+LOOMARK_WHOLE_DOCUMENT_OUTPUT=/tmp/loomark-whole-document-input.json \
+  npm run bench:whole-document-input
+```
+
+The complete raw samples, environment, fixture hashes, trace summaries, exact
+counterfactual description, and comparison are in
+`2026-08-24-loomark-whole-document-input.json`.
+
+## Limitations
+
+- Absolute timings are from one headless Chromium host.
+- The matched native control showed cross-process variance. It establishes a
+  browser surface floor but does not justify an editing-surface migration.
+- Trace categories overlap and must not be summed.
+- Only end insertion was required to choose the first complete-source boundary.
+  The selected production implementation must run the broader #1351
+  correctness and sustained-input matrix.
+
+## Next slice
+
+Create one bounded production issue under #1351 and coordinate it with #1347:
+
+```text
+accepted revision
+  → enqueue replaceable persistence intent
+  → coalesce to latest intent
+  → materialize selected snapshot
+  → encode and write IndexedDB
+  → acknowledge durable revision
+```
+
+Do not add a durable operation tail or make persistence define canonical
+acceptance.


### PR DESCRIPTION
## Summary

- add one reproducible release-browser runner for the production LocalText input path at 64 KiB, 256 KiB, and 1 MiB
- preserve raw samples, representative Chrome trace summaries, fixture hashes, environment data, and a source-backed report
- select `persistence_first`: disabling LocalText persistence before complete-source materialization reduced the 1 MiB W2 long-task p95 from 94 ms to 52 ms (`0.553×`)

Closes #1353.

## Decision

At 1 MiB, the production 250 ms flush window produced a W2 long task in 30/30 samples. The single throwaway persistence counterfactual reduced that incidence to 5/30 and the maximum from 127 ms to 52 ms. The counterfactual was reverted; this PR changes no production behavior or persistence contract.

The smallest follow-up is #1360: enqueue and coalesce unencoded, revision-bound persistence intents before materializing and encoding the selected Source checkpoint. The evidence does not authorize a durable operation tail, CRDT hydration, Worker protocol, or editing-surface migration.

Evidence:

- `docs/evidence/2026-08-24-loomark-whole-document-input.md`
- `docs/evidence/2026-08-24-loomark-whole-document-input.json`

## UI and review evidence

N/A — measurement runner and evidence only; no UI or visual behavior changes.

- [x] Any claimed Canopy rule cites its repository source; external guidance, recommendations, and preferences are labeled as such

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| standalone release server | `apps/loomark/examples/vanilla/serve-standalone-dist.mjs` | Yes | serves the production Warren output without a second host |
| Chrome trace pattern | `apps/loomark/examples/vanilla/bench-projection-placement.mjs` | Yes | reuses the existing CDP categories and summary approach |
| Playwright browser package | `apps/loomark/examples/vanilla/package.json` | Yes | drives trusted keyboard input and isolated browser contexts |
| IndexedDB production seam | `apps/loomark/internal/archive_storage/storage.mbt` | Yes | observes the existing LocalText key and request boundary |
| Node `crypto`, `os`, and process APIs | Node standard library | Yes | fixture hashes and reproducible environment metadata |

No MoonBit functions, helpers, types, loops, or APIs were added. Runner-local JavaScript helpers only own server lifecycle, fixture generation, browser observation, trace summarization, and JSON reporting; they are not a product abstraction.

## Validation scope

Boundary matrix / first failing regression:

- matched native textarea versus production Loomark at 64 KiB, 256 KiB, and 1 MiB
- W0 immediate mutation/handler, W1 preview probe, W2 250 ms flush, IndexedDB request/acknowledgment, and 400 ms long tasks
- one selected counterfactual only: persistence disabled before `prepare_local_text`
- production LocalText restore, edit, persistence, retry, migration, recovery, and Raw-only browser coverage remained green

Target packages:

```text
--no-target "JavaScript-only benchmark runner and evidence report for Issue #1353"
```

Additional conditional gates:

- Loomark standalone release E2E: 15/15 passed
- benchmark production smoke with representative trace: passed
- evidence consistency assertions: passed
- Slopless report review: no findings
- independent attribution review: no findings

## PR-ready evidence

Validated HEAD: `a358a1fc5726d6d98990b1901da4a6d20681bd6b`

Validated base: `origin/main@89b33c058a7d65854e38c76873739e8ce407b441`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh \
  --no-target "JavaScript-only benchmark runner and evidence report for Issue #1353"
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for the exact HEAD and base above.
- [x] The base was fetched again and `--verify-evidence` passed immediately before this PR was opened.
- [x] The committed `.mbti` diff against the validated base was reviewed; there is no `.mbti` change.
- [x] No submodule pointer changed.
- [x] Validation was rerun after every commit, amend, and rebase.
- [x] Independent review findings were resolved before the final validation.
