### PR TITLE
perf(loomark): consume faster Markdown semantics

### DIFF
--- a/apps/canvas/moon.mod
+++ b/apps/canvas/moon.mod
@@ -10,7 +10,7 @@ import {
   "dowdiness/canvas-layout@0.1.0",
   "dowdiness/loom@0.1.0",
   "dowdiness/rabbita_codemirror@0.0.1",
-  "dowdiness/incr@0.15.0",
+  "dowdiness/incr@0.15.1",
   "dowdiness/dom_boundary@0.1.0",
   "dowdiness/js_ffi@0.1.0",
   "dowdiness/rabbita-menu@0.1.0",

--- a/apps/ideal/moon.mod
+++ b/apps/ideal/moon.mod
@@ -19,7 +19,7 @@ import {
   "dowdiness/event-graph-walker@0.7.1",
   "dowdiness/visualizer@0.1.0",
   "dowdiness/canvas-spatial@0.1.0",
-  "dowdiness/incr@0.15.0",
+  "dowdiness/incr@0.15.1",
 }
 
 preferred_target = "js"

--- a/apps/loomark/CONTEXT.md
+++ b/apps/loomark/CONTEXT.md
@@ -44,7 +44,7 @@ _Avoid_: warm-up, preloading
 
 **Preview refresh**:
 Replacing Preview from the latest committed Document text. Refresh is delayed
-by 50 ms after input so rapid changes normally produce one visible update.
+by 32 ms after input so rapid changes normally produce one visible update.
 _Avoid_: projection refresh, render loop
 
 **Stale Preview**:

--- a/apps/loomark/app/update.mbt
+++ b/apps/loomark/app/update.mbt
@@ -2,7 +2,7 @@
 const AUTOSAVE_QUIET_MS : Int = 250
 
 ///|
-const PREVIEW_QUIET_MS : Int = 50
+const PREVIEW_QUIET_MS : Int = 32
 
 ///|
 const COMPACT_MAX_WIDTH : Int = 640

--- a/docs/plans/2026-08-26-loomark-preview-split-production.md
+++ b/docs/plans/2026-08-26-loomark-preview-split-production.md
@@ -43,7 +43,7 @@ attachment.
 
 | Event | Document text | Parser | Visible Preview | Autosave |
 |---|---|---|---|---|
-| Exact textarea edit | Updates immediately | One `apply_edit` command after the native handler returns | Keeps the last result; refresh is debounced by 50 ms | Existing behavior |
+| Exact textarea edit | Updates immediately | One `apply_edit` command after the native handler returns | Keeps the last result; refresh is debounced by 32 ms | Existing behavior |
 | `ReplaceAll` fallback | Updates immediately | One `set_source` command after the native handler returns | Same debounce | Existing behavior |
 | IME intermediate update | Unchanged | No new work | Previously scheduled work may finish | Unchanged |
 | IME end | Applies once | Advances once | Schedules one refresh | Existing behavior |
@@ -53,7 +53,7 @@ attachment.
 | Semantic or Html failure | Unchanged | Healthy pair remains | Last result remains with a stale alert | Continues |
 | Allowed retry | Unchanged | Replaces only an unusable pair; otherwise reuses it | Publishes success or keeps the failure | Unchanged |
 
-The 50 ms debounce applies only to reading the Markdown attachment, building
+The 32 ms debounce applies only to reading the Markdown attachment, building
 typed Html, and publishing a visible result. Parser source synchronization does
 not wait for the debounce.
 
@@ -207,14 +207,14 @@ adding a Worker or artificial warm-up.
 
 Reuse the existing Autosave pattern:
 
-- schedule a refresh request with candidate Document text after 50 ms;
+- schedule a refresh request with candidate Document text after 32 ms;
 - when it arrives, compare the candidate with current Model text;
 - ignore a different, older candidate; and
 - read the attachment and build typed Html only for a current candidate.
 
 Do not add a counter or cancellable timeout handle. Entering Preview or Split
 while a normal refresh is pending does not force or reschedule it. If text
-changes and returns to the same value within 50 ms, an older equal-text request
+changes and returns to the same value within 32 ms, an older equal-text request
 may cause one extra refresh. That does not change correctness and is not optimized in this slice.
 
 Once Preview has been prepared, the same rules continue while Text mode hides
@@ -385,7 +385,7 @@ Stop here if the persistent textarea cannot be proven.
 
 1. Add tests that `ReplaceRange` maps to one `apply_edit` and `ReplaceAll` to one
    `set_source` after the native handler returns.
-2. Add the Autosave-style 50 ms candidate comparison and verify that only
+2. Add the Autosave-style 32 ms candidate comparison and verify that only
    semantic read, typed Html, and publication wait.
 3. Cover IME: intermediate events schedule no new work; previously scheduled
    work may finish; composition end advances once.
@@ -407,7 +407,7 @@ Extend `standalone.spec.ts` without production debug APIs:
   and Autosave paths;
 - independent native Text and Preview scrolling in both Split orientations,
   with the textarea scrollbar at its pane's right edge;
-- 50 ms refresh behavior and IME boundary;
+- 32 ms refresh behavior and IME boundary;
 - initial and stale failure reducer coverage, with browser coverage only where a
   real boundary can fail without a production hook; and
 - all existing storage, recovery, exact-input, and 10 ms Text-input tests.

--- a/modules/canopy/core/proj_node.mbt
+++ b/modules/canopy/core/proj_node.mbt
@@ -262,7 +262,7 @@ pub fn[T] assign_fresh_ids(
 
 ///|
 pub impl[T : ToJson] ToJson for ProjNode[T] with fn to_json(self) {
-  let children_json : Array[Json] = self.children.map(c => c.to_json())
+  let children_json : Array[Json] = self.children.map(c => ToJson::to_json(c))
   {
     "node_id": self.node_id,
     "kind": self.kind.to_json(),

--- a/modules/canopy/core/source_map.mbt
+++ b/modules/canopy/core/source_map.mbt
@@ -104,7 +104,7 @@ fn SourceMap::node_to_range_at_position(
   self : SourceMap,
   position : Int,
 ) -> Map[NodeId, Range] {
-  self.ranges.fold(init=Map::default(), fn(acc, item) {
+  self.ranges.fold(init=Default::default(), fn(acc, item) {
     if item.0.contains(position) {
       acc.set(item.1, item.0)
     }

--- a/modules/canopy/core/test_expr_wbtest.mbt
+++ b/modules/canopy/core/test_expr_wbtest.mbt
@@ -264,7 +264,7 @@ test "ProjNode::fold — branch passes folded children to f" {
   let b = ProjNode(Leaf("b"), 3, 4, 12, [])
   let root = ProjNode(Branch("r", [Leaf("a"), Leaf("b")]), 0, 5, 10, [a, b])
   let result = root.fold((n, children) => {
-    children.length().to_string() + ":" + n.id().to_string()
+    children.length().to_string() + ":" + Show::to_string(n.id())
   })
   // root has 2 children, id=10
   inspect(result, content="2:NodeId(10)")
@@ -341,6 +341,6 @@ test "ProjNode::walk_preorder passes correct FoldNode fields" {
 ///|
 test "ToJson for ProjNode[TestExpr] compiles" {
   let node = ProjNode(Leaf("x"), 0, 1, 0, [])
-  let json = node.to_json()
+  let json = ToJson::to_json(node)
   inspect(json.stringify().length() > 0, content="true")
 }

--- a/modules/canopy/lang/lambda/alpha/alpha_key.mbt
+++ b/modules/canopy/lang/lambda/alpha/alpha_key.mbt
@@ -42,7 +42,7 @@ impl Hash for AlphaKeyRepr with fn hash_combine(self, hasher) {
     KUnit => hasher.combine_int(1)
     KVar(alpha_ref) => {
       hasher.combine_int(2)
-      alpha_ref.hash_combine(hasher)
+      Hash::hash_combine(alpha_ref, hasher)
     }
     KLam(body) => {
       hasher.combine_int(3)

--- a/modules/canopy/lang/lambda/scope/go_to_definition_wbtest.mbt
+++ b/modules/canopy/lang/lambda/scope/go_to_definition_wbtest.mbt
@@ -30,7 +30,7 @@ fn build_fixture_with_spans(
 test "go_to_definition: module def — body var jumps to the name token" {
   // "let x = 1\nx" — name "x" at 4..5; body var "x" at 10.
   let (g, sm) = build_fixture_with_spans("let x = 1\nx")
-  guard go_to_definition(g, sm, 10) is Some(r)
+  guard! go_to_definition(g, sm, 10) is Some(r)
   inspect(r.start, content="4")
   inspect(r.end, content="5")
 }
@@ -42,7 +42,7 @@ test "go_to_definition: shadowed module def — later def wins (production id pa
   // 14..15, NOT 4..5. This exercises the module-def binder through the
   // production first-class LetDef id path while Option D supplies the token span.
   let (g, sm) = build_fixture_with_spans("let x = 1\nlet x = 2\nx")
-  guard go_to_definition(g, sm, 20) is Some(r)
+  guard! go_to_definition(g, sm, 20) is Some(r)
   inspect(r.start, content="14")
   inspect(r.end, content="15")
 }
@@ -54,7 +54,7 @@ test "go_to_definition: block-local def — body var jumps to the block binder" 
   // proving binder_span locates a nested decl on its own LetDef node and never
   // falls back to the root module-name span.
   let (g, sm) = build_fixture_with_spans("let x = { let y = 1\n  y }\nx")
-  guard go_to_definition(g, sm, 22) is Some(r)
+  guard! go_to_definition(g, sm, 22) is Some(r)
   inspect(r.start, content="14")
   inspect(r.end, content="15")
 }
@@ -63,7 +63,7 @@ test "go_to_definition: block-local def — body var jumps to the block binder" 
 test "go_to_definition: lambda param — body var jumps to the param token" {
   // "(x) => x" — param "x" at 1..2; body var "x" at 7.
   let (g, sm) = build_fixture_with_spans("(x) => x")
-  guard go_to_definition(g, sm, 7) is Some(r)
+  guard! go_to_definition(g, sm, 7) is Some(r)
   inspect(r.start, content="1")
   inspect(r.end, content="2")
 }
@@ -73,7 +73,7 @@ test "go_to_definition: nested lambda shadowing — innermost param wins" {
   // "(x) => (x) => x" — outer param at 1..2, inner param at 8..9; innermost use at 14
   // resolves to the inner lambda parameter.
   let (g, sm) = build_fixture_with_spans("(x) => (x) => x")
-  guard go_to_definition(g, sm, 14) is Some(r)
+  guard! go_to_definition(g, sm, 14) is Some(r)
   inspect(r.start, content="8")
   inspect(r.end, content="9")
 }
@@ -86,7 +86,7 @@ test "go_to_definition: caret on a wrapping paren resolves to the inner var's bi
   // Intended position→node behavior, not identifier-token-strict (Codex P2 on
   // PR #405 — verified intentional, pinned here).
   let (g, sm) = build_fixture_with_spans("let x = 1\n(x)")
-  guard go_to_definition(g, sm, 10) is Some(r)
+  guard! go_to_definition(g, sm, 10) is Some(r)
   inspect(r.start, content="4")
   inspect(r.end, content="5")
 }

--- a/modules/canopy/lang/lambda/scope/graph_wbtest.mbt
+++ b/modules/canopy/lang/lambda/scope/graph_wbtest.mbt
@@ -49,9 +49,9 @@ test "build: module defs become ModuleDef decls in root scope" {
   let (_proj, registry, source_map) = build_fixture("let a = 1\nlet b = 2\nb")
   let g = build(registry, source_map)
   inspect(g.decls.length(), content="2")
-  guard g.decls[0].kind is ModuleDef(def_index=d0)
+  guard! g.decls[0].kind is ModuleDef(def_index=d0)
   inspect(d0, content="0")
-  guard g.decls[1].kind is ModuleDef(def_index=d1)
+  guard! g.decls[1].kind is ModuleDef(def_index=d1)
   inspect(d1, content="1")
   let ScopeId(s0) = g.decls[0].scope
   inspect(s0, content="0")
@@ -68,7 +68,7 @@ test "build_parent_map: child maps to parent" {
   @core.collect_registry(root, registry)
   let parents = build_parent_map(registry)
   inspect(parents.get(@core.NodeId::from_int(1)) is Some(_), content="true")
-  guard parents.get(@core.NodeId::from_int(1)) is Some(p)
+  guard! parents.get(@core.NodeId::from_int(1)) is Some(p)
   inspect(p == @core.NodeId::from_int(0), content="true")
   inspect(parents.get(@core.NodeId::from_int(0)) is None, content="true")
 }
@@ -108,12 +108,12 @@ test "build: duplicate module defs use structural binder ids and cutoffs" {
   inspect(g.decls[0].node_id == proj.children[0].id(), content="true")
   inspect(g.decls[1].node_id == proj.children[1].id(), content="true")
   let init_var = find_var_in_def_init(proj, 1, "x")
-  guard declaration(g, init_var) is Some(init_decl)
-  guard init_decl.kind is ModuleDef(def_index=init_index)
+  guard! declaration(g, init_var) is Some(init_decl)
+  guard! init_decl.kind is ModuleDef(def_index=init_index)
   inspect(init_index, content="0")
   let body_var = find_var_in_body(proj, "x")
-  guard declaration(g, body_var) is Some(body_decl)
-  guard body_decl.kind is ModuleDef(def_index=body_index)
+  guard! declaration(g, body_var) is Some(body_decl)
+  guard! body_decl.kind is ModuleDef(def_index=body_index)
   inspect(body_index, content="1")
 }
 
@@ -121,8 +121,8 @@ test "build: duplicate module defs use structural binder ids and cutoffs" {
 test "declaration_for_name_at: module nodes use full local cutoff" {
   let (proj, registry, source_map) = build_fixture("let x = 1\nlet x = 2\nx")
   let g = build(registry, source_map)
-  guard declaration_for_name_at(g, proj.id(), "x") is Some(root_decl)
-  guard root_decl.kind is ModuleDef(def_index=root_index)
+  guard! declaration_for_name_at(g, proj.id(), "x") is Some(root_decl)
+  guard! root_decl.kind is ModuleDef(def_index=root_index)
   inspect(root_index, content="1")
 
   let (nested, nested_registry, nested_source_map) = build_fixture(
@@ -130,9 +130,9 @@ test "declaration_for_name_at: module nodes use full local cutoff" {
   )
   let nested_graph = build(nested_registry, nested_source_map)
   let block = nested.children[0].children[0]
-  guard declaration_for_name_at(nested_graph, block.id(), "x")
+  guard! declaration_for_name_at(nested_graph, block.id(), "x")
     is Some(block_decl)
-  guard block_decl.kind is ModuleDef(def_index=block_index)
+  guard! block_decl.kind is ModuleDef(def_index=block_index)
   inspect(block_index, content="0")
 }
 
@@ -141,7 +141,7 @@ test "resolve: lambda param" {
   let (proj, registry, source_map) = build_fixture("(x) => x")
   let g = build(registry, source_map)
   let var_node = find_var_node(proj, "x")
-  guard declaration(g, var_node) is Some(decl)
+  guard! declaration(g, var_node) is Some(decl)
   inspect(decl.kind is LamParam(_), content="true")
 }
 
@@ -158,8 +158,8 @@ test "resolve: second def init binds to first def" {
   let (proj, registry, source_map) = build_fixture("let x = 1\nlet x = x\nx")
   let g = build(registry, source_map)
   let init_var = find_var_in_def_init(proj, 1, "x")
-  guard declaration(g, init_var) is Some(decl)
-  guard decl.kind is ModuleDef(def_index~)
+  guard! declaration(g, init_var) is Some(decl)
+  guard! decl.kind is ModuleDef(def_index~)
   inspect(def_index, content="0")
 }
 
@@ -168,7 +168,7 @@ test "resolve: innermost lambda shadowing" {
   let (proj, registry, source_map) = build_fixture("(x) => (x) => x")
   let g = build(registry, source_map)
   let var_node = find_var_node(proj, "x")
-  guard declaration(g, var_node) is Some(decl)
+  guard! declaration(g, var_node) is Some(decl)
   inspect(decl.kind is LamParam(_), content="true")
 }
 
@@ -177,8 +177,8 @@ test "resolve: body binds to latest def" {
   let (proj, registry, source_map) = build_fixture("let x = 1\nlet x = 2\nx")
   let g = build(registry, source_map)
   let body_var = find_var_in_body(proj, "x")
-  guard declaration(g, body_var) is Some(decl)
-  guard decl.kind is ModuleDef(def_index~)
+  guard! declaration(g, body_var) is Some(decl)
+  guard! decl.kind is ModuleDef(def_index~)
   inspect(def_index, content="1")
 }
 
@@ -215,7 +215,7 @@ test "scope_for_node: ref node uses resolution start scope" {
   let (proj, registry, source_map) = build_fixture("let x = 1\nx")
   let g = build(registry, source_map)
   let body_var = find_var_in_body(proj, "x")
-  guard g.scopes.iter().find_first(fn(s) { s.parent is None }) is Some(root)
+  guard! g.scopes.iter().find_first(fn(s) { s.parent is None }) is Some(root)
   inspect(scope_for_node(g, body_var) == Some(root.id), content="true")
 }
 
@@ -223,7 +223,7 @@ test "scope_for_node: ref node uses resolution start scope" {
 test "scope_for_node: module declaration node uses declaring scope" {
   let (proj, registry, source_map) = build_fixture("let x = 1\nx")
   let g = build(registry, source_map)
-  guard g.scopes.iter().find_first(fn(s) { s.parent is None }) is Some(root)
+  guard! g.scopes.iter().find_first(fn(s) { s.parent is None }) is Some(root)
   inspect(
     scope_for_node(g, proj.children[0].id()) == Some(root.id),
     content="true",
@@ -234,10 +234,11 @@ test "scope_for_node: module declaration node uses declaring scope" {
 test "scope_for_node: lambda binder node uses expression scope" {
   let (proj, registry, source_map) = build_fixture("(x) => x")
   let g = build(registry, source_map)
-  guard g.decls.iter().find_first(fn(d) { d.kind is LamParam(_) }) is Some(decl)
+  guard! g.decls.iter().find_first(fn(d) { d.kind is LamParam(_) })
+    is Some(decl)
   inspect(decl.node_id == proj.id(), content="true")
   inspect(scope_for_node(g, proj.id()) != Some(decl.scope), content="true")
-  guard scope_for_node(g, proj.id()) is Some(expr_scope)
+  guard! scope_for_node(g, proj.id()) is Some(expr_scope)
   let ScopeId(expr_i) = expr_scope
   inspect(g.scopes[expr_i].parent is None, content="true")
   let ScopeId(decl_i) = decl.scope

--- a/modules/canopy/lang/lambda/scope/references_outside_subtree_wbtest.mbt
+++ b/modules/canopy/lang/lambda/scope/references_outside_subtree_wbtest.mbt
@@ -143,8 +143,8 @@ test "references_outside_subtree: subtree is just the body — def init refs exc
 test "declaration_for_name_at_module_end: root def visible" {
   let (proj, registry, source_map) = build_fixture("let x = 0\n0")
   let g = build(registry, source_map)
-  guard declaration_for_name_at_module_end(g, proj.id(), "x") is Some(decl)
-  guard decl.kind is ModuleDef(def_index~)
+  guard! declaration_for_name_at_module_end(g, proj.id(), "x") is Some(decl)
+  guard! decl.kind is ModuleDef(def_index~)
   inspect(def_index, content="0")
 }
 
@@ -163,8 +163,8 @@ test "declaration_for_name_at_module_end: shadowed — later wins" {
   // let x = 0\nlet x = 1\n0 — at module end, x resolves to def 1.
   let (proj, registry, source_map) = build_fixture("let x = 0\nlet x = 1\n0")
   let g = build(registry, source_map)
-  guard declaration_for_name_at_module_end(g, proj.id(), "x") is Some(decl)
-  guard decl.kind is ModuleDef(def_index~)
+  guard! declaration_for_name_at_module_end(g, proj.id(), "x") is Some(decl)
+  guard! decl.kind is ModuleDef(def_index~)
   inspect(def_index, content="1")
 }
 
@@ -198,8 +198,8 @@ test "declaration_for_name_at_module_end: block module — block-local visible" 
   )
   let g = build(registry, source_map)
   let block = proj.children[0].children[0]
-  guard declaration_for_name_at_module_end(g, block.id(), "x") is Some(decl)
-  guard decl.kind is ModuleDef(def_index~)
+  guard! declaration_for_name_at_module_end(g, block.id(), "x") is Some(decl)
+  guard! decl.kind is ModuleDef(def_index~)
   inspect(def_index, content="0")
   // z not visible — block is inside z's init, cutoff excludes own def.
   inspect(

--- a/modules/canopy/moon.mod
+++ b/modules/canopy/moon.mod
@@ -6,7 +6,7 @@ import {
   "moonbitlang/quickcheck@0.14.0",
   "moonbitlang/x@0.4.38",
   "moonbitlang/async@0.20.1",
-  "dowdiness/incr@0.15.0",
+  "dowdiness/incr@0.15.1",
   "dowdiness/diagnostic@0.1.0",
   "dowdiness/event-graph-walker@0.7.1",
   "dowdiness/byte_codec@0.1.0",

--- a/modules/canopy/projection/source_map_token_spans_wbtest.mbt
+++ b/modules/canopy/projection/source_map_token_spans_wbtest.mbt
@@ -24,7 +24,7 @@ test "token span: lambda param" {
   let lambda_id = proj.id()
   let param_span = sm.get_token_span(lambda_id, "param")
   // param "x" inside the arrow-lambda parameter list starts at 1
-  guard param_span is Some(span)
+  guard! param_span is Some(span)
   inspect(span.start, content="1")
   inspect(span.end, content="2")
 }
@@ -39,7 +39,7 @@ test "token span: lambda param multi-char" {
   @lambda_proj.populate_token_spans(sm, syntax, proj)
   let lambda_id = proj.id()
   let param_span = sm.get_token_span(lambda_id, "param")
-  guard param_span is Some(span)
+  guard! param_span is Some(span)
   inspect(span.start, content="1")
   inspect(span.end, content="4")
 }
@@ -55,13 +55,13 @@ test "token span: nested lambda params" {
   @lambda_proj.populate_token_spans(sm, syntax, proj)
   // Outer lambda
   let outer_id = proj.id()
-  guard sm.get_token_span(outer_id, "param") is Some(outer_span)
+  guard! sm.get_token_span(outer_id, "param") is Some(outer_span)
   inspect(outer_span.start, content="1")
   inspect(outer_span.end, content="2")
   // Inner lambda is the first child of outer
   let inner_lambda = proj.children[0]
   let inner_id = inner_lambda.id()
-  guard sm.get_token_span(inner_id, "param") is Some(inner_span)
+  guard! sm.get_token_span(inner_id, "param") is Some(inner_span)
   inspect(inner_span.start, content="4")
   inspect(inner_span.end, content="5")
 }
@@ -77,11 +77,11 @@ test "token span: let def name" {
   @lambda_proj.populate_token_spans(sm, syntax, proj)
   let module_id = proj.id()
   let let_def_id = proj.children[0].id()
-  guard sm.get_token_span(let_def_id, @lambda_proj.LET_DEF_NAME_ROLE)
+  guard! sm.get_token_span(let_def_id, @lambda_proj.LET_DEF_NAME_ROLE)
     is Some(span)
   inspect(span.start, content="4")
   inspect(span.end, content="5")
-  guard sm.get_token_span(module_id, "name:0") is Some(fallback)
+  guard! sm.get_token_span(module_id, "name:0") is Some(fallback)
   inspect(fallback.start, content="4")
   inspect(fallback.end, content="5")
 }
@@ -96,17 +96,23 @@ test "token span: multiple let defs" {
   @lambda_proj.populate_token_spans(sm, syntax, proj)
   let module_id = proj.id()
   // First let: "x" at position 4..5
-  guard sm.get_token_span(proj.children[0].id(), @lambda_proj.LET_DEF_NAME_ROLE)
+  guard! sm.get_token_span(
+      proj.children[0].id(),
+      @lambda_proj.LET_DEF_NAME_ROLE,
+    )
     is Some(x_span)
   inspect(x_span.start, content="4")
   inspect(x_span.end, content="5")
   // Second let: "y" at position 14..15
-  guard sm.get_token_span(proj.children[1].id(), @lambda_proj.LET_DEF_NAME_ROLE)
+  guard! sm.get_token_span(
+      proj.children[1].id(),
+      @lambda_proj.LET_DEF_NAME_ROLE,
+    )
     is Some(y_span)
   inspect(y_span.start, content="14")
   inspect(y_span.end, content="15")
-  guard sm.get_token_span(module_id, "name:0") is Some(_)
-  guard sm.get_token_span(module_id, "name:1") is Some(_)
+  guard! sm.get_token_span(module_id, "name:0") is Some(_)
+  guard! sm.get_token_span(module_id, "name:1") is Some(_)
 }
 
 ///|
@@ -132,12 +138,12 @@ test "token span: lambda inside let def" {
   // LetDef node should have canonical "name" plus module fallback "name:0".
   let module_id = proj.id()
   let let_def = proj.children[0]
-  guard sm.get_token_span(let_def.id(), @lambda_proj.LET_DEF_NAME_ROLE)
+  guard! sm.get_token_span(let_def.id(), @lambda_proj.LET_DEF_NAME_ROLE)
     is Some(_)
-  guard sm.get_token_span(module_id, "name:0") is Some(_)
+  guard! sm.get_token_span(module_id, "name:0") is Some(_)
   // The lambda (child 0 of LetDef = init of first def) should have "param"
   let lambda_node = let_def.children[0]
-  guard sm.get_token_span(lambda_node.id(), "param") is Some(param_span)
+  guard! sm.get_token_span(lambda_node.id(), "param") is Some(param_span)
   // The parameter list starts at position 8; x is at position 9..10
   inspect(param_span.start, content="9")
   inspect(param_span.end, content="10")
@@ -153,11 +159,11 @@ test "token span: get_token_span returns None for missing role" {
   @lambda_proj.populate_token_spans(sm, syntax, proj)
   let lambda_id = proj.id()
   // "param" exists
-  guard sm.get_token_span(lambda_id, "param") is Some(_)
+  guard! sm.get_token_span(lambda_id, "param") is Some(_)
   // "name" does not
-  guard sm.get_token_span(lambda_id, "name") is None
+  guard! sm.get_token_span(lambda_id, "name") is None
   // Non-existent node
-  guard sm.get_token_span(NodeId::from_int(999), "param") is None
+  guard! sm.get_token_span(NodeId::from_int(999), "param") is None
 }
 
 ///|
@@ -165,7 +171,7 @@ test "token span: set_token_span manual" {
   let sm = SourceMap::new()
   let nid = NodeId::from_int(42)
   sm.set_token_span(nid, "test_role", Range::new(10, 20))
-  guard sm.get_token_span(nid, "test_role") is Some(span)
+  guard! sm.get_token_span(nid, "test_role") is Some(span)
   inspect(span.start, content="10")
   inspect(span.end, content="20")
 }

--- a/modules/canopy/protocol/view_node.mbt
+++ b/modules/canopy/protocol/view_node.mbt
@@ -125,10 +125,14 @@ pub impl ToJson for ViewNode with fn to_json(self) {
   }
   let (range_start, range_end) = self.text_range
   m["text_range"] = Json::array([range_start.to_json(), range_end.to_json()])
-  m["token_spans"] = Json::array(self.token_spans.map(fn(ts) { ts.to_json() }))
+  m["token_spans"] = Json::array(
+    self.token_spans.map(fn(ts) { ToJson::to_json(ts) }),
+  )
   m["editable"] = self.editable.to_json()
   m["css_class"] = self.css_class.to_json()
-  m["children"] = Json::array(self.children.map(fn(c) { c.to_json() }))
-  m["annotations"] = Json::array(self.annotations.map(fn(a) { a.to_json() }))
+  m["children"] = Json::array(self.children.map(fn(c) { ToJson::to_json(c) }))
+  m["annotations"] = Json::array(
+    self.annotations.map(fn(a) { ToJson::to_json(a) }),
+  )
   Json::object(m)
 }

--- a/modules/canopy/protocol/view_patch.mbt
+++ b/modules/canopy/protocol/view_patch.mbt
@@ -151,7 +151,7 @@ pub impl ToJson for Diagnostic with fn to_json(self) {
   let m : Map[String, Json] = Map([])
   m["from"] = self.from.to_json()
   m["to"] = self.to.to_json()
-  m["severity"] = self.severity.to_json()
+  m["severity"] = ToJson::to_json(self.severity)
   m["message"] = self.message.to_json()
   m["code"] = match self.code {
     Some(code) => code.to_json()
@@ -165,7 +165,7 @@ pub impl ToJson for Diagnostic with fn to_json(self) {
     Some(id) => id.to_json()
     None => Json::null()
   }
-  m["fixes"] = Json::array(self.fixes.map(fix => fix.to_json()))
+  m["fixes"] = Json::array(self.fixes.map(fix => ToJson::to_json(fix)))
   Json::object(m)
 }
 
@@ -191,13 +191,13 @@ pub impl ToJson for ViewPatch with fn to_json(self) {
     ReplaceNode(node_id~, node~) => {
       m["type"] = "ReplaceNode".to_json()
       m["node_id"] = node_id.to_json()
-      m["node"] = node.to_json()
+      m["node"] = ToJson::to_json(node)
     }
     InsertChild(parent_id~, index~, child~) => {
       m["type"] = "InsertChild".to_json()
       m["parent_id"] = parent_id.to_json()
       m["index"] = index.to_json()
-      m["child"] = child.to_json()
+      m["child"] = ToJson::to_json(child)
     }
     RemoveChild(parent_id~, index~, child_id~) => {
       m["type"] = "RemoveChild".to_json()
@@ -217,11 +217,15 @@ pub impl ToJson for ViewPatch with fn to_json(self) {
     }
     SetDecorations(decorations~) => {
       m["type"] = "SetDecorations".to_json()
-      m["decorations"] = Json::array(decorations.map(fn(d) { d.to_json() }))
+      m["decorations"] = Json::array(
+        decorations.map(fn(d) { ToJson::to_json(d) }),
+      )
     }
     SetDiagnostics(diagnostics~) => {
       m["type"] = "SetDiagnostics".to_json()
-      m["diagnostics"] = Json::array(diagnostics.map(fn(d) { d.to_json() }))
+      m["diagnostics"] = Json::array(
+        diagnostics.map(fn(d) { ToJson::to_json(d) }),
+      )
     }
     SetSelection(anchor~, head~) => {
       m["type"] = "SetSelection".to_json()
@@ -235,7 +239,7 @@ pub impl ToJson for ViewPatch with fn to_json(self) {
     FullTree(root~) => {
       m["type"] = "FullTree".to_json()
       m["root"] = match root {
-        Some(r) => r.to_json()
+        Some(r) => ToJson::to_json(r)
         None => Json::null()
       }
     }

--- a/modules/cognition/moon.mod
+++ b/modules/cognition/moon.mod
@@ -3,7 +3,7 @@ name = "dowdiness/cognition"
 version = "0.1.0"
 
 import {
-  "dowdiness/incr@0.15.0",
+  "dowdiness/incr@0.15.1",
 }
 
 repository = "https://github.com/dowdiness/canopy"

--- a/modules/cognition/provider_boundary_store.mbt
+++ b/modules/cognition/provider_boundary_store.mbt
@@ -455,7 +455,7 @@ fn normalize_provider_dependencies(
       normalized.push(dependency)
     }
   }
-  normalized.sort_by(fn(a, b) { a.compare(b) })
+  normalized.sort_by(fn(a, b) { Compare::compare(a, b) })
   normalized
 }
 

--- a/modules/cognition/reactive.mbt
+++ b/modules/cognition/reactive.mbt
@@ -181,11 +181,11 @@ fn dependency_edges_from(
     }
   }
   edges.sort_by(fn(a, b) {
-    let by_from = a.from.compare(b.from)
+    let by_from = Compare::compare(a.from, b.from)
     if by_from != 0 {
       by_from
     } else {
-      a.input.compare(b.input)
+      Compare::compare(a.input, b.input)
     }
   })
   edges

--- a/modules/cognition/store.mbt
+++ b/modules/cognition/store.mbt
@@ -204,7 +204,7 @@ pub fn CognitionStore::is_dirty(
 ///|
 pub fn CognitionStore::dirty_keys(self : CognitionStore) -> Array[CognitionKey] {
   let keys = self.dirty.keys().to_array()
-  keys.sort_by(fn(a, b) { a.compare(b) })
+  keys.sort_by(fn(a, b) { Compare::compare(a, b) })
   keys
 }
 
@@ -301,7 +301,7 @@ pub fn CognitionStore::dirty_dependents(
 ) -> Array[CognitionKey] {
   let changed : Array[CognitionKey] = []
   self.collect_dirty_dependents(key, changed)
-  changed.sort_by(fn(a, b) { a.compare(b) })
+  changed.sort_by(fn(a, b) { Compare::compare(a, b) })
   changed
 }
 
@@ -917,7 +917,7 @@ fn CognitionStore::selected_file_summary_keys(
     if score_a != score_b {
       score_b.compare(score_a)
     } else {
-      a.compare(b)
+      Compare::compare(a, b)
     }
   })
   keys

--- a/modules/visualizer/moon.mod
+++ b/modules/visualizer/moon.mod
@@ -3,7 +3,7 @@ name = "dowdiness/visualizer"
 version = "0.1.0"
 
 import {
-  "dowdiness/incr@0.15.0",
+  "dowdiness/incr@0.15.1",
   "dowdiness/graphviz@0.1.0",
   "dowdiness/svg-dsl@0.1.0",
   "dowdiness/alga@0.3.0",

--- a/scripts/local-validation.nu
+++ b/scripts/local-validation.nu
@@ -244,6 +244,33 @@ def affected-validation-packages [root: string, changes: list<any>] {
   combine-package-and-module-targets $root $direct_packages (module-targets $changes)
 }
 
+def module-test-target [root: string, package: string] {
+  let module = (module-for-package $root $package)
+  if $module == null {
+    fail $"cannot resolve module for package ($package)"
+  }
+  let directory = if $module == "." {
+    $root
+  } else {
+    $root | path join $module
+  }
+  let absolute_package = if $package == "." {
+    $root
+  } else {
+    $root | path join $package
+  }
+  let relative_package = (
+    $absolute_package
+    | path expand
+    | path relative-to ($directory | path expand)
+    | into string
+  )
+  {
+    directory: $directory
+    package: (if $relative_package == "" { "." } else { $relative_package })
+  }
+}
+
 def clean-worktree [] {
   let status = (git-output ["status" "--porcelain=v1" "--untracked-files=all" "--ignore-submodules=none"])
   if ($status | is-not-empty) {
@@ -294,9 +321,14 @@ def validate-push [base: string] {
   report-workspace-manifests $changes
   report-removed-module-manifests $changes
   let packages = (affected-validation-packages $root $changes)
+  let strict_checker = ($root | path join "scripts/check-strict.sh")
   for package in $packages {
-    ^./scripts/check-strict.sh $package
-    ^moon test --release $package
+    ^$strict_checker $package
+    let test_target = (module-test-target $root $package)
+    do {
+      cd $test_target.directory
+      ^moon test --release $test_target.package
+    }
   }
   ^git diff --check $"($base_sha)...($head)"
   clean-worktree

--- a/scripts/test-local-validation.sh
+++ b/scripts/test-local-validation.sh
@@ -36,6 +36,9 @@ printf '_build/\n' >"$fixture/.gitignore"
 cat >"$fake_bin/moon" <<'FAKE_MOON'
 #!/usr/bin/env bash
 set -euo pipefail
+if [ "${LOCAL_VALIDATION_LOG_PWD:-0}" = 1 ]; then
+  printf 'pwd=%s ' "$PWD" >>"$LOCAL_VALIDATION_TEST_LOG"
+fi
 printf 'moon' >>"$LOCAL_VALIDATION_TEST_LOG"
 printf ' %s' "$@" >>"$LOCAL_VALIDATION_TEST_LOG"
 printf '\n' >>"$LOCAL_VALIDATION_TEST_LOG"
@@ -232,19 +235,25 @@ grep -q 'workspace validation is deferred to GitHub CI: moon.work' "$tmp_dir/glo
 git -C "$fixture" tag nested-base
 printf 'pub fn nested() -> Int { 2 }\n' >"$fixture/nested/module/pkg/main.mbt"
 printf 'pub fn answer() -> Int { 45 }\n' >"$fixture/pkg/main.mbt"
-git -C "$fixture" add nested/module/pkg/main.mbt pkg/main.mbt
-git -C "$fixture" commit --quiet -m "change nested and root module packages"
+mkdir -p "$fixture/spaced module/pkg space"
+printf 'name = "spaced"\n' >"$fixture/spaced module/moon.mod"
+printf 'package "fixture/spaced"\n' >"$fixture/spaced module/pkg space/moon.pkg"
+printf 'pub fn spaced_nested() -> Int { 3 }\n' >"$fixture/spaced module/pkg space/main.mbt"
+git -C "$fixture" add nested/module/pkg/main.mbt pkg/main.mbt "spaced module"
+git -C "$fixture" commit --quiet -m "change nested, root, and spaced module packages"
 (
   cd "$fixture"
-  PATH="$fake_bin:$PATH" LOCAL_VALIDATION_TEST_LOG="$log" \
+  PATH="$fake_bin:$PATH" LOCAL_VALIDATION_TEST_LOG="$log" LOCAL_VALIDATION_LOG_PWD=1 \
     nu scripts/local-validation.nu validate-push --base nested-base
 )
-cat >"$expected" <<'EXPECTED_NESTED_PUSH'
+cat >"$expected" <<EXPECTED_NESTED_PUSH
 check-strict.sh nested/module/pkg
-moon test --release pkg
+pwd=$fixture/nested/module moon test --release pkg
 check-strict.sh pkg
-moon test --release pkg
+pwd=$fixture moon test --release pkg
+check-strict.sh spaced module/pkg space
+pwd=$fixture/spaced module moon test --release pkg space
 EXPECTED_NESTED_PUSH
-diff -u "$expected" "$log" || fail "pre-push validation leaked the nested module directory into another package"
+diff -u "$expected" "$log" || fail "pre-push validation lost module-local PWD or spaced package boundaries"
 
 echo "ok: local validation prepares and validates affected MoonBit targets"

--- a/scripts/test-local-validation.sh
+++ b/scripts/test-local-validation.sh
@@ -228,4 +228,23 @@ diff -u "$expected" "$log" || fail "pre-push validation did not check and test t
 grep -q 'workspace validation is deferred to GitHub CI: moon.work' "$tmp_dir/global-push.out" ||
   fail "workspace manifest validation did not report its global scope"
 
+: >"$log"
+git -C "$fixture" tag nested-base
+printf 'pub fn nested() -> Int { 2 }\n' >"$fixture/nested/module/pkg/main.mbt"
+printf 'pub fn answer() -> Int { 45 }\n' >"$fixture/pkg/main.mbt"
+git -C "$fixture" add nested/module/pkg/main.mbt pkg/main.mbt
+git -C "$fixture" commit --quiet -m "change nested and root module packages"
+(
+  cd "$fixture"
+  PATH="$fake_bin:$PATH" LOCAL_VALIDATION_TEST_LOG="$log" \
+    nu scripts/local-validation.nu validate-push --base nested-base
+)
+cat >"$expected" <<'EXPECTED_NESTED_PUSH'
+check-strict.sh nested/module/pkg
+moon test --release pkg
+check-strict.sh pkg
+moon test --release pkg
+EXPECTED_NESTED_PUSH
+diff -u "$expected" "$log" || fail "pre-push validation leaked the nested module directory into another package"
+
 echo "ok: local validation prepares and validates affected MoonBit targets"


### PR DESCRIPTION
## Summary

- advance `deps/loom` to formal Loom main merge `67ebcdcf37eb936294d910706a04b94103c27e4a`, which contains Loom PR #930's root-CST aggregate equality optimization and PR #932's MoonBit compatibility release
- align every Canopy-owned `dowdiness/incr` dependency with published `incr@0.15.1`; the nested submodule resolves to tagged release commit `01104c8e38dc1452f76327a544b7d7f13bf414e2`
- reduce Loomark's late-edit semantic read p95 by about 44% and shorten its visible Preview quiet window from 50 ms to 32 ms
- make the pre-push validator run nested MoonBit packages from their owning module roots, with a regression covering nested-to-root package transitions
- qualify existing deprecated `Default`, `ToJson`, `Hash`, and `Compare` calls and mark intentional test assertion panics with `guard!`, allowing the affected module manifests to pass the existing strict local gate

The temporary Loom integration branch/tag is no longer part of the dependency chain. Canopy now follows ordinary Loom main, while stable raw behavior, parser transitions, semantic ownership, and Preview publication remain unchanged.

## UI and review evidence

N/A — no labels, interaction, layout, or styles changed.

- [x] Visible-label removal preserves accessible names, visible focus, and the keyboard path (not applicable)
- [x] Interactive bounds, pointer feedback, and viewport reflow were checked in the rendered UI (unchanged; standalone E2E 16/16)
- [x] Any claimed Canopy rule cites its repository source; no new rule claim is made

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `CstNode::Eq` | `deps/loom/seam/cst_node.mbt` | Yes | Exact structural equality provides cached-hash rejection and collision-safe fallback |
| `MarkdownSemanticAttachment::document` | `deps/loom/examples/markdown` | Yes | Existing Loomark semantic-read boundary remains unchanged |
| `Parser::apply_edit` / `set_source` | `deps/loom/loom/pipeline` | Yes | Existing incremental transition contract remains unchanged |
| `Default::default`, `ToJson::to_json`, `Hash::hash_combine`, `Compare::compare` | MoonBit core traits | Yes | Replaces deprecated promoted/default calls without changing behavior |
| `guard!` | MoonBit language | Yes | Makes existing test assertion panics explicit; guards with recovery `else` branches remain unchanged |
| `DerivedMap` / immutable `Vector` / imperative cache | `deps/loom/incr`, MoonBit core | No | Loom #930's measurements located the cost in aggregate equality; additional cache structures were unnecessary |

New helper: `module-test-target` in `scripts/local-validation.nu`. It is a pure routing boundary from repository-relative package to owning module directory plus module-relative package. The imperative shell only changes directory and runs the existing test command. No new MoonBit helper, type, loop, cache, or public API was introduced.

## Validation scope

Boundary matrix / regression evidence:

- exact same-root equality fallback and old-document lifetime remain covered in Loom #930
- the formal Loom merge contains `ccf806b5239742b573e094ba98ef2f37edc7d1e4`
- Loom and nested incr checkouts are clean and reachable from `origin/main`, `origin/release/0.15`, and `v0.15.1` as applicable
- the local-validation nested-module test failed before the routing fix and passes after it
- intentional no-`else` test guards use `guard!`; guards with explicit recovery remain unchanged

Fresh production-browser results after switching to formal Loom main, across three launches with 20 warmups and 44 samples each:

| Phase | Result |
|------|--------|
| Input-to-visible mean | 79.30 / 78.95 / 80.19 ms |
| Input-to-visible p95 | 88.5 / 87.8 / 88.4 ms |
| Input-to-visible max | 106.5 / 108.5 / 111.6 ms |

These match the prior faster-Loom + 32 ms baseline. The production build is uninstrumented, so internal phase arrays were intentionally absent in this confirmation run.

Targeted and workspace gates:

- `NEW_MOON_MOD=0 moon check apps/loomark --target js` — pass
- `NEW_MOON_MOD=0 moon test apps/loomark/app --target js` — 1/1
- `./scripts/test-loomark-standalone-e2e.sh` — 16/16, including both 10 ms Text-input gates
- `./scripts/check-documentation-lifecycle.sh` — pass
- workspace `moon check` — 419 existing warnings, 0 errors
- workspace `moon test` — 4,809 wasm + 2,501 JS + 109 native passed
- affected strict package checks and release tests — pass through the normal pre-push gate
- `./scripts/test-local-validation.sh` — pass
- independent MoonBit review — PASS, no findings

## Push and CI readiness

- [x] The branch contains the fetched `origin/main`.
- [x] The normal push completed after Lefthook's submodule reachability, tooling, and affected MoonBit gates passed.
- [x] The committed `.mbti` diff against `origin/main` was reviewed; there is no `.mbti` change.
- [x] Loom and nested incr commits are reachable from their owning remotes and release lineage.
- [x] The branch was pushed after every manifest, gitlink, tooling, and warning-cleanup commit.
- [x] Independent review findings were resolved before final validation.
- [x] GitHub CI's `All Checks Passed` gate is green.
