### PR TITLE
perf(loomark): coalesce source intents before encoding

### DIFF
--- a/apps/loomark/examples/vanilla/bench-whole-document-input.mjs
+++ b/apps/loomark/examples/vanilla/bench-whole-document-input.mjs
@@ -15,6 +15,8 @@ const localTextKey = "loomark.active-document-text"
 const databaseName = "loomark.local-repository"
 const storeName = "archives"
 const settleMs = 400
+const w2StartMs = 200
+const w2EndMs = 400
 const sizes = parseSizes(process.env.LOOMARK_WHOLE_DOCUMENT_SIZES ?? "65536,262144,1048576")
 const warmups = parseCount(process.env.LOOMARK_WHOLE_DOCUMENT_WARMUPS ?? "5", "LOOMARK_WHOLE_DOCUMENT_WARMUPS", 0)
 const samples = parseCount(process.env.LOOMARK_WHOLE_DOCUMENT_SAMPLES ?? "30", "LOOMARK_WHOLE_DOCUMENT_SAMPLES", 1)
@@ -422,6 +424,9 @@ async function withBrowser(action) {
 }
 
 function summarizeRows(rows) {
+  const w2MaximumPerSample = rows.map(row => row.long_tasks
+    .filter(task => task.offset_ms >= w2StartMs && task.offset_ms <= w2EndMs)
+    .reduce((maximum, task) => Math.max(maximum, task.duration_ms), 0))
   const metrics = [
     "native_mutation_ms",
     "input_handler_ms",
@@ -441,6 +446,14 @@ function summarizeRows(rows) {
         (maximum, value) => Math.max(maximum, value),
         0,
       ),
+    },
+  ], [
+    "w2_long_tasks",
+    {
+      window_start_ms: w2StartMs,
+      window_end_ms: w2EndMs,
+      samples_with_long_tasks: w2MaximumPerSample.filter(value => value > 0).length,
+      maximum_per_sample_ms: summarize(w2MaximumPerSample),
     },
   ]]))
 }

--- a/apps/loomark/examples/vanilla/tests/standalone.spec.ts
+++ b/apps/loomark/examples/vanilla/tests/standalone.spec.ts
@@ -221,6 +221,9 @@ type ObservedLocalTextPut = {
   encodedUtf16: number
 }
 
