### PR TITLE
perf(loomark): use syntax-only preview lowering

### DIFF
--- a/apps/loomark/CONTEXT.md
+++ b/apps/loomark/CONTEXT.md
@@ -38,12 +38,13 @@ resizable divider.
 _Avoid_: dual editor, two-pane editor
 
 **Preview preparation**:
-Creating Preview resources after Preview or Split is selected for the first
-time. Preparation is skipped when a document remains in Text mode.
+Creating one long-lived syntax Parser after Preview or Split is selected for
+the first time. Preparation is skipped when a document remains in Text mode.
 _Avoid_: warm-up, preloading
 
 **Preview refresh**:
-Replacing Preview from the latest committed Document text. Refresh is delayed
+Reading one coherent syntax snapshot, lowering it directly to MarkdownIR, and
+replacing Preview from the latest committed Document text. Refresh is delayed
 by 32 ms after input so rapid changes normally produce one visible update.
 _Avoid_: projection refresh, render loop
 

--- a/apps/loomark/internal/preview/engine.mbt
+++ b/apps/loomark/internal/preview/engine.mbt
@@ -15,16 +15,12 @@ pub(all) struct PreviewOutput {
 ///|
 priv enum EngineState {
   NoPair
-  Healthy(
-    parser~ : @loom.Parser[@markdown.Block],
-    attachment~ : @markdown.MarkdownSemanticAttachment,
-    source~ : String
-  )
+  Healthy(parser~ : @loom.SyntaxParser, source~ : String)
   Broken
 }
 
 ///|
-/// Imperative owner of at most one live Parser/Markdown attachment pair.
+/// Imperative owner of at most one live syntax Parser.
 pub struct PreviewEngine {
   priv mut state : EngineState
 }
@@ -35,49 +31,45 @@ pub fn PreviewEngine::PreviewEngine() -> PreviewEngine {
 }
 
 ///|
-fn create_pair(source : String) -> Result[EngineState, PreviewFailure] {
+fn create_parser_state(source : String) -> Result[EngineState, PreviewFailure] {
   try
-    @loom.new_parser(
+    @loom.new_syntax_parser(
       @loom.SourceId("loomark-preview"),
       source,
-      @markdown.markdown_grammar,
+      @markdown.markdown_grammar.to_syntax_grammar(),
     )
   catch {
     _ => Err(InitializationFailed)
   } noraise {
-    parser => {
-      let attachment = @markdown.MarkdownSemanticAttachment::MarkdownSemanticAttachment(
-        parser,
-      )
-      Ok(Healthy(parser~, attachment~, source~))
-    }
+    parser => Ok(Healthy(parser~, source~))
   }
 }
 
 ///|
-fn output(attachment : @markdown.MarkdownSemanticAttachment) -> PreviewOutput {
-  let document = attachment.document()
+fn output(parser : @loom.SyntaxParser) -> PreviewOutput {
+  let snapshot = parser.snapshot().read_or_abort()
+  let document = @markdown.experimental_markdown_ir_from_syntax_with_diagnostics(
+    parser.source_id(),
+    snapshot.syntax,
+    snapshot.diagnostics,
+  )
   { html: render(document), empty: is_empty(document) }
 }
 
 ///|
-fn PreviewEngine::break_pair(self : PreviewEngine) -> Unit {
-  match self.state {
-    Healthy(attachment~, ..) => attachment.dispose()
-    NoPair | Broken => ()
-  }
+fn PreviewEngine::break_parser(self : PreviewEngine) -> Unit {
   self.state = Broken
 }
 
 ///|
-/// Create the first pair, or replace an unusable pair, from current text.
+/// Create the first Parser, or replace an unusable Parser, from current text.
 pub fn PreviewEngine::prepare(
   self : PreviewEngine,
   source : String,
 ) -> Result[PreviewOutput, PreviewFailure] {
   match self.state {
     NoPair | Broken =>
-      match create_pair(source) {
+      match create_parser_state(source) {
         Ok(state) => {
           self.state = state
           self.refresh(source)
@@ -87,18 +79,18 @@ pub fn PreviewEngine::prepare(
           Err(failure)
         }
       }
-    Healthy(source=known_source, attachment~, ..) =>
+    Healthy(source=known_source, parser~) =>
       if known_source == source {
-        Ok(output(attachment))
+        Ok(output(parser))
       } else {
-        self.break_pair()
+        self.break_parser()
         Err(OutOfSync)
       }
   }
 }
 
 ///|
-/// Advance a healthy pair once for one committed Document change.
+/// Advance a healthy Parser once for one committed Document change.
 pub fn PreviewEngine::apply(
   self : PreviewEngine,
   change : @text_change.TextChange,
@@ -107,9 +99,9 @@ pub fn PreviewEngine::apply(
   match self.state {
     NoPair => Ok(())
     Broken => Err(Unusable)
-    Healthy(parser~, attachment~, source=old_source) => {
+    Healthy(parser~, source=old_source) => {
       guard change.apply(old_source) == Some(new_source) else {
-        self.break_pair()
+        self.break_parser()
         return Err(OutOfSync)
       }
       let result : Result[Unit, PreviewFailure] = try {
@@ -128,11 +120,11 @@ pub fn PreviewEngine::apply(
       }
       match result {
         Ok(_) => {
-          self.state = Healthy(parser~, attachment~, source=new_source)
+          self.state = Healthy(parser~, source=new_source)
           Ok(())
         }
         Err(failure) => {
-          self.break_pair()
+          self.break_parser()
           Err(failure)
         }
       }
@@ -141,19 +133,20 @@ pub fn PreviewEngine::apply(
 }
 
 ///|
-/// Read and materialize the current semantic result. Broken pairs are replaced
-/// here because callers invoke refresh only at an allowed retry boundary.
+/// Read and materialize the current semantic result. Broken Parsers are
+/// replaced here because callers invoke refresh only at an allowed retry
+/// boundary.
 pub fn PreviewEngine::refresh(
   self : PreviewEngine,
   source : String,
 ) -> Result[PreviewOutput, PreviewFailure] {
   match self.state {
     NoPair | Broken => self.prepare(source)
-    Healthy(source=known_source, attachment~, ..) =>
+    Healthy(source=known_source, parser~) =>
       if known_source == source {
-        Ok(output(attachment))
+        Ok(output(parser))
       } else {
-        self.break_pair()
+        self.break_parser()
         Err(OutOfSync)
       }
   }
@@ -161,7 +154,7 @@ pub fn PreviewEngine::refresh(
 
 ///|
 fn PreviewEngine::discard(self : PreviewEngine) -> Unit {
-  self.break_pair()
+  self.break_parser()
 }
 
 ///|

--- a/apps/loomark/internal/preview/engine_wbtest.mbt
+++ b/apps/loomark/internal/preview/engine_wbtest.mbt
@@ -1,12 +1,12 @@
 ///|
 test "PreviewEngine stays uninitialized until preparation" {
   let engine = PreviewEngine::PreviewEngine()
-  guard engine.state is NoPair else { abort("pair initialized too early") }
+  guard engine.state is NoPair else { abort("parser initialized too early") }
   assert_eq(
     engine.apply(@text_change.ReplaceAll("Text only"), "Text only"),
     Ok(()),
   )
-  guard engine.state is NoPair else { abort("Text-only change created pair") }
+  guard engine.state is NoPair else { abort("Text-only change created parser") }
 }
 
 ///|
@@ -23,12 +23,12 @@ test "PreviewEngine prepares one semantic result and advances exact edits" {
   assert_true(!refreshed.empty)
   match engine.state {
     Healthy(source~, ..) => assert_eq(source, "# Heading\n")
-    NoPair | Broken => abort("expected healthy Preview pair")
+    NoPair | Broken => abort("expected healthy Preview parser")
   }
 }
 
 ///|
-test "PreviewEngine keeps a healthy pair for ReplaceAll" {
+test "PreviewEngine keeps a healthy parser for ReplaceAll" {
   let engine = PreviewEngine::PreviewEngine()
   ignore(engine.prepare("Before\n"))
   assert_eq(
@@ -41,27 +41,27 @@ test "PreviewEngine keeps a healthy pair for ReplaceAll" {
   assert_true(!result.empty)
   match engine.state {
     Healthy(source~, ..) => assert_eq(source, "# After\n")
-    NoPair | Broken => abort("expected healthy Preview pair")
+    NoPair | Broken => abort("expected healthy Preview parser")
   }
 }
 
 ///|
-test "PreviewEngine discards a stale preparation pair before retry" {
+test "PreviewEngine discards a stale preparation parser before retry" {
   let engine = PreviewEngine::PreviewEngine()
   ignore(engine.prepare("stale\n"))
   engine.discard()
-  guard engine.state is Broken else { abort("stale pair stayed active") }
+  guard engine.state is Broken else { abort("stale parser stayed active") }
   guard engine.refresh("latest\n") is Ok(_) else {
-    abort("discarded pair was not replaced")
+    abort("discarded parser was not replaced")
   }
   match engine.state {
     Healthy(source~, ..) => assert_eq(source, "latest\n")
-    NoPair | Broken => abort("expected replacement Preview pair")
+    NoPair | Broken => abort("expected replacement Preview parser")
   }
 }
 
 ///|
-test "PreviewEngine replaces only an unusable pair on allowed refresh" {
+test "PreviewEngine replaces only an unusable parser on allowed refresh" {
   let engine = PreviewEngine::PreviewEngine()
   ignore(engine.prepare("Before\n"))
   let inconsistent = @text_change.ReplaceRange(
@@ -72,14 +72,14 @@ test "PreviewEngine replaces only an unusable pair on allowed refresh" {
   guard engine.apply(inconsistent, "not-the-change") is Err(_) else {
     abort("inconsistent transition should fail")
   }
-  guard engine.state is Broken else { abort("failed pair stayed active") }
+  guard engine.state is Broken else { abort("failed parser stayed active") }
 
   guard engine.refresh("latest\n") is Ok(result) else {
-    abort("broken pair replacement failed")
+    abort("broken parser replacement failed")
   }
   assert_true(!result.empty)
   match engine.state {
     Healthy(source~, ..) => assert_eq(source, "latest\n")
-    NoPair | Broken => abort("expected replacement Preview pair")
+    NoPair | Broken => abort("expected replacement Preview parser")
   }
 }

--- a/apps/loomark/internal/preview/preview_cycle_benchmark_wbtest.mbt
+++ b/apps/loomark/internal/preview/preview_cycle_benchmark_wbtest.mbt
@@ -1,0 +1,98 @@
+///|
+fn preview_cycle_fixture(
+  block_count : Int,
+  interior~ : Bool,
+) -> (String, Array[(@text_change.TextChange, String)]) {
+  let source = StringBuilder::StringBuilder()
+  let positions : Array[Int] = []
+  let mut source_offset = 0
+  for index = 0; index < block_count / 2; index = index + 1 {
+    let unit = "## Heading \{index}\n\nParagraph \{index} with **bold**, [link](https://example.com/\{index}), and 日本語 😀.\n\n"
+    guard unit.find("Paragraph") is Some(paragraph_offset) else {
+      abort("benchmark paragraph missing")
+    }
+    let relative_offset = if interior { 3 } else { 0 }
+    positions.push(source_offset + paragraph_offset + relative_offset)
+    source.write_string(unit)
+    source_offset += unit.length()
+  }
+  let initial = source.to_string()
+  let operations : Array[(@text_change.TextChange, String)] = []
+  let selected : Array[Int] = Array::makei(16, index => {
+    positions[index * positions.length() / 16]
+  })
+  let mut current = initial
+  for position in selected {
+    let inserted = if interior { "A" } else { "p" }
+    let change = @text_change.ReplaceRange(
+      start=position,
+      delete_len=1,
+      inserted~,
+    )
+    guard change.apply(current) is Some(next) else {
+      abort("benchmark forward edit failed")
+    }
+    operations.push((change, next))
+    current = next
+  }
+  for index = selected.length() - 1; index >= 0; index = index - 1 {
+    let inserted = if interior { "a" } else { "P" }
+    let change = @text_change.ReplaceRange(
+      start=selected[index],
+      delete_len=1,
+      inserted~,
+    )
+    guard change.apply(current) is Some(next) else {
+      abort("benchmark reverse edit failed")
+    }
+    operations.push((change, next))
+    current = next
+  }
+  guard current == initial else { abort("benchmark edit cycle did not close") }
+  (initial, operations)
+}
+
+///|
+fn benchmark_preview_cycle(
+  b : @bench.T,
+  block_count : Int,
+  interior~ : Bool,
+) -> Unit {
+  let (initial, operations) = preview_cycle_fixture(block_count, interior~)
+  let engine = PreviewEngine::PreviewEngine()
+  guard engine.prepare(initial) is Ok(_) else {
+    abort("benchmark Preview preparation failed")
+  }
+  let mut operation_index = 0
+  b.bench(() => {
+    let (change, source) = operations[operation_index]
+    guard engine.apply(change, source) is Ok(_) else {
+      abort("benchmark Parser transition failed")
+    }
+    guard engine.refresh(source) is Ok(output) else {
+      abort("benchmark Preview refresh failed")
+    }
+    b.keep(output)
+    operation_index = (operation_index + 1) % operations.length()
+  })
+}
+
+///|
+test "Loomark Preview cycle: practical 500-block boundary edits" (b : @bench.T) {
+  benchmark_preview_cycle(b, 500, interior=false)
+}
+
+///|
+test "Loomark Preview cycle: practical 500-block interior edits" (b : @bench.T) {
+  benchmark_preview_cycle(b, 500, interior=true)
+}
+
+///|
+test "Loomark Preview cycle: scaling 2500-block boundary edits" (b : @bench.T) {
+  benchmark_preview_cycle(b, 2500, interior=false)
+}
+
+///|
+test "Loomark Preview cycle: scaling 2500-block interior edits" (b : @bench.T) {
+  benchmark_preview_cycle(b, 2500, interior=true)
+}

--- a/apps/loomark/internal/preview/renderer_wbtest.mbt
+++ b/apps/loomark/internal/preview/renderer_wbtest.mbt
@@ -1,16 +1,16 @@
 ///|
 fn preview_test_document(source : String) -> @markdown.MarkdownIR raise {
-  let parser = @loom.new_parser(
+  let parser = @loom.new_syntax_parser(
     @loom.SourceId("loomark-preview-test"),
     source,
-    @markdown.markdown_grammar,
+    @markdown.markdown_grammar.to_syntax_grammar(),
   )
-  let attachment = @markdown.MarkdownSemanticAttachment::MarkdownSemanticAttachment(
-    parser,
+  let snapshot = parser.snapshot().read_or_abort()
+  @markdown.experimental_markdown_ir_from_syntax_with_diagnostics(
+    parser.source_id(),
+    snapshot.syntax,
+    snapshot.diagnostics,
   )
-  let document = attachment.document()
-  attachment.dispose()
-  document
 }
 
 ///|
@@ -94,6 +94,13 @@ test "Preview renderer rejects unsafe destinations" {
   assert_eq(safe_destination("java script:alert(1)", image=false), None)
   assert_eq(safe_destination("java\u0000script:alert(1)", image=false), None)
   assert_eq(safe_destination("java\tscript:alert(1)", image=false), None)
+}
+
+///|
+test "Preview renderer preserves syntax diagnostics during direct lowering" {
+  let rendered = render_preview("[unclosed\n")
+  assert_preview_contains(rendered, "Recovered Markdown: [")
+  assert_preview_contains(rendered, "data-loomark-preview-diagnostic")
 }
 
 ///|

--- a/docs/plans/2026-08-26-loomark-preview-split-production.md
+++ b/docs/plans/2026-08-26-loomark-preview-split-production.md
@@ -5,7 +5,10 @@
 **Status:** Implementation reached the practical-corpus performance stop
 condition. See
 [production performance evidence](../evidence/2026-08-26-loomark-preview-split-production-performance.md)
-before continuing.
+before continuing. The parser strategy was later refined by the
+[SyntaxParser reassessment](../research/2026-08-28-loomark-syntax-parser-strategy-reassessment.md):
+Loomark now keeps one syntax Parser and directly lowers its coherent snapshot at
+each allowed Preview refresh.
 
 This plan extends the completed
 [standard Rabbita Text app](2026-08-24-loomark-standard-rabbita-text-app.md).
@@ -23,8 +26,7 @@ Add three editor modes to the current standard Rabbita app:
 - **Split** shows that textarea and the same Preview in RUI resizable panels.
 
 Document text remains the only editing and saving authority. Preview is derived
-state. A session that stays in Text mode creates no Parser or Markdown
-attachment.
+state. A session that stays in Text mode creates no Parser.
 
 ## Non-goals
 
@@ -47,15 +49,15 @@ attachment.
 | `ReplaceAll` fallback | Updates immediately | One `set_source` command after the native handler returns | Same debounce | Existing behavior |
 | IME intermediate update | Unchanged | No new work | Previously scheduled work may finish | Unchanged |
 | IME end | Applies once | Advances once | Schedules one refresh | Existing behavior |
-| First Preview or Split selection | Unchanged | Shows Preparing, then creates one pair after a paint opportunity | Shows Preparing, then first result | Unchanged |
+| First Preview or Split selection | Unchanged | Shows Preparing, then creates one Parser after a paint opportunity | Shows Preparing, then first result | Unchanged |
 | Return to Text during preparation | Unchanged | Preparation continues | Result is retained but hidden | Unchanged |
-| Parser transition failure | Unchanged | Pair becomes unusable | Last result remains with a stale alert | Continues |
-| Semantic or Html failure | Unchanged | Healthy pair remains | Last result remains with a stale alert | Continues |
-| Allowed retry | Unchanged | Replaces only an unusable pair; otherwise reuses it | Publishes success or keeps the failure | Unchanged |
+| Parser transition failure | Unchanged | Parser becomes unusable | Last result remains with a stale alert | Continues |
+| Semantic or Html invariant violation | Unchanged | No recoverable error channel; execution aborts | No new result | Continues only if execution survives |
+| Allowed retry | Unchanged | Replaces only an unusable Parser; otherwise reuses it | Publishes success or keeps the failure | Unchanged |
 
-The 32 ms debounce applies only to reading the Markdown attachment, building
-typed Html, and publishing a visible result. Parser source synchronization does
-not wait for the debounce.
+The 32 ms debounce applies only to reading the coherent syntax snapshot,
+lowering MarkdownIR, building typed Html, and publishing a visible result.
+Parser source synchronization does not wait for the debounce.
 
 ## Package and file map
 
@@ -76,7 +78,7 @@ apps/loomark/
     *_wbtest.mbt                              # pure transition tests where useful
   internal/preview/
     moon.pkg                                  # new package
-    engine.mbt                                # Parser and attachment shell
+    engine.mbt                                # syntax Parser and direct semantic-read shell
     renderer.mbt                              # pure MarkdownIR -> typed Html
     preview_wbtest.mbt                        # engine and renderer behavior
     renderer_benchmark_wbtest.mbt             # 500/2,500-block materialization
@@ -96,7 +98,7 @@ Keep these decisions deterministic:
 - whether first preparation is required;
 - whether a delayed refresh still matches current Document text;
 - whether a failure shows an initial message or a stale last result;
-- whether an allowed retry reuses a healthy pair or replaces an unusable pair;
+- whether an allowed retry reuses a healthy Parser or replaces an unusable one;
 - exhaustive `MarkdownIR` to typed Rabbita Html rendering; and
 - safe URL classification.
 
@@ -108,14 +110,14 @@ not read the DOM, viewport, Parser, clock, browser storage, or RUI state.
 Effects remain in these owners:
 
 - app-owned `TextArea`: native browser input and textarea element;
-- `PreviewEngine`: Parser, `MarkdownSemanticAttachment`, and their lifecycle;
+- `PreviewEngine`: syntax Parser, coherent snapshot reads, and its lifecycle;
 - Rabbita commands: Parser transitions, delayed refresh, and preparation;
 - standard Rabbita resize subscription: viewport changes;
 - RUI: panel ratio, pointer drag, keyboard resize, and separator semantics; and
 - browser storage: unchanged open and save effects.
 
-Do not put Parser, attachment, RUI ratio, DOM handles, commands, or scroll state
-in the app Model.
+Do not put Parser, RUI ratio, DOM handles, commands, or scroll state in the app
+Model.
 
 ## State and messages
 
@@ -158,32 +160,34 @@ It stays outside the Model.
 
 Its private state has three cases:
 
-1. no pair yet;
-2. one healthy Parser and `MarkdownSemanticAttachment`, plus the Parser source;
+1. no Parser yet;
+2. one healthy `SyntaxParser`, plus the Parser source; and
 3. unusable after a Parser transition failure.
 
 Required behavior:
 
-- First preparation creates `@loom.Parser[@markdown.Block]` with
-  `@markdown.markdown_grammar`, then attaches
-  `MarkdownSemanticAttachment`.
+- First preparation creates `@loom.SyntaxParser` with
+  `@markdown.markdown_grammar.to_syntax_grammar()`.
 - `ReplaceRange` validates against the engine's known source and calls one
-  `Parser::apply_edit(@loom.Edit::new(...), new_text)`.
-- `ReplaceAll` calls one `Parser::set_source(new_text)` and does not recreate a
-  healthy pair.
+  `SyntaxParser::apply_edit(@loom.Edit::new(...), new_text)`.
+- `ReplaceAll` calls one `SyntaxParser::set_source(new_text)` and does not
+  recreate a healthy Parser.
 - Parser work runs as a Rabbita command after the native input handler returns.
-- A Parser transition failure disposes the attachment and marks the pair
-  unusable. Do not apply later exact edits to that pair.
-- At the next allowed retry, create one replacement pair from current Document
-  text. Never keep two active pairs.
-- A semantic read or renderer failure retains its healthy pair; retry reads it
-  again.
-- `MarkdownSemanticAttachment::dispose()` runs before replacing an unusable
-  pair. The current app has one page-lifetime document and no in-app close
-  action, so no new close protocol is introduced.
+- A Parser transition failure marks the Parser unusable. Do not apply later
+  exact edits to it.
+- At the next allowed retry, create one replacement Parser from current Document
+  text. Never keep two active Parsers.
+- An allowed refresh reads one coherent `SyntaxSnapshot`, lowers it with
+  `experimental_markdown_ir_from_syntax_with_diagnostics`, and builds typed
+  Html. No compatibility `Block` AST or retained semantic attachment is created.
+- Snapshot reading, direct MarkdownIR lowering, and typed rendering are total
+  for a healthy Parser. Internal invariant aborts are not converted into
+  `PreviewFailure`. The current app has one page-lifetime document and no
+  in-app close action, so no new close protocol is introduced.
 
-Return structured `Result` values to update. Do not hide failures in mutable
-flags or abort the app.
+Return structured `Result` values for recoverable Parser initialization,
+transition, and source-consistency failures. Do not hide those failures in
+mutable flags or abort the app.
 
 ## Initial preparation and refresh
 
@@ -210,7 +214,8 @@ Reuse the existing Autosave pattern:
 - schedule a refresh request with candidate Document text after 32 ms;
 - when it arrives, compare the candidate with current Model text;
 - ignore a different, older candidate; and
-- read the attachment and build typed Html only for a current candidate.
+- lower the current coherent syntax snapshot and build typed Html only for a
+  current candidate.
 
 Do not add a counter or cancellable timeout handle. Entering Preview or Split
 while a normal refresh is pending does not force or reschedule it. If text
@@ -317,11 +322,12 @@ completed Markdown is not a live region.
 | Responsibility | Existing candidate | Decision |
 |---|---|---|
 | Exact Document change | `@text_change.TextChange::apply` | Reuse for Model update and engine validation. |
-| Incremental Parser change | `Parser::apply_edit` | Reuse for every healthy `ReplaceRange`. |
-| Complete replacement | `Parser::set_source` | Reuse for `ReplaceAll`; do not rebuild a healthy pair. |
-| Parser construction | `@loom.new_parser` / `Parser::new` | Reuse the existing public facade used by Markdown consumers. |
-| Semantic document | `MarkdownSemanticAttachment::document` | Reuse; do not fold syntax independently. |
-| Attachment cleanup | `MarkdownSemanticAttachment::dispose` | Reuse before broken-pair replacement. |
+| Incremental Parser change | `SyntaxParser::apply_edit` | Reuse for every healthy `ReplaceRange`. |
+| Complete replacement | `SyntaxParser::set_source` | Reuse for `ReplaceAll`; do not rebuild a healthy Parser. |
+| Parser construction | `@loom.new_syntax_parser` | Reuse to avoid constructing an unused compatibility `Block` AST. |
+| Coherent parse result | `SyntaxParser::snapshot` | Reuse one source/syntax/diagnostics snapshot. |
+| Semantic document | `experimental_markdown_ir_from_syntax_with_diagnostics` | Reuse for one stateless lowering at each allowed refresh. |
+| Retained semantic cache | `MarkdownSemanticAttachment` | Checked but not reused; measured boundary fallbacks make its structural-key read substantially slower in Loomark. |
 | Preview rendering | Historical direct typed-Html renderer | Restore the pure renderer only. |
 | Resizable layout | RUI resizable panel group, panels, handle | Reuse; RUI owns ratio and interaction. |
 | Mode tabs | RUI tabs | Checked but not reused because Arrow keys automatically activate. |
@@ -375,8 +381,8 @@ Stop here if the persistent textarea cannot be proven.
 
 1. Add pure update tests for mode selection, first preparation, no preparation
    in Text-only use, failure display, and allowed retry decisions.
-2. Add `PreviewEngine`, Parser/attachment creation, latest-text Prepare handling,
-   and disposal on broken-pair replacement.
+2. Add `PreviewEngine`, lazy syntax-Parser creation, latest-text Prepare handling,
+   and replacement of a broken Parser.
 3. Prove Preparing is inserted before cold work with browser-only observation;
    add no production test hook.
 4. Keep initial, current, and stale display states distinct.
@@ -457,9 +463,8 @@ git diff --check
 ```
 
 After `moon info`, the public app interface must remain only
-`app() -> @rabbita.Val[@rabbita.Html]`. Review the new internal Preview
-interface for accidental Parser, attachment, mutable collection, or RUI type
-leaks. Any widened generated trait bound is an API regression.
+`app() -> @rabbita.Val[@rabbita.Html]`. Review the new internal Preview interface for accidental Parser, mutable
+collection, or RUI type leaks. Any widened generated trait bound is an API regression.
 
 ## Documentation, tests, and evidence
 

--- a/docs/research/2026-08-27-loomark-parser-transition-performance.md
+++ b/docs/research/2026-08-27-loomark-parser-transition-performance.md
@@ -1,0 +1,152 @@
+# Loomark parser-transition performance investigation
+
+**Date:** 2026-08-27
+
+**Status:** The diagnosis remains valid. The implementation recommendation is superseded by [the 2026-08-28 strategy reassessment](2026-08-28-loomark-syntax-parser-strategy-reassessment.md), which compares the keyed syntax attachment with direct MarkdownIR lowering.
+
+**Original decision:** Prototype the syntax-only semantic attachment as a two-repository change. Do not optimize `TextChange`, runtime publication, or block-boundary parsing in the same slice.
+
+## Definition
+
+A Loomark parser transition advances the one live Preview parser from the previous committed Document text to the next text. `PreviewEngine::apply` validates the `TextChange`, maps `ReplaceRange` to `Parser::apply_edit`, and maps `ReplaceAll` to `Parser::set_source` (`apps/loomark/internal/preview/engine.mbt`). Once Preview is `Ready` or `Failed`, the application attempts this transition for each committed edit; `Unrequested` and `Preparing` do not transition a parser. Only semantic read, typed Html construction, and publication wait for the 32 ms quiet window (`apps/loomark/app/update.mbt`).
+
+Inside Loom, `Parser::apply_edit` calls the imperative engine and publishes one coherent snapshot through `Runtime::batch` (`deps/loom/loom/pipeline/parser.mbt`). The engine runs `incremental_parse`, then accepts the resulting tree and computes the grammar AST through `to_ast` (`deps/loom/loom/incremental/imperative_parser.mbt`). Markdown currently supplies a memoized `CstFold` for that compatibility `Block` AST (`deps/loom/loom/factories.mbt`, `deps/loom/loom/core/cst_fold.mbt`).
+
+The parser transition is therefore separate from textarea event handling, the 32 ms quiet window, MarkdownIR semantic read, typed Html construction, and DOM publication.
+
+## Method
+
+The deployment-target investigation used a JavaScript release build in headless Chromium with the production Loomark surface. The fixture contained 250 heading/paragraph units, approximately 500 Markdown blocks and 22,420 UTF-16 code units. Each launch used 20 warm-up edits followed by 44 measured edits at paragraph 248.
+
+Temporary `performance.now()` boundaries divided the transition into:
+
+1. `TextChange` consistency validation;
+2. imperative incremental parsing;
+3. AST acceptance/folding;
+4. snapshot publication;
+5. later MarkdownIR semantic read; and
+6. typed Html construction.
+
+The instrumentation and prototypes were investigation-only. They were not added to production state or public browser APIs.
+
+The historical production investigation reported a 16.5 ms median and 27.9 ms p95 parser transition (`docs/evidence/2026-08-26-loomark-preview-split-production-performance.md`). That measurement preceded the formal Loom lineage and toolchain update. The new measurements reproduce the same general cost but locate it more precisely.
+
+## Results
+
+### Edit at the paragraph boundary
+
+The edit replaced the first character of `Paragraph 248`. Markdown block reparse requires an edit to be strictly inside the candidate block, so this edit correctly fell through to the normal incremental parser (`deps/loom/loom/core/block_reparse.mbt`).
+
+| Phase | Launch 1 | Launch 2 | Launch 3 |
+|---|---:|---:|---:|
+| Parser median | 21.0 ms | 20.9 ms | 21.2 ms |
+| Parser p95 | 23.7 ms | 22.6 ms | 26.0 ms |
+| Parser maximum | 56.9 ms | 59.0 ms | 57.9 ms |
+| Incremental parse median | 6.5 ms | 6.2 ms | 6.5 ms |
+| AST accept/fold median | 14.4 ms | 14.4 ms | 14.7 ms |
+| AST accept/fold maximum | 49.7 ms | 52.1 ms | 51.3 ms |
+| Snapshot publication p95 | 0.1 ms | 0.1 ms | 0.1 ms |
+| Input-to-visible mean | 80.8 ms | 81.5 ms | 82.1 ms |
+| Input-to-visible p95 | 88.6 ms | 88.7 ms | 90.0 ms |
+
+Within incremental parsing, `parse_tokens_indexed` accounted for approximately 6.1–6.4 ms median. Token-buffer update, old-token-cache maintenance, reuse-cursor construction, diagnostics finalization, and the rejected block-reparse precheck were each at or below approximately 0.3 ms.
+
+The periodic maximum occurs inside `CstFold` AST acceptance. Its timing is consistent with the fold cache's documented 64-fold reachability compaction (`deps/loom/loom/core/cst_fold.mbt`), rather than runtime publication or renderer work.
+
+### Edit strictly inside the paragraph
+
+An edit 14 code units into the same paragraph used block reparse successfully.
+
+| Phase | Current `Parser[Block]` result |
+|---|---:|
+| Parser median | 0.4–0.5 ms |
+| Parser p95 | 0.8–1.0 ms |
+| Block reparse median | 0.3–0.4 ms |
+| Semantic read median | 2.2–2.4 ms |
+| Input-to-visible mean | 45.3–46.0 ms |
+
+For this interior-edit path, the compatibility Block fold already reuses cached results. The measured high-cost cases are block-boundary edits, edits that invalidate block ownership, and other normal-incremental fallbacks.
+
+### `ReplaceAll` characterization
+
+One synthetic `historyUndo` run exercised the `ReplaceAll` path. It is characterization only: it did not use a real browser undo stack and is not acceptance evidence.
+
+| Phase | Result |
+|---|---:|
+| Parser median | 64.7 ms |
+| Parser p95 | 81.5 ms |
+| Compatibility AST accept median | 53.2 ms |
+| Semantic read median | 54.4 ms |
+| Input-to-visible median | 158.3 ms |
+
+`ReplaceAll` intentionally performs a full reset. This result does not justify complete-source diffing during normal input or changing native undo ownership.
+
+## Diagnosis
+
+At the time of this measurement, Loomark consumed source-aware MarkdownIR from `MarkdownSemanticAttachment`; it did not consume the parser's compatibility `Block` AST. The attachment required `Parser[Block]`, so every fallback transition first paid for compatibility Block folding and later computed MarkdownIR separately (`deps/loom/examples/markdown/markdown_semantic_attachment.mbt`).
+
+The keyed MarkdownIR implementation already contains a syntax-only attachment core over `SyntaxParser` (`deps/loom/examples/markdown/reactive_keyed_markdown_ir.mbt`). The expensive work is therefore not required by Loomark's semantic output. It results from the current public attachment constructor boundary.
+
+## Prototype result
+
+A temporary prototype constructed Loomark's parser with `new_syntax_parser`, reused `Grammar::to_syntax_grammar`, and exposed the existing syntax-only keyed MarkdownIR attachment core through a prototype attachment.
+
+For the same paragraph-boundary edit:
+
+| Phase | Syntax-only prototype |
+|---|---:|
+| Parser median | 6.4–6.7 ms |
+| Parser p95 | 8.8–9.1 ms |
+| Parser maximum | 9.8–10.2 ms |
+| Input-to-visible mean | 64.2–64.5 ms |
+| Input-to-visible p95 | 69.5–69.9 ms |
+
+Relative to the equally instrumented Block-parser baseline, the prototype reduced parser median by about 68–69%, input-to-visible mean by about 21%, and input-to-visible p95 by about 21–22%. It also removed the compatibility fold's periodic 50 ms-class spike.
+
+For the strictly interior edit, the syntax-only prototype produced no material additional improvement because block reparse and fold reuse already made that path fast.
+
+Prototype correctness checks passed:
+
+- Loom and Canopy targeted JS checks;
+- Loomark app test: 1/1; and
+- production standalone browser E2E: 16/16, including both 10 ms Text-input gates.
+
+These results establish feasibility, not merge readiness.
+
+## Reuse check
+
+Existing APIs reused or validated:
+
+- `new_syntax_parser` and `Grammar::to_syntax_grammar`;
+- the existing private `attach_reactive_keyed_markdown_ir(SyntaxParser)` core;
+- `Parser::apply_edit`, `Parser::set_source`, and `Runtime::batch`;
+- current block-reparse, token-buffer, reuse-cursor, and `CstFold` mechanisms.
+
+`String` and `StringView` alternatives were considered for consistency validation, but browser validation cost was at most 0.1 ms and does not justify a new helper or API. No additional cache, low-level loop, worker, queue, or parser was justified.
+
+## Original recommended sequence (superseded)
+
+1. **Loom:** add an additive syntax-parser entry point for the existing semantic attachment, for example `MarkdownSemanticAttachment::from_syntax_parser`. Preserve the existing `Parser[Block]` constructor and `source_document` behavior. The syntax entry point needs an equivalent owning conversion from `SyntaxSnapshot`, and the attachment must continue to neither own nor dispose its parser. The exact name and internal representation remain an API-design decision.
+2. Add JS release benchmarks that compare Block-parser and syntax-parser semantic attachments for block-boundary, interior, and `ReplaceAll` transitions. Preserve full-parse parity, diagnostics, attachment disposal, and GC recovery tests.
+3. Merge and release the Loom API through its normal main lineage.
+4. **Canopy:** migrate only `PreviewEngine` to `SyntaxParser` and the new attachment entry point. Keep one live parser/attachment pair, per-edit transitions, `ReplaceAll` recovery, and the 32 ms publication policy unchanged.
+5. Re-run production Chromium measurements and the full standalone E2E suite on the exact candidate commit.
+
+A separate investigation may examine boundary-aware block reparse. Relaxing the strict ownership condition is correctness-sensitive and requires a syntax-form × terminator × container × operation matrix before design. It should not be combined with the syntax-parser attachment change.
+
+## Rejected options
+
+- Optimize `TextChange::apply`: measured consistency validation is negligible.
+- Optimize `Runtime::batch` publication: measured p95 is at most 0.1 ms.
+- Add another cache, parser, worker, queue, or coalescing layer: no measured need.
+- Delay parser transitions until the Preview debounce: violates the current parser-per-edit contract.
+- Change `ReplaceAll` into normal-input complete-source diffing: conflicts with the native edit boundary and does not address the measured dominant fold.
+- Modify structural equality or backdating semantics: unnecessary for the confirmed opportunity.
+
+## Limitations
+
+- Chromium was used; no Safari result is claimed.
+- The primary fixture is a large heading/paragraph document and does not cover every Markdown container or malformed boundary.
+- Temporary instrumentation adds small overhead, so comparisons are more reliable than absolute sub-millisecond values.
+- The synthetic `historyUndo` run is not a real native-undo measurement.
+- The syntax-only attachment was a prototype public surface. A production Loom change still requires API review, generated-interface review, package-local tests, and independent review.

--- a/docs/research/2026-08-28-loomark-syntax-parser-strategy-reassessment.md
+++ b/docs/research/2026-08-28-loomark-syntax-parser-strategy-reassessment.md
@@ -1,0 +1,219 @@
+# Loomark SyntaxParser strategy reassessment
+
+**Date:** 2026-08-28
+
+**Supersedes the implementation recommendation in:** [2026-08-27 Loomark parser-transition performance investigation](2026-08-27-loomark-parser-transition-performance.md)
+
+## Decision
+
+Use one long-lived `SyntaxParser` in Loomark and perform one direct, stateless MarkdownIR lowering from its coherent snapshot at each allowed Preview refresh. Do not add a syntax-specific `MarkdownSemanticAttachment` API for Loomark now.
+
+The intended Preview path is:
+
+```text
+committed TextChange
+  -> SyntaxParser::apply_edit or set_source
+  -> 32 ms candidate-text quiet-window check
+  -> SyntaxParser::snapshot().read_or_abort()
+  -> experimental_markdown_ir_from_syntax_with_diagnostics
+  -> typed Html
+  -> publication
+```
+
+This retains incremental parsing on every committed edit while treating semantic rendering as a one-shot operation after the quiet window. It removes the compatibility `Block` fold and the retained keyed semantic shell from Loomark. Other `Parser[Block]` and `MarkdownSemanticAttachment` consumers remain unchanged.
+
+## Why the first recommendation was reconsidered
+
+The first investigation compared the current `Parser[Block]` path with a syntax-only parser backed by the existing keyed MarkdownIR shell. That prototype reduced a 500-block boundary-edit parser transition from about 21 ms to 6.4–6.7 ms and input-to-visible latency from about 81 ms to 64–65 ms.
+
+It did not compare the keyed shell with Loom's existing public one-shot MarkdownIR lowering after the parser had already become syntax-only. That comparison changes the decision.
+
+Loom's accepted architecture deliberately keeps both forms:
+
+- retained keyed attachments for consumers that benefit from block-local semantic reuse; and
+- stateless one-shot lowering for direct export, rendering, and snapshot reads.
+
+See `deps/loom/docs/decisions/2026-08-04-markdown-semantic-attachment-boundary.md`, `deps/loom/docs/decisions/2026-06-16-markdown-ir-performance-policy.md`, and `deps/loom/examples/markdown/markdown_ir_lowering.mbt`.
+
+Loomark renders one complete Preview after a quiet window. It does not retain or transform the returned MarkdownIR, does not call `source_document()`, and already rebuilds typed Html for the complete document (`apps/loomark/internal/preview/engine.mbt`, `renderer.mbt`). The semantic operation is therefore snapshot-oriented even though the parser is long-lived.
+
+## Alternatives investigated
+
+### 1. SyntaxParser plus keyed semantic attachment
+
+A production-shaped prototype added `attach_markdown_semantics(SyntaxParser)` while preserving the existing `MarkdownSemanticAttachment(Parser[Block])`. Both constructors normalized complete snapshots into the same private keyed shell. `source_document()` read the shell's coherent snapshot, so the attachment no longer needed to store or dispose its parser.
+
+This is the best attachment design if a retained attachment is required. A free `attach_*` function matches `attach_markdown_projection` and `attach_markdown_role_spans` better than an asymmetric `from_syntax_parser` constructor.
+
+It still performs poorly when normal incremental parsing rebases reused CSTs onto the current source. The keyed shell's `CstNode` structural keys then pay expensive equality work across the document (`reactive_keyed_markdown_ir.mbt`).
+
+### 2. SyntaxParser plus direct MarkdownIR lowering
+
+This uses only existing public APIs:
+
+- `new_syntax_parser`;
+- `Grammar::to_syntax_grammar`;
+- `SyntaxParser::snapshot`; and
+- `experimental_markdown_ir_from_syntax_with_diagnostics`.
+
+No Loom public API, additional cache, lifecycle type, or second parser is needed. Source, syntax, and diagnostics come from one `SyntaxSnapshot`; `source_id` comes from that same parser. The direct lowering function is deterministic and non-raising. The returned MarkdownIR is consumed immediately by the typed renderer.
+
+This is the selected design.
+
+### 3. Disable or adapt CstFold while retaining Parser[Block]
+
+A JavaScript release prototype replaced memoized `CstFold` with direct recursive Block folding.
+
+| 500-block parser transition | Memoized CstFold | Direct recursive fold | SyntaxParser |
+|---|---:|---:|---:|
+| boundary median | 5.53–5.83 ms | 4.01–4.15 ms | 3.34–3.54 ms |
+| interior median | 0.41–0.45 ms | 0.63–0.67 ms | 0.14–0.18 ms |
+
+Disabling the cache improved fallback edits but remained slower than SyntaxParser and regressed the fast block-reparse path. It also continued constructing an AST Loomark never reads.
+
+CstFold statistics explained the fallback behavior: a boundary edit reported 499 parser reuses and only two AST recomputations, but the fold still performed about 500 structural cache hits. Parser reuse rebuilds current-source-backed tokens and nodes by contract, so structurally equal nodes are often not physically identical. A general reuse-provenance identity could improve this, but it would cross `seam`, parser events, CstFold, and Markdown derived-map keys. No small, validated prototype justified that redesign for Loomark.
+
+### 4. Lazy or optional AST in Parser[Ast]
+
+Moving AST computation into a lazy Derived would alter the coherent `ParseSnapshot[Ast]` contract and every existing AST consumer. If the semantic attachment then read a syntax-only snapshot to avoid forcing the AST, the result would reproduce SyntaxParser through a larger and riskier interface. `SyntaxParser` already exists for this responsibility (`deps/loom/loom/pipeline/syntax_parser.mbt`, `docs/api/choosing-a-parser.md`).
+
+### 5. Common SyntaxFeed interface
+
+An opaque feed containing `source_id`, runtime, and `Derived[SyntaxSnapshot]` could adapt both parser forms. A public trait cannot enforce that all three capabilities originate from one parser. No second independent consumer currently needs the opaque value. The new type and its methods would exist solely to avoid one Markdown constructor mismatch.
+
+### 6. MarkdownSemanticParser facade
+
+A facade owning SyntaxParser plus the semantic shell would duplicate `apply_edit`, `set_source`, runtime, source identity, failure, and disposal behavior. It would make independent parser attachments harder and add no capability. The parser plus a snapshot read is the deeper existing module.
+
+### 7. Adaptive keyed/direct strategy
+
+The measured ideal would use keyed lowering after successful block reparse and direct lowering after normal fallback. The current public snapshot exposes `reuse_count`, not a stable transition-kind contract. Treating `reuse_count == 1` as block reparse would be a performance heuristic.
+
+A skipped keyed read also leaves the retained shell stale. Warming it after direct output merely moves the expensive work, while disposing and recreating it adds another lifecycle mode. The complexity is not justified. Issue [Loom #933](https://github.com/dowdiness/loom/issues/933) may reduce boundary fallbacks without such a policy.
+
+## Deployment-target results
+
+All browser comparisons used JavaScript release builds, the same Chromium harness, 20 warm-up edits, and 44 measured edits. The 500-block corpus is Loomark's 250 heading/paragraph-unit fixture. The 2,500-block corpus uses 1,250 units. Typed Html and parser policies were unchanged between strategies.
+
+### 500 blocks
+
+| Edit and strategy | Parser median | Semantic median | Html median | Visible median | Visible p95 |
+|---|---:|---:|---:|---:|---:|
+| boundary, keyed attachment | 6.3 ms | 14.9 ms | 1.8 ms | 64.0 ms | 69.8 ms |
+| boundary, direct | 6.3 ms | 3.7 ms | 1.7 ms | 49.6 ms | 60.1 ms |
+| interior, keyed attachment | 0.4 ms | 2.2 ms | 1.8 ms | 47.1 ms | 49.6 ms |
+| interior, direct | 0.4 ms | 3.8 ms | 1.6 ms | 47.0 ms | 48.8 ms |
+
+Direct lowering materially improves the fallback case and is end-to-end neutral for the fast interior case.
+
+### 2,500 blocks
+
+| Edit and strategy | Parser median | Semantic median | Html median | Visible median | Visible p95 |
+|---|---:|---:|---:|---:|---:|
+| boundary, keyed attachment | 61.6 ms | 339.4 ms | 9.8 ms | 487.3 ms | 507.1 ms |
+| boundary, direct | 60.8 ms | 18.7 ms | 10.0 ms | 159.6 ms | 181.8 ms |
+| interior, keyed attachment | 0.6 ms | 8.2 ms | 8.6 ms | 90.4 ms | 107.1 ms |
+| interior, direct | 0.6 ms | 16.4 ms | 9.8 ms | 99.7 ms | 123.1 ms |
+
+The keyed shell wins a strictly interior edit by about 9 ms median, but loses a boundary fallback by about 328 ms median. Direct lowering gives a much lower and more predictable tail while retaining acceptable interior behavior.
+
+### Node release controls
+
+The result depends on CST reuse shape, not document size alone:
+
+- Loomark-shaped 500-block boundary cycle: keyed attachment 19.95–20.68 ms; direct 15.34–17.16 ms.
+- Loomark-shaped 2,500-block boundary cycle: keyed attachment 287–292 ms; direct 128–132 ms.
+- Generic paragraph 2,500-block interior cycle: keyed attachment 20.9–21.7 ms; direct 77.5–80.8 ms.
+
+These controls reject a universal claim that either semantic strategy is always faster. The browser product decision uses Loomark's complete pipeline and values bounded fallback latency over the keyed shell's large-document interior advantage.
+
+A synthetic 500-block `ReplaceAll` characterization measured direct SyntaxParser output at 57 ms median and 80.9 ms p95, versus the earlier `Parser[Block]` attachment characterization at 158.3 ms median. This is not native-undo acceptance evidence.
+
+Cold measurements were noisy and do not select a strategy. Direct 500-block launches ranged from 219–296 ms; syntax attachment launches ranged from 208–303 ms. One 2,500-block observation was 394 ms direct versus 434 ms attachment.
+
+## Semantics and ownership
+
+- `PreviewEngine` continues to own at most one live parser.
+- `ReplaceRange` still calls `apply_edit`; `ReplaceAll` still calls `set_source`.
+- Parser transitions still happen for every committed edit while Preview is live.
+- MarkdownIR lowering happens only in `refresh`, after the existing candidate-text quiet-window check.
+- `SyntaxParser::snapshot()` keeps source, syntax, diagnostics, and reuse metadata coherent.
+- Direct lowering neither mutates nor owns the parser.
+- There is no attachment, scope, watch, cache, or disposal lifecycle to expose or maintain.
+- Existing broken-parser replacement and `OutOfSync` checks stay unchanged.
+
+The direct lowering and current attachment `document()` are both total public operations over a healthy parser snapshot. Internal invariant aborts are contract violations in either path; the strategy does not remove a recoverable error channel.
+
+The current candidate-text quiet-window policy, including its deliberate lack of revision epochs or cancellation handles, is unchanged.
+
+## Validation evidence
+
+Temporary direct and syntax-attachment prototypes each passed:
+
+- Loomark production standalone E2E: 16/16;
+- both 10 ms Text-input gates;
+- Markdown semantic attachment tests, including coherent owning syntax snapshots: 9/9; and
+- targeted Markdown JS check.
+
+The selected Canopy implementation then passed the standalone E2E suite, both
+10 ms Text-input gates, 13 targeted app and Preview tests, and strict JS checks.
+Three fresh uninstrumented production launches measured the 500-block boundary
+fixture as follows:
+
+| Launch | Input-to-visible mean | Median | p95 | Maximum |
+|---|---:|---:|---:|---:|
+| 1 | 50.89 ms | 49.4 ms | 60.2 ms | 64.6 ms |
+| 2 | 52.20 ms | 50.3 ms | 61.2 ms | 61.5 ms |
+| 3 | 51.52 ms | 49.1 ms | 62.6 ms | 63.8 ms |
+
+The prior formal production confirmation on the keyed `Parser[Block]` path was
+79.30–80.19 ms mean and 87.8–88.5 ms p95. The candidate therefore reduces the
+complete product latency by about 35% mean while preserving the Text-input gate.
+
+Permanent varying-operand JavaScript release benchmarks recorded:
+
+| Preview cycle | Mean |
+|---|---:|
+| 500-block boundary | 10.18 ms |
+| 500-block interior | 4.78 ms |
+| 2,500-block boundary | 67.84 ms |
+| 2,500-block interior | 30.59 ms |
+
+Temporary prototypes and instrumentation were removed. The permanent benchmark
+uses 16 distributed edit locations followed by the inverse sequence, so every
+cycle restores its initial source.
+
+## Implemented sequence
+
+1. Implemented the Canopy-only direct strategy in `apps/loomark/internal/preview/engine.mbt` using existing Loom APIs.
+2. Preserved initial lazy parser construction, one live parser, parser-per-edit transitions, candidate-text quiet window, last-completed Preview, and retry boundaries.
+3. Updated engine and renderer tests plus Loomark context and planning documentation.
+4. Added permanent JS release benchmark rows for 500 and 2,500 blocks, covering boundary fallback and strictly interior block reparse with varying operands.
+5. Ran the complete standalone E2E suite and fresh production-browser measurements on the candidate tree.
+6. Kept Loom #933 separate. Reconsider a retained syntax attachment only after boundary reparsing or stable reuse provenance removes the keyed shell's fallback pathology.
+
+## Reuse check
+
+Reused:
+
+- `new_syntax_parser`;
+- `Grammar::to_syntax_grammar`;
+- `SyntaxParser::{apply_edit,set_source,snapshot,source_id}`;
+- `experimental_markdown_ir_from_syntax_with_diagnostics`;
+- existing typed renderer and Preview refresh policy.
+
+Checked but not selected:
+
+- `MarkdownSemanticAttachment`: retained for other consumers; its keyed lifecycle is not the best Loomark refresh strategy under the measured matrix.
+- `attach_markdown_projection`: returns compatibility `Block`, not the MarkdownIR required by Loomark's typed renderer.
+- direct recursive Block fold: still performs unused compatibility work.
+- common syntax-feed and MarkdownSemanticParser types: too little reuse across callers to justify their added surface.
+
+No new Loom function, helper, type, cache, low-level loop, worker, queue, parser, or public trait is required.
+
+## Limitations
+
+- Chromium is measured; no Safari result is claimed.
+- The edit matrix isolates paragraph boundary and interior replacements; Loom #933 owns the broader syntax/terminator/container matrix.
+- Allocation and heap retention were not separately measured. Direct lowering allocates one short-lived MarkdownIR per refresh; the attachment retains keyed Incr state and collects it after reads.
+- Large-document interior edits remain faster with the keyed attachment. The selection prioritizes the full Loomark pipeline, simpler ownership, and much lower fallback tails.


### PR DESCRIPTION
## Summary

- replace Loomark's compatibility `Parser[Block]` and retained Markdown semantic attachment with one long-lived `SyntaxParser`
- lower each coherent syntax snapshot directly to MarkdownIR at the existing 32 ms Preview refresh boundary, preserving per-edit Parser transitions and `ReplaceAll` recovery
- add diagnostics coverage, varying-operand 500/2,500-block release benchmarks, and source-backed strategy analysis

Production Chromium confirmation on the practical 500-block boundary fixture reduced input-to-visible mean from 79–80 ms to 50.89–52.20 ms and p95 from about 88 ms to 60.2–62.6 ms. Both 10 ms Text-input gates remain green.

## UI and review evidence

N/A — no visual labels, interaction geometry, focus behavior, or layout changed. The production browser suite verifies the existing Text/Preview/Split behavior.

- [x] Visible-label removal preserves accessible names, visible focus, and the keyboard path (N/A: no label removal)
- [x] Interactive bounds, pointer feedback, and viewport reflow were checked in the rendered UI (N/A: unchanged; existing E2E passed)
- [x] Any claimed Canopy rule cites its repository source; external guidance, recommendations, and preferences are labeled as such

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `new_syntax_parser` | `dowdiness/loom` | Yes | avoids constructing the compatibility Block AST |
| `SyntaxParser::{apply_edit,set_source,snapshot,source_id}` | `dowdiness/loom/pipeline` | Yes | preserves one Parser, exact edit dispatch, and coherent source/syntax/diagnostics |
| `experimental_markdown_ir_from_syntax_with_diagnostics` | `dowdiness/markdown` | Yes | performs the stateless semantic read required by Preview |
| `MarkdownSemanticAttachment` | `dowdiness/markdown` | No | measured structural-key work makes Loomark boundary fallbacks substantially slower |
| `new_parser` | `dowdiness/loom` | No | constructs a compatibility Block AST that Loomark does not consume |
| `StringBuilder`, `String::find`, `Array::makei`, `Option`/`Result` matching | MoonBit core | Yes | build varied benchmark fixtures and validate closed edit cycles |
| `Map`, `Set`, views, `cmp`/`math`, `Iter` | MoonBit core | No | no keyed collection, slicing, ordering, numeric, or iterator abstraction is needed by this change |

New helpers added:

- `preview_cycle_fixture`: test-only builder for 16 distributed forward edits and their inverse sequence
- `benchmark_preview_cycle`: test-only runner that exercises Parser transition plus direct semantic refresh without repeating one hot operand

No new public helper, type, trait, cache, worker, queue, or Parser was added.

## Validation scope

Boundary matrix / first failing regression:

- parser state: unrequested, healthy, broken/replacement
- change: exact `ReplaceRange`, `ReplaceAll`, inconsistent change
- semantic output: normal Markdown, malformed syntax with diagnostics, empty document
- position/scale: paragraph boundary and strict interior edits at 500 and 2,500 blocks
- browser behavior: lazy preparation, IME, native undo, stale Preview, Text/Preview/Split, and both 10 ms input gates

Target packages:

- `dowdiness/loomark/internal/preview`
- `dowdiness/loomark/app`

Additional conditional gates:

- targeted strict JS check: pass
- targeted app/Preview tests: 13/13 pass
- JavaScript release benchmarks: 6/6 pass
- standalone production E2E: 16/16 pass
- workspace release tests: 4,809 wasm + 2,502 JS + 109 native = 7,420 pass
- documentation lifecycle and Slopless: pass, 0 findings
- independent MoonBit and documentation reviews: pass
- no generated `.mbti`, manifest, or submodule-pointer changes

The workspace-wide strict check still encounters pre-existing deprecated warnings in vendored packages; the affected Loomark strict scope is clean.

## Push and CI readiness

```bash
git fetch origin main
git push
```

- [x] The branch contains the fetched `origin/main`, and the normal push completed without bypassing Lefthook's affected local checks.
- [x] The committed `.mbti` diff against `origin/main` was reviewed for unintended API or trait-bound changes.
- [x] Any changed submodule commit is pushed and reachable from its remote. (N/A: no submodule change.)
- [x] The branch was pushed again after every commit, amend, rebase, cherry-pick, submodule-pointer, manifest, or generated-interface change.
- [x] Independent review findings were resolved before the final validation.
- [ ] GitHub CI's `All Checks Passed` gate is green before merge.