+// Delay the application's first correlated transaction-completion callback.
+// IndexedDB may already have committed A, but the queue remains in flight until
+// this callback is released and can therefore coalesce later accepted source.
 function installArchivePutHold(key: string): void {
   const state = globalThis as typeof globalThis & {
     __loomarkArchiveAckHeld?: () => boolean
@@ -535,16 +538,22 @@ test("an in-flight LocalText write coalesces pending source before encoding", as
   await page.evaluate(() => {
     const scope = globalThis as typeof globalThis & {
       __loomarkPendingFlushes?: () => number
+      __loomarkCompletedFlushes?: () => number
       __loomarkRunNextFlush?: () => void
     }
     const nativeSetTimeout = globalThis.setTimeout.bind(globalThis)
     const pending: Array<() => void> = []
+    let completed = 0
     let syntheticTimer = -1
     scope.__loomarkPendingFlushes = () => pending.length
+    scope.__loomarkCompletedFlushes = () => completed
     scope.__loomarkRunNextFlush = () => { pending.shift()?.() }
     globalThis.setTimeout = ((handler: TimerHandler, timeout?: number, ...args: unknown[]) => {
       if (timeout === 250 && typeof handler === "function") {
-        pending.push(() => handler(...args))
+        pending.push(() => {
+          handler(...args)
+          completed += 1
+        })
         return syntheticTimer--
       }
       return nativeSetTimeout(handler, timeout, ...args)
@@ -571,8 +580,17 @@ test("an in-flight LocalText write coalesces pending source before encoding", as
 
   await replaceRawValue(input, "B")
   await flush()
+  await expect(input).toHaveValue("B")
+  await expect.poll(() => page.evaluate(() => (
+    globalThis as typeof globalThis & { __loomarkCompletedFlushes?: () => number }
+  ).__loomarkCompletedFlushes?.())).toBe(2)
+
   await replaceRawValue(input, "C")
   await flush()
+  await expect(input).toHaveValue("C")
+  await expect.poll(() => page.evaluate(() => (
+    globalThis as typeof globalThis & { __loomarkCompletedFlushes?: () => number }
+  ).__loomarkCompletedFlushes?.())).toBe(3)
 
   const observedBeforeRelease = await page.evaluate(() => (
     globalThis as typeof globalThis & {

--- a/apps/loomark/examples/vanilla/tests/standalone.spec.ts
+++ b/apps/loomark/examples/vanilla/tests/standalone.spec.ts
@@ -216,6 +216,74 @@ function removeArchivePutFailure(): void {
   delete state.__loomarkArchivePutOriginal
 }
 
+type ObservedLocalTextPut = {
+  source: string
+  encodedUtf16: number
+}
+
+function installArchivePutHold(key: string): void {
+  const state = globalThis as typeof globalThis & {
+    __loomarkArchiveAckHeld?: () => boolean
+    __loomarkArchiveReleaseAck?: () => void
+    __loomarkObservedLocalTextPuts?: () => ObservedLocalTextPut[]
+  }
+  const transactionPrototype = IDBTransaction.prototype
+  const completionDescriptor = Object.getOwnPropertyDescriptor(
+    transactionPrototype,
+    "oncomplete",
+  )
+  if (!completionDescriptor?.get || !completionDescriptor.set) {
+    throw new Error("IDBTransaction.oncomplete is not interceptable")
+  }
+  const heldTransactions = new WeakSet<IDBTransaction>()
+  const observed: ObservedLocalTextPut[] = []
+  let holdNext = true
+  let release: (() => void) | undefined
+  Object.defineProperty(transactionPrototype, "oncomplete", {
+    configurable: completionDescriptor.configurable,
+    enumerable: completionDescriptor.enumerable,
+    get() {
+      return completionDescriptor.get?.call(this)
+    },
+    set(handler: ((event: Event) => void) | null) {
+      completionDescriptor.set?.call(this, handler === null ? null : (event: Event) => {
+        if (heldTransactions.has(this) && release === undefined) {
+          release = () => handler.call(this, event)
+        } else {
+          handler.call(this, event)
+        }
+      })
+    },
+  })
+  const originalPut = IDBObjectStore.prototype.put
+  IDBObjectStore.prototype.put = function(
+    this: IDBObjectStore,
+    value: unknown,
+    recordKey?: IDBValidKey,
+  ) {
+    const request = originalPut.call(this, value, recordKey)
+    if (recordKey === key && typeof value === "string") {
+      const decoded = JSON.parse(value) as ArchiveEnvelope
+      observed.push({
+        source: decoded.portable_markdown ?? "",
+        encodedUtf16: value.length,
+      })
+      if (holdNext) {
+        holdNext = false
+        heldTransactions.add(this.transaction)
+      }
+    }
+    return request
+  }
+  state.__loomarkArchiveAckHeld = () => release !== undefined
+  state.__loomarkArchiveReleaseAck = () => {
+    const pending = release
+    release = undefined
+    pending?.()
+  }
+  state.__loomarkObservedLocalTextPuts = () => observed.slice()
+}
+
 async function replaceRawValue(input: Locator, value: string): Promise<void> {
   await input.evaluate((element, nextValue) => {
     const textarea = element as HTMLTextAreaElement
@@ -252,6 +320,7 @@ async function replaceRawValue(input: Locator, value: string): Promise<void> {
  * | page lifetime | reload or close | the page ends ownership without claiming unmount or host reuse |
  * | local baseline | first visit with an empty repository | one LocalText record establishes the active document identity |
  * | local durability | quiet flush then reload | LocalText reopens with stable document identity and durable source |
+ * | in-flight replacement | A write acknowledgment held while B then C are accepted | only A and C are encoded and C reloads |
  * | compatibility | legacy v1 fallback | source opens without history decode and v1 bytes remain untouched |
  * | recovery | corrupt, unsupported, or unreadable record | storage remains unchanged and no editable document mounts |
  * | replacement failure | accepted edit after provider failure | applied source remains visible and reload restores the prior durable archive |
@@ -451,6 +520,84 @@ test("standalone A to B to A keeps the prior Source record until the latest quie
   })
   await expect.poll(() => readArchiveEnvelope(page).then(record => record?.portable_markdown))
     .toBe("A")
+})
+
+test("an in-flight LocalText write coalesces pending source before encoding", async ({ page }) => {
+  await page.goto("/")
+  await waitForBaseline(page)
+  const documentId = (await readArchiveEnvelope(page))?.document_id
+  expect(documentId).toBeTruthy()
+  const encodedUtf16 = JSON.stringify({
+    format: "loomark-local-text-v1",
+    document_id: documentId,
+    portable_markdown: "A",
+  }).length
+  await page.evaluate(() => {
+    const scope = globalThis as typeof globalThis & {
+      __loomarkPendingFlushes?: () => number
+      __loomarkRunNextFlush?: () => void
+    }
+    const nativeSetTimeout = globalThis.setTimeout.bind(globalThis)
+    const pending: Array<() => void> = []
+    let syntheticTimer = -1
+    scope.__loomarkPendingFlushes = () => pending.length
+    scope.__loomarkRunNextFlush = () => { pending.shift()?.() }
+    globalThis.setTimeout = ((handler: TimerHandler, timeout?: number, ...args: unknown[]) => {
+      if (timeout === 250 && typeof handler === "function") {
+        pending.push(() => handler(...args))
+        return syntheticTimer--
+      }
+      return nativeSetTimeout(handler, timeout, ...args)
+    }) as typeof globalThis.setTimeout
+  })
+  await page.evaluate(installArchivePutHold, LOCAL_TEXT_KEY)
+
+  const input = page.locator("#loomark-input")
+  const flush = async () => {
+    await expect.poll(() => page.evaluate(() => (
+      globalThis as typeof globalThis & { __loomarkPendingFlushes?: () => number }
+    ).__loomarkPendingFlushes?.())).toBe(1)
+    await page.evaluate(() => {
+      ;(globalThis as typeof globalThis & { __loomarkRunNextFlush?: () => void })
+        .__loomarkRunNextFlush?.()
+    })
+  }
+
+  await replaceRawValue(input, "A")
+  await flush()
+  await expect.poll(() => page.evaluate(() => (
+    globalThis as typeof globalThis & { __loomarkArchiveAckHeld?: () => boolean }
+  ).__loomarkArchiveAckHeld?.())).toBe(true)
+
+  await replaceRawValue(input, "B")
+  await flush()
+  await replaceRawValue(input, "C")
+  await flush()
+
+  const observedBeforeRelease = await page.evaluate(() => (
+    globalThis as typeof globalThis & {
+      __loomarkObservedLocalTextPuts?: () => ObservedLocalTextPut[]
+    }
+  ).__loomarkObservedLocalTextPuts?.())
+  expect(observedBeforeRelease?.map(write => write.source)).toEqual(["A"])
+
+  await page.evaluate(() => {
+    ;(globalThis as typeof globalThis & { __loomarkArchiveReleaseAck?: () => void })
+      .__loomarkArchiveReleaseAck?.()
+  })
+  await expect.poll(() => page.evaluate(() => (
+    globalThis as typeof globalThis & {
+      __loomarkObservedLocalTextPuts?: () => ObservedLocalTextPut[]
+    }
+  ).__loomarkObservedLocalTextPuts?.())).toEqual([
+    { source: "A", encodedUtf16 },
+    { source: "C", encodedUtf16 },
+  ])
+  await expect.poll(() => readArchiveEnvelope(page).then(record => record?.portable_markdown))
+    .toBe("C")
+
+  await page.reload()
+  await expect(page.locator("#loomark-input")).toHaveValue("C")
 })
 
 test("legacy v1 source opens without history decode and remains untouched", async ({ page }) => {

--- a/apps/loomark/internal/rabbita/document_transaction.mbt
+++ b/apps/loomark/internal/rabbita/document_transaction.mbt
@@ -119,13 +119,9 @@ fn local_text_replacement(
   guard model.archive_persistence_enabled else {
     return (model, @rabbita_runtime.none)
   }
-  let prepared = @repository.prepare_local_text(
-    document_id=model.document_id,
-    source~,
-  )
-  let (archive_queue, pending) = model.archive_queue.enqueue(
+  let (archive_queue, pending) = model.archive_queue.enqueue_local_text(
     document_version=model.document_version,
-    archive=prepared,
+    source~,
   )
   ({ ..model, archive_queue, }, local_archive_write_command(pending, emit))
 }
@@ -141,13 +137,9 @@ fn retry_local_persistence(
     return (model, @rabbita_runtime.none)
   }
   if model.runtime_state is EditorRuntimeState::LocalText(source) {
-    let prepared = @repository.prepare_local_text(
-      document_id=model.document_id,
-      source~,
-    )
-    let (archive_queue, pending) = model.archive_queue.retry(
+    let (archive_queue, pending) = model.archive_queue.retry_local_text(
       document_version=model.document_version,
-      archive=prepared,
+      source~,
     )
     return (
       { ..model, archive_queue, },

--- a/apps/loomark/internal/rabbita/standalone_bootstrap.mbt
+++ b/apps/loomark/internal/rabbita/standalone_bootstrap.mbt
@@ -249,10 +249,9 @@ fn start_local_text(
     durable=if persist { None } else { Some(model.document_version) },
   )
   let (archive_queue, command) = if persist {
-    let prepared = @repository.prepare_local_text(document_id~, source~)
-    let (queue, pending) = queue.enqueue(
+    let (queue, pending) = queue.enqueue_local_text(
       document_version=model.document_version,
-      archive=prepared,
+      source~,
     )
     (queue, local_archive_write_command(pending, emit))
   } else {

--- a/apps/loomark/repository/local_persistence_queue.mbt
+++ b/apps/loomark/repository/local_persistence_queue.mbt
@@ -48,7 +48,19 @@ pub(all) enum LocalArchiveQueueCompletion {
 } derive(Eq)
 
 ///|
-/// One complete immutable archive replacement and its Session correlation.
+/// The immutable payload held by a queued write.
+///
+/// FullHistory is already prepared by its capability-owned shell. LocalText
+/// remains unencoded until this queue selects it and the storage shell requests
+/// its encoded replacement.
+priv enum LocalArchivePendingPayload {
+  Prepared(PreparedLocalArchive)
+  LocalText(String)
+} derive(Eq)
+
+///|
+/// One selected immutable replacement and its Session correlation.
+///
 /// The queue epoch prevents a delayed write from a previous queue lifetime
 /// from matching a newly created queue for the same logical document.
 pub struct LocalArchivePendingWrite {
@@ -56,20 +68,32 @@ pub struct LocalArchivePendingWrite {
   priv request_id : Int
   priv document_id : @archive.LoomarkDocumentId
   priv document_version : @markdown.MarkdownDocumentVersion
-  priv archive : PreparedLocalArchive
+  priv payload : LocalArchivePendingPayload
 } derive(Eq)
 
 ///|
+/// Materialize the selected replacement for the storage shell.
+///
+/// Pending LocalText values never escape the queue, so superseded source is
+/// not encoded. Prepared FullHistory bytes pass through unchanged.
 pub fn LocalArchivePendingWrite::encoded(self : Self) -> String {
-  self.archive.encoded()
+  match self.payload {
+    LocalArchivePendingPayload::Prepared(archive) => archive.encoded()
+    LocalArchivePendingPayload::LocalText(source) =>
+      prepare_local_text(document_id=self.document_id, source~).encoded()
+  }
 }
 
 ///|
-/// Return the prepared record format for exhaustive storage routing.
+/// Return the selected record format without materializing LocalText.
 pub fn LocalArchivePendingWrite::record_kind(
   self : Self,
 ) -> LocalArchiveRecordKind {
-  self.archive.record_kind()
+  match self.payload {
+    LocalArchivePendingPayload::Prepared(archive) => archive.record_kind()
+    LocalArchivePendingPayload::LocalText(_) =>
+      LocalArchiveRecordKind::LocalText
+  }
 }
 
 ///|
@@ -160,26 +184,26 @@ pub fn LocalArchivePersistenceQueue::status(
 fn LocalArchivePersistenceQueue::allocate_pending(
   self : Self,
   document_version~ : @markdown.MarkdownDocumentVersion,
-  archive~ : PreparedLocalArchive,
+  payload : LocalArchivePendingPayload,
 ) -> (LocalArchivePersistenceQueue, LocalArchivePendingWrite) {
   let pending = LocalArchivePendingWrite::{
     queue_epoch: self.queue_epoch,
     request_id: self.next_request_value,
     document_id: self.document_id,
     document_version,
-    archive,
+    payload,
   }
   ({ ..self, next_request_value: self.next_request_value + 1 }, pending)
 }
 
 ///|
-/// Accept a complete archive, starting it or coalescing it as the latest.
-pub fn LocalArchivePersistenceQueue::enqueue(
+/// Start one payload or coalesce it as the latest pending payload.
+fn LocalArchivePersistenceQueue::enqueue_payload(
   self : Self,
   document_version~ : @markdown.MarkdownDocumentVersion,
-  archive~ : PreparedLocalArchive,
+  payload : LocalArchivePendingPayload,
 ) -> (LocalArchivePersistenceQueue, LocalArchivePendingWrite?) {
-  let (next, pending) = self.allocate_pending(document_version~, archive~)
+  let (next, pending) = self.allocate_pending(document_version~, payload)
   match next.in_flight {
     None =>
       (
@@ -206,17 +230,69 @@ pub fn LocalArchivePersistenceQueue::enqueue(
 }
 
 ///|
+/// Accept a complete archive, starting it or coalescing it as the latest.
+pub fn LocalArchivePersistenceQueue::enqueue(
+  self : Self,
+  document_version~ : @markdown.MarkdownDocumentVersion,
+  archive~ : PreparedLocalArchive,
+) -> (LocalArchivePersistenceQueue, LocalArchivePendingWrite?) {
+  self.enqueue_payload(
+    document_version~,
+    LocalArchivePendingPayload::Prepared(archive),
+  )
+}
+
+///|
+/// Accept unencoded source text, starting it or coalescing it as the latest.
+pub fn LocalArchivePersistenceQueue::enqueue_local_text(
+  self : Self,
+  document_version~ : @markdown.MarkdownDocumentVersion,
+  source~ : String,
+) -> (LocalArchivePersistenceQueue, LocalArchivePendingWrite?) {
+  self.enqueue_payload(
+    document_version~,
+    LocalArchivePendingPayload::LocalText(source),
+  )
+}
+
+///|
+/// Retry a payload only for the current failed version; an active write is busy.
+fn LocalArchivePersistenceQueue::retry_payload(
+  self : Self,
+  document_version~ : @markdown.MarkdownDocumentVersion,
+  payload : LocalArchivePendingPayload,
+) -> (LocalArchivePersistenceQueue, LocalArchivePendingWrite?) {
+  guard self.failure is Some(_) && self.in_flight is None else {
+    return (self, None)
+  }
+  guard self.current == document_version else { return (self, None) }
+  self.enqueue_payload(document_version~, payload)
+}
+
+///|
 /// Retry only the current failed version; an active write makes it busy.
 pub fn LocalArchivePersistenceQueue::retry(
   self : Self,
   document_version~ : @markdown.MarkdownDocumentVersion,
   archive~ : PreparedLocalArchive,
 ) -> (LocalArchivePersistenceQueue, LocalArchivePendingWrite?) {
-  guard self.failure is Some(_) && self.in_flight is None else {
-    return (self, None)
-  }
-  guard self.current == document_version else { return (self, None) }
-  self.enqueue(document_version~, archive~)
+  self.retry_payload(
+    document_version~,
+    LocalArchivePendingPayload::Prepared(archive),
+  )
+}
+
+///|
+/// Retry unencoded source text only for the current failed version.
+pub fn LocalArchivePersistenceQueue::retry_local_text(
+  self : Self,
+  document_version~ : @markdown.MarkdownDocumentVersion,
+  source~ : String,
+) -> (LocalArchivePersistenceQueue, LocalArchivePendingWrite?) {
+  self.retry_payload(
+    document_version~,
+    LocalArchivePendingPayload::LocalText(source),
+  )
 }
 
 ///|

--- a/apps/loomark/repository/pkg.generated.mbti
+++ b/apps/loomark/repository/pkg.generated.mbti
@@ -73,9 +73,11 @@ pub struct LocalArchivePersistenceQueue {
 pub fn LocalArchivePersistenceQueue::LocalArchivePersistenceQueue(document_id~ : @archive.LoomarkDocumentId, queue_epoch~ : String, current~ : @dowdiness/canopy/editor/markdown.MarkdownDocumentVersion, durable~ : @dowdiness/canopy/editor/markdown.MarkdownDocumentVersion?) -> Self
 pub fn LocalArchivePersistenceQueue::complete(Self, LocalArchivePendingWrite, LocalArchiveWriteOutcome) -> (Self, LocalArchiveQueueCompletion)
 pub fn LocalArchivePersistenceQueue::enqueue(Self, document_version~ : @dowdiness/canopy/editor/markdown.MarkdownDocumentVersion, archive~ : PreparedLocalArchive) -> (Self, LocalArchivePendingWrite?)
+pub fn LocalArchivePersistenceQueue::enqueue_local_text(Self, document_version~ : @dowdiness/canopy/editor/markdown.MarkdownDocumentVersion, source~ : String) -> (Self, LocalArchivePendingWrite?)
 pub fn LocalArchivePersistenceQueue::mark_failed(Self, document_version~ : @dowdiness/canopy/editor/markdown.MarkdownDocumentVersion, error~ : LocalArchivePersistenceFailure) -> Self
 pub fn LocalArchivePersistenceQueue::rebind_epoch(Self, queue_epoch~ : String) -> Self
 pub fn LocalArchivePersistenceQueue::retry(Self, document_version~ : @dowdiness/canopy/editor/markdown.MarkdownDocumentVersion, archive~ : PreparedLocalArchive) -> (Self, LocalArchivePendingWrite?)
+pub fn LocalArchivePersistenceQueue::retry_local_text(Self, document_version~ : @dowdiness/canopy/editor/markdown.MarkdownDocumentVersion, source~ : String) -> (Self, LocalArchivePendingWrite?)
 pub fn LocalArchivePersistenceQueue::status(Self) -> LocalArchivePersistenceStatus
 
 pub(all) enum LocalArchivePersistenceStatus {

--- a/apps/loomark/repository/repository.mbt
+++ b/apps/loomark/repository/repository.mbt
@@ -242,6 +242,11 @@ const LOCAL_TEXT_FORMAT : String = "loomark-local-text-v1"
 
 ///|
 /// Prepare the standalone source record without consulting CRDT state.
+///
+/// This LocalText v1 transformation is total for valid `String` and document
+/// identity inputs: it constructs and stringifies a MoonBit `Json` value and
+/// has no recoverable preparation-failure channel. IndexedDB replacement
+/// remains fallible and is reported through the correlated write completion.
 pub fn prepare_local_text(
   document_id~ : @archive.LoomarkDocumentId,
   source~ : String,

--- a/apps/loomark/repository/repository_wbtest.mbt
+++ b/apps/loomark/repository/repository_wbtest.mbt
@@ -284,14 +284,21 @@ test "persistence queue waits for the latest same-version source" {
     current=version,
     durable=None,
   )
-  let first = prepare_local_text(document_id~, source="one")
-  let second = prepare_local_text(document_id~, source="two")
-  let (queue, first_write) = queue.enqueue(
+  let (queue, first_write) = queue.enqueue_local_text(
     document_version=version,
-    archive=first,
+    source="one",
   )
   guard first_write is Some(first_write) else { fail("expected first write") }
-  let (queue, _) = queue.enqueue(document_version=version, archive=second)
+  let (queue, second_write) = queue.enqueue_local_text(
+    document_version=version,
+    source="two",
+  )
+  assert_true(second_write is None)
+  let (queue, third_write) = queue.enqueue_local_text(
+    document_version=version,
+    source="three",
+  )
+  assert_true(third_write is None)
   let (queue, completion) = queue.complete(
     first_write,
     LocalArchiveWriteOutcome::Stored,
@@ -299,10 +306,147 @@ test "persistence queue waits for the latest same-version source" {
   guard completion is LocalArchiveQueueCompletion::Promoted(promoted) else {
     fail("expected latest source promotion")
   }
+  assert_eq(
+    promoted.encoded(),
+    prepare_local_text(document_id~, source="three").encoded(),
+  )
   assert_true(queue.status() is LocalArchivePersistenceStatus::Applied(..))
   let (queue, _) = queue.complete(promoted, LocalArchiveWriteOutcome::Stored)
   assert_true(queue.status() is LocalArchivePersistenceStatus::DurableLocal(_))
   ignore(editor)
+}
+
+///|
+test "persistence queue retries unencoded local text" {
+  let (_, document_id, version) = queue_document(
+    "repository-local-text-retry", "doc-local-text-retry", "before",
+  )
+  let queue = LocalArchivePersistenceQueue::LocalArchivePersistenceQueue(
+    document_id~,
+    queue_epoch="repository-local-text-retry",
+    current=version,
+    durable=None,
+  )
+  let (queue, first_write) = queue.enqueue_local_text(
+    document_version=version,
+    source="failed",
+  )
+  guard first_write is Some(first_write) else { fail("expected first write") }
+  let (queue, _) = queue.complete(
+    first_write,
+    LocalArchiveWriteOutcome::Failed(LocalArchiveStorageWriteFailure::Failed),
+  )
+  let (queue, retry_write) = queue.retry_local_text(
+    document_version=version,
+    source="latest",
+  )
+  guard retry_write is Some(retry_write) else {
+    fail("expected local text retry write")
+  }
+  assert_eq(
+    retry_write.encoded(),
+    prepare_local_text(document_id~, source="latest").encoded(),
+  )
+  let (queue, completion) = queue.complete(
+    retry_write,
+    LocalArchiveWriteOutcome::Stored,
+  )
+  assert_true(completion is LocalArchiveQueueCompletion::Completed)
+  assert_true(queue.status() is LocalArchivePersistenceStatus::DurableLocal(_))
+}
+
+///|
+test "local text A to B to A rejects the first A acknowledgment" {
+  let (_, document_id, version) = queue_document(
+    "repository-local-text-aba", "doc-local-text-aba", "before",
+  )
+  let queue = LocalArchivePersistenceQueue::LocalArchivePersistenceQueue(
+    document_id~,
+    queue_epoch="repository-local-text-aba",
+    current=version,
+    durable=None,
+  )
+  let (queue, first_a) = queue.enqueue_local_text(
+    document_version=version,
+    source="A",
+  )
+  guard first_a is Some(first_a) else { fail("expected first A write") }
+  let (queue, _) = queue.enqueue_local_text(
+    document_version=version,
+    source="B",
+  )
+  let (queue, _) = queue.enqueue_local_text(
+    document_version=version,
+    source="A",
+  )
+  let (queue, completion) = queue.complete(
+    first_a,
+    LocalArchiveWriteOutcome::Stored,
+  )
+  guard completion is LocalArchiveQueueCompletion::Promoted(later_a) else {
+    fail("expected later A promotion")
+  }
+  let (queue, stale) = queue.complete(first_a, LocalArchiveWriteOutcome::Stored)
+  assert_true(stale is LocalArchiveQueueCompletion::Ignored)
+  assert_eq(
+    later_a.encoded(),
+    prepare_local_text(document_id~, source="A").encoded(),
+  )
+  let (queue, completion) = queue.complete(
+    later_a,
+    LocalArchiveWriteOutcome::Stored,
+  )
+  assert_true(completion is LocalArchiveQueueCompletion::Completed)
+  assert_true(queue.status() is LocalArchivePersistenceStatus::DurableLocal(_))
+}
+
+///|
+test "local text supersedes a prepared pending archive" {
+  let (editor, document_id, initial_version) = queue_document(
+    "repository-local-text-mixed", "doc-local-text-mixed", "zero",
+  )
+  let (first_version, first_archive) = queue_archive_after_replace(
+    editor~,
+    document_id~,
+    "one",
+  )
+  let queue = LocalArchivePersistenceQueue::LocalArchivePersistenceQueue(
+    document_id~,
+    queue_epoch="repository-local-text-mixed",
+    current=initial_version,
+    durable=None,
+  )
+  let (queue, first_write) = queue.enqueue(
+    document_version=first_version,
+    archive=first_archive,
+  )
+  guard first_write is Some(first_write) else { fail("expected first write") }
+  let (second_version, second_archive) = queue_archive_after_replace(
+    editor~,
+    document_id~,
+    "two",
+  )
+  let (queue, _) = queue.enqueue(
+    document_version=second_version,
+    archive=second_archive,
+  )
+  let (queue, _) = queue.enqueue_local_text(
+    document_version=second_version,
+    source="latest source",
+  )
+  let (queue, completion) = queue.complete(
+    first_write,
+    LocalArchiveWriteOutcome::Stored,
+  )
+  guard completion is LocalArchiveQueueCompletion::Promoted(promoted) else {
+    fail("expected local text promotion")
+  }
+  assert_true(promoted.record_kind() is LocalArchiveRecordKind::LocalText)
+  assert_eq(
+    promoted.encoded(),
+    prepare_local_text(document_id~, source="latest source").encoded(),
+  )
+  ignore(queue)
 }
 
 ///|

--- a/docs/evidence/2026-08-24-loomark-persistence-intent-coalescing-raw.json
+++ b/docs/evidence/2026-08-24-loomark-persistence-intent-coalescing-raw.json
@@ -1,0 +1,5574 @@
+{
+  "schema": "loomark-persistence-intent-coalescing-raw-v1",
+  "baseline": {
+    "schema": "loomark-whole-document-input-v1",
+    "environment": {
+      "commit": "298f3ccf527de1447adde3bcab82140dd4eaddb2",
+      "browser": "149.0.7827.55",
+      "node": "v24.14.1",
+      "platform": "linux",
+      "os_release": "6.18.33.2-microsoft-standard-WSL2",
+      "architecture": "x64",
+      "cpu": "AMD Ryzen 7 6800H with Radeon Graphics",
+      "headless": true,
+      "viewport": {
+        "width": 1280,
+        "height": 720
+      },
+      "warmups": 5,
+      "samples": 30,
+      "trace_samples": 0,
+      "settle_ms": 400,
+      "persistence_required": true
+    },
+    "invocation": {
+      "sizes": [
+        1048576
+      ],
+      "environment": {
+        "LOOMARK_WHOLE_DOCUMENT_SIZES": "1048576",
+        "LOOMARK_WHOLE_DOCUMENT_WARMUPS": "5",
+        "LOOMARK_WHOLE_DOCUMENT_SAMPLES": "30",
+        "LOOMARK_WHOLE_DOCUMENT_TRACE_SAMPLES": "0",
+        "LOOMARK_WHOLE_DOCUMENT_REQUIRE_PERSISTENCE": null
+      }
+    },
+    "fixtures": [
+      {
+        "requested_utf16": 1048576,
+        "utf16_length": 1048576,
+        "utf8_bytes": 1048576,
+        "sha256": "bd2b39512f137e45eb14063920e77769422728321640fc9214787e00a5dd74ae"
+      }
+    ],
+    "scenarios": [
+      {
+        "size_utf16": 1048576,
+        "surface": "native_textarea",
+        "matched_width_px": 736,
+        "summary": {
+          "native_mutation_ms": {
+            "samples": 30,
+            "p50_ms": 36.5,
+            "p95_ms": 40.7,
+            "maximum_ms": 92.4
+          },
+          "input_handler_ms": {
+            "samples": 30,
+            "p50_ms": 0,
+            "p95_ms": 0.1,
+            "maximum_ms": 0.1
+          },
+          "put_request_offset_ms": {
+            "samples": 0,
+            "p50_ms": null,
+            "p95_ms": null,
+            "maximum_ms": null
+          },
+          "put_acknowledgment_ms": {
+            "samples": 0,
+            "p50_ms": null,
+            "p95_ms": null,
+            "maximum_ms": null
+          },
+          "browser_command_wall_ms": {
+            "samples": 30,
+            "p50_ms": 69.38,
+            "p95_ms": 77.282,
+            "maximum_ms": 124.047
+          },
+          "long_tasks": {
+            "samples_with_long_tasks": 0,
+            "count": 0,
+            "maximum_ms": 0
+          }
+        },
+        "samples": [
+          {
+            "native_mutation_ms": 37.8,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 69.492
+          },
+          {
+            "native_mutation_ms": 40.7,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 73.994
+          },
+          {
+            "native_mutation_ms": 36.3,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 72.226
+          },
+          {
+            "native_mutation_ms": 36.9,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 68.95
+          },
+          {
+            "native_mutation_ms": 35.7,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 66.11
+          },
+          {
+            "native_mutation_ms": 35.5,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 70.123
+          },
+          {
+            "native_mutation_ms": 36.5,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 67.01
+          },
+          {
+            "native_mutation_ms": 34.6,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 66.336
+          },
+          {
+            "native_mutation_ms": 36.9,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 72.017
+          },
+          {
+            "native_mutation_ms": 35.4,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 66.902
+          },
+          {
+            "native_mutation_ms": 38.1,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 69.38
+          },
+          {
+            "native_mutation_ms": 37.3,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 72.307
+          },
+          {
+            "native_mutation_ms": 34.7,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 66.554
+          },
+          {
+            "native_mutation_ms": 35.9,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 66.972
+          },
+          {
+            "native_mutation_ms": 36.5,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 71.265
+          },
+          {
+            "native_mutation_ms": 35.3,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 67.691
+          },
+          {
+            "native_mutation_ms": 35.7,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 66.651
+          },
+          {
+            "native_mutation_ms": 38.1,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 73.5
+          },
+          {
+            "native_mutation_ms": 35.3,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 67.518
+          },
+          {
+            "native_mutation_ms": 38.7,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 69.587
+          },
+          {
+            "native_mutation_ms": 38.3,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 75.073
+          },
+          {
+            "native_mutation_ms": 34.4,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 64.163
+          },
+          {
+            "native_mutation_ms": 92.4,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 124.047
+          },
+          {
+            "native_mutation_ms": 36.3,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 71.82
+          },
+          {
+            "native_mutation_ms": 34.9,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 65.125
+          },
+          {
+            "native_mutation_ms": 35,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 67.61
+          },
+          {
+            "native_mutation_ms": 37.3,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 72.142
+          },
+          {
+            "native_mutation_ms": 38.4,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 69.134
+          },
+          {
+            "native_mutation_ms": 39.7,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 71.406
+          },
+          {
+            "native_mutation_ms": 39.6,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 77.282
+          }
+        ]
+      },
+      {
+        "size_utf16": 1048576,
+        "surface": "loomark_production",
+        "matched_width_px": 736,
+        "summary": {
+          "native_mutation_ms": {
+            "samples": 30,
+            "p50_ms": 34.9,
+            "p95_ms": 37.5,
+            "maximum_ms": 37.9
+          },
+          "input_handler_ms": {
+            "samples": 30,
+            "p50_ms": 0,
+            "p95_ms": 0.1,
+            "maximum_ms": 0.1
+          },
+          "put_request_offset_ms": {
+            "samples": 30,
+            "p50_ms": 318.4,
+            "p95_ms": 341.3,
+            "maximum_ms": 342.2
+          },
+          "put_acknowledgment_ms": {
+            "samples": 30,
+            "p50_ms": 8.6,
+            "p95_ms": 32.5,
+            "maximum_ms": 38.6
+          },
+          "browser_command_wall_ms": {
+            "samples": 30,
+            "p50_ms": 73.392,
+            "p95_ms": 79.263,
+            "maximum_ms": 81.582
+          },
+          "long_tasks": {
+            "samples_with_long_tasks": 30,
+            "count": 40,
+            "maximum_ms": 91
+          }
+        },
+        "samples": [
+          {
+            "native_mutation_ms": 36.2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 323.8,
+            "put_acknowledgment_ms": 25.2,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 37.7,
+                "duration_ms": 54
+              },
+              {
+                "offset_ms": 250.2,
+                "duration_ms": 73
+              }
+            ],
+            "browser_command_wall_ms": 74.98
+          },
+          {
+            "native_mutation_ms": 34.8,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 315,
+            "put_acknowledgment_ms": 6.1,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 36.1,
+                "duration_ms": 59
+              },
+              {
+                "offset_ms": 250.4,
+                "duration_ms": 64
+              }
+            ],
+            "browser_command_wall_ms": 72.463
+          },
+          {
+            "native_mutation_ms": 34.3,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 312.4,
+            "put_acknowledgment_ms": 0.4,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.4,
+                "duration_ms": 62
+              }
+            ],
+            "browser_command_wall_ms": 72.303
+          },
+          {
+            "native_mutation_ms": 36.5,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 332.3,
+            "put_acknowledgment_ms": 0.3,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.4,
+                "duration_ms": 82
+              }
+            ],
+            "browser_command_wall_ms": 74.041
+          },
+          {
+            "native_mutation_ms": 34.5,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 319.4,
+            "put_acknowledgment_ms": 17.5,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.4,
+                "duration_ms": 69
+              }
+            ],
+            "browser_command_wall_ms": 79.263
+          },
+          {
+            "native_mutation_ms": 36.2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 329.5,
+            "put_acknowledgment_ms": 6.3,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.6,
+                "duration_ms": 79
+              }
+            ],
+            "browser_command_wall_ms": 73.392
+          },
+          {
+            "native_mutation_ms": 37.9,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 312.4,
+            "put_acknowledgment_ms": 29.9,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.2,
+                "duration_ms": 62
+              }
+            ],
+            "browser_command_wall_ms": 75.978
+          },
+          {
+            "native_mutation_ms": 36.5,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 321.9,
+            "put_acknowledgment_ms": 32.2,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.4,
+                "duration_ms": 71
+              }
+            ],
+            "browser_command_wall_ms": 73.896
+          },
+          {
+            "native_mutation_ms": 37.5,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 330.9,
+            "put_acknowledgment_ms": 0.4,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.4,
+                "duration_ms": 80
+              }
+            ],
+            "browser_command_wall_ms": 74.96
+          },
+          {
+            "native_mutation_ms": 34.5,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 311,
+            "put_acknowledgment_ms": 8.4,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.3,
+                "duration_ms": 60
+              }
+            ],
+            "browser_command_wall_ms": 70.791
+          },
+          {
+            "native_mutation_ms": 36.3,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 321.4,
+            "put_acknowledgment_ms": 31.5,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.4,
+                "duration_ms": 71
+              }
+            ],
+            "browser_command_wall_ms": 75.584
+          },
+          {
+            "native_mutation_ms": 36,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": 315.3,
+            "put_acknowledgment_ms": 6.7,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.4,
+                "duration_ms": 65
+              },
+              {
+                "offset_ms": 322.3,
+                "duration_ms": 68
+              }
+            ],
+            "browser_command_wall_ms": 73.474
+          },
+          {
+            "native_mutation_ms": 34.9,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": 317.1,
+            "put_acknowledgment_ms": 32.5,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.4,
+                "duration_ms": 66
+              }
+            ],
+            "browser_command_wall_ms": 72.55
+          },
+          {
+            "native_mutation_ms": 37,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 341.3,
+            "put_acknowledgment_ms": 8.8,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 43.2,
+                "duration_ms": 54
+              },
+              {
+                "offset_ms": 250.4,
+                "duration_ms": 91
+              }
+            ],
+            "browser_command_wall_ms": 81.582
+          },
+          {
+            "native_mutation_ms": 35.6,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 323.3,
+            "put_acknowledgment_ms": 11.8,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.3,
+                "duration_ms": 73
+              },
+              {
+                "offset_ms": 336.8,
+                "duration_ms": 51
+              }
+            ],
+            "browser_command_wall_ms": 73.393
+          },
+          {
+            "native_mutation_ms": 33.4,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 312.3,
+            "put_acknowledgment_ms": 31.6,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.3,
+                "duration_ms": 62
+              }
+            ],
+            "browser_command_wall_ms": 68.878
+          },
+          {
+            "native_mutation_ms": 33.8,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": 313.3,
+            "put_acknowledgment_ms": 0.5,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.4,
+                "duration_ms": 63
+              },
+              {
+                "offset_ms": 320.7,
+                "duration_ms": 54
+              }
+            ],
+            "browser_command_wall_ms": 70.653
+          },
+          {
+            "native_mutation_ms": 33.8,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 318.4,
+            "put_acknowledgment_ms": 38.6,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.6,
+                "duration_ms": 67
+              }
+            ],
+            "browser_command_wall_ms": 70.695
+          },
+          {
+            "native_mutation_ms": 34.1,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 340.9,
+            "put_acknowledgment_ms": 8.6,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 35.3,
+                "duration_ms": 71
+              },
+              {
+                "offset_ms": 250.6,
+                "duration_ms": 90
+              }
+            ],
+            "browser_command_wall_ms": 70.319
+          },
+          {
+            "native_mutation_ms": 35.4,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": 318.5,
+            "put_acknowledgment_ms": 18.4,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.4,
+                "duration_ms": 68
+              }
+            ],
+            "browser_command_wall_ms": 74.409
+          },
+          {
+            "native_mutation_ms": 36.4,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": 315,
+            "put_acknowledgment_ms": 0.4,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.4,
+                "duration_ms": 64
+              },
+              {
+                "offset_ms": 321.3,
+                "duration_ms": 53
+              }
+            ],
+            "browser_command_wall_ms": 73.336
+          },
+          {
+            "native_mutation_ms": 34,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 316.6,
+            "put_acknowledgment_ms": 31.3,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 251.3,
+                "duration_ms": 65
+              }
+            ],
+            "browser_command_wall_ms": 70.939
+          },
+          {
+            "native_mutation_ms": 33.4,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 331.7,
+            "put_acknowledgment_ms": 8,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.3,
+                "duration_ms": 81
+              }
+            ],
+            "browser_command_wall_ms": 77.243
+          },
+          {
+            "native_mutation_ms": 34.2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 307.2,
+            "put_acknowledgment_ms": 8.1,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.4,
+                "duration_ms": 56
+              }
+            ],
+            "browser_command_wall_ms": 71.461
+          },
+          {
+            "native_mutation_ms": 36,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 312.9,
+            "put_acknowledgment_ms": 0.4,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.3,
+                "duration_ms": 62
+              }
+            ],
+            "browser_command_wall_ms": 74.278
+          },
+          {
+            "native_mutation_ms": 33.6,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": 309.5,
+            "put_acknowledgment_ms": 31.7,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.5,
+                "duration_ms": 59
+              }
+            ],
+            "browser_command_wall_ms": 70.237
+          },
+          {
+            "native_mutation_ms": 34.8,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 342.2,
+            "put_acknowledgment_ms": 15.2,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 35.9,
+                "duration_ms": 54
+              },
+              {
+                "offset_ms": 250.4,
+                "duration_ms": 91
+              }
+            ],
+            "browser_command_wall_ms": 71.848
+          },
+          {
+            "native_mutation_ms": 35.1,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 320.3,
+            "put_acknowledgment_ms": 9.7,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.4,
+                "duration_ms": 70
+              }
+            ],
+            "browser_command_wall_ms": 71.593
+          },
+          {
+            "native_mutation_ms": 36.1,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 308.3,
+            "put_acknowledgment_ms": 0.1,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.4,
+                "duration_ms": 58
+              }
+            ],
+            "browser_command_wall_ms": 75.335
+          },
+          {
+            "native_mutation_ms": 34,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 326.1,
+            "put_acknowledgment_ms": 7.2,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.7,
+                "duration_ms": 75
+              },
+              {
+                "offset_ms": 333.7,
+                "duration_ms": 51
+              }
+            ],
+            "browser_command_wall_ms": 78.103
+          }
+        ]
+      }
+    ],
+    "traces": []
+  },
+  "candidate_launches": [
+    {
+      "schema": "loomark-whole-document-input-v1",
+      "environment": {
+        "commit": "0458a5827598bcdec4a14c956b8d93dd43e9ec73",
+        "browser": "149.0.7827.55",
+        "node": "v24.14.1",
+        "platform": "linux",
+        "os_release": "6.18.33.2-microsoft-standard-WSL2",
+        "architecture": "x64",
+        "cpu": "AMD Ryzen 7 6800H with Radeon Graphics",
+        "headless": true,
+        "viewport": {
+          "width": 1280,
+          "height": 720
+        },
+        "warmups": 5,
+        "samples": 30,
+        "trace_samples": 0,
+        "settle_ms": 400,
+        "persistence_required": true
+      },
+      "invocation": {
+        "sizes": [
+          1048576
+        ],
+        "environment": {
+          "LOOMARK_WHOLE_DOCUMENT_SIZES": "1048576",
+          "LOOMARK_WHOLE_DOCUMENT_WARMUPS": "5",
+          "LOOMARK_WHOLE_DOCUMENT_SAMPLES": "30",
+          "LOOMARK_WHOLE_DOCUMENT_TRACE_SAMPLES": "0",
+          "LOOMARK_WHOLE_DOCUMENT_REQUIRE_PERSISTENCE": null
+        }
+      },
+      "fixtures": [
+        {
+          "requested_utf16": 1048576,
+          "utf16_length": 1048576,
+          "utf8_bytes": 1048576,
+          "sha256": "bd2b39512f137e45eb14063920e77769422728321640fc9214787e00a5dd74ae"
+        }
+      ],
+      "scenarios": [
+        {
+          "size_utf16": 1048576,
+          "surface": "native_textarea",
+          "matched_width_px": 736,
+          "summary": {
+            "native_mutation_ms": {
+              "samples": 30,
+              "p50_ms": 35.7,
+              "p95_ms": 39.5,
+              "maximum_ms": 40.2
+            },
+            "input_handler_ms": {
+              "samples": 30,
+              "p50_ms": 0,
+              "p95_ms": 0.1,
+              "maximum_ms": 0.1
+            },
+            "put_request_offset_ms": {
+              "samples": 0,
+              "p50_ms": null,
+              "p95_ms": null,
+              "maximum_ms": null
+            },
+            "put_acknowledgment_ms": {
+              "samples": 0,
+              "p50_ms": null,
+              "p95_ms": null,
+              "maximum_ms": null
+            },
+            "browser_command_wall_ms": {
+              "samples": 30,
+              "p50_ms": 66.061,
+              "p95_ms": 69.718,
+              "maximum_ms": 72.389
+            },
+            "long_tasks": {
+              "samples_with_long_tasks": 0,
+              "count": 0,
+              "maximum_ms": 0
+            }
+          },
+          "samples": [
+            {
+              "native_mutation_ms": 36.1,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 64.987
+            },
+            {
+              "native_mutation_ms": 35.9,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 66.261
+            },
+            {
+              "native_mutation_ms": 34,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 67.65
+            },
+            {
+              "native_mutation_ms": 34.1,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 63.231
+            },
+            {
+              "native_mutation_ms": 37,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 66.063
+            },
+            {
+              "native_mutation_ms": 35.5,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 67.953
+            },
+            {
+              "native_mutation_ms": 40.2,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 67.645
+            },
+            {
+              "native_mutation_ms": 36.9,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 65.713
+            },
+            {
+              "native_mutation_ms": 36.6,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 69.331
+            },
+            {
+              "native_mutation_ms": 35.1,
+              "input_handler_ms": 0.1,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 64.882
+            },
+            {
+              "native_mutation_ms": 34.4,
+              "input_handler_ms": 0.1,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 64.431
+            },
+            {
+              "native_mutation_ms": 34.9,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 66.826
+            },
+            {
+              "native_mutation_ms": 35.5,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 63.614
+            },
+            {
+              "native_mutation_ms": 36,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 63.897
+            },
+            {
+              "native_mutation_ms": 36.9,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 69.718
+            },
+            {
+              "native_mutation_ms": 36.3,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 66.514
+            },
+            {
+              "native_mutation_ms": 37.3,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 67.224
+            },
+            {
+              "native_mutation_ms": 34.5,
+              "input_handler_ms": 0.1,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 68.257
+            },
+            {
+              "native_mutation_ms": 34.4,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 64.633
+            },
+            {
+              "native_mutation_ms": 34.5,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 63.407
+            },
+            {
+              "native_mutation_ms": 35.7,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 67.814
+            },
+            {
+              "native_mutation_ms": 36.5,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 65.098
+            },
+            {
+              "native_mutation_ms": 36.1,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 64.866
+            },
+            {
+              "native_mutation_ms": 36.9,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 69.673
+            },
+            {
+              "native_mutation_ms": 35,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 66.061
+            },
+            {
+              "native_mutation_ms": 35.4,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 65.284
+            },
+            {
+              "native_mutation_ms": 35,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 67.817
+            },
+            {
+              "native_mutation_ms": 35.3,
+              "input_handler_ms": 0.1,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 65.219
+            },
+            {
+              "native_mutation_ms": 35.8,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 64.031
+            },
+            {
+              "native_mutation_ms": 39.5,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 72.389
+            }
+          ]
+        },
+        {
+          "size_utf16": 1048576,
+          "surface": "loomark_production",
+          "matched_width_px": 736,
+          "summary": {
+            "native_mutation_ms": {
+              "samples": 30,
+              "p50_ms": 33.9,
+              "p95_ms": 41.5,
+              "maximum_ms": 117.9
+            },
+            "input_handler_ms": {
+              "samples": 30,
+              "p50_ms": 0,
+              "p95_ms": 0.1,
+              "maximum_ms": 0.1
+            },
+            "put_request_offset_ms": {
+              "samples": 30,
+              "p50_ms": 317,
+              "p95_ms": 364,
+              "maximum_ms": 441.8
+            },
+            "put_acknowledgment_ms": {
+              "samples": 30,
+              "p50_ms": 9.8,
+              "p95_ms": 37.9,
+              "maximum_ms": 39.4
+            },
+            "browser_command_wall_ms": {
+              "samples": 30,
+              "p50_ms": 69.608,
+              "p95_ms": 76.822,
+              "maximum_ms": 154.091
+            },
+            "long_tasks": {
+              "samples_with_long_tasks": 30,
+              "count": 38,
+              "maximum_ms": 191
+            }
+          },
+          "samples": [
+            {
+              "native_mutation_ms": 34.7,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 313.5,
+              "put_acknowledgment_ms": 26.8,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.4,
+                  "duration_ms": 63
+                }
+              ],
+              "browser_command_wall_ms": 70.606
+            },
+            {
+              "native_mutation_ms": 32.7,
+              "input_handler_ms": 0.1,
+              "put_request_offset_ms": 315.4,
+              "put_acknowledgment_ms": 0.5,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.5,
+                  "duration_ms": 65
+                }
+              ],
+              "browser_command_wall_ms": 67.885
+            },
+            {
+              "native_mutation_ms": 35,
+              "input_handler_ms": 0.1,
+              "put_request_offset_ms": 311.1,
+              "put_acknowledgment_ms": 22.2,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.5,
+                  "duration_ms": 60
+                }
+              ],
+              "browser_command_wall_ms": 69.09
+            },
+            {
+              "native_mutation_ms": 35.3,
+              "input_handler_ms": 0.1,
+              "put_request_offset_ms": 333.8,
+              "put_acknowledgment_ms": 0.2,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.5,
+                  "duration_ms": 83
+                }
+              ],
+              "browser_command_wall_ms": 69.924
+            },
+            {
+              "native_mutation_ms": 33.9,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 310.5,
+              "put_acknowledgment_ms": 27.1,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.4,
+                  "duration_ms": 60
+                }
+              ],
+              "browser_command_wall_ms": 69.608
+            },
+            {
+              "native_mutation_ms": 34.9,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 315.3,
+              "put_acknowledgment_ms": 0.5,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.3,
+                  "duration_ms": 65
+                },
+                {
+                  "offset_ms": 321.6,
+                  "duration_ms": 52
+                }
+              ],
+              "browser_command_wall_ms": 70.15
+            },
+            {
+              "native_mutation_ms": 34.5,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 314.9,
+              "put_acknowledgment_ms": 29.6,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.4,
+                  "duration_ms": 64
+                }
+              ],
+              "browser_command_wall_ms": 68.639
+            },
+            {
+              "native_mutation_ms": 41.5,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 328.6,
+              "put_acknowledgment_ms": 9.8,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.3,
+                  "duration_ms": 78
+                }
+              ],
+              "browser_command_wall_ms": 76.134
+            },
+            {
+              "native_mutation_ms": 31.1,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 310.6,
+              "put_acknowledgment_ms": 27.5,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.8,
+                  "duration_ms": 59
+                }
+              ],
+              "browser_command_wall_ms": 72.273
+            },
+            {
+              "native_mutation_ms": 33.4,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 315.3,
+              "put_acknowledgment_ms": 6.3,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.4,
+                  "duration_ms": 64
+                },
+                {
+                  "offset_ms": 322,
+                  "duration_ms": 51
+                }
+              ],
+              "browser_command_wall_ms": 68.983
+            },
+            {
+              "native_mutation_ms": 34.9,
+              "input_handler_ms": 0.1,
+              "put_request_offset_ms": 335.1,
+              "put_acknowledgment_ms": 39.4,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.6,
+                  "duration_ms": 84
+                }
+              ],
+              "browser_command_wall_ms": 69.292
+            },
+            {
+              "native_mutation_ms": 32.6,
+              "input_handler_ms": 0.1,
+              "put_request_offset_ms": 334.4,
+              "put_acknowledgment_ms": 0.5,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.4,
+                  "duration_ms": 84
+                }
+              ],
+              "browser_command_wall_ms": 65.829
+            },
+            {
+              "native_mutation_ms": 34.3,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 309.7,
+              "put_acknowledgment_ms": 34.4,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.5,
+                  "duration_ms": 59
+                }
+              ],
+              "browser_command_wall_ms": 70.051
+            },
+            {
+              "native_mutation_ms": 33.6,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 316.2,
+              "put_acknowledgment_ms": 7.2,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.3,
+                  "duration_ms": 66
+                },
+                {
+                  "offset_ms": 323.9,
+                  "duration_ms": 52
+                }
+              ],
+              "browser_command_wall_ms": 76.406
+            },
+            {
+              "native_mutation_ms": 117.9,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 333.4,
+              "put_acknowledgment_ms": 35.6,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.5,
+                  "duration_ms": 83
+                }
+              ],
+              "browser_command_wall_ms": 154.091
+            },
+            {
+              "native_mutation_ms": 34,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 344.4,
+              "put_acknowledgment_ms": 0.2,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 41.6,
+                  "duration_ms": 50
+                },
+                {
+                  "offset_ms": 250.4,
+                  "duration_ms": 94
+                }
+              ],
+              "browser_command_wall_ms": 76.822
+            },
+            {
+              "native_mutation_ms": 33.3,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 325.3,
+              "put_acknowledgment_ms": 0.1,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.3,
+                  "duration_ms": 75
+                }
+              ],
+              "browser_command_wall_ms": 66.747
+            },
+            {
+              "native_mutation_ms": 36.7,
+              "input_handler_ms": 0.1,
+              "put_request_offset_ms": 364,
+              "put_acknowledgment_ms": 13.2,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.4,
+                  "duration_ms": 113
+                }
+              ],
+              "browser_command_wall_ms": 71.632
+            },
+            {
+              "native_mutation_ms": 31.9,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 342.4,
+              "put_acknowledgment_ms": 26.9,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.3,
+                  "duration_ms": 92
+                }
+              ],
+              "browser_command_wall_ms": 65.177
+            },
+            {
+              "native_mutation_ms": 33.5,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 317,
+              "put_acknowledgment_ms": 0.3,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.4,
+                  "duration_ms": 66
+                }
+              ],
+              "browser_command_wall_ms": 67.453
+            },
+            {
+              "native_mutation_ms": 32.1,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 441.8,
+              "put_acknowledgment_ms": 0.5,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.6,
+                  "duration_ms": 191
+                }
+              ],
+              "browser_command_wall_ms": 65.676
+            },
+            {
+              "native_mutation_ms": 31.6,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 342.8,
+              "put_acknowledgment_ms": 0.4,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 38.6,
+                  "duration_ms": 50
+                },
+                {
+                  "offset_ms": 250.3,
+                  "duration_ms": 92
+                }
+              ],
+              "browser_command_wall_ms": 71.212
+            },
+            {
+              "native_mutation_ms": 34.9,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 312.9,
+              "put_acknowledgment_ms": 11.5,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.4,
+                  "duration_ms": 62
+                }
+              ],
+              "browser_command_wall_ms": 76.059
+            },
+            {
+              "native_mutation_ms": 36.7,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 311.7,
+              "put_acknowledgment_ms": 6.8,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.4,
+                  "duration_ms": 61
+                }
+              ],
+              "browser_command_wall_ms": 71.187
+            },
+            {
+              "native_mutation_ms": 36.9,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 309.9,
+              "put_acknowledgment_ms": 37.9,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.4,
+                  "duration_ms": 59
+                }
+              ],
+              "browser_command_wall_ms": 71.191
+            },
+            {
+              "native_mutation_ms": 32.6,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 343.6,
+              "put_acknowledgment_ms": 9,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 34,
+                  "duration_ms": 51
+                },
+                {
+                  "offset_ms": 250.3,
+                  "duration_ms": 93
+                }
+              ],
+              "browser_command_wall_ms": 67.69
+            },
+            {
+              "native_mutation_ms": 33.9,
+              "input_handler_ms": 0.1,
+              "put_request_offset_ms": 320.1,
+              "put_acknowledgment_ms": 10.2,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.4,
+                  "duration_ms": 69
+                }
+              ],
+              "browser_command_wall_ms": 67.413
+            },
+            {
+              "native_mutation_ms": 33.4,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 323.2,
+              "put_acknowledgment_ms": 30.2,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.3,
+                  "duration_ms": 73
+                }
+              ],
+              "browser_command_wall_ms": 67.531
+            },
+            {
+              "native_mutation_ms": 34.1,
+              "input_handler_ms": 0.1,
+              "put_request_offset_ms": 321.4,
+              "put_acknowledgment_ms": 0.4,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 33.7,
+                  "duration_ms": 50
+                },
+                {
+                  "offset_ms": 250.5,
+                  "duration_ms": 71
+                },
+                {
+                  "offset_ms": 328.4,
+                  "duration_ms": 50
+                }
+              ],
+              "browser_command_wall_ms": 68.82
+            },
+            {
+              "native_mutation_ms": 31.4,
+              "input_handler_ms": 0.1,
+              "put_request_offset_ms": 313.5,
+              "put_acknowledgment_ms": 31.9,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.4,
+                  "duration_ms": 63
+                }
+              ],
+              "browser_command_wall_ms": 74.534
+            }
+          ]
+        }
+      ],
+      "traces": []
+    },
+    {
+      "schema": "loomark-whole-document-input-v1",
+      "environment": {
+        "commit": "0458a5827598bcdec4a14c956b8d93dd43e9ec73",
+        "browser": "149.0.7827.55",
+        "node": "v24.14.1",
+        "platform": "linux",
+        "os_release": "6.18.33.2-microsoft-standard-WSL2",
+        "architecture": "x64",
+        "cpu": "AMD Ryzen 7 6800H with Radeon Graphics",
+        "headless": true,
+        "viewport": {
+          "width": 1280,
+          "height": 720
+        },
+        "warmups": 5,
+        "samples": 30,
+        "trace_samples": 0,
+        "settle_ms": 400,
+        "persistence_required": true
+      },
+      "invocation": {
+        "sizes": [
+          1048576
+        ],
+        "environment": {
+          "LOOMARK_WHOLE_DOCUMENT_SIZES": "1048576",
+          "LOOMARK_WHOLE_DOCUMENT_WARMUPS": "5",
+          "LOOMARK_WHOLE_DOCUMENT_SAMPLES": "30",
+          "LOOMARK_WHOLE_DOCUMENT_TRACE_SAMPLES": "0",
+          "LOOMARK_WHOLE_DOCUMENT_REQUIRE_PERSISTENCE": null
+        }
+      },
+      "fixtures": [
+        {
+          "requested_utf16": 1048576,
+          "utf16_length": 1048576,
+          "utf8_bytes": 1048576,
+          "sha256": "bd2b39512f137e45eb14063920e77769422728321640fc9214787e00a5dd74ae"
+        }
+      ],
+      "scenarios": [
+        {
+          "size_utf16": 1048576,
+          "surface": "native_textarea",
+          "matched_width_px": 736,
+          "summary": {
+            "native_mutation_ms": {
+              "samples": 30,
+              "p50_ms": 36.2,
+              "p95_ms": 40.9,
+              "maximum_ms": 138.1
+            },
+            "input_handler_ms": {
+              "samples": 30,
+              "p50_ms": 0,
+              "p95_ms": 0.1,
+              "maximum_ms": 0.1
+            },
+            "put_request_offset_ms": {
+              "samples": 0,
+              "p50_ms": null,
+              "p95_ms": null,
+              "maximum_ms": null
+            },
+            "put_acknowledgment_ms": {
+              "samples": 0,
+              "p50_ms": null,
+              "p95_ms": null,
+              "maximum_ms": null
+            },
+            "browser_command_wall_ms": {
+              "samples": 30,
+              "p50_ms": 66.603,
+              "p95_ms": 75.923,
+              "maximum_ms": 172.085
+            },
+            "long_tasks": {
+              "samples_with_long_tasks": 0,
+              "count": 0,
+              "maximum_ms": 0
+            }
+          },
+          "samples": [
+            {
+              "native_mutation_ms": 36.2,
+              "input_handler_ms": 0.1,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 66.548
+            },
+            {
+              "native_mutation_ms": 35.1,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 65.036
+            },
+            {
+              "native_mutation_ms": 35.6,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 67.756
+            },
+            {
+              "native_mutation_ms": 37.2,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 65.72
+            },
+            {
+              "native_mutation_ms": 37.7,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 66.838
+            },
+            {
+              "native_mutation_ms": 40.9,
+              "input_handler_ms": 0.1,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 75.923
+            },
+            {
+              "native_mutation_ms": 37.2,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 66.557
+            },
+            {
+              "native_mutation_ms": 35.9,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 68.095
+            },
+            {
+              "native_mutation_ms": 36,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 70.132
+            },
+            {
+              "native_mutation_ms": 35.7,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 65.075
+            },
+            {
+              "native_mutation_ms": 35.8,
+              "input_handler_ms": 0.1,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 64.746
+            },
+            {
+              "native_mutation_ms": 37.1,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 68.958
+            },
+            {
+              "native_mutation_ms": 36.5,
+              "input_handler_ms": 0.1,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 65.683
+            },
+            {
+              "native_mutation_ms": 37.5,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 67.094
+            },
+            {
+              "native_mutation_ms": 35.8,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 69.688
+            },
+            {
+              "native_mutation_ms": 35.3,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 66.386
+            },
+            {
+              "native_mutation_ms": 138.1,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 172.085
+            },
+            {
+              "native_mutation_ms": 37.5,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 66.244
+            },
+            {
+              "native_mutation_ms": 35.7,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 66.265
+            },
+            {
+              "native_mutation_ms": 34.3,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 68.808
+            },
+            {
+              "native_mutation_ms": 35.4,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 66.092
+            },
+            {
+              "native_mutation_ms": 37,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 66.603
+            },
+            {
+              "native_mutation_ms": 35.2,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 67.972
+            },
+            {
+              "native_mutation_ms": 38,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 69.188
+            },
+            {
+              "native_mutation_ms": 36.4,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 65.617
+            },
+            {
+              "native_mutation_ms": 37,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 70.726
+            },
+            {
+              "native_mutation_ms": 39.4,
+              "input_handler_ms": 0.1,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 69.067
+            },
+            {
+              "native_mutation_ms": 35.4,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 65.698
+            },
+            {
+              "native_mutation_ms": 36,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 70.943
+            },
+            {
+              "native_mutation_ms": 36.2,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 66.34
+            }
+          ]
+        },
+        {
+          "size_utf16": 1048576,
+          "surface": "loomark_production",
+          "matched_width_px": 736,
+          "summary": {
+            "native_mutation_ms": {
+              "samples": 30,
+              "p50_ms": 34,
+              "p95_ms": 65,
+              "maximum_ms": 163.8
+            },
+            "input_handler_ms": {
+              "samples": 30,
+              "p50_ms": 0,
+              "p95_ms": 0.1,
+              "maximum_ms": 0.1
+            },
+            "put_request_offset_ms": {
+              "samples": 30,
+              "p50_ms": 317,
+              "p95_ms": 341.9,
+              "maximum_ms": 343.2
+            },
+            "put_acknowledgment_ms": {
+              "samples": 30,
+              "p50_ms": 10.1,
+              "p95_ms": 34,
+              "maximum_ms": 35.8
+            },
+            "browser_command_wall_ms": {
+              "samples": 30,
+              "p50_ms": 69.8,
+              "p95_ms": 98.108,
+              "maximum_ms": 199.721
+            },
+            "long_tasks": {
+              "samples_with_long_tasks": 30,
+              "count": 39,
+              "maximum_ms": 92
+            }
+          },
+          "samples": [
+            {
+              "native_mutation_ms": 33.7,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 309.7,
+              "put_acknowledgment_ms": 32.1,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.4,
+                  "duration_ms": 59
+                }
+              ],
+              "browser_command_wall_ms": 70.204
+            },
+            {
+              "native_mutation_ms": 32.8,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 333.5,
+              "put_acknowledgment_ms": 0.5,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.5,
+                  "duration_ms": 83
+                }
+              ],
+              "browser_command_wall_ms": 67.941
+            },
+            {
+              "native_mutation_ms": 30.9,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 325.6,
+              "put_acknowledgment_ms": 31.6,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.4,
+                  "duration_ms": 75
+                }
+              ],
+              "browser_command_wall_ms": 66.166
+            },
+            {
+              "native_mutation_ms": 41.6,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 316.4,
+              "put_acknowledgment_ms": 0.4,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.5,
+                  "duration_ms": 66
+                }
+              ],
+              "browser_command_wall_ms": 76.592
+            },
+            {
+              "native_mutation_ms": 31.8,
+              "input_handler_ms": 0.1,
+              "put_request_offset_ms": 316.2,
+              "put_acknowledgment_ms": 32.7,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.5,
+                  "duration_ms": 65
+                }
+              ],
+              "browser_command_wall_ms": 72.878
+            },
+            {
+              "native_mutation_ms": 33.5,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 340.2,
+              "put_acknowledgment_ms": 8.8,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 34.1,
+                  "duration_ms": 50
+                },
+                {
+                  "offset_ms": 250.3,
+                  "duration_ms": 90
+                }
+              ],
+              "browser_command_wall_ms": 68.876
+            },
+            {
+              "native_mutation_ms": 31.7,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 309.9,
+              "put_acknowledgment_ms": 22.5,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.4,
+                  "duration_ms": 59
+                }
+              ],
+              "browser_command_wall_ms": 66.506
+            },
+            {
+              "native_mutation_ms": 34.4,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 317,
+              "put_acknowledgment_ms": 0.4,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.9,
+                  "duration_ms": 66
+                }
+              ],
+              "browser_command_wall_ms": 70.542
+            },
+            {
+              "native_mutation_ms": 34.1,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 311.5,
+              "put_acknowledgment_ms": 31.3,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 251.1,
+                  "duration_ms": 60
+                }
+              ],
+              "browser_command_wall_ms": 68.96
+            },
+            {
+              "native_mutation_ms": 33.8,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 329.1,
+              "put_acknowledgment_ms": 8.1,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.4,
+                  "duration_ms": 78
+                }
+              ],
+              "browser_command_wall_ms": 70.749
+            },
+            {
+              "native_mutation_ms": 31.9,
+              "input_handler_ms": 0.1,
+              "put_request_offset_ms": 309.6,
+              "put_acknowledgment_ms": 9.1,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.5,
+                  "duration_ms": 59
+                }
+              ],
+              "browser_command_wall_ms": 65.628
+            },
+            {
+              "native_mutation_ms": 34.4,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 322.3,
+              "put_acknowledgment_ms": 31.7,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.5,
+                  "duration_ms": 71
+                }
+              ],
+              "browser_command_wall_ms": 76.501
+            },
+            {
+              "native_mutation_ms": 34.4,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 321.4,
+              "put_acknowledgment_ms": 0.5,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 34.5,
+                  "duration_ms": 53
+                },
+                {
+                  "offset_ms": 250.4,
+                  "duration_ms": 71
+                },
+                {
+                  "offset_ms": 328,
+                  "duration_ms": 53
+                }
+              ],
+              "browser_command_wall_ms": 69.8
+            },
+            {
+              "native_mutation_ms": 32.1,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 310.6,
+              "put_acknowledgment_ms": 35.8,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.3,
+                  "duration_ms": 60
+                }
+              ],
+              "browser_command_wall_ms": 65.427
+            },
+            {
+              "native_mutation_ms": 163.8,
+              "input_handler_ms": 0.1,
+              "put_request_offset_ms": 343.2,
+              "put_acknowledgment_ms": 0.4,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 34.8,
+                  "duration_ms": 55
+                },
+                {
+                  "offset_ms": 250.4,
+                  "duration_ms": 92
+                }
+              ],
+              "browser_command_wall_ms": 199.721
+            },
+            {
+              "native_mutation_ms": 33.3,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 305.5,
+              "put_acknowledgment_ms": 19.5,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.3,
+                  "duration_ms": 55
+                }
+              ],
+              "browser_command_wall_ms": 66.468
+            },
+            {
+              "native_mutation_ms": 33.7,
+              "input_handler_ms": 0.1,
+              "put_request_offset_ms": 311.4,
+              "put_acknowledgment_ms": 29.7,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.5,
+                  "duration_ms": 61
+                }
+              ],
+              "browser_command_wall_ms": 69.42
+            },
+            {
+              "native_mutation_ms": 35.7,
+              "input_handler_ms": 0.1,
+              "put_request_offset_ms": 328.1,
+              "put_acknowledgment_ms": 0.3,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.3,
+                  "duration_ms": 77
+                },
+                {
+                  "offset_ms": 334.4,
+                  "duration_ms": 63
+                }
+              ],
+              "browser_command_wall_ms": 70.995
+            },
+            {
+              "native_mutation_ms": 34,
+              "input_handler_ms": 0.1,
+              "put_request_offset_ms": 315.3,
+              "put_acknowledgment_ms": 30.3,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.4,
+                  "duration_ms": 65
+                }
+              ],
+              "browser_command_wall_ms": 68.641
+            },
+            {
+              "native_mutation_ms": 31.4,
+              "input_handler_ms": 0.1,
+              "put_request_offset_ms": 341.9,
+              "put_acknowledgment_ms": 0.2,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 35.3,
+                  "duration_ms": 51
+                },
+                {
+                  "offset_ms": 250.4,
+                  "duration_ms": 91
+                }
+              ],
+              "browser_command_wall_ms": 67.665
+            },
+            {
+              "native_mutation_ms": 33.3,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 310.1,
+              "put_acknowledgment_ms": 10.1,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.3,
+                  "duration_ms": 60
+                }
+              ],
+              "browser_command_wall_ms": 73.497
+            },
+            {
+              "native_mutation_ms": 35.5,
+              "input_handler_ms": 0.1,
+              "put_request_offset_ms": 311.9,
+              "put_acknowledgment_ms": 32.2,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.5,
+                  "duration_ms": 61
+                }
+              ],
+              "browser_command_wall_ms": 71.641
+            },
+            {
+              "native_mutation_ms": 38.5,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 316.4,
+              "put_acknowledgment_ms": 0.4,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 36.4,
+                  "duration_ms": 54
+                },
+                {
+                  "offset_ms": 250.3,
+                  "duration_ms": 66
+                }
+              ],
+              "browser_command_wall_ms": 75.837
+            },
+            {
+              "native_mutation_ms": 33.4,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 318.1,
+              "put_acknowledgment_ms": 34,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.4,
+                  "duration_ms": 67
+                }
+              ],
+              "browser_command_wall_ms": 67.806
+            },
+            {
+              "native_mutation_ms": 35.8,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 327.2,
+              "put_acknowledgment_ms": 14.7,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.3,
+                  "duration_ms": 77
+                }
+              ],
+              "browser_command_wall_ms": 71.007
+            },
+            {
+              "native_mutation_ms": 65,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 321.3,
+              "put_acknowledgment_ms": 8.6,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.4,
+                  "duration_ms": 70
+                }
+              ],
+              "browser_command_wall_ms": 98.108
+            },
+            {
+              "native_mutation_ms": 35.8,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 322,
+              "put_acknowledgment_ms": 29.2,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.3,
+                  "duration_ms": 71
+                }
+              ],
+              "browser_command_wall_ms": 70.4
+            },
+            {
+              "native_mutation_ms": 35.1,
+              "input_handler_ms": 0.1,
+              "put_request_offset_ms": 316.9,
+              "put_acknowledgment_ms": 0.3,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 33.5,
+                  "duration_ms": 54
+                },
+                {
+                  "offset_ms": 250.4,
+                  "duration_ms": 66
+                },
+                {
+                  "offset_ms": 323.1,
+                  "duration_ms": 52
+                }
+              ],
+              "browser_command_wall_ms": 69.603
+            },
+            {
+              "native_mutation_ms": 35,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 317.9,
+              "put_acknowledgment_ms": 30.4,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.5,
+                  "duration_ms": 67
+                }
+              ],
+              "browser_command_wall_ms": 69.197
+            },
+            {
+              "native_mutation_ms": 34.7,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 332.1,
+              "put_acknowledgment_ms": 0.2,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.3,
+                  "duration_ms": 81
+                }
+              ],
+              "browser_command_wall_ms": 75.324
+            }
+          ]
+        }
+      ],
+      "traces": []
+    },
+    {
+      "schema": "loomark-whole-document-input-v1",
+      "environment": {
+        "commit": "0458a5827598bcdec4a14c956b8d93dd43e9ec73",
+        "browser": "149.0.7827.55",
+        "node": "v24.14.1",
+        "platform": "linux",
+        "os_release": "6.18.33.2-microsoft-standard-WSL2",
+        "architecture": "x64",
+        "cpu": "AMD Ryzen 7 6800H with Radeon Graphics",
+        "headless": true,
+        "viewport": {
+          "width": 1280,
+          "height": 720
+        },
+        "warmups": 5,
+        "samples": 30,
+        "trace_samples": 0,
+        "settle_ms": 400,
+        "persistence_required": true
+      },
+      "invocation": {
+        "sizes": [
+          1048576
+        ],
+        "environment": {
+          "LOOMARK_WHOLE_DOCUMENT_SIZES": "1048576",
+          "LOOMARK_WHOLE_DOCUMENT_WARMUPS": "5",
+          "LOOMARK_WHOLE_DOCUMENT_SAMPLES": "30",
+          "LOOMARK_WHOLE_DOCUMENT_TRACE_SAMPLES": "0",
+          "LOOMARK_WHOLE_DOCUMENT_REQUIRE_PERSISTENCE": null
+        }
+      },
+      "fixtures": [
+        {
+          "requested_utf16": 1048576,
+          "utf16_length": 1048576,
+          "utf8_bytes": 1048576,
+          "sha256": "bd2b39512f137e45eb14063920e77769422728321640fc9214787e00a5dd74ae"
+        }
+      ],
+      "scenarios": [
+        {
+          "size_utf16": 1048576,
+          "surface": "native_textarea",
+          "matched_width_px": 736,
+          "summary": {
+            "native_mutation_ms": {
+              "samples": 30,
+              "p50_ms": 36.4,
+              "p95_ms": 43.2,
+              "maximum_ms": 90.9
+            },
+            "input_handler_ms": {
+              "samples": 30,
+              "p50_ms": 0,
+              "p95_ms": 0.1,
+              "maximum_ms": 0.1
+            },
+            "put_request_offset_ms": {
+              "samples": 0,
+              "p50_ms": null,
+              "p95_ms": null,
+              "maximum_ms": null
+            },
+            "put_acknowledgment_ms": {
+              "samples": 0,
+              "p50_ms": null,
+              "p95_ms": null,
+              "maximum_ms": null
+            },
+            "browser_command_wall_ms": {
+              "samples": 30,
+              "p50_ms": 66.612,
+              "p95_ms": 77.175,
+              "maximum_ms": 121.584
+            },
+            "long_tasks": {
+              "samples_with_long_tasks": 0,
+              "count": 0,
+              "maximum_ms": 0
+            }
+          },
+          "samples": [
+            {
+              "native_mutation_ms": 34.3,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 63.121
+            },
+            {
+              "native_mutation_ms": 32.1,
+              "input_handler_ms": 0.1,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 61.668
+            },
+            {
+              "native_mutation_ms": 35.4,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 68.517
+            },
+            {
+              "native_mutation_ms": 32.1,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 59.592
+            },
+            {
+              "native_mutation_ms": 36.7,
+              "input_handler_ms": 0.1,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 65.367
+            },
+            {
+              "native_mutation_ms": 39.2,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 72.315
+            },
+            {
+              "native_mutation_ms": 90.9,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 121.584
+            },
+            {
+              "native_mutation_ms": 43.2,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 77.175
+            },
+            {
+              "native_mutation_ms": 35.2,
+              "input_handler_ms": 0.1,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 63.615
+            },
+            {
+              "native_mutation_ms": 35.4,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 63.59
+            },
+            {
+              "native_mutation_ms": 36.4,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 69.748
+            },
+            {
+              "native_mutation_ms": 37,
+              "input_handler_ms": 0.1,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 65.631
+            },
+            {
+              "native_mutation_ms": 37.5,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 66.52
+            },
+            {
+              "native_mutation_ms": 40,
+              "input_handler_ms": 0.1,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 74.638
+            },
+            {
+              "native_mutation_ms": 34.9,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 65.356
+            },
+            {
+              "native_mutation_ms": 34.9,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 65.139
+            },
+            {
+              "native_mutation_ms": 34.8,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 69.49
+            },
+            {
+              "native_mutation_ms": 35.7,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 65.412
+            },
+            {
+              "native_mutation_ms": 37.7,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 66.612
+            },
+            {
+              "native_mutation_ms": 37,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 69.968
+            },
+            {
+              "native_mutation_ms": 37.6,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 66.258
+            },
+            {
+              "native_mutation_ms": 37.4,
+              "input_handler_ms": 0.1,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 67.9
+            },
+            {
+              "native_mutation_ms": 36.1,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 71.001
+            },
+            {
+              "native_mutation_ms": 34.5,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 65.299
+            },
+            {
+              "native_mutation_ms": 36.8,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 67.237
+            },
+            {
+              "native_mutation_ms": 35.4,
+              "input_handler_ms": 0.1,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 67.942
+            },
+            {
+              "native_mutation_ms": 35.8,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 64.66
+            },
+            {
+              "native_mutation_ms": 37.9,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 66.931
+            },
+            {
+              "native_mutation_ms": 37.8,
+              "input_handler_ms": 0.1,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 71.158
+            },
+            {
+              "native_mutation_ms": 39.3,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": null,
+              "put_acknowledgment_ms": null,
+              "put_outcome": null,
+              "long_tasks": [],
+              "browser_command_wall_ms": 68.983
+            }
+          ]
+        },
+        {
+          "size_utf16": 1048576,
+          "surface": "loomark_production",
+          "matched_width_px": 736,
+          "summary": {
+            "native_mutation_ms": {
+              "samples": 30,
+              "p50_ms": 34.2,
+              "p95_ms": 37.3,
+              "maximum_ms": 37.7
+            },
+            "input_handler_ms": {
+              "samples": 30,
+              "p50_ms": 0,
+              "p95_ms": 0.1,
+              "maximum_ms": 0.1
+            },
+            "put_request_offset_ms": {
+              "samples": 30,
+              "p50_ms": 317.4,
+              "p95_ms": 340.9,
+              "maximum_ms": 356.8
+            },
+            "put_acknowledgment_ms": {
+              "samples": 30,
+              "p50_ms": 11,
+              "p95_ms": 32,
+              "maximum_ms": 33.5
+            },
+            "browser_command_wall_ms": {
+              "samples": 30,
+              "p50_ms": 68.584,
+              "p95_ms": 77.063,
+              "maximum_ms": 80.626
+            },
+            "long_tasks": {
+              "samples_with_long_tasks": 30,
+              "count": 40,
+              "maximum_ms": 106
+            }
+          },
+          "samples": [
+            {
+              "native_mutation_ms": 31.7,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 316.6,
+              "put_acknowledgment_ms": 30.9,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.4,
+                  "duration_ms": 66
+                }
+              ],
+              "browser_command_wall_ms": 66.515
+            },
+            {
+              "native_mutation_ms": 34.3,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 313.9,
+              "put_acknowledgment_ms": 12.6,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.5,
+                  "duration_ms": 63
+                }
+              ],
+              "browser_command_wall_ms": 70.268
+            },
+            {
+              "native_mutation_ms": 31.5,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 335.2,
+              "put_acknowledgment_ms": 30.9,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.6,
+                  "duration_ms": 84
+                }
+              ],
+              "browser_command_wall_ms": 65.853
+            },
+            {
+              "native_mutation_ms": 35.5,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 337.5,
+              "put_acknowledgment_ms": 0.4,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 32.9,
+                  "duration_ms": 50
+                },
+                {
+                  "offset_ms": 250.3,
+                  "duration_ms": 87
+                }
+              ],
+              "browser_command_wall_ms": 69.392
+            },
+            {
+              "native_mutation_ms": 35.1,
+              "input_handler_ms": 0.1,
+              "put_request_offset_ms": 309.9,
+              "put_acknowledgment_ms": 29.3,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.4,
+                  "duration_ms": 59
+                }
+              ],
+              "browser_command_wall_ms": 77.063
+            },
+            {
+              "native_mutation_ms": 34.4,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 310.6,
+              "put_acknowledgment_ms": 5.5,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.4,
+                  "duration_ms": 60
+                }
+              ],
+              "browser_command_wall_ms": 72.314
+            },
+            {
+              "native_mutation_ms": 32.1,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 317.4,
+              "put_acknowledgment_ms": 33.5,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.3,
+                  "duration_ms": 67
+                }
+              ],
+              "browser_command_wall_ms": 66.065
+            },
+            {
+              "native_mutation_ms": 31.3,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 337.4,
+              "put_acknowledgment_ms": 0.5,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 31.2,
+                  "duration_ms": 50
+                },
+                {
+                  "offset_ms": 250.3,
+                  "duration_ms": 87
+                }
+              ],
+              "browser_command_wall_ms": 63.985
+            },
+            {
+              "native_mutation_ms": 31.7,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 311,
+              "put_acknowledgment_ms": 25.3,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.4,
+                  "duration_ms": 60
+                }
+              ],
+              "browser_command_wall_ms": 66.3
+            },
+            {
+              "native_mutation_ms": 33.9,
+              "input_handler_ms": 0.1,
+              "put_request_offset_ms": 339.3,
+              "put_acknowledgment_ms": 6.5,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.8,
+                  "duration_ms": 88
+                }
+              ],
+              "browser_command_wall_ms": 68.466
+            },
+            {
+              "native_mutation_ms": 31.6,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 335,
+              "put_acknowledgment_ms": 31.7,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.4,
+                  "duration_ms": 84
+                }
+              ],
+              "browser_command_wall_ms": 64.035
+            },
+            {
+              "native_mutation_ms": 32.3,
+              "input_handler_ms": 0.1,
+              "put_request_offset_ms": 312.2,
+              "put_acknowledgment_ms": 0.2,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 39.1,
+                  "duration_ms": 52
+                },
+                {
+                  "offset_ms": 250.5,
+                  "duration_ms": 61
+                }
+              ],
+              "browser_command_wall_ms": 72.824
+            },
+            {
+              "native_mutation_ms": 32.5,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 312.3,
+              "put_acknowledgment_ms": 23.5,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.8,
+                  "duration_ms": 61
+                }
+              ],
+              "browser_command_wall_ms": 65.569
+            },
+            {
+              "native_mutation_ms": 37.3,
+              "input_handler_ms": 0.1,
+              "put_request_offset_ms": 340.9,
+              "put_acknowledgment_ms": 8.4,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 33.8,
+                  "duration_ms": 52
+                },
+                {
+                  "offset_ms": 250.3,
+                  "duration_ms": 90
+                }
+              ],
+              "browser_command_wall_ms": 72.12
+            },
+            {
+              "native_mutation_ms": 32.2,
+              "input_handler_ms": 0.1,
+              "put_request_offset_ms": 309.8,
+              "put_acknowledgment_ms": 8.7,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.3,
+                  "duration_ms": 59
+                }
+              ],
+              "browser_command_wall_ms": 65.313
+            },
+            {
+              "native_mutation_ms": 35.9,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 313.5,
+              "put_acknowledgment_ms": 0.1,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.5,
+                  "duration_ms": 63
+                }
+              ],
+              "browser_command_wall_ms": 70.412
+            },
+            {
+              "native_mutation_ms": 37,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 315.4,
+              "put_acknowledgment_ms": 0.4,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 32.7,
+                  "duration_ms": 50
+                },
+                {
+                  "offset_ms": 250.3,
+                  "duration_ms": 65
+                },
+                {
+                  "offset_ms": 322.1,
+                  "duration_ms": 70
+                }
+              ],
+              "browser_command_wall_ms": 71.358
+            },
+            {
+              "native_mutation_ms": 34.2,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 312.7,
+              "put_acknowledgment_ms": 22.1,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.7,
+                  "duration_ms": 62
+                }
+              ],
+              "browser_command_wall_ms": 67.564
+            },
+            {
+              "native_mutation_ms": 36.9,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 328.9,
+              "put_acknowledgment_ms": 0.3,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 42.5,
+                  "duration_ms": 53
+                },
+                {
+                  "offset_ms": 250.3,
+                  "duration_ms": 78
+                }
+              ],
+              "browser_command_wall_ms": 80.626
+            },
+            {
+              "native_mutation_ms": 31.1,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 322.4,
+              "put_acknowledgment_ms": 19.8,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.4,
+                  "duration_ms": 72
+                }
+              ],
+              "browser_command_wall_ms": 65.052
+            },
+            {
+              "native_mutation_ms": 34.9,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 317.1,
+              "put_acknowledgment_ms": 0.3,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 35,
+                  "duration_ms": 50
+                },
+                {
+                  "offset_ms": 250.3,
+                  "duration_ms": 66
+                }
+              ],
+              "browser_command_wall_ms": 71.458
+            },
+            {
+              "native_mutation_ms": 34.4,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 308.8,
+              "put_acknowledgment_ms": 22.4,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.4,
+                  "duration_ms": 58
+                }
+              ],
+              "browser_command_wall_ms": 68.473
+            },
+            {
+              "native_mutation_ms": 33,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 335,
+              "put_acknowledgment_ms": 15.8,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.4,
+                  "duration_ms": 84
+                }
+              ],
+              "browser_command_wall_ms": 67.487
+            },
+            {
+              "native_mutation_ms": 31.2,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 319.2,
+              "put_acknowledgment_ms": 11,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.6,
+                  "duration_ms": 68
+                },
+                {
+                  "offset_ms": 332.7,
+                  "duration_ms": 59
+                }
+              ],
+              "browser_command_wall_ms": 63.665
+            },
+            {
+              "native_mutation_ms": 34.6,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 324.3,
+              "put_acknowledgment_ms": 29.2,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.4,
+                  "duration_ms": 74
+                }
+              ],
+              "browser_command_wall_ms": 68.584
+            },
+            {
+              "native_mutation_ms": 34.7,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 340.4,
+              "put_acknowledgment_ms": 6.7,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.3,
+                  "duration_ms": 90
+                },
+                {
+                  "offset_ms": 347.4,
+                  "duration_ms": 50
+                }
+              ],
+              "browser_command_wall_ms": 69.694
+            },
+            {
+              "native_mutation_ms": 35.1,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 324,
+              "put_acknowledgment_ms": 32,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.4,
+                  "duration_ms": 73
+                }
+              ],
+              "browser_command_wall_ms": 69.574
+            },
+            {
+              "native_mutation_ms": 33.5,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 334.5,
+              "put_acknowledgment_ms": 8.1,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.3,
+                  "duration_ms": 84
+                }
+              ],
+              "browser_command_wall_ms": 74.133
+            },
+            {
+              "native_mutation_ms": 37.7,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 310.4,
+              "put_acknowledgment_ms": 18.5,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.4,
+                  "duration_ms": 60
+                }
+              ],
+              "browser_command_wall_ms": 70.014
+            },
+            {
+              "native_mutation_ms": 35.7,
+              "input_handler_ms": 0,
+              "put_request_offset_ms": 356.8,
+              "put_acknowledgment_ms": 0.4,
+              "put_outcome": "stored",
+              "long_tasks": [
+                {
+                  "offset_ms": 250.3,
+                  "duration_ms": 106
+                }
+              ],
+              "browser_command_wall_ms": 70.903
+            }
+          ]
+        }
+      ],
+      "traces": []
+    }
+  ],
+  "candidate_matrix": {
+    "schema": "loomark-whole-document-input-v1",
+    "environment": {
+      "commit": "0458a5827598bcdec4a14c956b8d93dd43e9ec73",
+      "browser": "149.0.7827.55",
+      "node": "v24.14.1",
+      "platform": "linux",
+      "os_release": "6.18.33.2-microsoft-standard-WSL2",
+      "architecture": "x64",
+      "cpu": "AMD Ryzen 7 6800H with Radeon Graphics",
+      "headless": true,
+      "viewport": {
+        "width": 1280,
+        "height": 720
+      },
+      "warmups": 5,
+      "samples": 30,
+      "trace_samples": 0,
+      "settle_ms": 400,
+      "persistence_required": true
+    },
+    "invocation": {
+      "sizes": [
+        65536,
+        262144,
+        1048576
+      ],
+      "environment": {
+        "LOOMARK_WHOLE_DOCUMENT_SIZES": "65536,262144,1048576",
+        "LOOMARK_WHOLE_DOCUMENT_WARMUPS": "5",
+        "LOOMARK_WHOLE_DOCUMENT_SAMPLES": "30",
+        "LOOMARK_WHOLE_DOCUMENT_TRACE_SAMPLES": "0",
+        "LOOMARK_WHOLE_DOCUMENT_REQUIRE_PERSISTENCE": null
+      }
+    },
+    "fixtures": [
+      {
+        "requested_utf16": 65536,
+        "utf16_length": 65536,
+        "utf8_bytes": 65536,
+        "sha256": "e4708b363c3f9a2137896aac85d78146eb50793513794a149c25b866df72d127"
+      },
+      {
+        "requested_utf16": 262144,
+        "utf16_length": 262144,
+        "utf8_bytes": 262144,
+        "sha256": "e44d180d726326b85132ed435e835e334114a0cee226588bffe4044ff5a3fd3f"
+      },
+      {
+        "requested_utf16": 1048576,
+        "utf16_length": 1048576,
+        "utf8_bytes": 1048576,
+        "sha256": "bd2b39512f137e45eb14063920e77769422728321640fc9214787e00a5dd74ae"
+      }
+    ],
+    "scenarios": [
+      {
+        "size_utf16": 65536,
+        "surface": "native_textarea",
+        "matched_width_px": 736,
+        "summary": {
+          "native_mutation_ms": {
+            "samples": 30,
+            "p50_ms": 2.2,
+            "p95_ms": 2.9,
+            "maximum_ms": 3.8
+          },
+          "input_handler_ms": {
+            "samples": 30,
+            "p50_ms": 0,
+            "p95_ms": 0.1,
+            "maximum_ms": 0.1
+          },
+          "put_request_offset_ms": {
+            "samples": 0,
+            "p50_ms": null,
+            "p95_ms": null,
+            "maximum_ms": null
+          },
+          "put_acknowledgment_ms": {
+            "samples": 0,
+            "p50_ms": null,
+            "p95_ms": null,
+            "maximum_ms": null
+          },
+          "browser_command_wall_ms": {
+            "samples": 30,
+            "p50_ms": 4.424,
+            "p95_ms": 6.14,
+            "maximum_ms": 6.233
+          },
+          "long_tasks": {
+            "samples_with_long_tasks": 0,
+            "count": 0,
+            "maximum_ms": 0
+          }
+        },
+        "samples": [
+          {
+            "native_mutation_ms": 2.2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.707
+          },
+          {
+            "native_mutation_ms": 2.3,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.477
+          },
+          {
+            "native_mutation_ms": 2.2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.261
+          },
+          {
+            "native_mutation_ms": 2.3,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.874
+          },
+          {
+            "native_mutation_ms": 2.4,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.431
+          },
+          {
+            "native_mutation_ms": 2.9,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 5.591
+          },
+          {
+            "native_mutation_ms": 2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 3.909
+          },
+          {
+            "native_mutation_ms": 2.2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.345
+          },
+          {
+            "native_mutation_ms": 2.9,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 5.255
+          },
+          {
+            "native_mutation_ms": 3.8,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 6.14
+          },
+          {
+            "native_mutation_ms": 1.9,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 3.947
+          },
+          {
+            "native_mutation_ms": 2.6,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.781
+          },
+          {
+            "native_mutation_ms": 2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.222
+          },
+          {
+            "native_mutation_ms": 2.1,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.204
+          },
+          {
+            "native_mutation_ms": 2.2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.037
+          },
+          {
+            "native_mutation_ms": 2.6,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.643
+          },
+          {
+            "native_mutation_ms": 2.2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.122
+          },
+          {
+            "native_mutation_ms": 2.1,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.693
+          },
+          {
+            "native_mutation_ms": 2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.25
+          },
+          {
+            "native_mutation_ms": 2.1,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.302
+          },
+          {
+            "native_mutation_ms": 2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.209
+          },
+          {
+            "native_mutation_ms": 2.3,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.422
+          },
+          {
+            "native_mutation_ms": 2.2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.277
+          },
+          {
+            "native_mutation_ms": 2.3,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.812
+          },
+          {
+            "native_mutation_ms": 2.2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 5.171
+          },
+          {
+            "native_mutation_ms": 2.2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.819
+          },
+          {
+            "native_mutation_ms": 2.2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.663
+          },
+          {
+            "native_mutation_ms": 2.3,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 6.233
+          },
+          {
+            "native_mutation_ms": 2.1,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.424
+          },
+          {
+            "native_mutation_ms": 2.1,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.421
+          }
+        ]
+      },
+      {
+        "size_utf16": 65536,
+        "surface": "loomark_production",
+        "matched_width_px": 736,
+        "summary": {
+          "native_mutation_ms": {
+            "samples": 30,
+            "p50_ms": 2.1,
+            "p95_ms": 3.5,
+            "maximum_ms": 5.1
+          },
+          "input_handler_ms": {
+            "samples": 30,
+            "p50_ms": 0,
+            "p95_ms": 0.1,
+            "maximum_ms": 0.1
+          },
+          "put_request_offset_ms": {
+            "samples": 30,
+            "p50_ms": 252.4,
+            "p95_ms": 254.1,
+            "maximum_ms": 254.2
+          },
+          "put_acknowledgment_ms": {
+            "samples": 30,
+            "p50_ms": 0.4,
+            "p95_ms": 2.1,
+            "maximum_ms": 2.6
+          },
+          "browser_command_wall_ms": {
+            "samples": 30,
+            "p50_ms": 4.762,
+            "p95_ms": 5.95,
+            "maximum_ms": 7.689
+          },
+          "long_tasks": {
+            "samples_with_long_tasks": 0,
+            "count": 0,
+            "maximum_ms": 0
+          }
+        },
+        "samples": [
+          {
+            "native_mutation_ms": 2.2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 252.4,
+            "put_acknowledgment_ms": 0.2,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.911
+          },
+          {
+            "native_mutation_ms": 2.1,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 252.9,
+            "put_acknowledgment_ms": 0.4,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.6
+          },
+          {
+            "native_mutation_ms": 2.3,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 252.7,
+            "put_acknowledgment_ms": 0.4,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 5.249
+          },
+          {
+            "native_mutation_ms": 2.2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 252.9,
+            "put_acknowledgment_ms": 2.6,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 5.052
+          },
+          {
+            "native_mutation_ms": 2.3,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 253.9,
+            "put_acknowledgment_ms": 0.3,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.839
+          },
+          {
+            "native_mutation_ms": 2.6,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": 254.1,
+            "put_acknowledgment_ms": 2.1,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 5.18
+          },
+          {
+            "native_mutation_ms": 1.9,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 252,
+            "put_acknowledgment_ms": 0.3,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.509
+          },
+          {
+            "native_mutation_ms": 5.1,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 252.1,
+            "put_acknowledgment_ms": 2.1,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 7.689
+          },
+          {
+            "native_mutation_ms": 2.2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 252.3,
+            "put_acknowledgment_ms": 0.3,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.749
+          },
+          {
+            "native_mutation_ms": 2,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": 252.4,
+            "put_acknowledgment_ms": 0.2,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.762
+          },
+          {
+            "native_mutation_ms": 2.7,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 252,
+            "put_acknowledgment_ms": 0.3,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.831
+          },
+          {
+            "native_mutation_ms": 2.1,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 252.4,
+            "put_acknowledgment_ms": 0.5,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.283
+          },
+          {
+            "native_mutation_ms": 2.1,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 252.4,
+            "put_acknowledgment_ms": 0.5,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.317
+          },
+          {
+            "native_mutation_ms": 2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 252.1,
+            "put_acknowledgment_ms": 0.2,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.464
+          },
+          {
+            "native_mutation_ms": 2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 252.4,
+            "put_acknowledgment_ms": 0.2,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.809
+          },
+          {
+            "native_mutation_ms": 2.4,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 252.1,
+            "put_acknowledgment_ms": 0.2,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 5.05
+          },
+          {
+            "native_mutation_ms": 2.1,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 251.8,
+            "put_acknowledgment_ms": 1.6,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.518
+          },
+          {
+            "native_mutation_ms": 2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 252.3,
+            "put_acknowledgment_ms": 1.2,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.335
+          },
+          {
+            "native_mutation_ms": 1.9,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 252.7,
+            "put_acknowledgment_ms": 0.3,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.097
+          },
+          {
+            "native_mutation_ms": 2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 251.9,
+            "put_acknowledgment_ms": 0.5,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.786
+          },
+          {
+            "native_mutation_ms": 3.5,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 252.5,
+            "put_acknowledgment_ms": 1.5,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 5.95
+          },
+          {
+            "native_mutation_ms": 2.1,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 252.4,
+            "put_acknowledgment_ms": 0.2,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.607
+          },
+          {
+            "native_mutation_ms": 1.9,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 252,
+            "put_acknowledgment_ms": 0.4,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.706
+          },
+          {
+            "native_mutation_ms": 2.3,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 252.2,
+            "put_acknowledgment_ms": 0.4,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 5.188
+          },
+          {
+            "native_mutation_ms": 2.7,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 253.3,
+            "put_acknowledgment_ms": 0.3,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 5.207
+          },
+          {
+            "native_mutation_ms": 2.1,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 254.2,
+            "put_acknowledgment_ms": 0.3,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.356
+          },
+          {
+            "native_mutation_ms": 2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 254,
+            "put_acknowledgment_ms": 0.2,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.829
+          },
+          {
+            "native_mutation_ms": 2.1,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 252.2,
+            "put_acknowledgment_ms": 1.5,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.764
+          },
+          {
+            "native_mutation_ms": 1.9,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 252.8,
+            "put_acknowledgment_ms": 0.4,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.384
+          },
+          {
+            "native_mutation_ms": 2.1,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 254.1,
+            "put_acknowledgment_ms": 0.4,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 4.647
+          }
+        ]
+      },
+      {
+        "size_utf16": 262144,
+        "surface": "native_textarea",
+        "matched_width_px": 736,
+        "summary": {
+          "native_mutation_ms": {
+            "samples": 30,
+            "p50_ms": 7.8,
+            "p95_ms": 9.5,
+            "maximum_ms": 71.1
+          },
+          "input_handler_ms": {
+            "samples": 30,
+            "p50_ms": 0,
+            "p95_ms": 0.1,
+            "maximum_ms": 0.1
+          },
+          "put_request_offset_ms": {
+            "samples": 0,
+            "p50_ms": null,
+            "p95_ms": null,
+            "maximum_ms": null
+          },
+          "put_acknowledgment_ms": {
+            "samples": 0,
+            "p50_ms": null,
+            "p95_ms": null,
+            "maximum_ms": null
+          },
+          "browser_command_wall_ms": {
+            "samples": 30,
+            "p50_ms": 13.74,
+            "p95_ms": 17.836,
+            "maximum_ms": 77.304
+          },
+          "long_tasks": {
+            "samples_with_long_tasks": 0,
+            "count": 0,
+            "maximum_ms": 0
+          }
+        },
+        "samples": [
+          {
+            "native_mutation_ms": 6.5,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 11.356
+          },
+          {
+            "native_mutation_ms": 7.8,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 13.897
+          },
+          {
+            "native_mutation_ms": 8.1,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 13.777
+          },
+          {
+            "native_mutation_ms": 8.2,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 13.373
+          },
+          {
+            "native_mutation_ms": 7.7,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 12.735
+          },
+          {
+            "native_mutation_ms": 6.9,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 11.983
+          },
+          {
+            "native_mutation_ms": 7.9,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 15.148
+          },
+          {
+            "native_mutation_ms": 9.3,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 16.374
+          },
+          {
+            "native_mutation_ms": 7.4,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 15.8
+          },
+          {
+            "native_mutation_ms": 6.7,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 12.486
+          },
+          {
+            "native_mutation_ms": 6.7,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 12.149
+          },
+          {
+            "native_mutation_ms": 7.5,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 14.82
+          },
+          {
+            "native_mutation_ms": 9.5,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 17.836
+          },
+          {
+            "native_mutation_ms": 8.2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 13.244
+          },
+          {
+            "native_mutation_ms": 7.3,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 12.488
+          },
+          {
+            "native_mutation_ms": 7.4,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 12.56
+          },
+          {
+            "native_mutation_ms": 8.2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 13.789
+          },
+          {
+            "native_mutation_ms": 7.7,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 13.715
+          },
+          {
+            "native_mutation_ms": 8.1,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 13.74
+          },
+          {
+            "native_mutation_ms": 71.1,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 77.304
+          },
+          {
+            "native_mutation_ms": 7.7,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 12.867
+          },
+          {
+            "native_mutation_ms": 8.7,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 14.345
+          },
+          {
+            "native_mutation_ms": 8.7,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 14.948
+          },
+          {
+            "native_mutation_ms": 8.2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 14.296
+          },
+          {
+            "native_mutation_ms": 8.1,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 13.204
+          },
+          {
+            "native_mutation_ms": 7.7,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 13.17
+          },
+          {
+            "native_mutation_ms": 7.7,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 14.881
+          },
+          {
+            "native_mutation_ms": 7.8,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 13.795
+          },
+          {
+            "native_mutation_ms": 9.1,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 16.687
+          },
+          {
+            "native_mutation_ms": 6.9,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 12.984
+          }
+        ]
+      },
+      {
+        "size_utf16": 262144,
+        "surface": "loomark_production",
+        "matched_width_px": 736,
+        "summary": {
+          "native_mutation_ms": {
+            "samples": 30,
+            "p50_ms": 7.7,
+            "p95_ms": 9.1,
+            "maximum_ms": 61.7
+          },
+          "input_handler_ms": {
+            "samples": 30,
+            "p50_ms": 0,
+            "p95_ms": 0.1,
+            "maximum_ms": 0.1
+          },
+          "put_request_offset_ms": {
+            "samples": 30,
+            "p50_ms": 256.6,
+            "p95_ms": 257.8,
+            "maximum_ms": 258.6
+          },
+          "put_acknowledgment_ms": {
+            "samples": 30,
+            "p50_ms": 2.2,
+            "p95_ms": 4.5,
+            "maximum_ms": 4.8
+          },
+          "browser_command_wall_ms": {
+            "samples": 30,
+            "p50_ms": 14.458,
+            "p95_ms": 20.831,
+            "maximum_ms": 67.792
+          },
+          "long_tasks": {
+            "samples_with_long_tasks": 0,
+            "count": 0,
+            "maximum_ms": 0
+          }
+        },
+        "samples": [
+          {
+            "native_mutation_ms": 8.6,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 257,
+            "put_acknowledgment_ms": 3.1,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 18.382
+          },
+          {
+            "native_mutation_ms": 7.5,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 256.7,
+            "put_acknowledgment_ms": 0.5,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 16.698
+          },
+          {
+            "native_mutation_ms": 7.6,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": 256.6,
+            "put_acknowledgment_ms": 4.8,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 14.458
+          },
+          {
+            "native_mutation_ms": 7,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 257.8,
+            "put_acknowledgment_ms": 3.4,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 13.594
+          },
+          {
+            "native_mutation_ms": 8.3,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 257,
+            "put_acknowledgment_ms": 3.3,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 14.688
+          },
+          {
+            "native_mutation_ms": 6.6,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 257.2,
+            "put_acknowledgment_ms": 2.4,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 12.489
+          },
+          {
+            "native_mutation_ms": 61.7,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 258.6,
+            "put_acknowledgment_ms": 2.7,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 67.792
+          },
+          {
+            "native_mutation_ms": 8.4,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 256.4,
+            "put_acknowledgment_ms": 4.2,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 15.619
+          },
+          {
+            "native_mutation_ms": 7.7,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 256.5,
+            "put_acknowledgment_ms": 0.4,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 13.328
+          },
+          {
+            "native_mutation_ms": 8.1,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 256.7,
+            "put_acknowledgment_ms": 2.1,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 15.706
+          },
+          {
+            "native_mutation_ms": 7.5,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 256.7,
+            "put_acknowledgment_ms": 2.8,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 15.202
+          },
+          {
+            "native_mutation_ms": 7,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 256.1,
+            "put_acknowledgment_ms": 2.8,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 15.126
+          },
+          {
+            "native_mutation_ms": 8.9,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 256.4,
+            "put_acknowledgment_ms": 4.5,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 15.06
+          },
+          {
+            "native_mutation_ms": 8.5,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 256.2,
+            "put_acknowledgment_ms": 0.2,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 16.628
+          },
+          {
+            "native_mutation_ms": 7.7,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 256.9,
+            "put_acknowledgment_ms": 0.4,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 13.351
+          },
+          {
+            "native_mutation_ms": 6.8,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 256.4,
+            "put_acknowledgment_ms": 2.1,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 15.268
+          },
+          {
+            "native_mutation_ms": 7.1,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": 256.6,
+            "put_acknowledgment_ms": 0.4,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 14.095
+          },
+          {
+            "native_mutation_ms": 7.5,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 255.8,
+            "put_acknowledgment_ms": 3.7,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 14.444
+          },
+          {
+            "native_mutation_ms": 9.1,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 256.6,
+            "put_acknowledgment_ms": 0.5,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 17.199
+          },
+          {
+            "native_mutation_ms": 7,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 256.7,
+            "put_acknowledgment_ms": 3,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 14.053
+          },
+          {
+            "native_mutation_ms": 6.8,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 256.9,
+            "put_acknowledgment_ms": 0.4,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 13.466
+          },
+          {
+            "native_mutation_ms": 7.7,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 256.4,
+            "put_acknowledgment_ms": 0.4,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 13.977
+          },
+          {
+            "native_mutation_ms": 7.5,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 256.3,
+            "put_acknowledgment_ms": 0.3,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 14.154
+          },
+          {
+            "native_mutation_ms": 7,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 256.4,
+            "put_acknowledgment_ms": 2.6,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 14.174
+          },
+          {
+            "native_mutation_ms": 8,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 256.5,
+            "put_acknowledgment_ms": 2.4,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 13.843
+          },
+          {
+            "native_mutation_ms": 8.2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 257.6,
+            "put_acknowledgment_ms": 2.2,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 14.946
+          },
+          {
+            "native_mutation_ms": 8.5,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 256,
+            "put_acknowledgment_ms": 2.1,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 15.809
+          },
+          {
+            "native_mutation_ms": 8.2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 256.7,
+            "put_acknowledgment_ms": 3.9,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 14.116
+          },
+          {
+            "native_mutation_ms": 7.8,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 256.5,
+            "put_acknowledgment_ms": 0.3,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 20.831
+          },
+          {
+            "native_mutation_ms": 6.4,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 256.9,
+            "put_acknowledgment_ms": 0.4,
+            "put_outcome": "stored",
+            "long_tasks": [],
+            "browser_command_wall_ms": 13.109
+          }
+        ]
+      },
+      {
+        "size_utf16": 1048576,
+        "surface": "native_textarea",
+        "matched_width_px": 736,
+        "summary": {
+          "native_mutation_ms": {
+            "samples": 30,
+            "p50_ms": 36.9,
+            "p95_ms": 47.4,
+            "maximum_ms": 67.5
+          },
+          "input_handler_ms": {
+            "samples": 30,
+            "p50_ms": 0,
+            "p95_ms": 0.1,
+            "maximum_ms": 0.1
+          },
+          "put_request_offset_ms": {
+            "samples": 0,
+            "p50_ms": null,
+            "p95_ms": null,
+            "maximum_ms": null
+          },
+          "put_acknowledgment_ms": {
+            "samples": 0,
+            "p50_ms": null,
+            "p95_ms": null,
+            "maximum_ms": null
+          },
+          "browser_command_wall_ms": {
+            "samples": 30,
+            "p50_ms": 67.571,
+            "p95_ms": 80.603,
+            "maximum_ms": 97.289
+          },
+          "long_tasks": {
+            "samples_with_long_tasks": 0,
+            "count": 0,
+            "maximum_ms": 0
+          }
+        },
+        "samples": [
+          {
+            "native_mutation_ms": 37.1,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 65.677
+          },
+          {
+            "native_mutation_ms": 38.3,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 67.84
+          },
+          {
+            "native_mutation_ms": 37.5,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 71.212
+          },
+          {
+            "native_mutation_ms": 37,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 67.821
+          },
+          {
+            "native_mutation_ms": 35.7,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 66.587
+          },
+          {
+            "native_mutation_ms": 34.6,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 67.737
+          },
+          {
+            "native_mutation_ms": 39.4,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 68.166
+          },
+          {
+            "native_mutation_ms": 35.4,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 64.871
+          },
+          {
+            "native_mutation_ms": 37,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 69.406
+          },
+          {
+            "native_mutation_ms": 37.7,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 68.041
+          },
+          {
+            "native_mutation_ms": 37,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 67.563
+          },
+          {
+            "native_mutation_ms": 36.9,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 71.714
+          },
+          {
+            "native_mutation_ms": 35.7,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 66.279
+          },
+          {
+            "native_mutation_ms": 34.4,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 65.386
+          },
+          {
+            "native_mutation_ms": 35,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 67.571
+          },
+          {
+            "native_mutation_ms": 40,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 69.7
+          },
+          {
+            "native_mutation_ms": 38.2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 67.354
+          },
+          {
+            "native_mutation_ms": 47.4,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 80.603
+          },
+          {
+            "native_mutation_ms": 36.9,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 65.199
+          },
+          {
+            "native_mutation_ms": 37.3,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 67.126
+          },
+          {
+            "native_mutation_ms": 36.2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 70.454
+          },
+          {
+            "native_mutation_ms": 35.8,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 65.987
+          },
+          {
+            "native_mutation_ms": 35.1,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 65.512
+          },
+          {
+            "native_mutation_ms": 34.9,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 68.262
+          },
+          {
+            "native_mutation_ms": 36.2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 66.244
+          },
+          {
+            "native_mutation_ms": 36.3,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 65.303
+          },
+          {
+            "native_mutation_ms": 37.3,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 69.647
+          },
+          {
+            "native_mutation_ms": 37,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 67.539
+          },
+          {
+            "native_mutation_ms": 67.5,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 97.289
+          },
+          {
+            "native_mutation_ms": 36.8,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": null,
+            "put_acknowledgment_ms": null,
+            "put_outcome": null,
+            "long_tasks": [],
+            "browser_command_wall_ms": 70.673
+          }
+        ]
+      },
+      {
+        "size_utf16": 1048576,
+        "surface": "loomark_production",
+        "matched_width_px": 736,
+        "summary": {
+          "native_mutation_ms": {
+            "samples": 30,
+            "p50_ms": 32.9,
+            "p95_ms": 37.4,
+            "maximum_ms": 40.9
+          },
+          "input_handler_ms": {
+            "samples": 30,
+            "p50_ms": 0,
+            "p95_ms": 0.1,
+            "maximum_ms": 0.1
+          },
+          "put_request_offset_ms": {
+            "samples": 30,
+            "p50_ms": 320.4,
+            "p95_ms": 339.5,
+            "maximum_ms": 419.5
+          },
+          "put_acknowledgment_ms": {
+            "samples": 30,
+            "p50_ms": 9.9,
+            "p95_ms": 38.9,
+            "maximum_ms": 48.1
+          },
+          "browser_command_wall_ms": {
+            "samples": 30,
+            "p50_ms": 68.368,
+            "p95_ms": 76.843,
+            "maximum_ms": 78.836
+          },
+          "long_tasks": {
+            "samples_with_long_tasks": 30,
+            "count": 39,
+            "maximum_ms": 169
+          }
+        },
+        "samples": [
+          {
+            "native_mutation_ms": 34.3,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 320.7,
+            "put_acknowledgment_ms": 0.2,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.3,
+                "duration_ms": 70
+              },
+              {
+                "offset_ms": 349.1,
+                "duration_ms": 50
+              }
+            ],
+            "browser_command_wall_ms": 68.775
+          },
+          {
+            "native_mutation_ms": 32.3,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": 308.4,
+            "put_acknowledgment_ms": 28.7,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.6,
+                "duration_ms": 57
+              }
+            ],
+            "browser_command_wall_ms": 68.368
+          },
+          {
+            "native_mutation_ms": 32,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 330.5,
+            "put_acknowledgment_ms": 0.4,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 34.5,
+                "duration_ms": 53
+              },
+              {
+                "offset_ms": 250.5,
+                "duration_ms": 80
+              },
+              {
+                "offset_ms": 337.3,
+                "duration_ms": 51
+              }
+            ],
+            "browser_command_wall_ms": 67.382
+          },
+          {
+            "native_mutation_ms": 40.9,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 308.3,
+            "put_acknowledgment_ms": 32.4,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.6,
+                "duration_ms": 57
+              }
+            ],
+            "browser_command_wall_ms": 76.843
+          },
+          {
+            "native_mutation_ms": 32.9,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 330.3,
+            "put_acknowledgment_ms": 0.3,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.4,
+                "duration_ms": 80
+              }
+            ],
+            "browser_command_wall_ms": 73.841
+          },
+          {
+            "native_mutation_ms": 32.4,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": 306.5,
+            "put_acknowledgment_ms": 9.9,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.4,
+                "duration_ms": 56
+              }
+            ],
+            "browser_command_wall_ms": 67.734
+          },
+          {
+            "native_mutation_ms": 31.2,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 314.3,
+            "put_acknowledgment_ms": 6.2,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.3,
+                "duration_ms": 64
+              }
+            ],
+            "browser_command_wall_ms": 66.027
+          },
+          {
+            "native_mutation_ms": 32.6,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 419.5,
+            "put_acknowledgment_ms": 28.3,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.5,
+                "duration_ms": 169
+              }
+            ],
+            "browser_command_wall_ms": 67.35
+          },
+          {
+            "native_mutation_ms": 32.9,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 330.7,
+            "put_acknowledgment_ms": 0.2,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.4,
+                "duration_ms": 80
+              }
+            ],
+            "browser_command_wall_ms": 66.621
+          },
+          {
+            "native_mutation_ms": 32.8,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 305.8,
+            "put_acknowledgment_ms": 14,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.4,
+                "duration_ms": 55
+              }
+            ],
+            "browser_command_wall_ms": 68.134
+          },
+          {
+            "native_mutation_ms": 33.4,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 320.4,
+            "put_acknowledgment_ms": 48.1,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.3,
+                "duration_ms": 70
+              }
+            ],
+            "browser_command_wall_ms": 67.353
+          },
+          {
+            "native_mutation_ms": 31.9,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 314.5,
+            "put_acknowledgment_ms": 7.3,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.3,
+                "duration_ms": 64
+              }
+            ],
+            "browser_command_wall_ms": 67.331
+          },
+          {
+            "native_mutation_ms": 32.3,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 325.5,
+            "put_acknowledgment_ms": 32.3,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.4,
+                "duration_ms": 75
+              }
+            ],
+            "browser_command_wall_ms": 68.534
+          },
+          {
+            "native_mutation_ms": 30.9,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 331.1,
+            "put_acknowledgment_ms": 8.6,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.7,
+                "duration_ms": 80
+              }
+            ],
+            "browser_command_wall_ms": 72.18
+          },
+          {
+            "native_mutation_ms": 37.4,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 308.4,
+            "put_acknowledgment_ms": 18.9,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.5,
+                "duration_ms": 58
+              }
+            ],
+            "browser_command_wall_ms": 72.26
+          },
+          {
+            "native_mutation_ms": 31.4,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 310.3,
+            "put_acknowledgment_ms": 7,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.3,
+                "duration_ms": 60
+              },
+              {
+                "offset_ms": 317.7,
+                "duration_ms": 50
+              }
+            ],
+            "browser_command_wall_ms": 66.142
+          },
+          {
+            "native_mutation_ms": 30.5,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": 329.8,
+            "put_acknowledgment_ms": 31.8,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.5,
+                "duration_ms": 79
+              }
+            ],
+            "browser_command_wall_ms": 65.631
+          },
+          {
+            "native_mutation_ms": 31.5,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": 336.2,
+            "put_acknowledgment_ms": 17.1,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.3,
+                "duration_ms": 86
+              }
+            ],
+            "browser_command_wall_ms": 65.397
+          },
+          {
+            "native_mutation_ms": 34.7,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": 323.3,
+            "put_acknowledgment_ms": 10.5,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.4,
+                "duration_ms": 73
+              },
+              {
+                "offset_ms": 335.2,
+                "duration_ms": 58
+              }
+            ],
+            "browser_command_wall_ms": 70.46
+          },
+          {
+            "native_mutation_ms": 36.3,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 312.4,
+            "put_acknowledgment_ms": 30.2,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.5,
+                "duration_ms": 62
+              }
+            ],
+            "browser_command_wall_ms": 72.978
+          },
+          {
+            "native_mutation_ms": 35,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 328.4,
+            "put_acknowledgment_ms": 0.3,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.4,
+                "duration_ms": 78
+              },
+              {
+                "offset_ms": 335.4,
+                "duration_ms": 69
+              }
+            ],
+            "browser_command_wall_ms": 72.547
+          },
+          {
+            "native_mutation_ms": 33.2,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": 339.5,
+            "put_acknowledgment_ms": 31.9,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.5,
+                "duration_ms": 89
+              }
+            ],
+            "browser_command_wall_ms": 69.107
+          },
+          {
+            "native_mutation_ms": 35,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": 336,
+            "put_acknowledgment_ms": 0.3,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 33.2,
+                "duration_ms": 51
+              },
+              {
+                "offset_ms": 250.4,
+                "duration_ms": 85
+              }
+            ],
+            "browser_command_wall_ms": 69.062
+          },
+          {
+            "native_mutation_ms": 34,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 309.6,
+            "put_acknowledgment_ms": 9.9,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.3,
+                "duration_ms": 59
+              }
+            ],
+            "browser_command_wall_ms": 68.777
+          },
+          {
+            "native_mutation_ms": 35.5,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": 323,
+            "put_acknowledgment_ms": 29.2,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.4,
+                "duration_ms": 72
+              }
+            ],
+            "browser_command_wall_ms": 78.836
+          },
+          {
+            "native_mutation_ms": 36.3,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 315.9,
+            "put_acknowledgment_ms": 0.3,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 32.6,
+                "duration_ms": 50
+              },
+              {
+                "offset_ms": 250.3,
+                "duration_ms": 65
+              },
+              {
+                "offset_ms": 323.4,
+                "duration_ms": 50
+              }
+            ],
+            "browser_command_wall_ms": 70.041
+          },
+          {
+            "native_mutation_ms": 31.9,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 317.2,
+            "put_acknowledgment_ms": 38.9,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.5,
+                "duration_ms": 66
+              }
+            ],
+            "browser_command_wall_ms": 65.792
+          },
+          {
+            "native_mutation_ms": 34.5,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 334.2,
+            "put_acknowledgment_ms": 0.3,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.3,
+                "duration_ms": 84
+              }
+            ],
+            "browser_command_wall_ms": 70.329
+          },
+          {
+            "native_mutation_ms": 33.4,
+            "input_handler_ms": 0,
+            "put_request_offset_ms": 319.2,
+            "put_acknowledgment_ms": 12.9,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.4,
+                "duration_ms": 68
+              }
+            ],
+            "browser_command_wall_ms": 67.446
+          },
+          {
+            "native_mutation_ms": 32.1,
+            "input_handler_ms": 0.1,
+            "put_request_offset_ms": 316.6,
+            "put_acknowledgment_ms": 0.3,
+            "put_outcome": "stored",
+            "long_tasks": [
+              {
+                "offset_ms": 250.4,
+                "duration_ms": 66
+              }
+            ],
+            "browser_command_wall_ms": 66.67
+          }
+        ]
+      }
+    ],
+    "traces": []
+  }
+}

--- a/docs/evidence/2026-08-24-loomark-persistence-intent-coalescing.json
+++ b/docs/evidence/2026-08-24-loomark-persistence-intent-coalescing.json
@@ -1,0 +1,129 @@
+{
+  "schema": "loomark-persistence-intent-coalescing-evidence-v1",
+  "issue": 1360,
+  "base_commit": "298f3ccf527de1447adde3bcab82140dd4eaddb2",
+  "candidate_code_commit": "0458a5827598bcdec4a14c956b8d93dd43e9ec73",
+  "environment": {
+    "browser": "149.0.7827.55",
+    "node": "v24.14.1",
+    "platform": "linux",
+    "os_release": "6.18.33.2-microsoft-standard-WSL2",
+    "architecture": "x64",
+    "cpu": "AMD Ryzen 7 6800H with Radeon Graphics",
+    "headless": true,
+    "viewport": { "width": 1280, "height": 720 },
+    "warmups_per_scenario": 5,
+    "samples_per_scenario": 30,
+    "settle_ms": 400,
+    "persistence_required": true
+  },
+  "fixture_1mib": {
+    "utf16_length": 1048576,
+    "utf8_bytes": 1048576,
+    "sha256": "bd2b39512f137e45eb14063920e77769422728321640fc9214787e00a5dd74ae"
+  },
+  "baseline": {
+    "raw_sha256": "96043a54950e718fc1ddee3b3e0e321571c5412ff615629dc9a003a54d0c72b6",
+    "w2_samples_with_long_tasks": 30,
+    "w2_maximum_long_task_p50_ms": 68,
+    "w2_maximum_long_task_p95_ms": 91,
+    "w2_maximum_long_task_max_ms": 91,
+    "put_request_offset_p95_ms": 341.3,
+    "put_acknowledgment_p95_ms": 32.5,
+    "native_mutation_p95_ms": 37.5,
+    "input_handler_p95_ms": 0.1
+  },
+  "candidate_1mib_launches": [
+    {
+      "raw_sha256": "4c979704ece33dbd074c80d4697faa14ce0b932d2358cdd821514fd237f6fd36",
+      "w2_samples_with_long_tasks": 30,
+      "w2_maximum_long_task_p50_ms": 66,
+      "w2_maximum_long_task_p95_ms": 113,
+      "w2_maximum_long_task_max_ms": 191,
+      "put_request_offset_p95_ms": 364.0,
+      "put_acknowledgment_p95_ms": 37.9,
+      "native_mutation_p95_ms": 41.5,
+      "input_handler_p95_ms": 0.1
+    },
+    {
+      "raw_sha256": "dcf05766ec599c32e553703e073672b22d0a48f8cc70564ae459201615df7e1d",
+      "w2_samples_with_long_tasks": 30,
+      "w2_maximum_long_task_p50_ms": 66,
+      "w2_maximum_long_task_p95_ms": 91,
+      "w2_maximum_long_task_max_ms": 92,
+      "put_request_offset_p95_ms": 341.9,
+      "put_acknowledgment_p95_ms": 34.0,
+      "native_mutation_p95_ms": 65.0,
+      "input_handler_p95_ms": 0.1
+    },
+    {
+      "raw_sha256": "87aa6817d6711fbf73a4e44f174d42488f15318539432e045e0484dee20a1318",
+      "w2_samples_with_long_tasks": 30,
+      "w2_maximum_long_task_p50_ms": 68,
+      "w2_maximum_long_task_p95_ms": 90,
+      "w2_maximum_long_task_max_ms": 106,
+      "put_request_offset_p95_ms": 340.9,
+      "put_acknowledgment_p95_ms": 32.0,
+      "native_mutation_p95_ms": 37.3,
+      "input_handler_p95_ms": 0.1
+    }
+  ],
+  "candidate_1mib_launch_medians": {
+    "w2_samples_with_long_tasks": 30,
+    "w2_maximum_long_task_p50_ms": 66,
+    "w2_maximum_long_task_p95_ms": 91,
+    "w2_maximum_long_task_max_ms": 106,
+    "put_request_offset_p95_ms": 341.9,
+    "put_acknowledgment_p95_ms": 34.0,
+    "native_mutation_p95_ms": 41.5,
+    "input_handler_p95_ms": 0.1
+  },
+  "candidate_matrix": {
+    "raw_sha256": "294e1041a6ebffed3fc3f2b9835ddcc7a488c067d742f509b7758a3daf8a29ec",
+    "scenarios": [
+      {
+        "size_utf16": 65536,
+        "w2_samples_with_long_tasks": 0,
+        "w2_maximum_long_task_p95_ms": 0,
+        "native_mutation_p95_ms": 3.5,
+        "input_handler_p95_ms": 0.1,
+        "put_request_offset_p95_ms": 254.1,
+        "put_acknowledgment_p95_ms": 2.1
+      },
+      {
+        "size_utf16": 262144,
+        "w2_samples_with_long_tasks": 0,
+        "w2_maximum_long_task_p95_ms": 0,
+        "native_mutation_p95_ms": 9.1,
+        "input_handler_p95_ms": 0.1,
+        "put_request_offset_p95_ms": 257.8,
+        "put_acknowledgment_p95_ms": 4.5
+      },
+      {
+        "size_utf16": 1048576,
+        "w2_samples_with_long_tasks": 30,
+        "w2_maximum_long_task_p50_ms": 70,
+        "w2_maximum_long_task_p95_ms": 89,
+        "w2_maximum_long_task_max_ms": 169,
+        "native_mutation_p95_ms": 37.4,
+        "input_handler_p95_ms": 0.1,
+        "put_request_offset_p95_ms": 339.5,
+        "put_acknowledgment_p95_ms": 38.9
+      }
+    ]
+  },
+  "selected_materialization": {
+    "observed_local_text_puts_per_sample": 1,
+    "candidate_1mib_materializations_across_30_measured_samples": 30,
+    "candidate_1mib_encoded_utf16_total": 31460955,
+    "candidate_1mib_encoded_utf16_min_per_sample": 1048684,
+    "candidate_1mib_encoded_utf16_max_per_sample": 1048713,
+    "derivation": "storage.replace calls selected pending.encoded exactly once; the runner observed one acknowledged LocalText put per sample; encoded lengths use the fixed v1 JSON shape and measured ASCII source lengths"
+  },
+  "decision": {
+    "historical_material_win_gate_ms": 70.5,
+    "candidate_reached_gate": false,
+    "result": "STOP",
+    "reason": "Pre-encoding latest-intent coalescing is implemented and preserves correctness, but this runner exercises one idle selected checkpoint per sample. The selected 1 MiB checkpoint still materializes and encodes the complete Source and remains a long task. No Worker, chunking, format migration, or second queue is authorized by this evidence."
+  }
+}

--- a/docs/evidence/2026-08-24-loomark-persistence-intent-coalescing.json
+++ b/docs/evidence/2026-08-24-loomark-persistence-intent-coalescing.json
@@ -1,9 +1,12 @@
 {
   "schema": "loomark-persistence-intent-coalescing-evidence-v1",
   "issue": 1360,
-  "raw_evidence": "2026-08-24-loomark-persistence-intent-coalescing-raw.json",
-  "base_commit": "298f3ccf527de1447adde3bcab82140dd4eaddb2",
-  "candidate_code_commit": "0458a5827598bcdec4a14c956b8d93dd43e9ec73",
+  "initial_raw_evidence": "2026-08-24-loomark-persistence-intent-coalescing-raw.json",
+  "initial_base_commit": "298f3ccf527de1447adde3bcab82140dd4eaddb2",
+  "initial_candidate_code_commit": "0458a5827598bcdec4a14c956b8d93dd43e9ec73",
+  "paired_immediate_input_raw_evidence": "2026-08-24-loomark-persistence-intent-immediate-input-paired-raw.json",
+  "paired_base_commit": "1f24c66042115763040a029d05fc753eb30902a4",
+  "paired_candidate_code_commit": "8b792bf495000549aa0f9664871a2c8a3da7dec9",
   "environment": {
     "browser": "149.0.7827.55",
     "node": "v24.14.1",
@@ -120,6 +123,77 @@
     "candidate_1mib_encoded_utf16_min_per_sample": 1048684,
     "candidate_1mib_encoded_utf16_max_per_sample": 1048713,
     "derivation": "storage.replace calls selected pending.encoded exactly once; the runner observed one acknowledged LocalText put per sample; encoded lengths use the fixed v1 JSON shape and measured ASCII source lengths"
+  },
+  "local_text_preparation_contract": {
+    "recoverable": false,
+    "result_shape": "PreparedLocalArchive",
+    "reason": "prepare_local_text constructs and stringifies a MoonBit Json value from valid String and LoomarkDocumentId inputs; it has no recoverable preparation-failure channel",
+    "fallible_boundary": "correlated IndexedDB replacement"
+  },
+  "immediate_input_gate": {
+    "threshold_ratio": 1.1,
+    "metric": "loomark_production.native_mutation_ms.p95_ms",
+    "aggregation": "median of five adjacent candidate/base p95 ratios",
+    "launch_order": [
+      "base",
+      "candidate",
+      "candidate",
+      "base",
+      "base",
+      "candidate",
+      "candidate",
+      "base",
+      "base",
+      "candidate"
+    ],
+    "fixed_before_samples_were_observed": true,
+    "pairs": [
+      {
+        "pair": 1,
+        "base_p95_ms": 38.2,
+        "candidate_p95_ms": 36.2,
+        "ratio": 0.9476439790575917,
+        "base_raw_sha256": "a98692fb1fd29e775825cf9e4f3a5849a3af2ebda5d384589030fc07a140947a",
+        "candidate_raw_sha256": "7083d9329c11be0f7ab0a60f14612128bce64612975202dad41cf8eb09ab20b7"
+      },
+      {
+        "pair": 2,
+        "base_p95_ms": 34.6,
+        "candidate_p95_ms": 34.5,
+        "ratio": 0.9971098265895953,
+        "base_raw_sha256": "34d926870ea925fd5f8bccbd904b84d08fe7f5de7a5a02e2e120a40c4ff2447c",
+        "candidate_raw_sha256": "614899c3a0f6e3bfbac65f5f676de2dab67314bfe3f56b26671a67c70f1b92de"
+      },
+      {
+        "pair": 3,
+        "base_p95_ms": 38.2,
+        "candidate_p95_ms": 35.8,
+        "ratio": 0.9371727748691098,
+        "base_raw_sha256": "6eacb71e405e4a65349180addb5f4ef168f426152d2afa7667dec998fef7aad4",
+        "candidate_raw_sha256": "6ba4fb34589d9cbf04bbcad0c023d352bd2de0975929fb3ba6c8a4b41d270396"
+      },
+      {
+        "pair": 4,
+        "base_p95_ms": 42.7,
+        "candidate_p95_ms": 35.8,
+        "ratio": 0.838407494145199,
+        "base_raw_sha256": "9d36d3d63b7e933f38983d08a431708fb469d4a4d1eb1ee12945b1d0abd42c2b",
+        "candidate_raw_sha256": "3252a41d11c85166bd782db36c1315443db3cef6a6b2a1bc2e7e9cf0e89c76b4"
+      },
+      {
+        "pair": 5,
+        "base_p95_ms": 42.7,
+        "candidate_p95_ms": 40.3,
+        "ratio": 0.9437939110070256,
+        "base_raw_sha256": "3a3fc9458112800f4f3cdce97571ab71a24f64379a899a3bb2aa94aa4764dae5",
+        "candidate_raw_sha256": "89a2793517071858e477f2db8b4666cbf0a7991f00ebc4a1ef49de9c92264f3a"
+      }
+    ],
+    "observed_ratio": 0.9437939110070256,
+    "maximum_pair_ratio": 0.9971098265895953,
+    "input_handler_base_p95_median_ms": 0.1,
+    "input_handler_candidate_p95_median_ms": 0.1,
+    "passed": true
   },
   "decision": {
     "historical_material_win_gate_ms": 70.5,

--- a/docs/evidence/2026-08-24-loomark-persistence-intent-coalescing.json
+++ b/docs/evidence/2026-08-24-loomark-persistence-intent-coalescing.json
@@ -1,6 +1,7 @@
 {
   "schema": "loomark-persistence-intent-coalescing-evidence-v1",
   "issue": 1360,
+  "raw_evidence": "2026-08-24-loomark-persistence-intent-coalescing-raw.json",
   "base_commit": "298f3ccf527de1447adde3bcab82140dd4eaddb2",
   "candidate_code_commit": "0458a5827598bcdec4a14c956b8d93dd43e9ec73",
   "environment": {

--- a/docs/evidence/2026-08-24-loomark-persistence-intent-coalescing.md
+++ b/docs/evidence/2026-08-24-loomark-persistence-intent-coalescing.md
@@ -1,0 +1,165 @@
+# Loomark persistence-intent coalescing
+
+- **Issue:** [#1360](https://github.com/dowdiness/canopy/issues/1360)
+- **Base:** `298f3ccf527de1447adde3bcab82140dd4eaddb2`
+- **Measured code:** `0458a5827598bcdec4a14c956b8d93dd43e9ec73`
+- **Decision:** `STOP` after implementing the selected boundary
+
+## Result
+
+Loomark now queues standalone LocalText as an immutable unencoded source intent.
+The existing persistence queue keeps one selected write and one replaceable
+latest value. It materializes and encodes LocalText only after that value has
+been selected as the first write or promoted after the preceding
+acknowledgment. A superseded pending source never reaches `prepare_local_text`.
+
+This establishes the required boundary for later bounded checkpoint scheduling,
+but it does not make one selected 1 MiB checkpoint cheap. Three 30-sample
+candidate launches had a median W2 per-sample maximum long-task p95 of 91 ms,
+equal to the current-main baseline and above the historical 70.5 ms material-win
+gate. The complete 64 KiB/256 KiB/1 MiB candidate matrix reproduced the same
+cliff: no W2 long tasks at 64 KiB or 256 KiB, and 30/30 samples with a W2 long
+task at 1 MiB.
+
+Per #1360's stop condition, this result does not authorize a Worker, chunked
+encoding, a new record format, or a second persistence queue.
+
+## Boundary change
+
+Before:
+
+```text
+accepted LocalText source
+  -> prepare_local_text and stringify
+  -> enqueue prepared replacement
+  -> discard an older prepared pending replacement
+```
+
+After:
+
+```text
+accepted LocalText source
+  -> enqueue immutable unencoded payload
+  -> replace older pending payload
+  -> select first or promoted write
+  -> storage shell requests exact LocalText v1 encoding
+  -> IndexedDB replacement
+  -> correlated acknowledgment
+```
+
+The FullHistory path still queues an already prepared replacement. Both payload
+kinds reuse `LocalArchivePersistenceQueue`, `LocalArchivePendingWrite`, request
+identity, document identity, queue epoch, opaque document version, completion,
+failure, and retry transitions.
+
+## Correctness evidence
+
+Repository tests cover:
+
+- the first LocalText intent becoming the selected write;
+- two different pending sources coalescing to the latest without exposing an
+  intermediate write;
+- byte-identical LocalText v1 encoding after promotion;
+- LocalText failure and retry;
+- A→B→A request-identity fencing;
+- a LocalText payload superseding a prepared pending payload;
+- existing prepared FullHistory promotion, stale completion, document switch,
+  queue epoch, failure, and retry behavior.
+
+Validation completed before measurement:
+
+- repository JS tests: 19/19;
+- internal Rabbita JS tests: 162/162;
+- Loomark module JS tests: 7,508/7,508;
+- standalone browser tests: 15/15;
+- independent MoonBit review: PASS with no remaining blocker or warning;
+- generated repository interface: two intentional additive methods and no
+  trait-bound drift.
+
+The persistence effect remains a one-shot Rabbita `Cmd`; no `Sub` or second
+scheduler was added. `record_kind()` does not materialize LocalText, and the
+storage adapter calls `encoded()` exactly once for the selected write.
+
+## Performance method
+
+The release standalone build ran in headless Chromium 149.0.7827.55 on Linux
+WSL2 with an AMD Ryzen 7 6800H, Node v24.14.1, and a 1280×720 viewport. Each
+scenario used a fresh browser process, five warmups, thirty real-keyboard
+samples, persistence required, and a 400 ms observation window. The 1 MiB ASCII
+fixture had SHA-256
+`bd2b39512f137e45eb14063920e77769422728321640fc9214787e00a5dd74ae`.
+
+W2 is the 200–400 ms interval after input, containing the nominal 250 ms quiet
+flush. The per-sample W2 value is the maximum long-task duration in that
+interval.
+
+### Current-main baseline
+
+| Metric | Base `298f3ccf` |
+|---|---:|
+| W2 samples with long tasks | 30/30 |
+| W2 maximum long task p50 | 68 ms |
+| W2 maximum long task p95 | 91 ms |
+| W2 maximum long task maximum | 91 ms |
+| IndexedDB request offset p95 | 341.3 ms |
+| IndexedDB acknowledgment p95 | 32.5 ms |
+| Native mutation p95 | 37.5 ms |
+| Input-handler p95 | 0.1 ms |
+
+### Candidate launches at 1 MiB
+
+| Launch | W2 incidence | W2 p50 | W2 p95 | W2 max | Put offset p95 | Ack p95 | Native p95 |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| 1 | 30/30 | 66 ms | 113 ms | 191 ms | 364.0 ms | 37.9 ms | 41.5 ms |
+| 2 | 30/30 | 66 ms | 91 ms | 92 ms | 341.9 ms | 34.0 ms | 65.0 ms |
+| 3 | 30/30 | 68 ms | 90 ms | 106 ms | 340.9 ms | 32.0 ms | 37.3 ms |
+| **Launch median** | **30/30** | **66 ms** | **91 ms** | **106 ms** | **341.9 ms** | **34.0 ms** | **41.5 ms** |
+
+The first and second launches show host noise in different metrics. The stable
+conclusion is not a regression magnitude: every launch missed the 70.5 ms gate,
+and the median W2 p95 was unchanged from the current-main baseline.
+
+### Candidate size matrix
+
+| Source | W2 incidence | W2 p95 | Native p95 | Input-handler p95 | Put offset p95 | Ack p95 |
+|---:|---:|---:|---:|---:|---:|---:|
+| 64 KiB | 0/30 | 0 ms | 3.5 ms | 0.1 ms | 254.1 ms | 2.1 ms |
+| 256 KiB | 0/30 | 0 ms | 9.1 ms | 0.1 ms | 257.8 ms | 4.5 ms |
+| 1 MiB | 30/30 | 89 ms | 37.4 ms | 0.1 ms | 339.5 ms | 38.9 ms |
+
+## Materialization and durability accounting
+
+The runner observed one acknowledged LocalText `put` per measured sample. Code
+inspection and independent review confirm that `storage.replace` calls the
+selected write's `encoded()` method exactly once. The thirty measured 1 MiB
+samples therefore performed thirty selected materializations and encoded
+31,460,955 UTF-16 units in total, ranging from 1,048,684 to 1,048,713 units per
+sample as the fixture grew.
+
+No superseded intent was materialized in the deterministic queue matrix. The
+browser runner deliberately exercises one idle selected checkpoint per sample,
+so it measures the remaining selected-checkpoint cost rather than a coalescing
+burst.
+
+IndexedDB request and acknowledgment timings are reported separately above. In
+this pre-#1351 LocalText model, ordinary source edits do not yet receive the
+independent revision-bound `TextSnapshot` required by #1347, so the runner
+cannot honestly report a distinct advancing durable revision. A successful
+correlated acknowledgment still remains the only event that advances the
+existing durable status; revision-bound checkpoint progress remains owned by
+#1351 and #1347.
+
+## Decision
+
+Keep the unencoded latest-intent boundary. It removes provably wasted
+materialization when pending work is superseded and is required before adding
+#1347's max-wait checkpoints. Do not claim that it fixes the single selected
+1 MiB checkpoint. That checkpoint remains complete-source JSON work and still
+creates a long task.
+
+Further work requires a separate evidence-backed decision after #1351 provides
+revision-bound snapshots. This issue does not authorize guessing between
+Worker placement, chunking, or a different Source representation.
+
+The compact machine-readable result and raw-run digests are in
+[`2026-08-24-loomark-persistence-intent-coalescing.json`](2026-08-24-loomark-persistence-intent-coalescing.json).

--- a/docs/evidence/2026-08-24-loomark-persistence-intent-coalescing.md
+++ b/docs/evidence/2026-08-24-loomark-persistence-intent-coalescing.md
@@ -91,7 +91,9 @@ fixture had SHA-256
 
 W2 is the 200–400 ms interval after input, containing the nominal 250 ms quiet
 flush. The per-sample W2 value is the maximum long-task duration in that
-interval.
+interval. The raw samples retain every 0–400 ms long-task offset and duration;
+the W2 summaries apply the 200 ms lower bound. The checked-in runner now emits
+this bounded W2 summary directly.
 
 ### Current-main baseline
 
@@ -163,3 +165,6 @@ Worker placement, chunking, or a different Source representation.
 
 The compact machine-readable result and raw-run digests are in
 [`2026-08-24-loomark-persistence-intent-coalescing.json`](2026-08-24-loomark-persistence-intent-coalescing.json).
+The complete baseline, three candidate launches, and candidate size-matrix
+samples are in
+[`2026-08-24-loomark-persistence-intent-coalescing-raw.json`](2026-08-24-loomark-persistence-intent-coalescing-raw.json).

--- a/docs/evidence/2026-08-24-loomark-persistence-intent-coalescing.md
+++ b/docs/evidence/2026-08-24-loomark-persistence-intent-coalescing.md
@@ -1,8 +1,10 @@
 # Loomark persistence-intent coalescing
 
 - **Issue:** [#1360](https://github.com/dowdiness/canopy/issues/1360)
-- **Base:** `298f3ccf527de1447adde3bcab82140dd4eaddb2`
-- **Measured code:** `0458a5827598bcdec4a14c956b8d93dd43e9ec73`
+- **Initial base:** `298f3ccf527de1447adde3bcab82140dd4eaddb2`
+- **Initial measured code:** `0458a5827598bcdec4a14c956b8d93dd43e9ec73`
+- **Paired-guard base:** `1f24c66042115763040a029d05fc753eb30902a4`
+- **Paired-guard measured code:** `8b792bf495000549aa0f9664871a2c8a3da7dec9`
 - **Decision:** `STOP` after implementing the selected boundary
 
 ## Result
@@ -52,6 +54,12 @@ kinds reuse `LocalArchivePersistenceQueue`, `LocalArchivePendingWrite`, request
 identity, document identity, queue epoch, opaque document version, completion,
 failure, and retry transitions.
 
+`prepare_local_text` is total for valid `String` and `LoomarkDocumentId` inputs.
+It constructs and stringifies a MoonBit `Json` value and has no recoverable
+preparation-failure channel. `PreparationFailed` remains the fallible
+FullHistory-capture category; LocalText's fallible shell boundary begins at the
+correlated IndexedDB replacement.
+
 ## Correctness evidence
 
 Repository tests cover:
@@ -66,12 +74,19 @@ Repository tests cover:
 - existing prepared FullHistory promotion, stale completion, document switch,
   queue epoch, failure, and retry behavior.
 
+The standalone browser test now holds A's real IndexedDB transaction-completion
+callback, accepts and flushes B and then C while A remains in flight, releases
+A, and observes exactly two LocalText puts: A and C. Both encoded values are
+measured at the exact expected UTF-16 length; reload restores C. This traverses
+`queue.complete → Promoted → update_archive_queue → local_archive_write_command
+→ archive_storage.replace → pending.encoded → IndexedDB`.
+
 Validation completed before measurement:
 
 - repository JS tests: 19/19;
 - internal Rabbita JS tests: 162/162;
 - Loomark module JS tests: 7,508/7,508;
-- standalone browser tests: 15/15;
+- standalone browser tests: 16/16;
 - independent MoonBit review: PASS with no remaining blocker or warning;
 - generated repository interface: two intentional additive methods and no
   trait-bound drift.
@@ -129,6 +144,30 @@ and the median W2 p95 was unchanged from the current-main baseline.
 | 256 KiB | 0/30 | 0 ms | 9.1 ms | 0.1 ms | 257.8 ms | 4.5 ms |
 | 1 MiB | 30/30 | 89 ms | 37.4 ms | 0.1 ms | 339.5 ms | 38.9 ms |
 
+### Counterbalanced immediate-input guard
+
+The initial launch medians left the `1.10×` native-mutation guard unresolved:
+41.5/37.5 was `1.1067×`, while the size matrix reported 37.4 ms. Before the
+follow-up samples were observed, the comparison was fixed as five adjacent
+base/candidate pairs with alternating order (`B-C`, `C-B`, `B-C`, `C-B`,
+`B-C`). Each launch used five warmups and thirty 1 MiB samples. The decision
+statistic is the median of the five candidate/base native-mutation p95 ratios;
+the gate passes when that statistic is at most `1.10`.
+
+| Pair | Order | Base native p95 | Candidate native p95 | Ratio |
+|---:|---|---:|---:|---:|
+| 1 | B-C | 38.2 ms | 36.2 ms | 0.9476× |
+| 2 | C-B | 34.6 ms | 34.5 ms | 0.9971× |
+| 3 | B-C | 38.2 ms | 35.8 ms | 0.9372× |
+| 4 | C-B | 42.7 ms | 35.8 ms | 0.8384× |
+| 5 | B-C | 42.7 ms | 40.3 ms | 0.9438× |
+| **Median** | — | **38.2 ms** | **35.8 ms** | **0.9438×** |
+
+The maximum paired ratio was `0.9971×`. Input-handler p95 was 0.1 ms for every
+base and candidate launch. The immediate-input guard therefore **passes**.
+The same launches retained the selected-checkpoint STOP result: candidate W2
+long-task p95 had an 87 ms launch median and remained above 70.5 ms.
+
 ## Materialization and durability accounting
 
 The runner observed one acknowledged LocalText `put` per measured sample. Code
@@ -161,10 +200,14 @@ creates a long task.
 
 Further work requires a separate evidence-backed decision after #1351 provides
 revision-bound snapshots. This issue does not authorize guessing between
-Worker placement, chunking, or a different Source representation.
+Worker placement, chunking, or a different Source representation. The
+counterbalanced immediate-input guard passes; that result does not change the
+selected-checkpoint STOP.
 
 The compact machine-readable result and raw-run digests are in
 [`2026-08-24-loomark-persistence-intent-coalescing.json`](2026-08-24-loomark-persistence-intent-coalescing.json).
 The complete baseline, three candidate launches, and candidate size-matrix
 samples are in
 [`2026-08-24-loomark-persistence-intent-coalescing-raw.json`](2026-08-24-loomark-persistence-intent-coalescing-raw.json).
+The ten counterbalanced immediate-input launches are in
+[`2026-08-24-loomark-persistence-intent-immediate-input-paired-raw.json`](2026-08-24-loomark-persistence-intent-immediate-input-paired-raw.json).

--- a/docs/evidence/2026-08-24-loomark-persistence-intent-immediate-input-paired-raw.json
+++ b/docs/evidence/2026-08-24-loomark-persistence-intent-immediate-input-paired-raw.json
@@ -1,0 +1,8572 @@
+{
+  "schema": "loomark-persistence-intent-immediate-input-paired-raw-v1",
+  "protocol": {
+    "fixture_utf16": 1048576,
+    "pairs": 5,
+    "launch_order": [
+      "base",
+      "candidate",
+      "candidate",
+      "base",
+      "base",
+      "candidate",
+      "candidate",
+      "base",
+      "base",
+      "candidate"
+    ],
+    "warmups_per_launch": 5,
+    "samples_per_launch": 30,
+    "threshold_ratio": 1.1,
+    "metric": "loomark_production.native_mutation_ms.p95_ms",
+    "aggregation": "median of the five adjacent candidate/base p95 ratios",
+    "decision_rule": "pass when aggregation <= threshold_ratio",
+    "fixed_before_samples_were_observed": true
+  },
+  "pairs": [
+    {
+      "pair": 1,
+      "order": "base-candidate",
+      "base": {
+        "schema": "loomark-whole-document-input-v1",
+        "environment": {
+          "commit": "1f24c66042115763040a029d05fc753eb30902a4",
+          "browser": "149.0.7827.55",
+          "node": "v24.14.1",
+          "platform": "linux",
+          "os_release": "6.18.33.2-microsoft-standard-WSL2",
+          "architecture": "x64",
+          "cpu": "AMD Ryzen 7 6800H with Radeon Graphics",
+          "headless": true,
+          "viewport": {
+            "width": 1280,
+            "height": 720
+          },
+          "warmups": 5,
+          "samples": 30,
+          "trace_samples": 0,
+          "settle_ms": 400,
+          "persistence_required": true
+        },
+        "invocation": {
+          "sizes": [
+            1048576
+          ],
+          "environment": {
+            "LOOMARK_WHOLE_DOCUMENT_SIZES": "1048576",
+            "LOOMARK_WHOLE_DOCUMENT_WARMUPS": "5",
+            "LOOMARK_WHOLE_DOCUMENT_SAMPLES": "30",
+            "LOOMARK_WHOLE_DOCUMENT_TRACE_SAMPLES": "0",
+            "LOOMARK_WHOLE_DOCUMENT_REQUIRE_PERSISTENCE": null
+          }
+        },
+        "fixtures": [
+          {
+            "requested_utf16": 1048576,
+            "utf16_length": 1048576,
+            "utf8_bytes": 1048576,
+            "sha256": "bd2b39512f137e45eb14063920e77769422728321640fc9214787e00a5dd74ae"
+          }
+        ],
+        "scenarios": [
+          {
+            "size_utf16": 1048576,
+            "surface": "native_textarea",
+            "matched_width_px": 736,
+            "summary": {
+              "native_mutation_ms": {
+                "samples": 30,
+                "p50_ms": 34.5,
+                "p95_ms": 73.9,
+                "maximum_ms": 92.8
+              },
+              "input_handler_ms": {
+                "samples": 30,
+                "p50_ms": 0,
+                "p95_ms": 0.1,
+                "maximum_ms": 0.1
+              },
+              "put_request_offset_ms": {
+                "samples": 0,
+                "p50_ms": null,
+                "p95_ms": null,
+                "maximum_ms": null
+              },
+              "put_acknowledgment_ms": {
+                "samples": 0,
+                "p50_ms": null,
+                "p95_ms": null,
+                "maximum_ms": null
+              },
+              "browser_command_wall_ms": {
+                "samples": 30,
+                "p50_ms": 66.088,
+                "p95_ms": 97.8,
+                "maximum_ms": 118.203
+              },
+              "long_tasks": {
+                "samples_with_long_tasks": 0,
+                "count": 0,
+                "maximum_ms": 0
+              }
+            },
+            "samples": [
+              {
+                "native_mutation_ms": 32.6,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 61.63
+              },
+              {
+                "native_mutation_ms": 32.9,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 61.998
+              },
+              {
+                "native_mutation_ms": 32,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 64.754
+              },
+              {
+                "native_mutation_ms": 39.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 71.008
+              },
+              {
+                "native_mutation_ms": 92.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 97.8
+              },
+              {
+                "native_mutation_ms": 46,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 88.307
+              },
+              {
+                "native_mutation_ms": 41.4,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 76.938
+              },
+              {
+                "native_mutation_ms": 73.9,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 118.203
+              },
+              {
+                "native_mutation_ms": 39.7,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 72.575
+              },
+              {
+                "native_mutation_ms": 41.6,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 75.558
+              },
+              {
+                "native_mutation_ms": 34.3,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 67.351
+              },
+              {
+                "native_mutation_ms": 34,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 63.774
+              },
+              {
+                "native_mutation_ms": 36.2,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 66.088
+              },
+              {
+                "native_mutation_ms": 34.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 66.84
+              },
+              {
+                "native_mutation_ms": 32.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 62.138
+              },
+              {
+                "native_mutation_ms": 36.3,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 64.616
+              },
+              {
+                "native_mutation_ms": 34,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 65.834
+              },
+              {
+                "native_mutation_ms": 34.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 62.945
+              },
+              {
+                "native_mutation_ms": 32.9,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 63.393
+              },
+              {
+                "native_mutation_ms": 34.9,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 67.609
+              },
+              {
+                "native_mutation_ms": 33.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 62.329
+              },
+              {
+                "native_mutation_ms": 33.7,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 62.743
+              },
+              {
+                "native_mutation_ms": 36.2,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 69.108
+              },
+              {
+                "native_mutation_ms": 34.5,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 62.989
+              },
+              {
+                "native_mutation_ms": 37.2,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 68.147
+              },
+              {
+                "native_mutation_ms": 32.2,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 64.724
+              },
+              {
+                "native_mutation_ms": 40.7,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 71.339
+              },
+              {
+                "native_mutation_ms": 33.9,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 62.177
+              },
+              {
+                "native_mutation_ms": 35.3,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 68.11
+              },
+              {
+                "native_mutation_ms": 35.9,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 66.382
+              }
+            ]
+          },
+          {
+            "size_utf16": 1048576,
+            "surface": "loomark_production",
+            "matched_width_px": 736,
+            "summary": {
+              "native_mutation_ms": {
+                "samples": 30,
+                "p50_ms": 31.9,
+                "p95_ms": 38.2,
+                "maximum_ms": 48.7
+              },
+              "input_handler_ms": {
+                "samples": 30,
+                "p50_ms": 0,
+                "p95_ms": 0.1,
+                "maximum_ms": 0.1
+              },
+              "put_request_offset_ms": {
+                "samples": 30,
+                "p50_ms": 315.5,
+                "p95_ms": 336.6,
+                "maximum_ms": 337.3
+              },
+              "put_acknowledgment_ms": {
+                "samples": 30,
+                "p50_ms": 8.6,
+                "p95_ms": 35.9,
+                "maximum_ms": 37.2
+              },
+              "browser_command_wall_ms": {
+                "samples": 30,
+                "p50_ms": 66.513,
+                "p95_ms": 74.213,
+                "maximum_ms": 81.869
+              },
+              "long_tasks": {
+                "samples_with_long_tasks": 30,
+                "count": 34,
+                "maximum_ms": 87
+              }
+            },
+            "samples": [
+              {
+                "native_mutation_ms": 31.9,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 336.6,
+                "put_acknowledgment_ms": 0.3,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 86
+                  }
+                ],
+                "browser_command_wall_ms": 66.118
+              },
+              {
+                "native_mutation_ms": 30.4,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 324.4,
+                "put_acknowledgment_ms": 28,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.5,
+                    "duration_ms": 74
+                  }
+                ],
+                "browser_command_wall_ms": 62.695
+              },
+              {
+                "native_mutation_ms": 31.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 315.1,
+                "put_acknowledgment_ms": 26.7,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.5,
+                    "duration_ms": 64
+                  }
+                ],
+                "browser_command_wall_ms": 71.556
+              },
+              {
+                "native_mutation_ms": 33.4,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 326.1,
+                "put_acknowledgment_ms": 0.3,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 75
+                  }
+                ],
+                "browser_command_wall_ms": 67.778
+              },
+              {
+                "native_mutation_ms": 31.2,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 304.2,
+                "put_acknowledgment_ms": 16.5,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.2,
+                    "duration_ms": 54
+                  }
+                ],
+                "browser_command_wall_ms": 64.077
+              },
+              {
+                "native_mutation_ms": 32.6,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 307.9,
+                "put_acknowledgment_ms": 29,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 57
+                  }
+                ],
+                "browser_command_wall_ms": 65.716
+              },
+              {
+                "native_mutation_ms": 31.6,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": 308.7,
+                "put_acknowledgment_ms": 6.4,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 58
+                  },
+                  {
+                    "offset_ms": 315.5,
+                    "duration_ms": 58
+                  }
+                ],
+                "browser_command_wall_ms": 65.676
+              },
+              {
+                "native_mutation_ms": 31.4,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 316.7,
+                "put_acknowledgment_ms": 31.4,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 66
+                  }
+                ],
+                "browser_command_wall_ms": 64.709
+              },
+              {
+                "native_mutation_ms": 33.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 326.1,
+                "put_acknowledgment_ms": 8.1,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 75
+                  }
+                ],
+                "browser_command_wall_ms": 66.976
+              },
+              {
+                "native_mutation_ms": 30.4,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 314.7,
+                "put_acknowledgment_ms": 10.8,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 64
+                  }
+                ],
+                "browser_command_wall_ms": 71.277
+              },
+              {
+                "native_mutation_ms": 30.7,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 312.5,
+                "put_acknowledgment_ms": 5.7,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 62
+                  }
+                ],
+                "browser_command_wall_ms": 63.769
+              },
+              {
+                "native_mutation_ms": 30.9,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": 308.4,
+                "put_acknowledgment_ms": 35.9,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 58
+                  }
+                ],
+                "browser_command_wall_ms": 64.018
+              },
+              {
+                "native_mutation_ms": 31.7,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 337.3,
+                "put_acknowledgment_ms": 0.4,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 87
+                  }
+                ],
+                "browser_command_wall_ms": 65.905
+              },
+              {
+                "native_mutation_ms": 30.6,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 307.3,
+                "put_acknowledgment_ms": 8.6,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.2,
+                    "duration_ms": 57
+                  }
+                ],
+                "browser_command_wall_ms": 63.69
+              },
+              {
+                "native_mutation_ms": 33.5,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 314.7,
+                "put_acknowledgment_ms": 6.7,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.2,
+                    "duration_ms": 64
+                  }
+                ],
+                "browser_command_wall_ms": 74.213
+              },
+              {
+                "native_mutation_ms": 48.7,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 318,
+                "put_acknowledgment_ms": 28.6,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 67
+                  }
+                ],
+                "browser_command_wall_ms": 81.869
+              },
+              {
+                "native_mutation_ms": 33.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 328.3,
+                "put_acknowledgment_ms": 0.4,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.2,
+                    "duration_ms": 78
+                  }
+                ],
+                "browser_command_wall_ms": 67.415
+              },
+              {
+                "native_mutation_ms": 38.2,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 306.8,
+                "put_acknowledgment_ms": 16.3,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 56
+                  }
+                ],
+                "browser_command_wall_ms": 73.925
+              },
+              {
+                "native_mutation_ms": 31.8,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": 322.7,
+                "put_acknowledgment_ms": 0.1,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 72
+                  },
+                  {
+                    "offset_ms": 335.2,
+                    "duration_ms": 62
+                  }
+                ],
+                "browser_command_wall_ms": 67.201
+              },
+              {
+                "native_mutation_ms": 34,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 313.7,
+                "put_acknowledgment_ms": 0.1,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 63
+                  }
+                ],
+                "browser_command_wall_ms": 69.184
+              },
+              {
+                "native_mutation_ms": 32.5,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 327.9,
+                "put_acknowledgment_ms": 0.3,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 77
+                  }
+                ],
+                "browser_command_wall_ms": 66.988
+              },
+              {
+                "native_mutation_ms": 32.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 315.8,
+                "put_acknowledgment_ms": 12.6,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 65
+                  }
+                ],
+                "browser_command_wall_ms": 73.297
+              },
+              {
+                "native_mutation_ms": 32,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 311.3,
+                "put_acknowledgment_ms": 5.8,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 33.1,
+                    "duration_ms": 51
+                  },
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 61
+                  }
+                ],
+                "browser_command_wall_ms": 66.001
+              },
+              {
+                "native_mutation_ms": 32.4,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 313.1,
+                "put_acknowledgment_ms": 37.2,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 63
+                  }
+                ],
+                "browser_command_wall_ms": 67.272
+              },
+              {
+                "native_mutation_ms": 31.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 325.6,
+                "put_acknowledgment_ms": 8.6,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 75
+                  }
+                ],
+                "browser_command_wall_ms": 65.903
+              },
+              {
+                "native_mutation_ms": 31.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 315.5,
+                "put_acknowledgment_ms": 20.9,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 65
+                  }
+                ],
+                "browser_command_wall_ms": 66.027
+              },
+              {
+                "native_mutation_ms": 34.2,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": 320.8,
+                "put_acknowledgment_ms": 27,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.5,
+                    "duration_ms": 70
+                  }
+                ],
+                "browser_command_wall_ms": 68.862
+              },
+              {
+                "native_mutation_ms": 31.6,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 326.3,
+                "put_acknowledgment_ms": 6.3,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 76
+                  },
+                  {
+                    "offset_ms": 336.7,
+                    "duration_ms": 63
+                  }
+                ],
+                "browser_command_wall_ms": 64.042
+              },
+              {
+                "native_mutation_ms": 32.5,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 312,
+                "put_acknowledgment_ms": 29.1,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.5,
+                    "duration_ms": 61
+                  }
+                ],
+                "browser_command_wall_ms": 66.513
+              },
+              {
+                "native_mutation_ms": 32.1,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": 328.9,
+                "put_acknowledgment_ms": 0.5,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.2,
+                    "duration_ms": 78
+                  }
+                ],
+                "browser_command_wall_ms": 66.618
+              }
+            ]
+          }
+        ],
+        "traces": []
+      },
+      "candidate": {
+        "schema": "loomark-whole-document-input-v1",
+        "environment": {
+          "commit": "8b792bf495000549aa0f9664871a2c8a3da7dec9",
+          "browser": "149.0.7827.55",
+          "node": "v24.14.1",
+          "platform": "linux",
+          "os_release": "6.18.33.2-microsoft-standard-WSL2",
+          "architecture": "x64",
+          "cpu": "AMD Ryzen 7 6800H with Radeon Graphics",
+          "headless": true,
+          "viewport": {
+            "width": 1280,
+            "height": 720
+          },
+          "warmups": 5,
+          "samples": 30,
+          "trace_samples": 0,
+          "settle_ms": 400,
+          "persistence_required": true
+        },
+        "invocation": {
+          "sizes": [
+            1048576
+          ],
+          "environment": {
+            "LOOMARK_WHOLE_DOCUMENT_SIZES": "1048576",
+            "LOOMARK_WHOLE_DOCUMENT_WARMUPS": "5",
+            "LOOMARK_WHOLE_DOCUMENT_SAMPLES": "30",
+            "LOOMARK_WHOLE_DOCUMENT_TRACE_SAMPLES": "0",
+            "LOOMARK_WHOLE_DOCUMENT_REQUIRE_PERSISTENCE": null
+          }
+        },
+        "fixtures": [
+          {
+            "requested_utf16": 1048576,
+            "utf16_length": 1048576,
+            "utf8_bytes": 1048576,
+            "sha256": "bd2b39512f137e45eb14063920e77769422728321640fc9214787e00a5dd74ae"
+          }
+        ],
+        "scenarios": [
+          {
+            "size_utf16": 1048576,
+            "surface": "native_textarea",
+            "matched_width_px": 736,
+            "summary": {
+              "native_mutation_ms": {
+                "samples": 30,
+                "p50_ms": 34.3,
+                "p95_ms": 36.2,
+                "maximum_ms": 60.1
+              },
+              "input_handler_ms": {
+                "samples": 30,
+                "p50_ms": 0,
+                "p95_ms": 0.1,
+                "maximum_ms": 0.1
+              },
+              "put_request_offset_ms": {
+                "samples": 0,
+                "p50_ms": null,
+                "p95_ms": null,
+                "maximum_ms": null
+              },
+              "put_acknowledgment_ms": {
+                "samples": 0,
+                "p50_ms": null,
+                "p95_ms": null,
+                "maximum_ms": null
+              },
+              "browser_command_wall_ms": {
+                "samples": 30,
+                "p50_ms": 64.843,
+                "p95_ms": 69.376,
+                "maximum_ms": 89.94
+              },
+              "long_tasks": {
+                "samples_with_long_tasks": 0,
+                "count": 0,
+                "maximum_ms": 0
+              },
+              "w2_long_tasks": {
+                "window_start_ms": 200,
+                "window_end_ms": 400,
+                "samples_with_long_tasks": 0,
+                "maximum_per_sample_ms": {
+                  "samples": 30,
+                  "p50_ms": 0,
+                  "p95_ms": 0,
+                  "maximum_ms": 0
+                }
+              }
+            },
+            "samples": [
+              {
+                "native_mutation_ms": 32.3,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 62.49
+              },
+              {
+                "native_mutation_ms": 31.9,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 59.555
+              },
+              {
+                "native_mutation_ms": 32.4,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 64.037
+              },
+              {
+                "native_mutation_ms": 33.8,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 62.603
+              },
+              {
+                "native_mutation_ms": 35.3,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 67.66
+              },
+              {
+                "native_mutation_ms": 34.5,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 68.856
+              },
+              {
+                "native_mutation_ms": 32.2,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 61.425
+              },
+              {
+                "native_mutation_ms": 33.4,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 62.055
+              },
+              {
+                "native_mutation_ms": 33.2,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 65.127
+              },
+              {
+                "native_mutation_ms": 33.6,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 62.279
+              },
+              {
+                "native_mutation_ms": 34.7,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 63.317
+              },
+              {
+                "native_mutation_ms": 33,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 66.146
+              },
+              {
+                "native_mutation_ms": 35.6,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 64.997
+              },
+              {
+                "native_mutation_ms": 34.3,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 63.314
+              },
+              {
+                "native_mutation_ms": 34.7,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 67.963
+              },
+              {
+                "native_mutation_ms": 33.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 61.963
+              },
+              {
+                "native_mutation_ms": 32.9,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 61.414
+              },
+              {
+                "native_mutation_ms": 35.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 68.72
+              },
+              {
+                "native_mutation_ms": 32.2,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 60.895
+              },
+              {
+                "native_mutation_ms": 34.7,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 64.673
+              },
+              {
+                "native_mutation_ms": 35.6,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 68.118
+              },
+              {
+                "native_mutation_ms": 35.2,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 64.843
+              },
+              {
+                "native_mutation_ms": 36,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 65.244
+              },
+              {
+                "native_mutation_ms": 36.2,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 69.376
+              },
+              {
+                "native_mutation_ms": 35.4,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 65.775
+              },
+              {
+                "native_mutation_ms": 60.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 89.94
+              },
+              {
+                "native_mutation_ms": 36.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 68.836
+              },
+              {
+                "native_mutation_ms": 36.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 66.382
+              },
+              {
+                "native_mutation_ms": 32.4,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 61.321
+              },
+              {
+                "native_mutation_ms": 32.5,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 65.257
+              }
+            ]
+          },
+          {
+            "size_utf16": 1048576,
+            "surface": "loomark_production",
+            "matched_width_px": 736,
+            "summary": {
+              "native_mutation_ms": {
+                "samples": 30,
+                "p50_ms": 32.6,
+                "p95_ms": 36.2,
+                "maximum_ms": 39.3
+              },
+              "input_handler_ms": {
+                "samples": 30,
+                "p50_ms": 0,
+                "p95_ms": 0.1,
+                "maximum_ms": 0.1
+              },
+              "put_request_offset_ms": {
+                "samples": 30,
+                "p50_ms": 312.1,
+                "p95_ms": 340.5,
+                "maximum_ms": 340.8
+              },
+              "put_acknowledgment_ms": {
+                "samples": 30,
+                "p50_ms": 7.9,
+                "p95_ms": 29.9,
+                "maximum_ms": 36.6
+              },
+              "browser_command_wall_ms": {
+                "samples": 30,
+                "p50_ms": 67.584,
+                "p95_ms": 76.047,
+                "maximum_ms": 78.721
+              },
+              "long_tasks": {
+                "samples_with_long_tasks": 30,
+                "count": 36,
+                "maximum_ms": 90
+              },
+              "w2_long_tasks": {
+                "window_start_ms": 200,
+                "window_end_ms": 400,
+                "samples_with_long_tasks": 30,
+                "maximum_per_sample_ms": {
+                  "samples": 30,
+                  "p50_ms": 61,
+                  "p95_ms": 90,
+                  "maximum_ms": 90
+                }
+              }
+            },
+            "samples": [
+              {
+                "native_mutation_ms": 32.3,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 305.3,
+                "put_acknowledgment_ms": 0.3,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 55
+                  }
+                ],
+                "browser_command_wall_ms": 66.614
+              },
+              {
+                "native_mutation_ms": 31.3,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 335.5,
+                "put_acknowledgment_ms": 0.4,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 85
+                  }
+                ],
+                "browser_command_wall_ms": 65.691
+              },
+              {
+                "native_mutation_ms": 32.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 304.2,
+                "put_acknowledgment_ms": 11.5,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 53
+                  }
+                ],
+                "browser_command_wall_ms": 68.36
+              },
+              {
+                "native_mutation_ms": 31.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 310.5,
+                "put_acknowledgment_ms": 0.2,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.5,
+                    "duration_ms": 60
+                  }
+                ],
+                "browser_command_wall_ms": 66.07
+              },
+              {
+                "native_mutation_ms": 34.5,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 305.5,
+                "put_acknowledgment_ms": 29.2,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 55
+                  }
+                ],
+                "browser_command_wall_ms": 76.047
+              },
+              {
+                "native_mutation_ms": 33.3,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 335.5,
+                "put_acknowledgment_ms": 8,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 85
+                  }
+                ],
+                "browser_command_wall_ms": 68.209
+              },
+              {
+                "native_mutation_ms": 33.4,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 308.1,
+                "put_acknowledgment_ms": 20.3,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 57
+                  }
+                ],
+                "browser_command_wall_ms": 67.951
+              },
+              {
+                "native_mutation_ms": 39.3,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 337.3,
+                "put_acknowledgment_ms": 5.9,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 87
+                  }
+                ],
+                "browser_command_wall_ms": 74.386
+              },
+              {
+                "native_mutation_ms": 33.3,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 315.1,
+                "put_acknowledgment_ms": 0.1,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 64
+                  },
+                  {
+                    "offset_ms": 323.1,
+                    "duration_ms": 51
+                  }
+                ],
+                "browser_command_wall_ms": 67.584
+              },
+              {
+                "native_mutation_ms": 34.9,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 318.7,
+                "put_acknowledgment_ms": 27.6,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 68
+                  }
+                ],
+                "browser_command_wall_ms": 72.372
+              },
+              {
+                "native_mutation_ms": 34.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 310,
+                "put_acknowledgment_ms": 6.2,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 59
+                  }
+                ],
+                "browser_command_wall_ms": 68.497
+              },
+              {
+                "native_mutation_ms": 31.7,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 312.1,
+                "put_acknowledgment_ms": 29.9,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 61
+                  }
+                ],
+                "browser_command_wall_ms": 73.114
+              },
+              {
+                "native_mutation_ms": 32.2,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 340.8,
+                "put_acknowledgment_ms": 0.4,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 34.1,
+                    "duration_ms": 50
+                  },
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 90
+                  },
+                  {
+                    "offset_ms": 349.3,
+                    "duration_ms": 60
+                  }
+                ],
+                "browser_command_wall_ms": 67.291
+              },
+              {
+                "native_mutation_ms": 34.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 314.9,
+                "put_acknowledgment_ms": 16,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 64
+                  }
+                ],
+                "browser_command_wall_ms": 68.99
+              },
+              {
+                "native_mutation_ms": 33.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 337.5,
+                "put_acknowledgment_ms": 6.5,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 87
+                  }
+                ],
+                "browser_command_wall_ms": 67.57
+              },
+              {
+                "native_mutation_ms": 32.4,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 306.8,
+                "put_acknowledgment_ms": 0.4,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 56
+                  },
+                  {
+                    "offset_ms": 321.1,
+                    "duration_ms": 56
+                  }
+                ],
+                "browser_command_wall_ms": 66.643
+              },
+              {
+                "native_mutation_ms": 32.4,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 314.2,
+                "put_acknowledgment_ms": 0.2,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 64
+                  }
+                ],
+                "browser_command_wall_ms": 67.556
+              },
+              {
+                "native_mutation_ms": 32.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 327,
+                "put_acknowledgment_ms": 7.9,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.2,
+                    "duration_ms": 76
+                  }
+                ],
+                "browser_command_wall_ms": 68.245
+              },
+              {
+                "native_mutation_ms": 36.2,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 340.5,
+                "put_acknowledgment_ms": 11.6,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 90
+                  }
+                ],
+                "browser_command_wall_ms": 78.721
+              },
+              {
+                "native_mutation_ms": 32.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 307.8,
+                "put_acknowledgment_ms": 26.8,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 57
+                  }
+                ],
+                "browser_command_wall_ms": 65.976
+              },
+              {
+                "native_mutation_ms": 32.9,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 323.6,
+                "put_acknowledgment_ms": 0.3,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 33.2,
+                    "duration_ms": 51
+                  },
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 73
+                  },
+                  {
+                    "offset_ms": 330.2,
+                    "duration_ms": 51
+                  }
+                ],
+                "browser_command_wall_ms": 67.425
+              },
+              {
+                "native_mutation_ms": 34.4,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 307.7,
+                "put_acknowledgment_ms": 29.5,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 57
+                  }
+                ],
+                "browser_command_wall_ms": 67.868
+              },
+              {
+                "native_mutation_ms": 32.3,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 325.5,
+                "put_acknowledgment_ms": 0.2,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.2,
+                    "duration_ms": 75
+                  }
+                ],
+                "browser_command_wall_ms": 66.99
+              },
+              {
+                "native_mutation_ms": 33.4,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 308.3,
+                "put_acknowledgment_ms": 8.4,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 58
+                  }
+                ],
+                "browser_command_wall_ms": 67.338
+              },
+              {
+                "native_mutation_ms": 32.6,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 307.8,
+                "put_acknowledgment_ms": 29.3,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.5,
+                    "duration_ms": 57
+                  }
+                ],
+                "browser_command_wall_ms": 67.65
+              },
+              {
+                "native_mutation_ms": 31.7,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 309.8,
+                "put_acknowledgment_ms": 0.3,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 59
+                  }
+                ],
+                "browser_command_wall_ms": 66.113
+              },
+              {
+                "native_mutation_ms": 32.6,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": 306.7,
+                "put_acknowledgment_ms": 29.7,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.5,
+                    "duration_ms": 56
+                  }
+                ],
+                "browser_command_wall_ms": 66.875
+              },
+              {
+                "native_mutation_ms": 31.3,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": 327,
+                "put_acknowledgment_ms": 0.3,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 76
+                  }
+                ],
+                "browser_command_wall_ms": 74.645
+              },
+              {
+                "native_mutation_ms": 31.4,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 315.9,
+                "put_acknowledgment_ms": 8.1,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.5,
+                    "duration_ms": 65
+                  }
+                ],
+                "browser_command_wall_ms": 65.692
+              },
+              {
+                "native_mutation_ms": 33.9,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 306,
+                "put_acknowledgment_ms": 36.6,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 55
+                  }
+                ],
+                "browser_command_wall_ms": 68.848
+              }
+            ]
+          }
+        ],
+        "traces": []
+      }
+    },
+    {
+      "pair": 2,
+      "order": "candidate-base",
+      "base": {
+        "schema": "loomark-whole-document-input-v1",
+        "environment": {
+          "commit": "1f24c66042115763040a029d05fc753eb30902a4",
+          "browser": "149.0.7827.55",
+          "node": "v24.14.1",
+          "platform": "linux",
+          "os_release": "6.18.33.2-microsoft-standard-WSL2",
+          "architecture": "x64",
+          "cpu": "AMD Ryzen 7 6800H with Radeon Graphics",
+          "headless": true,
+          "viewport": {
+            "width": 1280,
+            "height": 720
+          },
+          "warmups": 5,
+          "samples": 30,
+          "trace_samples": 0,
+          "settle_ms": 400,
+          "persistence_required": true
+        },
+        "invocation": {
+          "sizes": [
+            1048576
+          ],
+          "environment": {
+            "LOOMARK_WHOLE_DOCUMENT_SIZES": "1048576",
+            "LOOMARK_WHOLE_DOCUMENT_WARMUPS": "5",
+            "LOOMARK_WHOLE_DOCUMENT_SAMPLES": "30",
+            "LOOMARK_WHOLE_DOCUMENT_TRACE_SAMPLES": "0",
+            "LOOMARK_WHOLE_DOCUMENT_REQUIRE_PERSISTENCE": null
+          }
+        },
+        "fixtures": [
+          {
+            "requested_utf16": 1048576,
+            "utf16_length": 1048576,
+            "utf8_bytes": 1048576,
+            "sha256": "bd2b39512f137e45eb14063920e77769422728321640fc9214787e00a5dd74ae"
+          }
+        ],
+        "scenarios": [
+          {
+            "size_utf16": 1048576,
+            "surface": "native_textarea",
+            "matched_width_px": 736,
+            "summary": {
+              "native_mutation_ms": {
+                "samples": 30,
+                "p50_ms": 34,
+                "p95_ms": 36.7,
+                "maximum_ms": 38.4
+              },
+              "input_handler_ms": {
+                "samples": 30,
+                "p50_ms": 0,
+                "p95_ms": 0.1,
+                "maximum_ms": 0.1
+              },
+              "put_request_offset_ms": {
+                "samples": 0,
+                "p50_ms": null,
+                "p95_ms": null,
+                "maximum_ms": null
+              },
+              "put_acknowledgment_ms": {
+                "samples": 0,
+                "p50_ms": null,
+                "p95_ms": null,
+                "maximum_ms": null
+              },
+              "browser_command_wall_ms": {
+                "samples": 30,
+                "p50_ms": 64.737,
+                "p95_ms": 68.906,
+                "maximum_ms": 70.221
+              },
+              "long_tasks": {
+                "samples_with_long_tasks": 0,
+                "count": 0,
+                "maximum_ms": 0
+              }
+            },
+            "samples": [
+              {
+                "native_mutation_ms": 31.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 60.482
+              },
+              {
+                "native_mutation_ms": 33.9,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 61.994
+              },
+              {
+                "native_mutation_ms": 32.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 63.996
+              },
+              {
+                "native_mutation_ms": 36.7,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 66.231
+              },
+              {
+                "native_mutation_ms": 34.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 63.451
+              },
+              {
+                "native_mutation_ms": 33,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 65.054
+              },
+              {
+                "native_mutation_ms": 35,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 63.85
+              },
+              {
+                "native_mutation_ms": 33,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 62.943
+              },
+              {
+                "native_mutation_ms": 34,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 67.607
+              },
+              {
+                "native_mutation_ms": 36.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 64.996
+              },
+              {
+                "native_mutation_ms": 34,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 63.896
+              },
+              {
+                "native_mutation_ms": 35.2,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 67.55
+              },
+              {
+                "native_mutation_ms": 36,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 65.771
+              },
+              {
+                "native_mutation_ms": 35.9,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 66.974
+              },
+              {
+                "native_mutation_ms": 33.6,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 66.575
+              },
+              {
+                "native_mutation_ms": 35.3,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 64.663
+              },
+              {
+                "native_mutation_ms": 38.4,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 70.221
+              },
+              {
+                "native_mutation_ms": 34.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 67.033
+              },
+              {
+                "native_mutation_ms": 34.7,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 66.539
+              },
+              {
+                "native_mutation_ms": 36.7,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 67.578
+              },
+              {
+                "native_mutation_ms": 36,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 68.906
+              },
+              {
+                "native_mutation_ms": 34.4,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 63.549
+              },
+              {
+                "native_mutation_ms": 32.9,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 61.38
+              },
+              {
+                "native_mutation_ms": 32.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 65.219
+              },
+              {
+                "native_mutation_ms": 32.3,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 61.083
+              },
+              {
+                "native_mutation_ms": 34.5,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 62.47
+              },
+              {
+                "native_mutation_ms": 32.9,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 64.737
+              },
+              {
+                "native_mutation_ms": 31.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 59.909
+              },
+              {
+                "native_mutation_ms": 33.2,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 62.378
+              },
+              {
+                "native_mutation_ms": 33,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 65.369
+              }
+            ]
+          },
+          {
+            "size_utf16": 1048576,
+            "surface": "loomark_production",
+            "matched_width_px": 736,
+            "summary": {
+              "native_mutation_ms": {
+                "samples": 30,
+                "p50_ms": 31.6,
+                "p95_ms": 34.6,
+                "maximum_ms": 36.8
+              },
+              "input_handler_ms": {
+                "samples": 30,
+                "p50_ms": 0,
+                "p95_ms": 0.1,
+                "maximum_ms": 0.2
+              },
+              "put_request_offset_ms": {
+                "samples": 30,
+                "p50_ms": 308.9,
+                "p95_ms": 335.4,
+                "maximum_ms": 337.2
+              },
+              "put_acknowledgment_ms": {
+                "samples": 30,
+                "p50_ms": 9.2,
+                "p95_ms": 33.7,
+                "maximum_ms": 35.9
+              },
+              "browser_command_wall_ms": {
+                "samples": 30,
+                "p50_ms": 65.543,
+                "p95_ms": 71.807,
+                "maximum_ms": 72.062
+              },
+              "long_tasks": {
+                "samples_with_long_tasks": 30,
+                "count": 34,
+                "maximum_ms": 87
+              }
+            },
+            "samples": [
+              {
+                "native_mutation_ms": 33.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 318.8,
+                "put_acknowledgment_ms": 28.8,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.5,
+                    "duration_ms": 68
+                  }
+                ],
+                "browser_command_wall_ms": 66.619
+              },
+              {
+                "native_mutation_ms": 32,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": 323.5,
+                "put_acknowledgment_ms": 0.2,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 32.1,
+                    "duration_ms": 52
+                  },
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 73
+                  },
+                  {
+                    "offset_ms": 330.2,
+                    "duration_ms": 68
+                  }
+                ],
+                "browser_command_wall_ms": 65.181
+              },
+              {
+                "native_mutation_ms": 31.9,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": 327.6,
+                "put_acknowledgment_ms": 29,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.6,
+                    "duration_ms": 77
+                  }
+                ],
+                "browser_command_wall_ms": 66.223
+              },
+              {
+                "native_mutation_ms": 33.5,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 333.8,
+                "put_acknowledgment_ms": 0.2,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 83
+                  }
+                ],
+                "browser_command_wall_ms": 67.577
+              },
+              {
+                "native_mutation_ms": 30.9,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": 304.4,
+                "put_acknowledgment_ms": 10.8,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 54
+                  }
+                ],
+                "browser_command_wall_ms": 70.978
+              },
+              {
+                "native_mutation_ms": 30.7,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 311.9,
+                "put_acknowledgment_ms": 5.4,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 61
+                  }
+                ],
+                "browser_command_wall_ms": 64.688
+              },
+              {
+                "native_mutation_ms": 32.5,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 303.3,
+                "put_acknowledgment_ms": 35.9,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 53
+                  }
+                ],
+                "browser_command_wall_ms": 66.167
+              },
+              {
+                "native_mutation_ms": 31.6,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": 303.8,
+                "put_acknowledgment_ms": 8.1,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 53
+                  }
+                ],
+                "browser_command_wall_ms": 65.411
+              },
+              {
+                "native_mutation_ms": 31.2,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 303.9,
+                "put_acknowledgment_ms": 9.2,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.5,
+                    "duration_ms": 53
+                  }
+                ],
+                "browser_command_wall_ms": 64.815
+              },
+              {
+                "native_mutation_ms": 31.5,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": 306.8,
+                "put_acknowledgment_ms": 26.8,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 56
+                  }
+                ],
+                "browser_command_wall_ms": 65.097
+              },
+              {
+                "native_mutation_ms": 31.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 308.8,
+                "put_acknowledgment_ms": 6.1,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 58
+                  }
+                ],
+                "browser_command_wall_ms": 65.03
+              },
+              {
+                "native_mutation_ms": 30.2,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 324.7,
+                "put_acknowledgment_ms": 22.3,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 74
+                  }
+                ],
+                "browser_command_wall_ms": 70.635
+              },
+              {
+                "native_mutation_ms": 32.5,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 337.2,
+                "put_acknowledgment_ms": 8.2,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 87
+                  },
+                  {
+                    "offset_ms": 346,
+                    "duration_ms": 62
+                  }
+                ],
+                "browser_command_wall_ms": 66.18
+              },
+              {
+                "native_mutation_ms": 31.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 305.9,
+                "put_acknowledgment_ms": 16.8,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 55
+                  }
+                ],
+                "browser_command_wall_ms": 65.131
+              },
+              {
+                "native_mutation_ms": 30.9,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 323.4,
+                "put_acknowledgment_ms": 31.8,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 73
+                  }
+                ],
+                "browser_command_wall_ms": 64.89
+              },
+              {
+                "native_mutation_ms": 31.9,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 308.4,
+                "put_acknowledgment_ms": 0.5,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.1,
+                    "duration_ms": 58
+                  }
+                ],
+                "browser_command_wall_ms": 65.214
+              },
+              {
+                "native_mutation_ms": 31.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 305.6,
+                "put_acknowledgment_ms": 28.8,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 55
+                  }
+                ],
+                "browser_command_wall_ms": 72.062
+              },
+              {
+                "native_mutation_ms": 34.6,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 335.4,
+                "put_acknowledgment_ms": 0.4,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 32.2,
+                    "duration_ms": 53
+                  },
+                  {
+                    "offset_ms": 250.2,
+                    "duration_ms": 85
+                  }
+                ],
+                "browser_command_wall_ms": 67.792
+              },
+              {
+                "native_mutation_ms": 30.7,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 332.9,
+                "put_acknowledgment_ms": 16.8,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 82
+                  }
+                ],
+                "browser_command_wall_ms": 64.174
+              },
+              {
+                "native_mutation_ms": 32.4,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 335.4,
+                "put_acknowledgment_ms": 5.7,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.5,
+                    "duration_ms": 85
+                  }
+                ],
+                "browser_command_wall_ms": 66.687
+              },
+              {
+                "native_mutation_ms": 32.3,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 326.5,
+                "put_acknowledgment_ms": 20,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.2,
+                    "duration_ms": 76
+                  }
+                ],
+                "browser_command_wall_ms": 66.461
+              },
+              {
+                "native_mutation_ms": 31.2,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": 304.4,
+                "put_acknowledgment_ms": 26.1,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.5,
+                    "duration_ms": 54
+                  }
+                ],
+                "browser_command_wall_ms": 65.326
+              },
+              {
+                "native_mutation_ms": 36.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 325.6,
+                "put_acknowledgment_ms": 8.2,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 75
+                  }
+                ],
+                "browser_command_wall_ms": 70.177
+              },
+              {
+                "native_mutation_ms": 30.4,
+                "input_handler_ms": 0.2,
+                "put_request_offset_ms": 305.2,
+                "put_acknowledgment_ms": 10.5,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.6,
+                    "duration_ms": 54
+                  }
+                ],
+                "browser_command_wall_ms": 71.807
+              },
+              {
+                "native_mutation_ms": 31.5,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 309.1,
+                "put_acknowledgment_ms": 6.3,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 58
+                  }
+                ],
+                "browser_command_wall_ms": 65.436
+              },
+              {
+                "native_mutation_ms": 32.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 304.8,
+                "put_acknowledgment_ms": 33.7,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 54
+                  }
+                ],
+                "browser_command_wall_ms": 65.64
+              },
+              {
+                "native_mutation_ms": 31.4,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": 333,
+                "put_acknowledgment_ms": 7.8,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 82
+                  }
+                ],
+                "browser_command_wall_ms": 65.19
+              },
+              {
+                "native_mutation_ms": 31.7,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 304.7,
+                "put_acknowledgment_ms": 8.3,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 54
+                  }
+                ],
+                "browser_command_wall_ms": 65.268
+              },
+              {
+                "native_mutation_ms": 31.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 305.6,
+                "put_acknowledgment_ms": 26.7,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 55
+                  }
+                ],
+                "browser_command_wall_ms": 65.543
+              },
+              {
+                "native_mutation_ms": 32,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 308.9,
+                "put_acknowledgment_ms": 6.7,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 58
+                  }
+                ],
+                "browser_command_wall_ms": 66.064
+              }
+            ]
+          }
+        ],
+        "traces": []
+      },
+      "candidate": {
+        "schema": "loomark-whole-document-input-v1",
+        "environment": {
+          "commit": "8b792bf495000549aa0f9664871a2c8a3da7dec9",
+          "browser": "149.0.7827.55",
+          "node": "v24.14.1",
+          "platform": "linux",
+          "os_release": "6.18.33.2-microsoft-standard-WSL2",
+          "architecture": "x64",
+          "cpu": "AMD Ryzen 7 6800H with Radeon Graphics",
+          "headless": true,
+          "viewport": {
+            "width": 1280,
+            "height": 720
+          },
+          "warmups": 5,
+          "samples": 30,
+          "trace_samples": 0,
+          "settle_ms": 400,
+          "persistence_required": true
+        },
+        "invocation": {
+          "sizes": [
+            1048576
+          ],
+          "environment": {
+            "LOOMARK_WHOLE_DOCUMENT_SIZES": "1048576",
+            "LOOMARK_WHOLE_DOCUMENT_WARMUPS": "5",
+            "LOOMARK_WHOLE_DOCUMENT_SAMPLES": "30",
+            "LOOMARK_WHOLE_DOCUMENT_TRACE_SAMPLES": "0",
+            "LOOMARK_WHOLE_DOCUMENT_REQUIRE_PERSISTENCE": null
+          }
+        },
+        "fixtures": [
+          {
+            "requested_utf16": 1048576,
+            "utf16_length": 1048576,
+            "utf8_bytes": 1048576,
+            "sha256": "bd2b39512f137e45eb14063920e77769422728321640fc9214787e00a5dd74ae"
+          }
+        ],
+        "scenarios": [
+          {
+            "size_utf16": 1048576,
+            "surface": "native_textarea",
+            "matched_width_px": 736,
+            "summary": {
+              "native_mutation_ms": {
+                "samples": 30,
+                "p50_ms": 34.3,
+                "p95_ms": 38,
+                "maximum_ms": 38.5
+              },
+              "input_handler_ms": {
+                "samples": 30,
+                "p50_ms": 0,
+                "p95_ms": 0.1,
+                "maximum_ms": 0.1
+              },
+              "put_request_offset_ms": {
+                "samples": 0,
+                "p50_ms": null,
+                "p95_ms": null,
+                "maximum_ms": null
+              },
+              "put_acknowledgment_ms": {
+                "samples": 0,
+                "p50_ms": null,
+                "p95_ms": null,
+                "maximum_ms": null
+              },
+              "browser_command_wall_ms": {
+                "samples": 30,
+                "p50_ms": 64.422,
+                "p95_ms": 69.938,
+                "maximum_ms": 71.317
+              },
+              "long_tasks": {
+                "samples_with_long_tasks": 0,
+                "count": 0,
+                "maximum_ms": 0
+              },
+              "w2_long_tasks": {
+                "window_start_ms": 200,
+                "window_end_ms": 400,
+                "samples_with_long_tasks": 0,
+                "maximum_per_sample_ms": {
+                  "samples": 30,
+                  "p50_ms": 0,
+                  "p95_ms": 0,
+                  "maximum_ms": 0
+                }
+              }
+            },
+            "samples": [
+              {
+                "native_mutation_ms": 34.3,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 63.024
+              },
+              {
+                "native_mutation_ms": 32.6,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 60.484
+              },
+              {
+                "native_mutation_ms": 33.5,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 65.012
+              },
+              {
+                "native_mutation_ms": 34.3,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 62.612
+              },
+              {
+                "native_mutation_ms": 33.7,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 61.846
+              },
+              {
+                "native_mutation_ms": 32.4,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 65.09
+              },
+              {
+                "native_mutation_ms": 32.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 59.05
+              },
+              {
+                "native_mutation_ms": 32.3,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 60.063
+              },
+              {
+                "native_mutation_ms": 35.6,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 68.505
+              },
+              {
+                "native_mutation_ms": 31.8,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 60.208
+              },
+              {
+                "native_mutation_ms": 34,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 63.159
+              },
+              {
+                "native_mutation_ms": 34.3,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 66.31
+              },
+              {
+                "native_mutation_ms": 33.3,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 60.979
+              },
+              {
+                "native_mutation_ms": 33.7,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 62.096
+              },
+              {
+                "native_mutation_ms": 35.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 67.682
+              },
+              {
+                "native_mutation_ms": 33.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 61.912
+              },
+              {
+                "native_mutation_ms": 38,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 69.938
+              },
+              {
+                "native_mutation_ms": 37.8,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 71.317
+              },
+              {
+                "native_mutation_ms": 35.2,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 64.296
+              },
+              {
+                "native_mutation_ms": 36,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 64.011
+              },
+              {
+                "native_mutation_ms": 35.4,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 68.364
+              },
+              {
+                "native_mutation_ms": 35.4,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 65.005
+              },
+              {
+                "native_mutation_ms": 35.6,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 64.681
+              },
+              {
+                "native_mutation_ms": 35,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 69.433
+              },
+              {
+                "native_mutation_ms": 33.4,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 62.531
+              },
+              {
+                "native_mutation_ms": 35.5,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 64.422
+              },
+              {
+                "native_mutation_ms": 35.7,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 68.308
+              },
+              {
+                "native_mutation_ms": 35.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 65.54
+              },
+              {
+                "native_mutation_ms": 38.5,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 68.603
+              },
+              {
+                "native_mutation_ms": 35.3,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 67.877
+              }
+            ]
+          },
+          {
+            "size_utf16": 1048576,
+            "surface": "loomark_production",
+            "matched_width_px": 736,
+            "summary": {
+              "native_mutation_ms": {
+                "samples": 30,
+                "p50_ms": 32,
+                "p95_ms": 34.5,
+                "maximum_ms": 34.6
+              },
+              "input_handler_ms": {
+                "samples": 30,
+                "p50_ms": 0,
+                "p95_ms": 0.1,
+                "maximum_ms": 0.1
+              },
+              "put_request_offset_ms": {
+                "samples": 30,
+                "p50_ms": 310.8,
+                "p95_ms": 334.7,
+                "maximum_ms": 351
+              },
+              "put_acknowledgment_ms": {
+                "samples": 30,
+                "p50_ms": 9.7,
+                "p95_ms": 29.6,
+                "maximum_ms": 33.6
+              },
+              "browser_command_wall_ms": {
+                "samples": 30,
+                "p50_ms": 66.804,
+                "p95_ms": 75.479,
+                "maximum_ms": 78.485
+              },
+              "long_tasks": {
+                "samples_with_long_tasks": 30,
+                "count": 34,
+                "maximum_ms": 100
+              },
+              "w2_long_tasks": {
+                "window_start_ms": 200,
+                "window_end_ms": 400,
+                "samples_with_long_tasks": 30,
+                "maximum_per_sample_ms": {
+                  "samples": 30,
+                  "p50_ms": 60,
+                  "p95_ms": 84,
+                  "maximum_ms": 100
+                }
+              }
+            },
+            "samples": [
+              {
+                "native_mutation_ms": 31.6,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 351,
+                "put_acknowledgment_ms": 0.4,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 100
+                  }
+                ],
+                "browser_command_wall_ms": 66.636
+              },
+              {
+                "native_mutation_ms": 31.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 323.4,
+                "put_acknowledgment_ms": 6.5,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.2,
+                    "duration_ms": 73
+                  },
+                  {
+                    "offset_ms": 330.2,
+                    "duration_ms": 68
+                  }
+                ],
+                "browser_command_wall_ms": 66.426
+              },
+              {
+                "native_mutation_ms": 33.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 312.2,
+                "put_acknowledgment_ms": 28.6,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 61
+                  }
+                ],
+                "browser_command_wall_ms": 68.862
+              },
+              {
+                "native_mutation_ms": 31.7,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 326.6,
+                "put_acknowledgment_ms": 0.3,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 76
+                  }
+                ],
+                "browser_command_wall_ms": 66.809
+              },
+              {
+                "native_mutation_ms": 34,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 315,
+                "put_acknowledgment_ms": 0.2,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 64
+                  }
+                ],
+                "browser_command_wall_ms": 75.369
+              },
+              {
+                "native_mutation_ms": 32.4,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": 305.9,
+                "put_acknowledgment_ms": 29,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 55
+                  }
+                ],
+                "browser_command_wall_ms": 66.804
+              },
+              {
+                "native_mutation_ms": 30.7,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 308.9,
+                "put_acknowledgment_ms": 13.6,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 58
+                  }
+                ],
+                "browser_command_wall_ms": 65.036
+              },
+              {
+                "native_mutation_ms": 31.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 304.2,
+                "put_acknowledgment_ms": 28.3,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 54
+                  }
+                ],
+                "browser_command_wall_ms": 65.829
+              },
+              {
+                "native_mutation_ms": 32,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": 326,
+                "put_acknowledgment_ms": 0.2,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 75
+                  }
+                ],
+                "browser_command_wall_ms": 66.514
+              },
+              {
+                "native_mutation_ms": 31.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 304.9,
+                "put_acknowledgment_ms": 8.8,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 54
+                  }
+                ],
+                "browser_command_wall_ms": 73.51
+              },
+              {
+                "native_mutation_ms": 31.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 306.1,
+                "put_acknowledgment_ms": 29.6,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 55
+                  }
+                ],
+                "browser_command_wall_ms": 65.69
+              },
+              {
+                "native_mutation_ms": 31.6,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 310.8,
+                "put_acknowledgment_ms": 13,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 60
+                  }
+                ],
+                "browser_command_wall_ms": 65.982
+              },
+              {
+                "native_mutation_ms": 31.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 326.9,
+                "put_acknowledgment_ms": 28.3,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 76
+                  }
+                ],
+                "browser_command_wall_ms": 66.125
+              },
+              {
+                "native_mutation_ms": 33.7,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": 334.7,
+                "put_acknowledgment_ms": 7.5,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 34.7,
+                    "duration_ms": 54
+                  },
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 84
+                  }
+                ],
+                "browser_command_wall_ms": 69.317
+              },
+              {
+                "native_mutation_ms": 34.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 303.7,
+                "put_acknowledgment_ms": 9.1,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 53
+                  }
+                ],
+                "browser_command_wall_ms": 75.479
+              },
+              {
+                "native_mutation_ms": 34.6,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 304.7,
+                "put_acknowledgment_ms": 28.5,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 54
+                  }
+                ],
+                "browser_command_wall_ms": 71.478
+              },
+              {
+                "native_mutation_ms": 31.4,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 309,
+                "put_acknowledgment_ms": 0.4,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 33.3,
+                    "duration_ms": 54
+                  },
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 58
+                  }
+                ],
+                "browser_command_wall_ms": 65.837
+              },
+              {
+                "native_mutation_ms": 34.5,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 310.4,
+                "put_acknowledgment_ms": 29.1,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.2,
+                    "duration_ms": 60
+                  }
+                ],
+                "browser_command_wall_ms": 68.992
+              },
+              {
+                "native_mutation_ms": 32.3,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 326.6,
+                "put_acknowledgment_ms": 0.4,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 76
+                  }
+                ],
+                "browser_command_wall_ms": 66.059
+              },
+              {
+                "native_mutation_ms": 32.6,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 304.5,
+                "put_acknowledgment_ms": 12.2,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.2,
+                    "duration_ms": 54
+                  }
+                ],
+                "browser_command_wall_ms": 67.53
+              },
+              {
+                "native_mutation_ms": 32,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 311.8,
+                "put_acknowledgment_ms": 29.4,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 61
+                  }
+                ],
+                "browser_command_wall_ms": 66.795
+              },
+              {
+                "native_mutation_ms": 32,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 321.3,
+                "put_acknowledgment_ms": 6.4,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 71
+                  },
+                  {
+                    "offset_ms": 328.2,
+                    "duration_ms": 62
+                  }
+                ],
+                "browser_command_wall_ms": 66.794
+              },
+              {
+                "native_mutation_ms": 32.2,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": 310.6,
+                "put_acknowledgment_ms": 28.9,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 60
+                  }
+                ],
+                "browser_command_wall_ms": 66.89
+              },
+              {
+                "native_mutation_ms": 32.2,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 324.9,
+                "put_acknowledgment_ms": 7.9,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 74
+                  }
+                ],
+                "browser_command_wall_ms": 74.258
+              },
+              {
+                "native_mutation_ms": 31.2,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 303.4,
+                "put_acknowledgment_ms": 9.7,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 53
+                  }
+                ],
+                "browser_command_wall_ms": 66.973
+              },
+              {
+                "native_mutation_ms": 32.9,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 315.7,
+                "put_acknowledgment_ms": 33.6,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 65
+                  }
+                ],
+                "browser_command_wall_ms": 69.072
+              },
+              {
+                "native_mutation_ms": 32.4,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 309.4,
+                "put_acknowledgment_ms": 7.2,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.5,
+                    "duration_ms": 59
+                  }
+                ],
+                "browser_command_wall_ms": 67.145
+              },
+              {
+                "native_mutation_ms": 30.9,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 305.7,
+                "put_acknowledgment_ms": 29.4,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 55
+                  }
+                ],
+                "browser_command_wall_ms": 64.807
+              },
+              {
+                "native_mutation_ms": 34.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 326.4,
+                "put_acknowledgment_ms": 0.3,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.2,
+                    "duration_ms": 76
+                  }
+                ],
+                "browser_command_wall_ms": 78.485
+              },
+              {
+                "native_mutation_ms": 32.5,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 315.3,
+                "put_acknowledgment_ms": 11.8,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 65
+                  }
+                ],
+                "browser_command_wall_ms": 66.053
+              }
+            ]
+          }
+        ],
+        "traces": []
+      }
+    },
+    {
+      "pair": 3,
+      "order": "base-candidate",
+      "base": {
+        "schema": "loomark-whole-document-input-v1",
+        "environment": {
+          "commit": "1f24c66042115763040a029d05fc753eb30902a4",
+          "browser": "149.0.7827.55",
+          "node": "v24.14.1",
+          "platform": "linux",
+          "os_release": "6.18.33.2-microsoft-standard-WSL2",
+          "architecture": "x64",
+          "cpu": "AMD Ryzen 7 6800H with Radeon Graphics",
+          "headless": true,
+          "viewport": {
+            "width": 1280,
+            "height": 720
+          },
+          "warmups": 5,
+          "samples": 30,
+          "trace_samples": 0,
+          "settle_ms": 400,
+          "persistence_required": true
+        },
+        "invocation": {
+          "sizes": [
+            1048576
+          ],
+          "environment": {
+            "LOOMARK_WHOLE_DOCUMENT_SIZES": "1048576",
+            "LOOMARK_WHOLE_DOCUMENT_WARMUPS": "5",
+            "LOOMARK_WHOLE_DOCUMENT_SAMPLES": "30",
+            "LOOMARK_WHOLE_DOCUMENT_TRACE_SAMPLES": "0",
+            "LOOMARK_WHOLE_DOCUMENT_REQUIRE_PERSISTENCE": null
+          }
+        },
+        "fixtures": [
+          {
+            "requested_utf16": 1048576,
+            "utf16_length": 1048576,
+            "utf8_bytes": 1048576,
+            "sha256": "bd2b39512f137e45eb14063920e77769422728321640fc9214787e00a5dd74ae"
+          }
+        ],
+        "scenarios": [
+          {
+            "size_utf16": 1048576,
+            "surface": "native_textarea",
+            "matched_width_px": 736,
+            "summary": {
+              "native_mutation_ms": {
+                "samples": 30,
+                "p50_ms": 35.5,
+                "p95_ms": 37.8,
+                "maximum_ms": 40
+              },
+              "input_handler_ms": {
+                "samples": 30,
+                "p50_ms": 0,
+                "p95_ms": 0.1,
+                "maximum_ms": 0.1
+              },
+              "put_request_offset_ms": {
+                "samples": 0,
+                "p50_ms": null,
+                "p95_ms": null,
+                "maximum_ms": null
+              },
+              "put_acknowledgment_ms": {
+                "samples": 0,
+                "p50_ms": null,
+                "p95_ms": null,
+                "maximum_ms": null
+              },
+              "browser_command_wall_ms": {
+                "samples": 30,
+                "p50_ms": 66.214,
+                "p95_ms": 74.262,
+                "maximum_ms": 77.781
+              },
+              "long_tasks": {
+                "samples_with_long_tasks": 0,
+                "count": 0,
+                "maximum_ms": 0
+              }
+            },
+            "samples": [
+              {
+                "native_mutation_ms": 40,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 77.781
+              },
+              {
+                "native_mutation_ms": 32.7,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 62.239
+              },
+              {
+                "native_mutation_ms": 37.7,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 74.262
+              },
+              {
+                "native_mutation_ms": 35.6,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 66.143
+              },
+              {
+                "native_mutation_ms": 36.5,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 65.573
+              },
+              {
+                "native_mutation_ms": 37.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 71.433
+              },
+              {
+                "native_mutation_ms": 35.5,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 66.654
+              },
+              {
+                "native_mutation_ms": 32.7,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 62.481
+              },
+              {
+                "native_mutation_ms": 34.9,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 67.571
+              },
+              {
+                "native_mutation_ms": 34.4,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 63.419
+              },
+              {
+                "native_mutation_ms": 33.6,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 62.966
+              },
+              {
+                "native_mutation_ms": 33.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 66.738
+              },
+              {
+                "native_mutation_ms": 32.8,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 61.618
+              },
+              {
+                "native_mutation_ms": 35,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 66.405
+              },
+              {
+                "native_mutation_ms": 35,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 69.398
+              },
+              {
+                "native_mutation_ms": 35,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 65.382
+              },
+              {
+                "native_mutation_ms": 37,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 66.126
+              },
+              {
+                "native_mutation_ms": 34.9,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 70.907
+              },
+              {
+                "native_mutation_ms": 35.9,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 65.218
+              },
+              {
+                "native_mutation_ms": 35.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 64.804
+              },
+              {
+                "native_mutation_ms": 34.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 67.198
+              },
+              {
+                "native_mutation_ms": 34,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 68.214
+              },
+              {
+                "native_mutation_ms": 36.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 67.35
+              },
+              {
+                "native_mutation_ms": 37.5,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 67.583
+              },
+              {
+                "native_mutation_ms": 36.5,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 69.404
+              },
+              {
+                "native_mutation_ms": 36.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 65.921
+              },
+              {
+                "native_mutation_ms": 36.2,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 66.214
+              },
+              {
+                "native_mutation_ms": 36.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 70.586
+              },
+              {
+                "native_mutation_ms": 35.6,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 66.152
+              },
+              {
+                "native_mutation_ms": 35,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 65.585
+              }
+            ]
+          },
+          {
+            "size_utf16": 1048576,
+            "surface": "loomark_production",
+            "matched_width_px": 736,
+            "summary": {
+              "native_mutation_ms": {
+                "samples": 30,
+                "p50_ms": 32.8,
+                "p95_ms": 38.2,
+                "maximum_ms": 38.3
+              },
+              "input_handler_ms": {
+                "samples": 30,
+                "p50_ms": 0,
+                "p95_ms": 0.1,
+                "maximum_ms": 0.1
+              },
+              "put_request_offset_ms": {
+                "samples": 30,
+                "p50_ms": 314.9,
+                "p95_ms": 330,
+                "maximum_ms": 336.9
+              },
+              "put_acknowledgment_ms": {
+                "samples": 30,
+                "p50_ms": 9.6,
+                "p95_ms": 36.6,
+                "maximum_ms": 37.3
+              },
+              "browser_command_wall_ms": {
+                "samples": 30,
+                "p50_ms": 68.872,
+                "p95_ms": 77.962,
+                "maximum_ms": 80.649
+              },
+              "long_tasks": {
+                "samples_with_long_tasks": 30,
+                "count": 34,
+                "maximum_ms": 86
+              }
+            },
+            "samples": [
+              {
+                "native_mutation_ms": 32.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 316.8,
+                "put_acknowledgment_ms": 28.3,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 66
+                  }
+                ],
+                "browser_command_wall_ms": 72.827
+              },
+              {
+                "native_mutation_ms": 31.9,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 321.9,
+                "put_acknowledgment_ms": 6.7,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 71
+                  },
+                  {
+                    "offset_ms": 329,
+                    "duration_ms": 69
+                  }
+                ],
+                "browser_command_wall_ms": 66.543
+              },
+              {
+                "native_mutation_ms": 33.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 312.1,
+                "put_acknowledgment_ms": 36.6,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 61
+                  }
+                ],
+                "browser_command_wall_ms": 68.872
+              },
+              {
+                "native_mutation_ms": 36.2,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 326.1,
+                "put_acknowledgment_ms": 0.2,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 75
+                  }
+                ],
+                "browser_command_wall_ms": 71.27
+              },
+              {
+                "native_mutation_ms": 31.5,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": 315.4,
+                "put_acknowledgment_ms": 9.6,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 65
+                  }
+                ],
+                "browser_command_wall_ms": 68.238
+              },
+              {
+                "native_mutation_ms": 31.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 305.6,
+                "put_acknowledgment_ms": 29.1,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 55
+                  }
+                ],
+                "browser_command_wall_ms": 72.366
+              },
+              {
+                "native_mutation_ms": 32.6,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 308.8,
+                "put_acknowledgment_ms": 0.4,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 58
+                  }
+                ],
+                "browser_command_wall_ms": 67.288
+              },
+              {
+                "native_mutation_ms": 30.7,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 305.9,
+                "put_acknowledgment_ms": 33.5,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 55
+                  }
+                ],
+                "browser_command_wall_ms": 65.237
+              },
+              {
+                "native_mutation_ms": 32.2,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 326.2,
+                "put_acknowledgment_ms": 0.4,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.2,
+                    "duration_ms": 76
+                  }
+                ],
+                "browser_command_wall_ms": 67.623
+              },
+              {
+                "native_mutation_ms": 31.3,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 315.1,
+                "put_acknowledgment_ms": 10.8,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 64
+                  }
+                ],
+                "browser_command_wall_ms": 65.912
+              },
+              {
+                "native_mutation_ms": 33.5,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": 316.6,
+                "put_acknowledgment_ms": 29,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 66
+                  }
+                ],
+                "browser_command_wall_ms": 69.762
+              },
+              {
+                "native_mutation_ms": 32.2,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 312.5,
+                "put_acknowledgment_ms": 6.5,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 62
+                  }
+                ],
+                "browser_command_wall_ms": 66.719
+              },
+              {
+                "native_mutation_ms": 38.2,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 305.9,
+                "put_acknowledgment_ms": 29.7,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 55
+                  }
+                ],
+                "browser_command_wall_ms": 80.649
+              },
+              {
+                "native_mutation_ms": 33.7,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 326.3,
+                "put_acknowledgment_ms": 8.8,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 76
+                  }
+                ],
+                "browser_command_wall_ms": 69.905
+              },
+              {
+                "native_mutation_ms": 36.9,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 304.7,
+                "put_acknowledgment_ms": 19.8,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 54
+                  }
+                ],
+                "browser_command_wall_ms": 72.873
+              },
+              {
+                "native_mutation_ms": 33.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 328.6,
+                "put_acknowledgment_ms": 6.6,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 78
+                  }
+                ],
+                "browser_command_wall_ms": 67.814
+              },
+              {
+                "native_mutation_ms": 34.9,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 303.6,
+                "put_acknowledgment_ms": 17.3,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.2,
+                    "duration_ms": 53
+                  }
+                ],
+                "browser_command_wall_ms": 69.838
+              },
+              {
+                "native_mutation_ms": 33,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 310.2,
+                "put_acknowledgment_ms": 0.3,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 59
+                  }
+                ],
+                "browser_command_wall_ms": 68.628
+              },
+              {
+                "native_mutation_ms": 33.2,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 312.6,
+                "put_acknowledgment_ms": 30.4,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 62
+                  }
+                ],
+                "browser_command_wall_ms": 69.947
+              },
+              {
+                "native_mutation_ms": 34.4,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 327.8,
+                "put_acknowledgment_ms": 0.4,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 42.6,
+                    "duration_ms": 54
+                  },
+                  {
+                    "offset_ms": 250.2,
+                    "duration_ms": 77
+                  }
+                ],
+                "browser_command_wall_ms": 77.962
+              },
+              {
+                "native_mutation_ms": 36.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 316.9,
+                "put_acknowledgment_ms": 10.8,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 66
+                  },
+                  {
+                    "offset_ms": 328.6,
+                    "duration_ms": 56
+                  }
+                ],
+                "browser_command_wall_ms": 73.881
+              },
+              {
+                "native_mutation_ms": 38.3,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 314.9,
+                "put_acknowledgment_ms": 30.1,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 252.8,
+                    "duration_ms": 62
+                  }
+                ],
+                "browser_command_wall_ms": 75.232
+              },
+              {
+                "native_mutation_ms": 35,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 320.7,
+                "put_acknowledgment_ms": 6.3,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.2,
+                    "duration_ms": 70
+                  },
+                  {
+                    "offset_ms": 327.3,
+                    "duration_ms": 61
+                  }
+                ],
+                "browser_command_wall_ms": 70.264
+              },
+              {
+                "native_mutation_ms": 32.5,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": 312.5,
+                "put_acknowledgment_ms": 37.3,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 62
+                  }
+                ],
+                "browser_command_wall_ms": 66.74
+              },
+              {
+                "native_mutation_ms": 32.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 330,
+                "put_acknowledgment_ms": 0.2,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 79
+                  }
+                ],
+                "browser_command_wall_ms": 68.748
+              },
+              {
+                "native_mutation_ms": 31.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 305,
+                "put_acknowledgment_ms": 11.9,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 54
+                  }
+                ],
+                "browser_command_wall_ms": 66.01
+              },
+              {
+                "native_mutation_ms": 32.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 307.3,
+                "put_acknowledgment_ms": 28.6,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.5,
+                    "duration_ms": 56
+                  }
+                ],
+                "browser_command_wall_ms": 74.169
+              },
+              {
+                "native_mutation_ms": 32.8,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": 309.9,
+                "put_acknowledgment_ms": 5.8,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 59
+                  }
+                ],
+                "browser_command_wall_ms": 68.398
+              },
+              {
+                "native_mutation_ms": 33.5,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 318.6,
+                "put_acknowledgment_ms": 0.2,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 68
+                  }
+                ],
+                "browser_command_wall_ms": 70.623
+              },
+              {
+                "native_mutation_ms": 31.4,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 336.9,
+                "put_acknowledgment_ms": 8.1,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 86
+                  }
+                ],
+                "browser_command_wall_ms": 66.41
+              }
+            ]
+          }
+        ],
+        "traces": []
+      },
+      "candidate": {
+        "schema": "loomark-whole-document-input-v1",
+        "environment": {
+          "commit": "8b792bf495000549aa0f9664871a2c8a3da7dec9",
+          "browser": "149.0.7827.55",
+          "node": "v24.14.1",
+          "platform": "linux",
+          "os_release": "6.18.33.2-microsoft-standard-WSL2",
+          "architecture": "x64",
+          "cpu": "AMD Ryzen 7 6800H with Radeon Graphics",
+          "headless": true,
+          "viewport": {
+            "width": 1280,
+            "height": 720
+          },
+          "warmups": 5,
+          "samples": 30,
+          "trace_samples": 0,
+          "settle_ms": 400,
+          "persistence_required": true
+        },
+        "invocation": {
+          "sizes": [
+            1048576
+          ],
+          "environment": {
+            "LOOMARK_WHOLE_DOCUMENT_SIZES": "1048576",
+            "LOOMARK_WHOLE_DOCUMENT_WARMUPS": "5",
+            "LOOMARK_WHOLE_DOCUMENT_SAMPLES": "30",
+            "LOOMARK_WHOLE_DOCUMENT_TRACE_SAMPLES": "0",
+            "LOOMARK_WHOLE_DOCUMENT_REQUIRE_PERSISTENCE": null
+          }
+        },
+        "fixtures": [
+          {
+            "requested_utf16": 1048576,
+            "utf16_length": 1048576,
+            "utf8_bytes": 1048576,
+            "sha256": "bd2b39512f137e45eb14063920e77769422728321640fc9214787e00a5dd74ae"
+          }
+        ],
+        "scenarios": [
+          {
+            "size_utf16": 1048576,
+            "surface": "native_textarea",
+            "matched_width_px": 736,
+            "summary": {
+              "native_mutation_ms": {
+                "samples": 30,
+                "p50_ms": 36.1,
+                "p95_ms": 39.2,
+                "maximum_ms": 47.5
+              },
+              "input_handler_ms": {
+                "samples": 30,
+                "p50_ms": 0,
+                "p95_ms": 0.1,
+                "maximum_ms": 0.1
+              },
+              "put_request_offset_ms": {
+                "samples": 0,
+                "p50_ms": null,
+                "p95_ms": null,
+                "maximum_ms": null
+              },
+              "put_acknowledgment_ms": {
+                "samples": 0,
+                "p50_ms": null,
+                "p95_ms": null,
+                "maximum_ms": null
+              },
+              "browser_command_wall_ms": {
+                "samples": 30,
+                "p50_ms": 67.308,
+                "p95_ms": 72.556,
+                "maximum_ms": 81.422
+              },
+              "long_tasks": {
+                "samples_with_long_tasks": 0,
+                "count": 0,
+                "maximum_ms": 0
+              },
+              "w2_long_tasks": {
+                "window_start_ms": 200,
+                "window_end_ms": 400,
+                "samples_with_long_tasks": 0,
+                "maximum_per_sample_ms": {
+                  "samples": 30,
+                  "p50_ms": 0,
+                  "p95_ms": 0,
+                  "maximum_ms": 0
+                }
+              }
+            },
+            "samples": [
+              {
+                "native_mutation_ms": 37,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 66.388
+              },
+              {
+                "native_mutation_ms": 35.6,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 65.589
+              },
+              {
+                "native_mutation_ms": 36.9,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 70.474
+              },
+              {
+                "native_mutation_ms": 36.4,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 67.702
+              },
+              {
+                "native_mutation_ms": 35.3,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 67.647
+              },
+              {
+                "native_mutation_ms": 35.9,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 69.851
+              },
+              {
+                "native_mutation_ms": 36.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 67.308
+              },
+              {
+                "native_mutation_ms": 34.6,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 63.956
+              },
+              {
+                "native_mutation_ms": 39.2,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 71.125
+              },
+              {
+                "native_mutation_ms": 35.6,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 65.377
+              },
+              {
+                "native_mutation_ms": 36,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 65.01
+              },
+              {
+                "native_mutation_ms": 37.7,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 71.043
+              },
+              {
+                "native_mutation_ms": 36,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 69.823
+              },
+              {
+                "native_mutation_ms": 35.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 66.479
+              },
+              {
+                "native_mutation_ms": 35.2,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 65.435
+              },
+              {
+                "native_mutation_ms": 35.2,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 69.14
+              },
+              {
+                "native_mutation_ms": 36.4,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 65.54
+              },
+              {
+                "native_mutation_ms": 37.4,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 67.384
+              },
+              {
+                "native_mutation_ms": 37.6,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 70.587
+              },
+              {
+                "native_mutation_ms": 35.8,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 66.072
+              },
+              {
+                "native_mutation_ms": 36.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 66.639
+              },
+              {
+                "native_mutation_ms": 37.4,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 72.556
+              },
+              {
+                "native_mutation_ms": 34.4,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 65.1
+              },
+              {
+                "native_mutation_ms": 35.7,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 65.112
+              },
+              {
+                "native_mutation_ms": 34.6,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 67.534
+              },
+              {
+                "native_mutation_ms": 36.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 64.656
+              },
+              {
+                "native_mutation_ms": 37.5,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 69.233
+              },
+              {
+                "native_mutation_ms": 47.5,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 81.422
+              },
+              {
+                "native_mutation_ms": 36.3,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 65.142
+              },
+              {
+                "native_mutation_ms": 37.6,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 67.872
+              }
+            ]
+          },
+          {
+            "size_utf16": 1048576,
+            "surface": "loomark_production",
+            "matched_width_px": 736,
+            "summary": {
+              "native_mutation_ms": {
+                "samples": 30,
+                "p50_ms": 32.4,
+                "p95_ms": 35.8,
+                "maximum_ms": 35.8
+              },
+              "input_handler_ms": {
+                "samples": 30,
+                "p50_ms": 0,
+                "p95_ms": 0.1,
+                "maximum_ms": 0.1
+              },
+              "put_request_offset_ms": {
+                "samples": 30,
+                "p50_ms": 315.9,
+                "p95_ms": 336.5,
+                "maximum_ms": 338.1
+              },
+              "put_acknowledgment_ms": {
+                "samples": 30,
+                "p50_ms": 12.3,
+                "p95_ms": 36.4,
+                "maximum_ms": 36.7
+              },
+              "browser_command_wall_ms": {
+                "samples": 30,
+                "p50_ms": 67.177,
+                "p95_ms": 74.187,
+                "maximum_ms": 74.362
+              },
+              "long_tasks": {
+                "samples_with_long_tasks": 30,
+                "count": 34,
+                "maximum_ms": 88
+              },
+              "w2_long_tasks": {
+                "window_start_ms": 200,
+                "window_end_ms": 400,
+                "samples_with_long_tasks": 30,
+                "maximum_per_sample_ms": {
+                  "samples": 30,
+                  "p50_ms": 65,
+                  "p95_ms": 86,
+                  "maximum_ms": 88
+                }
+              }
+            },
+            "samples": [
+              {
+                "native_mutation_ms": 31.4,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 310.8,
+                "put_acknowledgment_ms": 29,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 60
+                  }
+                ],
+                "browser_command_wall_ms": 65.807
+              },
+              {
+                "native_mutation_ms": 31,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": 326.5,
+                "put_acknowledgment_ms": 16.3,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 76
+                  }
+                ],
+                "browser_command_wall_ms": 66.431
+              },
+              {
+                "native_mutation_ms": 33.2,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 317.9,
+                "put_acknowledgment_ms": 9.6,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.5,
+                    "duration_ms": 67
+                  },
+                  {
+                    "offset_ms": 329.8,
+                    "duration_ms": 52
+                  }
+                ],
+                "browser_command_wall_ms": 67.177
+              },
+              {
+                "native_mutation_ms": 31.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 315.9,
+                "put_acknowledgment_ms": 19.8,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.5,
+                    "duration_ms": 65
+                  }
+                ],
+                "browser_command_wall_ms": 65.943
+              },
+              {
+                "native_mutation_ms": 35.4,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 332,
+                "put_acknowledgment_ms": 0.2,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 34.3,
+                    "duration_ms": 50
+                  },
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 81
+                  },
+                  {
+                    "offset_ms": 338.5,
+                    "duration_ms": 68
+                  }
+                ],
+                "browser_command_wall_ms": 70.866
+              },
+              {
+                "native_mutation_ms": 32.9,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 311.3,
+                "put_acknowledgment_ms": 29.6,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 61
+                  }
+                ],
+                "browser_command_wall_ms": 68.87
+              },
+              {
+                "native_mutation_ms": 31.2,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 327,
+                "put_acknowledgment_ms": 8,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.1,
+                    "duration_ms": 77
+                  }
+                ],
+                "browser_command_wall_ms": 74.024
+              },
+              {
+                "native_mutation_ms": 31.9,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 302.9,
+                "put_acknowledgment_ms": 9,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 52
+                  }
+                ],
+                "browser_command_wall_ms": 67.093
+              },
+              {
+                "native_mutation_ms": 31,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": 307.7,
+                "put_acknowledgment_ms": 36.7,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.5,
+                    "duration_ms": 57
+                  }
+                ],
+                "browser_command_wall_ms": 66.506
+              },
+              {
+                "native_mutation_ms": 31.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 308.5,
+                "put_acknowledgment_ms": 7.1,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.2,
+                    "duration_ms": 58
+                  }
+                ],
+                "browser_command_wall_ms": 67.62
+              },
+              {
+                "native_mutation_ms": 31,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": 310.9,
+                "put_acknowledgment_ms": 28.7,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 60
+                  }
+                ],
+                "browser_command_wall_ms": 65.445
+              },
+              {
+                "native_mutation_ms": 32.4,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 333.9,
+                "put_acknowledgment_ms": 0.3,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.2,
+                    "duration_ms": 83
+                  }
+                ],
+                "browser_command_wall_ms": 74.187
+              },
+              {
+                "native_mutation_ms": 33.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 303.5,
+                "put_acknowledgment_ms": 12.9,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 53
+                  }
+                ],
+                "browser_command_wall_ms": 69.987
+              },
+              {
+                "native_mutation_ms": 33.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 313.8,
+                "put_acknowledgment_ms": 7,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 63
+                  }
+                ],
+                "browser_command_wall_ms": 68.311
+              },
+              {
+                "native_mutation_ms": 30.7,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 318.7,
+                "put_acknowledgment_ms": 25.7,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 68
+                  }
+                ],
+                "browser_command_wall_ms": 64.434
+              },
+              {
+                "native_mutation_ms": 35.1,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": 336.5,
+                "put_acknowledgment_ms": 14.8,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 86
+                  }
+                ],
+                "browser_command_wall_ms": 68.564
+              },
+              {
+                "native_mutation_ms": 35.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 318.8,
+                "put_acknowledgment_ms": 12.3,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 68
+                  }
+                ],
+                "browser_command_wall_ms": 72.596
+              },
+              {
+                "native_mutation_ms": 30.3,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 316.6,
+                "put_acknowledgment_ms": 5.9,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.7,
+                    "duration_ms": 66
+                  }
+                ],
+                "browser_command_wall_ms": 65.464
+              },
+              {
+                "native_mutation_ms": 32.2,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 332.7,
+                "put_acknowledgment_ms": 29.2,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 82
+                  }
+                ],
+                "browser_command_wall_ms": 64.389
+              },
+              {
+                "native_mutation_ms": 32.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 338.1,
+                "put_acknowledgment_ms": 0.5,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 32.9,
+                    "duration_ms": 63
+                  },
+                  {
+                    "offset_ms": 250.2,
+                    "duration_ms": 88
+                  }
+                ],
+                "browser_command_wall_ms": 66.735
+              },
+              {
+                "native_mutation_ms": 31.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 308,
+                "put_acknowledgment_ms": 12.9,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 57
+                  }
+                ],
+                "browser_command_wall_ms": 74.183
+              },
+              {
+                "native_mutation_ms": 34.4,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 310.1,
+                "put_acknowledgment_ms": 6.1,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 59
+                  }
+                ],
+                "browser_command_wall_ms": 68.958
+              },
+              {
+                "native_mutation_ms": 32.3,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": 314.3,
+                "put_acknowledgment_ms": 36.4,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 64
+                  }
+                ],
+                "browser_command_wall_ms": 64.402
+              },
+              {
+                "native_mutation_ms": 34.7,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 333.6,
+                "put_acknowledgment_ms": 0.4,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 83
+                  }
+                ],
+                "browser_command_wall_ms": 69.683
+              },
+              {
+                "native_mutation_ms": 31.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 319.9,
+                "put_acknowledgment_ms": 9.4,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 69
+                  }
+                ],
+                "browser_command_wall_ms": 65.402
+              },
+              {
+                "native_mutation_ms": 32.4,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": 308.4,
+                "put_acknowledgment_ms": 27.3,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 58
+                  }
+                ],
+                "browser_command_wall_ms": 64.538
+              },
+              {
+                "native_mutation_ms": 35.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 324.7,
+                "put_acknowledgment_ms": 6.5,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 74
+                  }
+                ],
+                "browser_command_wall_ms": 69.31
+              },
+              {
+                "native_mutation_ms": 32.6,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 304.4,
+                "put_acknowledgment_ms": 29.1,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 54
+                  }
+                ],
+                "browser_command_wall_ms": 74.362
+              },
+              {
+                "native_mutation_ms": 32.5,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 325,
+                "put_acknowledgment_ms": 0.3,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 74
+                  }
+                ],
+                "browser_command_wall_ms": 66.516
+              },
+              {
+                "native_mutation_ms": 33.2,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 308.7,
+                "put_acknowledgment_ms": 25,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 58
+                  }
+                ],
+                "browser_command_wall_ms": 67.616
+              }
+            ]
+          }
+        ],
+        "traces": []
+      }
+    },
+    {
+      "pair": 4,
+      "order": "candidate-base",
+      "base": {
+        "schema": "loomark-whole-document-input-v1",
+        "environment": {
+          "commit": "1f24c66042115763040a029d05fc753eb30902a4",
+          "browser": "149.0.7827.55",
+          "node": "v24.14.1",
+          "platform": "linux",
+          "os_release": "6.18.33.2-microsoft-standard-WSL2",
+          "architecture": "x64",
+          "cpu": "AMD Ryzen 7 6800H with Radeon Graphics",
+          "headless": true,
+          "viewport": {
+            "width": 1280,
+            "height": 720
+          },
+          "warmups": 5,
+          "samples": 30,
+          "trace_samples": 0,
+          "settle_ms": 400,
+          "persistence_required": true
+        },
+        "invocation": {
+          "sizes": [
+            1048576
+          ],
+          "environment": {
+            "LOOMARK_WHOLE_DOCUMENT_SIZES": "1048576",
+            "LOOMARK_WHOLE_DOCUMENT_WARMUPS": "5",
+            "LOOMARK_WHOLE_DOCUMENT_SAMPLES": "30",
+            "LOOMARK_WHOLE_DOCUMENT_TRACE_SAMPLES": "0",
+            "LOOMARK_WHOLE_DOCUMENT_REQUIRE_PERSISTENCE": null
+          }
+        },
+        "fixtures": [
+          {
+            "requested_utf16": 1048576,
+            "utf16_length": 1048576,
+            "utf8_bytes": 1048576,
+            "sha256": "bd2b39512f137e45eb14063920e77769422728321640fc9214787e00a5dd74ae"
+          }
+        ],
+        "scenarios": [
+          {
+            "size_utf16": 1048576,
+            "surface": "native_textarea",
+            "matched_width_px": 736,
+            "summary": {
+              "native_mutation_ms": {
+                "samples": 30,
+                "p50_ms": 35.3,
+                "p95_ms": 42.1,
+                "maximum_ms": 44.5
+              },
+              "input_handler_ms": {
+                "samples": 30,
+                "p50_ms": 0,
+                "p95_ms": 0.1,
+                "maximum_ms": 0.1
+              },
+              "put_request_offset_ms": {
+                "samples": 0,
+                "p50_ms": null,
+                "p95_ms": null,
+                "maximum_ms": null
+              },
+              "put_acknowledgment_ms": {
+                "samples": 0,
+                "p50_ms": null,
+                "p95_ms": null,
+                "maximum_ms": null
+              },
+              "browser_command_wall_ms": {
+                "samples": 30,
+                "p50_ms": 68.322,
+                "p95_ms": 74.561,
+                "maximum_ms": 84.476
+              },
+              "long_tasks": {
+                "samples_with_long_tasks": 0,
+                "count": 0,
+                "maximum_ms": 0
+              }
+            },
+            "samples": [
+              {
+                "native_mutation_ms": 38.3,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 68.787
+              },
+              {
+                "native_mutation_ms": 36.5,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 67.551
+              },
+              {
+                "native_mutation_ms": 34.7,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 68.704
+              },
+              {
+                "native_mutation_ms": 34.5,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 65.085
+              },
+              {
+                "native_mutation_ms": 36.6,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 69.14
+              },
+              {
+                "native_mutation_ms": 37.5,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 70.872
+              },
+              {
+                "native_mutation_ms": 34.7,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 65.327
+              },
+              {
+                "native_mutation_ms": 42.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 72.681
+              },
+              {
+                "native_mutation_ms": 36,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 69.044
+              },
+              {
+                "native_mutation_ms": 35.3,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 65.218
+              },
+              {
+                "native_mutation_ms": 38.2,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 69.028
+              },
+              {
+                "native_mutation_ms": 37.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 74.561
+              },
+              {
+                "native_mutation_ms": 36,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 68.93
+              },
+              {
+                "native_mutation_ms": 41,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 73.139
+              },
+              {
+                "native_mutation_ms": 44.5,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 84.476
+              },
+              {
+                "native_mutation_ms": 37.2,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 69.909
+              },
+              {
+                "native_mutation_ms": 37.7,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 67.689
+              },
+              {
+                "native_mutation_ms": 34.3,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 68.453
+              },
+              {
+                "native_mutation_ms": 35.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 66.055
+              },
+              {
+                "native_mutation_ms": 38.5,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 68.322
+              },
+              {
+                "native_mutation_ms": 35.2,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 69.216
+              },
+              {
+                "native_mutation_ms": 34.4,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 63.186
+              },
+              {
+                "native_mutation_ms": 34.2,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 64.053
+              },
+              {
+                "native_mutation_ms": 35.6,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 69.659
+              },
+              {
+                "native_mutation_ms": 34.7,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 65.078
+              },
+              {
+                "native_mutation_ms": 35.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 65.529
+              },
+              {
+                "native_mutation_ms": 33.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 67.601
+              },
+              {
+                "native_mutation_ms": 34.9,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 64.579
+              },
+              {
+                "native_mutation_ms": 34,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 62.83
+              },
+              {
+                "native_mutation_ms": 33.2,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 67.13
+              }
+            ]
+          },
+          {
+            "size_utf16": 1048576,
+            "surface": "loomark_production",
+            "matched_width_px": 736,
+            "summary": {
+              "native_mutation_ms": {
+                "samples": 30,
+                "p50_ms": 36.9,
+                "p95_ms": 42.7,
+                "maximum_ms": 51.6
+              },
+              "input_handler_ms": {
+                "samples": 30,
+                "p50_ms": 0,
+                "p95_ms": 0.1,
+                "maximum_ms": 0.1
+              },
+              "put_request_offset_ms": {
+                "samples": 30,
+                "p50_ms": 321.5,
+                "p95_ms": 345.6,
+                "maximum_ms": 347.7
+              },
+              "put_acknowledgment_ms": {
+                "samples": 30,
+                "p50_ms": 0.4,
+                "p95_ms": 36.3,
+                "maximum_ms": 38.2
+              },
+              "browser_command_wall_ms": {
+                "samples": 30,
+                "p50_ms": 75.03,
+                "p95_ms": 88.842,
+                "maximum_ms": 98.643
+              },
+              "long_tasks": {
+                "samples_with_long_tasks": 30,
+                "count": 37,
+                "maximum_ms": 97
+              }
+            },
+            "samples": [
+              {
+                "native_mutation_ms": 33.6,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 314.2,
+                "put_acknowledgment_ms": 0.2,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.5,
+                    "duration_ms": 63
+                  }
+                ],
+                "browser_command_wall_ms": 76.916
+              },
+              {
+                "native_mutation_ms": 33.7,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 320.5,
+                "put_acknowledgment_ms": 0.2,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.5,
+                    "duration_ms": 70
+                  }
+                ],
+                "browser_command_wall_ms": 69.814
+              },
+              {
+                "native_mutation_ms": 34,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 330.1,
+                "put_acknowledgment_ms": 0.2,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 79
+                  }
+                ],
+                "browser_command_wall_ms": 69.453
+              },
+              {
+                "native_mutation_ms": 34,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": 309.2,
+                "put_acknowledgment_ms": 24.3,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 58
+                  }
+                ],
+                "browser_command_wall_ms": 70.236
+              },
+              {
+                "native_mutation_ms": 38.2,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 326,
+                "put_acknowledgment_ms": 0.3,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 35.6,
+                    "duration_ms": 64
+                  },
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 75
+                  }
+                ],
+                "browser_command_wall_ms": 75.03
+              },
+              {
+                "native_mutation_ms": 36,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 321.5,
+                "put_acknowledgment_ms": 32,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 71
+                  }
+                ],
+                "browser_command_wall_ms": 73.645
+              },
+              {
+                "native_mutation_ms": 36.3,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 308.2,
+                "put_acknowledgment_ms": 9.6,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 57
+                  }
+                ],
+                "browser_command_wall_ms": 73.027
+              },
+              {
+                "native_mutation_ms": 37.7,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 309.5,
+                "put_acknowledgment_ms": 21.3,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.5,
+                    "duration_ms": 59
+                  }
+                ],
+                "browser_command_wall_ms": 82.437
+              },
+              {
+                "native_mutation_ms": 38.3,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 315.6,
+                "put_acknowledgment_ms": 0.2,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.6,
+                    "duration_ms": 65
+                  }
+                ],
+                "browser_command_wall_ms": 76.516
+              },
+              {
+                "native_mutation_ms": 37,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 320.7,
+                "put_acknowledgment_ms": 38.2,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 70
+                  }
+                ],
+                "browser_command_wall_ms": 73.448
+              },
+              {
+                "native_mutation_ms": 38.9,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 341.4,
+                "put_acknowledgment_ms": 9.4,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 35.2,
+                    "duration_ms": 53
+                  },
+                  {
+                    "offset_ms": 250.2,
+                    "duration_ms": 91
+                  }
+                ],
+                "browser_command_wall_ms": 75.089
+              },
+              {
+                "native_mutation_ms": 39.2,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 306.8,
+                "put_acknowledgment_ms": 0.3,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.2,
+                    "duration_ms": 56
+                  }
+                ],
+                "browser_command_wall_ms": 76.419
+              },
+              {
+                "native_mutation_ms": 37.4,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": 345.6,
+                "put_acknowledgment_ms": 0.4,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.6,
+                    "duration_ms": 95
+                  }
+                ],
+                "browser_command_wall_ms": 76.076
+              },
+              {
+                "native_mutation_ms": 38.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 324.3,
+                "put_acknowledgment_ms": 24.2,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 74
+                  }
+                ],
+                "browser_command_wall_ms": 76.784
+              },
+              {
+                "native_mutation_ms": 36.6,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 317.1,
+                "put_acknowledgment_ms": 0.3,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 66
+                  },
+                  {
+                    "offset_ms": 323,
+                    "duration_ms": 51
+                  }
+                ],
+                "browser_command_wall_ms": 82.068
+              },
+              {
+                "native_mutation_ms": 34.7,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 333.9,
+                "put_acknowledgment_ms": 36.3,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 83
+                  }
+                ],
+                "browser_command_wall_ms": 70.655
+              },
+              {
+                "native_mutation_ms": 36,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 340.6,
+                "put_acknowledgment_ms": 0.4,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 36.1,
+                    "duration_ms": 54
+                  },
+                  {
+                    "offset_ms": 250.2,
+                    "duration_ms": 90
+                  }
+                ],
+                "browser_command_wall_ms": 73.144
+              },
+              {
+                "native_mutation_ms": 37.2,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 340.6,
+                "put_acknowledgment_ms": 8.8,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 90
+                  }
+                ],
+                "browser_command_wall_ms": 75.484
+              },
+              {
+                "native_mutation_ms": 36.6,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 327.7,
+                "put_acknowledgment_ms": 14.3,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.5,
+                    "duration_ms": 77
+                  }
+                ],
+                "browser_command_wall_ms": 74.217
+              },
+              {
+                "native_mutation_ms": 39.6,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": 313.4,
+                "put_acknowledgment_ms": 33.8,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 63
+                  }
+                ],
+                "browser_command_wall_ms": 78.486
+              },
+              {
+                "native_mutation_ms": 51.6,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 347.7,
+                "put_acknowledgment_ms": 0.3,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 45.4,
+                    "duration_ms": 81
+                  },
+                  {
+                    "offset_ms": 250.6,
+                    "duration_ms": 97
+                  }
+                ],
+                "browser_command_wall_ms": 98.643
+              },
+              {
+                "native_mutation_ms": 39.4,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 311.6,
+                "put_acknowledgment_ms": 15.5,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 61
+                  }
+                ],
+                "browser_command_wall_ms": 76.979
+              },
+              {
+                "native_mutation_ms": 36.9,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 314.5,
+                "put_acknowledgment_ms": 0.4,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 64
+                  }
+                ],
+                "browser_command_wall_ms": 73.166
+              },
+              {
+                "native_mutation_ms": 42.7,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 317.3,
+                "put_acknowledgment_ms": 0.2,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.5,
+                    "duration_ms": 67
+                  }
+                ],
+                "browser_command_wall_ms": 88.842
+              },
+              {
+                "native_mutation_ms": 37.5,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 334.2,
+                "put_acknowledgment_ms": 0.2,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 83
+                  }
+                ],
+                "browser_command_wall_ms": 74.558
+              },
+              {
+                "native_mutation_ms": 35.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 310.7,
+                "put_acknowledgment_ms": 13.3,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 60
+                  },
+                  {
+                    "offset_ms": 326.4,
+                    "duration_ms": 60
+                  }
+                ],
+                "browser_command_wall_ms": 80.01
+              },
+              {
+                "native_mutation_ms": 41.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 322.8,
+                "put_acknowledgment_ms": 32.7,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 72
+                  }
+                ],
+                "browser_command_wall_ms": 78.328
+              },
+              {
+                "native_mutation_ms": 33.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 328.2,
+                "put_acknowledgment_ms": 0.4,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 78
+                  }
+                ],
+                "browser_command_wall_ms": 71.82
+              },
+              {
+                "native_mutation_ms": 36.4,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 324.9,
+                "put_acknowledgment_ms": 0.3,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.5,
+                    "duration_ms": 74
+                  }
+                ],
+                "browser_command_wall_ms": 74.99
+              },
+              {
+                "native_mutation_ms": 36.2,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 345.1,
+                "put_acknowledgment_ms": 0.3,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 36.1,
+                    "duration_ms": 53
+                  },
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 94
+                  }
+                ],
+                "browser_command_wall_ms": 73.331
+              }
+            ]
+          }
+        ],
+        "traces": []
+      },
+      "candidate": {
+        "schema": "loomark-whole-document-input-v1",
+        "environment": {
+          "commit": "8b792bf495000549aa0f9664871a2c8a3da7dec9",
+          "browser": "149.0.7827.55",
+          "node": "v24.14.1",
+          "platform": "linux",
+          "os_release": "6.18.33.2-microsoft-standard-WSL2",
+          "architecture": "x64",
+          "cpu": "AMD Ryzen 7 6800H with Radeon Graphics",
+          "headless": true,
+          "viewport": {
+            "width": 1280,
+            "height": 720
+          },
+          "warmups": 5,
+          "samples": 30,
+          "trace_samples": 0,
+          "settle_ms": 400,
+          "persistence_required": true
+        },
+        "invocation": {
+          "sizes": [
+            1048576
+          ],
+          "environment": {
+            "LOOMARK_WHOLE_DOCUMENT_SIZES": "1048576",
+            "LOOMARK_WHOLE_DOCUMENT_WARMUPS": "5",
+            "LOOMARK_WHOLE_DOCUMENT_SAMPLES": "30",
+            "LOOMARK_WHOLE_DOCUMENT_TRACE_SAMPLES": "0",
+            "LOOMARK_WHOLE_DOCUMENT_REQUIRE_PERSISTENCE": null
+          }
+        },
+        "fixtures": [
+          {
+            "requested_utf16": 1048576,
+            "utf16_length": 1048576,
+            "utf8_bytes": 1048576,
+            "sha256": "bd2b39512f137e45eb14063920e77769422728321640fc9214787e00a5dd74ae"
+          }
+        ],
+        "scenarios": [
+          {
+            "size_utf16": 1048576,
+            "surface": "native_textarea",
+            "matched_width_px": 736,
+            "summary": {
+              "native_mutation_ms": {
+                "samples": 30,
+                "p50_ms": 69.8,
+                "p95_ms": 135,
+                "maximum_ms": 146.2
+              },
+              "input_handler_ms": {
+                "samples": 30,
+                "p50_ms": 0,
+                "p95_ms": 0.1,
+                "maximum_ms": 0.1
+              },
+              "put_request_offset_ms": {
+                "samples": 0,
+                "p50_ms": null,
+                "p95_ms": null,
+                "maximum_ms": null
+              },
+              "put_acknowledgment_ms": {
+                "samples": 0,
+                "p50_ms": null,
+                "p95_ms": null,
+                "maximum_ms": null
+              },
+              "browser_command_wall_ms": {
+                "samples": 30,
+                "p50_ms": 109.939,
+                "p95_ms": 226.53,
+                "maximum_ms": 231.257
+              },
+              "long_tasks": {
+                "samples_with_long_tasks": 0,
+                "count": 0,
+                "maximum_ms": 0
+              },
+              "w2_long_tasks": {
+                "window_start_ms": 200,
+                "window_end_ms": 400,
+                "samples_with_long_tasks": 0,
+                "maximum_per_sample_ms": {
+                  "samples": 30,
+                  "p50_ms": 0,
+                  "p95_ms": 0,
+                  "maximum_ms": 0
+                }
+              }
+            },
+            "samples": [
+              {
+                "native_mutation_ms": 36.6,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 66.7
+              },
+              {
+                "native_mutation_ms": 37.7,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 68.215
+              },
+              {
+                "native_mutation_ms": 34.7,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 68.936
+              },
+              {
+                "native_mutation_ms": 35.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 69.517
+              },
+              {
+                "native_mutation_ms": 36.3,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 65.237
+              },
+              {
+                "native_mutation_ms": 42.5,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 72.547
+              },
+              {
+                "native_mutation_ms": 35.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 67.741
+              },
+              {
+                "native_mutation_ms": 35.5,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 64.21
+              },
+              {
+                "native_mutation_ms": 35,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 65.608
+              },
+              {
+                "native_mutation_ms": 51.3,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 118.759
+              },
+              {
+                "native_mutation_ms": 101.9,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 154.475
+              },
+              {
+                "native_mutation_ms": 89.4,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 171.238
+              },
+              {
+                "native_mutation_ms": 101.7,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 149.427
+              },
+              {
+                "native_mutation_ms": 63.6,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 66.967
+              },
+              {
+                "native_mutation_ms": 69.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 137.565
+              },
+              {
+                "native_mutation_ms": 132.2,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 135.854
+              },
+              {
+                "native_mutation_ms": 128.7,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 188.172
+              },
+              {
+                "native_mutation_ms": 109.2,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 219.326
+              },
+              {
+                "native_mutation_ms": 64.6,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 109.939
+              },
+              {
+                "native_mutation_ms": 94.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 96.064
+              },
+              {
+                "native_mutation_ms": 77.6,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 80.237
+              },
+              {
+                "native_mutation_ms": 131.3,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 135.354
+              },
+              {
+                "native_mutation_ms": 146.2,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 231.257
+              },
+              {
+                "native_mutation_ms": 131.6,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 133.837
+              },
+              {
+                "native_mutation_ms": 111.4,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 173.376
+              },
+              {
+                "native_mutation_ms": 135,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 222.343
+              },
+              {
+                "native_mutation_ms": 135,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 226.53
+              },
+              {
+                "native_mutation_ms": 67.7,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 70.368
+              },
+              {
+                "native_mutation_ms": 130.7,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 182.028
+              },
+              {
+                "native_mutation_ms": 38.7,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 74.879
+              }
+            ]
+          },
+          {
+            "size_utf16": 1048576,
+            "surface": "loomark_production",
+            "matched_width_px": 736,
+            "summary": {
+              "native_mutation_ms": {
+                "samples": 30,
+                "p50_ms": 32,
+                "p95_ms": 35.8,
+                "maximum_ms": 36
+              },
+              "input_handler_ms": {
+                "samples": 30,
+                "p50_ms": 0,
+                "p95_ms": 0.1,
+                "maximum_ms": 0.1
+              },
+              "put_request_offset_ms": {
+                "samples": 30,
+                "p50_ms": 312.9,
+                "p95_ms": 337.4,
+                "maximum_ms": 340.2
+              },
+              "put_acknowledgment_ms": {
+                "samples": 30,
+                "p50_ms": 8.6,
+                "p95_ms": 31.4,
+                "maximum_ms": 37.9
+              },
+              "browser_command_wall_ms": {
+                "samples": 30,
+                "p50_ms": 67.658,
+                "p95_ms": 75.455,
+                "maximum_ms": 76.933
+              },
+              "long_tasks": {
+                "samples_with_long_tasks": 30,
+                "count": 33,
+                "maximum_ms": 90
+              },
+              "w2_long_tasks": {
+                "window_start_ms": 200,
+                "window_end_ms": 400,
+                "samples_with_long_tasks": 30,
+                "maximum_per_sample_ms": {
+                  "samples": 30,
+                  "p50_ms": 62,
+                  "p95_ms": 87,
+                  "maximum_ms": 90
+                }
+              }
+            },
+            "samples": [
+              {
+                "native_mutation_ms": 35.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 314.3,
+                "put_acknowledgment_ms": 0.3,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 64
+                  }
+                ],
+                "browser_command_wall_ms": 68.373
+              },
+              {
+                "native_mutation_ms": 32,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 308.5,
+                "put_acknowledgment_ms": 31.4,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 58
+                  }
+                ],
+                "browser_command_wall_ms": 66.665
+              },
+              {
+                "native_mutation_ms": 34.7,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 332.6,
+                "put_acknowledgment_ms": 0.4,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.5,
+                    "duration_ms": 82
+                  }
+                ],
+                "browser_command_wall_ms": 69.842
+              },
+              {
+                "native_mutation_ms": 31.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 303.7,
+                "put_acknowledgment_ms": 10.2,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 53
+                  }
+                ],
+                "browser_command_wall_ms": 66.195
+              },
+              {
+                "native_mutation_ms": 34.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 312.9,
+                "put_acknowledgment_ms": 0.4,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 62
+                  }
+                ],
+                "browser_command_wall_ms": 75.455
+              },
+              {
+                "native_mutation_ms": 31.7,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 308.2,
+                "put_acknowledgment_ms": 30.4,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.2,
+                    "duration_ms": 58
+                  }
+                ],
+                "browser_command_wall_ms": 66.607
+              },
+              {
+                "native_mutation_ms": 32.9,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 332.5,
+                "put_acknowledgment_ms": 8.1,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.2,
+                    "duration_ms": 82
+                  }
+                ],
+                "browser_command_wall_ms": 69.094
+              },
+              {
+                "native_mutation_ms": 32.6,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 302.3,
+                "put_acknowledgment_ms": 10.7,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.2,
+                    "duration_ms": 52
+                  }
+                ],
+                "browser_command_wall_ms": 66.982
+              },
+              {
+                "native_mutation_ms": 31.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 313.3,
+                "put_acknowledgment_ms": 0.4,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 62
+                  }
+                ],
+                "browser_command_wall_ms": 66.743
+              },
+              {
+                "native_mutation_ms": 31.2,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 331.7,
+                "put_acknowledgment_ms": 30.8,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 81
+                  }
+                ],
+                "browser_command_wall_ms": 66.089
+              },
+              {
+                "native_mutation_ms": 31.7,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 330.4,
+                "put_acknowledgment_ms": 0.4,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 80
+                  }
+                ],
+                "browser_command_wall_ms": 67.5
+              },
+              {
+                "native_mutation_ms": 32.7,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 307.9,
+                "put_acknowledgment_ms": 8.6,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 57
+                  }
+                ],
+                "browser_command_wall_ms": 74.759
+              },
+              {
+                "native_mutation_ms": 31.9,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 308.9,
+                "put_acknowledgment_ms": 28.9,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 58
+                  }
+                ],
+                "browser_command_wall_ms": 66.157
+              },
+              {
+                "native_mutation_ms": 32.4,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": 312.8,
+                "put_acknowledgment_ms": 7.2,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 62
+                  }
+                ],
+                "browser_command_wall_ms": 69.395
+              },
+              {
+                "native_mutation_ms": 34.2,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 317.1,
+                "put_acknowledgment_ms": 27.9,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 66
+                  }
+                ],
+                "browser_command_wall_ms": 70.826
+              },
+              {
+                "native_mutation_ms": 33.5,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 340.2,
+                "put_acknowledgment_ms": 0.4,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 90
+                  }
+                ],
+                "browser_command_wall_ms": 70.162
+              },
+              {
+                "native_mutation_ms": 31.5,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 307.5,
+                "put_acknowledgment_ms": 9.3,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 57
+                  }
+                ],
+                "browser_command_wall_ms": 66.308
+              },
+              {
+                "native_mutation_ms": 33,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 308.9,
+                "put_acknowledgment_ms": 30.9,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.2,
+                    "duration_ms": 58
+                  }
+                ],
+                "browser_command_wall_ms": 70.219
+              },
+              {
+                "native_mutation_ms": 35.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 330.9,
+                "put_acknowledgment_ms": 7.3,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 36.4,
+                    "duration_ms": 54
+                  },
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 80
+                  },
+                  {
+                    "offset_ms": 338.7,
+                    "duration_ms": 72
+                  }
+                ],
+                "browser_command_wall_ms": 73.269
+              },
+              {
+                "native_mutation_ms": 31.5,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 314.9,
+                "put_acknowledgment_ms": 30.8,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 64
+                  }
+                ],
+                "browser_command_wall_ms": 68.048
+              },
+              {
+                "native_mutation_ms": 32.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 330.8,
+                "put_acknowledgment_ms": 0.2,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 80
+                  }
+                ],
+                "browser_command_wall_ms": 76.933
+              },
+              {
+                "native_mutation_ms": 33.3,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": 308.2,
+                "put_acknowledgment_ms": 10.3,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 57
+                  }
+                ],
+                "browser_command_wall_ms": 67.658
+              },
+              {
+                "native_mutation_ms": 34.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 308.6,
+                "put_acknowledgment_ms": 37.9,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.2,
+                    "duration_ms": 58
+                  }
+                ],
+                "browser_command_wall_ms": 69.948
+              },
+              {
+                "native_mutation_ms": 30.8,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": 313.6,
+                "put_acknowledgment_ms": 6.7,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 63
+                  }
+                ],
+                "browser_command_wall_ms": 66.536
+              },
+              {
+                "native_mutation_ms": 29.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 316.4,
+                "put_acknowledgment_ms": 29.5,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 66
+                  }
+                ],
+                "browser_command_wall_ms": 66.434
+              },
+              {
+                "native_mutation_ms": 31.3,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": 336.6,
+                "put_acknowledgment_ms": 8.5,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 86
+                  }
+                ],
+                "browser_command_wall_ms": 73.711
+              },
+              {
+                "native_mutation_ms": 36,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 308.4,
+                "put_acknowledgment_ms": 11,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 58
+                  }
+                ],
+                "browser_command_wall_ms": 70.692
+              },
+              {
+                "native_mutation_ms": 30.9,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 309.6,
+                "put_acknowledgment_ms": 5.5,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 59
+                  }
+                ],
+                "browser_command_wall_ms": 66.816
+              },
+              {
+                "native_mutation_ms": 30.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 308.6,
+                "put_acknowledgment_ms": 30.6,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 58
+                  }
+                ],
+                "browser_command_wall_ms": 67.08
+              },
+              {
+                "native_mutation_ms": 31.6,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 337.4,
+                "put_acknowledgment_ms": 0.3,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 34.8,
+                    "duration_ms": 50
+                  },
+                  {
+                    "offset_ms": 250.2,
+                    "duration_ms": 87
+                  }
+                ],
+                "browser_command_wall_ms": 67.474
+              }
+            ]
+          }
+        ],
+        "traces": []
+      }
+    },
+    {
+      "pair": 5,
+      "order": "base-candidate",
+      "base": {
+        "schema": "loomark-whole-document-input-v1",
+        "environment": {
+          "commit": "1f24c66042115763040a029d05fc753eb30902a4",
+          "browser": "149.0.7827.55",
+          "node": "v24.14.1",
+          "platform": "linux",
+          "os_release": "6.18.33.2-microsoft-standard-WSL2",
+          "architecture": "x64",
+          "cpu": "AMD Ryzen 7 6800H with Radeon Graphics",
+          "headless": true,
+          "viewport": {
+            "width": 1280,
+            "height": 720
+          },
+          "warmups": 5,
+          "samples": 30,
+          "trace_samples": 0,
+          "settle_ms": 400,
+          "persistence_required": true
+        },
+        "invocation": {
+          "sizes": [
+            1048576
+          ],
+          "environment": {
+            "LOOMARK_WHOLE_DOCUMENT_SIZES": "1048576",
+            "LOOMARK_WHOLE_DOCUMENT_WARMUPS": "5",
+            "LOOMARK_WHOLE_DOCUMENT_SAMPLES": "30",
+            "LOOMARK_WHOLE_DOCUMENT_TRACE_SAMPLES": "0",
+            "LOOMARK_WHOLE_DOCUMENT_REQUIRE_PERSISTENCE": null
+          }
+        },
+        "fixtures": [
+          {
+            "requested_utf16": 1048576,
+            "utf16_length": 1048576,
+            "utf8_bytes": 1048576,
+            "sha256": "bd2b39512f137e45eb14063920e77769422728321640fc9214787e00a5dd74ae"
+          }
+        ],
+        "scenarios": [
+          {
+            "size_utf16": 1048576,
+            "surface": "native_textarea",
+            "matched_width_px": 736,
+            "summary": {
+              "native_mutation_ms": {
+                "samples": 30,
+                "p50_ms": 36.2,
+                "p95_ms": 37.9,
+                "maximum_ms": 40.3
+              },
+              "input_handler_ms": {
+                "samples": 30,
+                "p50_ms": 0,
+                "p95_ms": 0.1,
+                "maximum_ms": 0.1
+              },
+              "put_request_offset_ms": {
+                "samples": 0,
+                "p50_ms": null,
+                "p95_ms": null,
+                "maximum_ms": null
+              },
+              "put_acknowledgment_ms": {
+                "samples": 0,
+                "p50_ms": null,
+                "p95_ms": null,
+                "maximum_ms": null
+              },
+              "browser_command_wall_ms": {
+                "samples": 30,
+                "p50_ms": 67.174,
+                "p95_ms": 71.302,
+                "maximum_ms": 74.964
+              },
+              "long_tasks": {
+                "samples_with_long_tasks": 0,
+                "count": 0,
+                "maximum_ms": 0
+              }
+            },
+            "samples": [
+              {
+                "native_mutation_ms": 32.9,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 61.431
+              },
+              {
+                "native_mutation_ms": 32.6,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 61.147
+              },
+              {
+                "native_mutation_ms": 33,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 65.015
+              },
+              {
+                "native_mutation_ms": 35.9,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 64.661
+              },
+              {
+                "native_mutation_ms": 37.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 68.453
+              },
+              {
+                "native_mutation_ms": 40.3,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 74.964
+              },
+              {
+                "native_mutation_ms": 37.6,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 67.174
+              },
+              {
+                "native_mutation_ms": 33,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 62.938
+              },
+              {
+                "native_mutation_ms": 34.5,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 67.15
+              },
+              {
+                "native_mutation_ms": 35.9,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 65.303
+              },
+              {
+                "native_mutation_ms": 37.2,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 66.6
+              },
+              {
+                "native_mutation_ms": 37,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 70.023
+              },
+              {
+                "native_mutation_ms": 36.6,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 68.589
+              },
+              {
+                "native_mutation_ms": 37.9,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 67.715
+              },
+              {
+                "native_mutation_ms": 36.5,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 71.149
+              },
+              {
+                "native_mutation_ms": 36.2,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 70.551
+              },
+              {
+                "native_mutation_ms": 36.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 66.342
+              },
+              {
+                "native_mutation_ms": 35.1,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 69.166
+              },
+              {
+                "native_mutation_ms": 35.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 62.824
+              },
+              {
+                "native_mutation_ms": 37.3,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 67.707
+              },
+              {
+                "native_mutation_ms": 36.5,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 70.624
+              },
+              {
+                "native_mutation_ms": 36.5,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 66.587
+              },
+              {
+                "native_mutation_ms": 37.7,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 68.085
+              },
+              {
+                "native_mutation_ms": 35,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 69.226
+              },
+              {
+                "native_mutation_ms": 36.5,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 67.206
+              },
+              {
+                "native_mutation_ms": 34.9,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 64.991
+              },
+              {
+                "native_mutation_ms": 34.4,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 68.536
+              },
+              {
+                "native_mutation_ms": 35.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 64.711
+              },
+              {
+                "native_mutation_ms": 36.6,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 66.274
+              },
+              {
+                "native_mutation_ms": 36.5,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 71.302
+              }
+            ]
+          },
+          {
+            "size_utf16": 1048576,
+            "surface": "loomark_production",
+            "matched_width_px": 736,
+            "summary": {
+              "native_mutation_ms": {
+                "samples": 30,
+                "p50_ms": 34.5,
+                "p95_ms": 42.7,
+                "maximum_ms": 50.6
+              },
+              "input_handler_ms": {
+                "samples": 30,
+                "p50_ms": 0,
+                "p95_ms": 0.1,
+                "maximum_ms": 0.1
+              },
+              "put_request_offset_ms": {
+                "samples": 30,
+                "p50_ms": 316.7,
+                "p95_ms": 347.1,
+                "maximum_ms": 442.9
+              },
+              "put_acknowledgment_ms": {
+                "samples": 30,
+                "p50_ms": 6.6,
+                "p95_ms": 37.3,
+                "maximum_ms": 38
+              },
+              "browser_command_wall_ms": {
+                "samples": 30,
+                "p50_ms": 72.219,
+                "p95_ms": 85.33,
+                "maximum_ms": 87.118
+              },
+              "long_tasks": {
+                "samples_with_long_tasks": 30,
+                "count": 37,
+                "maximum_ms": 192
+              }
+            },
+            "samples": [
+              {
+                "native_mutation_ms": 32.3,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": 306.4,
+                "put_acknowledgment_ms": 29.1,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.5,
+                    "duration_ms": 56
+                  }
+                ],
+                "browser_command_wall_ms": 74.112
+              },
+              {
+                "native_mutation_ms": 34.3,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 311.5,
+                "put_acknowledgment_ms": 0.2,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 61
+                  }
+                ],
+                "browser_command_wall_ms": 68.981
+              },
+              {
+                "native_mutation_ms": 32.7,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 307.1,
+                "put_acknowledgment_ms": 37.2,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 56
+                  }
+                ],
+                "browser_command_wall_ms": 67.564
+              },
+              {
+                "native_mutation_ms": 33,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 313.1,
+                "put_acknowledgment_ms": 10.2,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 33.5,
+                    "duration_ms": 53
+                  },
+                  {
+                    "offset_ms": 250.5,
+                    "duration_ms": 62
+                  }
+                ],
+                "browser_command_wall_ms": 67.444
+              },
+              {
+                "native_mutation_ms": 32.6,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 317.7,
+                "put_acknowledgment_ms": 30.5,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 67
+                  }
+                ],
+                "browser_command_wall_ms": 67.668
+              },
+              {
+                "native_mutation_ms": 32.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 313.1,
+                "put_acknowledgment_ms": 0.2,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 62
+                  }
+                ],
+                "browser_command_wall_ms": 74.957
+              },
+              {
+                "native_mutation_ms": 34.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 442.9,
+                "put_acknowledgment_ms": 6.2,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 192
+                  }
+                ],
+                "browser_command_wall_ms": 70.497
+              },
+              {
+                "native_mutation_ms": 32.6,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 329.9,
+                "put_acknowledgment_ms": 0.2,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.2,
+                    "duration_ms": 79
+                  }
+                ],
+                "browser_command_wall_ms": 75.619
+              },
+              {
+                "native_mutation_ms": 37.2,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 318.5,
+                "put_acknowledgment_ms": 0.1,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 68
+                  }
+                ],
+                "browser_command_wall_ms": 75.096
+              },
+              {
+                "native_mutation_ms": 33.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 320.5,
+                "put_acknowledgment_ms": 37.3,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 70
+                  }
+                ],
+                "browser_command_wall_ms": 71.087
+              },
+              {
+                "native_mutation_ms": 34,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 311.3,
+                "put_acknowledgment_ms": 6.5,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 61
+                  }
+                ],
+                "browser_command_wall_ms": 69.001
+              },
+              {
+                "native_mutation_ms": 31.3,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 306.8,
+                "put_acknowledgment_ms": 0.2,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 56
+                  }
+                ],
+                "browser_command_wall_ms": 65.787
+              },
+              {
+                "native_mutation_ms": 34.7,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 341.2,
+                "put_acknowledgment_ms": 10.1,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 42.3,
+                    "duration_ms": 51
+                  },
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 91
+                  }
+                ],
+                "browser_command_wall_ms": 78.082
+              },
+              {
+                "native_mutation_ms": 32,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": 321.1,
+                "put_acknowledgment_ms": 15.6,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 70
+                  }
+                ],
+                "browser_command_wall_ms": 68.052
+              },
+              {
+                "native_mutation_ms": 34.2,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 314.3,
+                "put_acknowledgment_ms": 6.6,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 64
+                  }
+                ],
+                "browser_command_wall_ms": 69.865
+              },
+              {
+                "native_mutation_ms": 35.9,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 321.5,
+                "put_acknowledgment_ms": 38,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 71
+                  }
+                ],
+                "browser_command_wall_ms": 71.258
+              },
+              {
+                "native_mutation_ms": 40.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 334.1,
+                "put_acknowledgment_ms": 0.2,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 83
+                  }
+                ],
+                "browser_command_wall_ms": 76.698
+              },
+              {
+                "native_mutation_ms": 35.7,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": 306.4,
+                "put_acknowledgment_ms": 8.5,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 56
+                  }
+                ],
+                "browser_command_wall_ms": 72.219
+              },
+              {
+                "native_mutation_ms": 36.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 317.8,
+                "put_acknowledgment_ms": 30.1,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 67
+                  }
+                ],
+                "browser_command_wall_ms": 74.733
+              },
+              {
+                "native_mutation_ms": 36.6,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 327.9,
+                "put_acknowledgment_ms": 0.2,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 36.6,
+                    "duration_ms": 56
+                  },
+                  {
+                    "offset_ms": 250.2,
+                    "duration_ms": 77
+                  },
+                  {
+                    "offset_ms": 334.4,
+                    "duration_ms": 67
+                  }
+                ],
+                "browser_command_wall_ms": 74.265
+              },
+              {
+                "native_mutation_ms": 37.7,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 316.7,
+                "put_acknowledgment_ms": 0.1,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 66
+                  }
+                ],
+                "browser_command_wall_ms": 85.33
+              },
+              {
+                "native_mutation_ms": 35.2,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 347.1,
+                "put_acknowledgment_ms": 0.3,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 96
+                  }
+                ],
+                "browser_command_wall_ms": 71.856
+              },
+              {
+                "native_mutation_ms": 40,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 308.1,
+                "put_acknowledgment_ms": 13.3,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 57
+                  }
+                ],
+                "browser_command_wall_ms": 78.858
+              },
+              {
+                "native_mutation_ms": 37.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 323.5,
+                "put_acknowledgment_ms": 29.4,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 73
+                  }
+                ],
+                "browser_command_wall_ms": 76.483
+              },
+              {
+                "native_mutation_ms": 34.5,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 314.3,
+                "put_acknowledgment_ms": 0.4,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 36.2,
+                    "duration_ms": 53
+                  },
+                  {
+                    "offset_ms": 250.2,
+                    "duration_ms": 64
+                  }
+                ],
+                "browser_command_wall_ms": 71.742
+              },
+              {
+                "native_mutation_ms": 37.6,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 319.5,
+                "put_acknowledgment_ms": 32.2,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 69
+                  }
+                ],
+                "browser_command_wall_ms": 74.638
+              },
+              {
+                "native_mutation_ms": 42.7,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 345.9,
+                "put_acknowledgment_ms": 0.3,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 35,
+                    "duration_ms": 52
+                  },
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 95
+                  }
+                ],
+                "browser_command_wall_ms": 78.853
+              },
+              {
+                "native_mutation_ms": 50.6,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 308.4,
+                "put_acknowledgment_ms": 12.2,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.2,
+                    "duration_ms": 58
+                  }
+                ],
+                "browser_command_wall_ms": 87.118
+              },
+              {
+                "native_mutation_ms": 34.5,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 312.3,
+                "put_acknowledgment_ms": 0.4,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 35,
+                    "duration_ms": 54
+                  },
+                  {
+                    "offset_ms": 250.5,
+                    "duration_ms": 62
+                  }
+                ],
+                "browser_command_wall_ms": 70.646
+              },
+              {
+                "native_mutation_ms": 31.9,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 308,
+                "put_acknowledgment_ms": 31.4,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 57
+                  }
+                ],
+                "browser_command_wall_ms": 74.626
+              }
+            ]
+          }
+        ],
+        "traces": []
+      },
+      "candidate": {
+        "schema": "loomark-whole-document-input-v1",
+        "environment": {
+          "commit": "8b792bf495000549aa0f9664871a2c8a3da7dec9",
+          "browser": "149.0.7827.55",
+          "node": "v24.14.1",
+          "platform": "linux",
+          "os_release": "6.18.33.2-microsoft-standard-WSL2",
+          "architecture": "x64",
+          "cpu": "AMD Ryzen 7 6800H with Radeon Graphics",
+          "headless": true,
+          "viewport": {
+            "width": 1280,
+            "height": 720
+          },
+          "warmups": 5,
+          "samples": 30,
+          "trace_samples": 0,
+          "settle_ms": 400,
+          "persistence_required": true
+        },
+        "invocation": {
+          "sizes": [
+            1048576
+          ],
+          "environment": {
+            "LOOMARK_WHOLE_DOCUMENT_SIZES": "1048576",
+            "LOOMARK_WHOLE_DOCUMENT_WARMUPS": "5",
+            "LOOMARK_WHOLE_DOCUMENT_SAMPLES": "30",
+            "LOOMARK_WHOLE_DOCUMENT_TRACE_SAMPLES": "0",
+            "LOOMARK_WHOLE_DOCUMENT_REQUIRE_PERSISTENCE": null
+          }
+        },
+        "fixtures": [
+          {
+            "requested_utf16": 1048576,
+            "utf16_length": 1048576,
+            "utf8_bytes": 1048576,
+            "sha256": "bd2b39512f137e45eb14063920e77769422728321640fc9214787e00a5dd74ae"
+          }
+        ],
+        "scenarios": [
+          {
+            "size_utf16": 1048576,
+            "surface": "native_textarea",
+            "matched_width_px": 736,
+            "summary": {
+              "native_mutation_ms": {
+                "samples": 30,
+                "p50_ms": 46,
+                "p95_ms": 124.9,
+                "maximum_ms": 146
+              },
+              "input_handler_ms": {
+                "samples": 30,
+                "p50_ms": 0,
+                "p95_ms": 0.1,
+                "maximum_ms": 0.1
+              },
+              "put_request_offset_ms": {
+                "samples": 0,
+                "p50_ms": null,
+                "p95_ms": null,
+                "maximum_ms": null
+              },
+              "put_acknowledgment_ms": {
+                "samples": 0,
+                "p50_ms": null,
+                "p95_ms": null,
+                "maximum_ms": null
+              },
+              "browser_command_wall_ms": {
+                "samples": 30,
+                "p50_ms": 84.043,
+                "p95_ms": 192.981,
+                "maximum_ms": 194.009
+              },
+              "long_tasks": {
+                "samples_with_long_tasks": 0,
+                "count": 0,
+                "maximum_ms": 0
+              },
+              "w2_long_tasks": {
+                "window_start_ms": 200,
+                "window_end_ms": 400,
+                "samples_with_long_tasks": 0,
+                "maximum_per_sample_ms": {
+                  "samples": 30,
+                  "p50_ms": 0,
+                  "p95_ms": 0,
+                  "maximum_ms": 0
+                }
+              }
+            },
+            "samples": [
+              {
+                "native_mutation_ms": 53.6,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 94.585
+              },
+              {
+                "native_mutation_ms": 124.9,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 194.009
+              },
+              {
+                "native_mutation_ms": 90.5,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 137.61
+              },
+              {
+                "native_mutation_ms": 56.3,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 90.205
+              },
+              {
+                "native_mutation_ms": 49.4,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 96.149
+              },
+              {
+                "native_mutation_ms": 57.9,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 92.766
+              },
+              {
+                "native_mutation_ms": 40.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 72.099
+              },
+              {
+                "native_mutation_ms": 146,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 192.981
+              },
+              {
+                "native_mutation_ms": 50.7,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 90.588
+              },
+              {
+                "native_mutation_ms": 52.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 98.236
+              },
+              {
+                "native_mutation_ms": 58.7,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 92.834
+              },
+              {
+                "native_mutation_ms": 46,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 79.982
+              },
+              {
+                "native_mutation_ms": 38.4,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 76.729
+              },
+              {
+                "native_mutation_ms": 42.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 78.067
+              },
+              {
+                "native_mutation_ms": 50.2,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 88.946
+              },
+              {
+                "native_mutation_ms": 45.6,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 86.948
+              },
+              {
+                "native_mutation_ms": 44.4,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 81.353
+              },
+              {
+                "native_mutation_ms": 43.6,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 84.043
+              },
+              {
+                "native_mutation_ms": 38.2,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 74.08
+              },
+              {
+                "native_mutation_ms": 42.3,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 78.849
+              },
+              {
+                "native_mutation_ms": 49.5,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 86.92
+              },
+              {
+                "native_mutation_ms": 37.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 72.001
+              },
+              {
+                "native_mutation_ms": 78.5,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 114.672
+              },
+              {
+                "native_mutation_ms": 41.4,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 79.033
+              },
+              {
+                "native_mutation_ms": 41.6,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 78.837
+              },
+              {
+                "native_mutation_ms": 39.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 72.47
+              },
+              {
+                "native_mutation_ms": 38,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 74.695
+              },
+              {
+                "native_mutation_ms": 42.4,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 79.979
+              },
+              {
+                "native_mutation_ms": 47.4,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 83.375
+              },
+              {
+                "native_mutation_ms": 49.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": null,
+                "put_acknowledgment_ms": null,
+                "put_outcome": null,
+                "long_tasks": [],
+                "browser_command_wall_ms": 96.695
+              }
+            ]
+          },
+          {
+            "size_utf16": 1048576,
+            "surface": "loomark_production",
+            "matched_width_px": 736,
+            "summary": {
+              "native_mutation_ms": {
+                "samples": 30,
+                "p50_ms": 32.7,
+                "p95_ms": 40.3,
+                "maximum_ms": 67.2
+              },
+              "input_handler_ms": {
+                "samples": 30,
+                "p50_ms": 0,
+                "p95_ms": 0.1,
+                "maximum_ms": 0.1
+              },
+              "put_request_offset_ms": {
+                "samples": 30,
+                "p50_ms": 315,
+                "p95_ms": 340.4,
+                "maximum_ms": 495.2
+              },
+              "put_acknowledgment_ms": {
+                "samples": 30,
+                "p50_ms": 7.8,
+                "p95_ms": 36.7,
+                "maximum_ms": 49
+              },
+              "browser_command_wall_ms": {
+                "samples": 30,
+                "p50_ms": 67.962,
+                "p95_ms": 86.611,
+                "maximum_ms": 102.273
+              },
+              "long_tasks": {
+                "samples_with_long_tasks": 30,
+                "count": 33,
+                "maximum_ms": 245
+              },
+              "w2_long_tasks": {
+                "window_start_ms": 200,
+                "window_end_ms": 400,
+                "samples_with_long_tasks": 30,
+                "maximum_per_sample_ms": {
+                  "samples": 30,
+                  "p50_ms": 64,
+                  "p95_ms": 90,
+                  "maximum_ms": 245
+                }
+              }
+            },
+            "samples": [
+              {
+                "native_mutation_ms": 33.9,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 333.2,
+                "put_acknowledgment_ms": 0.4,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.5,
+                    "duration_ms": 82
+                  }
+                ],
+                "browser_command_wall_ms": 67.962
+              },
+              {
+                "native_mutation_ms": 32.7,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": 329.3,
+                "put_acknowledgment_ms": 0.2,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 79
+                  }
+                ],
+                "browser_command_wall_ms": 67.549
+              },
+              {
+                "native_mutation_ms": 31.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 305.9,
+                "put_acknowledgment_ms": 27.2,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 55
+                  }
+                ],
+                "browser_command_wall_ms": 73.957
+              },
+              {
+                "native_mutation_ms": 32.3,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 330.7,
+                "put_acknowledgment_ms": 0.3,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 80
+                  }
+                ],
+                "browser_command_wall_ms": 68.702
+              },
+              {
+                "native_mutation_ms": 34.2,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 317.4,
+                "put_acknowledgment_ms": 19.6,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 67
+                  }
+                ],
+                "browser_command_wall_ms": 68.98
+              },
+              {
+                "native_mutation_ms": 32.3,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 338.6,
+                "put_acknowledgment_ms": 6.7,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 88
+                  }
+                ],
+                "browser_command_wall_ms": 66.639
+              },
+              {
+                "native_mutation_ms": 32.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 310.2,
+                "put_acknowledgment_ms": 18.3,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 60
+                  }
+                ],
+                "browser_command_wall_ms": 66.475
+              },
+              {
+                "native_mutation_ms": 32.7,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 338.4,
+                "put_acknowledgment_ms": 0.4,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 88
+                  }
+                ],
+                "browser_command_wall_ms": 67.955
+              },
+              {
+                "native_mutation_ms": 31.6,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": 312.5,
+                "put_acknowledgment_ms": 0.5,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.5,
+                    "duration_ms": 62
+                  },
+                  {
+                    "offset_ms": 319,
+                    "duration_ms": 53
+                  }
+                ],
+                "browser_command_wall_ms": 66.736
+              },
+              {
+                "native_mutation_ms": 32.5,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 313.5,
+                "put_acknowledgment_ms": 29.4,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 63
+                  }
+                ],
+                "browser_command_wall_ms": 67.232
+              },
+              {
+                "native_mutation_ms": 32.9,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 329.1,
+                "put_acknowledgment_ms": 0.2,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 78
+                  }
+                ],
+                "browser_command_wall_ms": 67.679
+              },
+              {
+                "native_mutation_ms": 33.5,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 305.4,
+                "put_acknowledgment_ms": 10.4,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 55
+                  }
+                ],
+                "browser_command_wall_ms": 76.262
+              },
+              {
+                "native_mutation_ms": 32.7,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 311.1,
+                "put_acknowledgment_ms": 0.3,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.5,
+                    "duration_ms": 60
+                  }
+                ],
+                "browser_command_wall_ms": 67.931
+              },
+              {
+                "native_mutation_ms": 33.6,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 305.8,
+                "put_acknowledgment_ms": 36.7,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.2,
+                    "duration_ms": 55
+                  }
+                ],
+                "browser_command_wall_ms": 69.023
+              },
+              {
+                "native_mutation_ms": 31.5,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": 329.6,
+                "put_acknowledgment_ms": 0.7,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 79
+                  }
+                ],
+                "browser_command_wall_ms": 66.054
+              },
+              {
+                "native_mutation_ms": 32,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": 305.6,
+                "put_acknowledgment_ms": 7.4,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 55
+                  }
+                ],
+                "browser_command_wall_ms": 67.449
+              },
+              {
+                "native_mutation_ms": 32.1,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": 319.3,
+                "put_acknowledgment_ms": 28.5,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 69
+                  }
+                ],
+                "browser_command_wall_ms": 70.435
+              },
+              {
+                "native_mutation_ms": 34.6,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 310.8,
+                "put_acknowledgment_ms": 0.5,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 60
+                  },
+                  {
+                    "offset_ms": 317,
+                    "duration_ms": 50
+                  }
+                ],
+                "browser_command_wall_ms": 70.266
+              },
+              {
+                "native_mutation_ms": 35.1,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": 323.2,
+                "put_acknowledgment_ms": 32.2,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 72
+                  }
+                ],
+                "browser_command_wall_ms": 86.611
+              },
+              {
+                "native_mutation_ms": 40.3,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 340.4,
+                "put_acknowledgment_ms": 9.7,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 38.4,
+                    "duration_ms": 60
+                  },
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 90
+                  }
+                ],
+                "browser_command_wall_ms": 79.991
+              },
+              {
+                "native_mutation_ms": 36.3,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 309.8,
+                "put_acknowledgment_ms": 22.6,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 59
+                  }
+                ],
+                "browser_command_wall_ms": 72.123
+              },
+              {
+                "native_mutation_ms": 34.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 340.2,
+                "put_acknowledgment_ms": 0.3,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 90
+                  }
+                ],
+                "browser_command_wall_ms": 71.178
+              },
+              {
+                "native_mutation_ms": 31.1,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 315,
+                "put_acknowledgment_ms": 17.3,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 64
+                  }
+                ],
+                "browser_command_wall_ms": 66.906
+              },
+              {
+                "native_mutation_ms": 31,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 327.9,
+                "put_acknowledgment_ms": 6.1,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 77
+                  }
+                ],
+                "browser_command_wall_ms": 65.602
+              },
+              {
+                "native_mutation_ms": 37.4,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 303.7,
+                "put_acknowledgment_ms": 27.1,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 53
+                  }
+                ],
+                "browser_command_wall_ms": 73.052
+              },
+              {
+                "native_mutation_ms": 32.8,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 305.3,
+                "put_acknowledgment_ms": 29.5,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 55
+                  }
+                ],
+                "browser_command_wall_ms": 67.72
+              },
+              {
+                "native_mutation_ms": 67.2,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": 333.4,
+                "put_acknowledgment_ms": 7.8,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 83
+                  }
+                ],
+                "browser_command_wall_ms": 102.273
+              },
+              {
+                "native_mutation_ms": 31.8,
+                "input_handler_ms": 0.1,
+                "put_request_offset_ms": 304.9,
+                "put_acknowledgment_ms": 10.5,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 54
+                  }
+                ],
+                "browser_command_wall_ms": 73.199
+              },
+              {
+                "native_mutation_ms": 33.9,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 310.2,
+                "put_acknowledgment_ms": 0.3,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.4,
+                    "duration_ms": 59
+                  }
+                ],
+                "browser_command_wall_ms": 68.27
+              },
+              {
+                "native_mutation_ms": 32.5,
+                "input_handler_ms": 0,
+                "put_request_offset_ms": 495.2,
+                "put_acknowledgment_ms": 49,
+                "put_outcome": "stored",
+                "long_tasks": [
+                  {
+                    "offset_ms": 250.3,
+                    "duration_ms": 245
+                  }
+                ],
+                "browser_command_wall_ms": 65.74
+              }
+            ]
+          }
+        ],
+        "traces": []
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Queue immutable unencoded LocalText intents in the existing `LocalArchivePersistenceQueue`, retaining one selected write and one replaceable latest intent.
- Materialize and JSON-encode LocalText only after first selection, promotion, or retry; superseded pending intents never call `prepare_local_text`.
- Preserve FullHistory compatibility, LocalText v1 bytes, request/document/version/epoch fencing, failure/retry behavior, and publish the remaining selected-checkpoint cost with raw evidence.
- Define LocalText preparation as a total MoonBit `Json` transformation; recoverable failure begins at the correlated IndexedDB boundary, while `PreparationFailed` remains a FullHistory capture category.

Closes #1360.

## UI and review evidence

N/A — persistence scheduling, repository tests, benchmark instrumentation, and evidence only; no UI or visual behavior changed.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `LocalArchivePersistenceQueue` and `LocalArchivePendingWrite` | `apps/loomark/repository/local_persistence_queue.mbt` | Yes | Deepened the existing one-in-flight/one-latest queue rather than adding another scheduler. |
| `PreparedLocalArchive`, `prepare_local_text`, and `LocalArchiveRecordKind` | `apps/loomark/repository` | Yes | FullHistory remains prepared; LocalText preparation moved behind selected-write materialization without changing v1 bytes. |
| `MarkdownDocumentVersion`, `LoomarkDocumentId`, queue epoch, and request ID | editor/archive/repository packages | Yes | Existing correlation fences continue to own acknowledgment and stale-completion decisions. |
| MoonBit `String`, `Option`, `Result`, and immutable enum/struct patterns | MoonBit core | Yes | `String` is the immutable unencoded payload; existing `Option`/pattern matching models selected and pending writes. |
| MoonBit `Map`, `Set`, `StringView`, `Bytes`, `Buffer`/`StringBuilder`, `Array`, `Iter`, `cmp`, and `math` | MoonBit core | No | The queue stores at most two immutable payloads and performs no lookup, slicing, byte manipulation, collection transformation, ordering, or arithmetic that these APIs would improve. |

New helpers added (if any):

- Private `LocalArchivePendingPayload` distinguishes already prepared FullHistory from unencoded LocalText without exposing either queue representation.
- Private `enqueue_payload` and `retry_payload` centralize the unchanged queue transitions so both payload kinds share one state machine.
- Public `enqueue_local_text` and `retry_local_text` are the package boundary required by the Rabbita shell; they do not introduce a second queue.

Remaining imperative code is limited to the existing one-shot Rabbita `Cmd` and IndexedDB storage adapter. Queue selection and acknowledgment transitions remain deterministic.

## Validation scope

Boundary matrix / first failing regression:

- Idle LocalText: selected once and encoded to exact existing LocalText v1 bytes.
- A/B/C while a write is active: only C survives promotion; B is never exposed for preparation.
- Failure/retry: only the latest eligible LocalText source is selected for retry.
- A→B→A: the first A acknowledgment cannot satisfy the later A request.
- Mixed payloads: LocalText can supersede a prepared pending FullHistory archive without changing the active write.
- Standalone in-flight replacement: hold A's application acknowledgment, accept and flush B then C, observe exactly A+C puts at exact UTF-16 lengths, release A, traverse promotion/storage, and reload C.
- Existing stale completion, document identity, queue epoch, storage failure, and durable-status tests remain green.

Target packages:

- `apps/loomark/repository`
- `apps/loomark/internal/rabbita`

Additional conditional gates:

- Repository JS tests: 19/19.
- Internal Rabbita JS tests: 162/162.
- Loomark module JS tests: 7,508/7,508.
- Standalone browser tests: 16/16.
- Independent MoonBit/API review after request-changes fixes: PASS.
- Independent performance-evidence review after request-changes fixes: PASS.
- Slopless evidence review: no findings.
- The checked-in runner now emits the 200–400 ms W2 maximum-per-sample summary directly.

Performance result at 1 MiB:

- Initial current-main and candidate W2 long-task p95: 91 ms and 91 ms.
- Five counterbalanced current-main/candidate pairs: candidate W2 p95 launch median 87 ms, still above the 70.5 ms material-win gate.
- Predeclared immediate-input gate: median of five paired candidate/base native-mutation p95 ratios, threshold `1.10×`.
- Observed immediate-input ratio: `0.9438×`; maximum pair ratio `0.9971×`; input-handler p95 0.1 ms in every base and candidate launch. **PASS.**
- Selected-checkpoint result: **STOP** under the issue's explicit stop condition. The coalescing boundary is retained, but this PR does not add a Worker, chunking, another queue, or a new persistence format.

Complete raw samples, ten counterbalanced launches, and compact evidence are under `docs/evidence/2026-08-24-loomark-persistence-intent-*`.

## Push and CI readiness

Pushed HEAD: `d2a709d7c57c9946bb8159968928f5cc13e6e759`

Fetched base: `origin/main@7786c260816e37f08242066835b6e2a0be7be96d`

```bash
git fetch origin main
git push --force-with-lease
```

- [x] The branch contains the fetched `origin/main`; the required post-rebase force-with-lease push completed without bypassing Lefthook's affected local checks.
- [x] The committed `.mbti` diff against `origin/main` was reviewed: two intentional additive LocalText queue methods and no trait-bound drift.
- [x] No submodule pointer changed.
- [x] The branch was pushed again after the base rebase and every later commit.
- [x] Independent review findings were resolved, and post-rebase MoonBit review passed without findings.
- [x] GitHub CI's `All Checks Passed` gate is green for `d2a709d7c57c9946bb8159968928f5cc13e6e759`.


