### PR TITLE
feat(loomark): render task checkboxes in Preview

### DIFF
--- a/apps/loomark/CONTEXT.md
+++ b/apps/loomark/CONTEXT.md
@@ -24,7 +24,8 @@ _Avoid_: source mode, raw mode
 
 **Preview**:
 A read-only parse-derived view of Document text. It may lag behind Document text
-and never determines editing or saving.
+and never determines editing or saving. Loomark explicitly enables GFM task-list
+semantics here; task checkboxes display Document text state and remain disabled.
 _Avoid_: rendered document, accepted text
 
 **Preview mode**:

--- a/apps/loomark/internal/preview/engine.mbt
+++ b/apps/loomark/internal/preview/engine.mbt
@@ -52,6 +52,7 @@ fn output(parser : @loom.SyntaxParser) -> PreviewOutput {
     parser.source_id(),
     snapshot.syntax,
     snapshot.diagnostics,
+    extensions=@markdown.MarkdownExtensions::task_list(),
   )
   { html: render(document), empty: is_empty(document) }
 }

--- a/apps/loomark/internal/preview/renderer.mbt
+++ b/apps/loomark/internal/preview/renderer.mbt
@@ -128,13 +128,44 @@ fn render_list_children(
 fn render_list_item_children(
   node : @markdown.MarkdownIR,
   render_paragraphs : Bool,
+  task : @markdown.MarkdownIRTask?,
 ) -> Array[@rabbita.Html] {
+  let task_prefix = match task {
+    Some(task) =>
+      [
+        @html.input(
+          input_type=@html.Checkbox,
+          checked=task.checked(),
+          attrs=@html.Attrs::build()
+            .disabled(true)
+            .class(
+              "mr-2 size-4 align-[-0.125em] accent-lm-accent disabled:opacity-100",
+            )
+            .data_set("loomark-task-checkbox", ""),
+        ),
+        @html.text(" "),
+      ]
+    None => []
+  }
   node
   .children()
-  .map(child => {
+  .mapi((index, child) => {
     match child.view() {
-      @markdown.Paragraph =>
-        render_node(child, unwrap_list_item_paragraph=!render_paragraphs)
+      @markdown.Paragraph => {
+        let children = render_children(child)
+        let children = if index == 0 && task is Some(_) {
+          let prefixed = task_prefix.copy()
+          prefixed.append(children)
+          prefixed
+        } else {
+          children
+        }
+        if render_paragraphs {
+          @rui.typography_p(children)
+        } else {
+          @html.fragment(children)
+        }
+      }
       _ => render_node(child)
     }
   })
@@ -169,8 +200,9 @@ fn render_node(
   let children = match node_view {
     @markdown.UnorderedList(spread~, ..) | @markdown.OrderedList(spread~, ..) =>
       render_list_children(node, spread)
-    @markdown.ListItem(spread~, ..) | @markdown.OrderedListItem(spread~, ..) =>
-      render_list_item_children(node, spread || list_parent_spread)
+    @markdown.ListItem(spread~, task~, ..)
+    | @markdown.OrderedListItem(spread~, task~, ..) =>
+      render_list_item_children(node, spread || list_parent_spread, task)
     _ => render_children(node)
   }
   match node_view {
@@ -199,7 +231,7 @@ fn render_node(
         None => @html.ol(attrs~, children)
       }
     }
-    @markdown.ListItem(spread~, marker~) =>
+    @markdown.ListItem(spread~, marker~, ..) =>
       @html.li(
         attrs=@html.Attrs::build()
           .data_set(
@@ -209,7 +241,7 @@ fn render_node(
           .data_set("loomark-list-marker", unordered_marker(marker)),
         children,
       )
-    @markdown.OrderedListItem(spread~, marker~) =>
+    @markdown.OrderedListItem(spread~, marker~, ..) =>
       @html.li(
         attrs=@html.Attrs::build()
           .data_set(

--- a/apps/loomark/internal/preview/renderer_wbtest.mbt
+++ b/apps/loomark/internal/preview/renderer_wbtest.mbt
@@ -10,6 +10,7 @@ fn preview_test_document(source : String) -> @markdown.MarkdownIR raise {
     parser.source_id(),
     snapshot.syntax,
     snapshot.diagnostics,
+    extensions=@markdown.MarkdownExtensions::task_list(),
   )
 }
 
@@ -101,6 +102,38 @@ test "Preview renderer preserves syntax diagnostics during direct lowering" {
   let rendered = render_preview("[unclosed\n")
   assert_preview_contains(rendered, "Recovered Markdown: [")
   assert_preview_contains(rendered, "data-loomark-preview-diagnostic")
+}
+
+///|
+test "Preview renders GFM task markers as disabled checkboxes" {
+  let unchecked = render_preview("- [ ] todo\n")
+  let checked = render_preview("- [x] done\n")
+  let invalid = render_preview("- [y] literal\n")
+  let later = render_preview("- first\n\n  [x] second\n")
+  let loose = render_preview("- [ ] todo\n\n  continued\n")
+
+  assert_preview_contains(unchecked, "type=\"checkbox\"")
+  assert_preview_contains(unchecked, "disabled")
+  assert_true(!unchecked.contains("checked"))
+  assert_preview_contains(unchecked, "todo")
+  assert_true(!unchecked.contains("[ ]"))
+
+  assert_preview_contains(checked, "type=\"checkbox\"")
+  assert_preview_contains(checked, "disabled")
+  assert_preview_contains(checked, "checked")
+  assert_preview_contains(checked, "done")
+  assert_true(!checked.contains("[x]"))
+
+  assert_true(!invalid.contains("type=\"checkbox\""))
+  assert_true(!later.contains("type=\"checkbox\""))
+  assert_preview_contains(later, "[x] second")
+
+  guard loose.find("<p") is Some(paragraph_start) &&
+    loose.find("type=\"checkbox\"") is Some(checkbox) &&
+    loose.find("</p>") is Some(paragraph_end) else {
+    abort("expected loose task paragraph and checkbox")
+  }
+  assert_true(paragraph_start < checkbox && checkbox < paragraph_end)
 }
 
 ///|


### PR DESCRIPTION
## Summary

- bump Loom to merged PR dowdiness/loom#935 and explicitly enable its GFM task-list extension only in Loomark Preview lowering
- render checked and unchecked task state as native disabled checkboxes while preserving tight and loose list paragraph structure
- keep invalid and later-paragraph markers from becoming checkboxes, and document that Preview remains read-only

## UI and review evidence

- [x] N/A — no visible label was removed; native disabled checkboxes expose their checked state to assistive technology and are not focusable actions
- [x] Rendered in production Chromium at desktop and 390 px widths; checkbox alignment, checked state, disabled state, and viewport reflow were inspected
- [x] The read-only behavior follows `apps/loomark/CONTEXT.md` and `.impeccable.md`'s human-authority/accessibility invariants; no external preference is presented as a Canopy requirement

Browser accessibility evidence exposed three checkbox nodes, all disabled, with only the checked source item reported checked. Chromium reported no console warnings or errors. Impeccable's mechanical detector returned no findings.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `MarkdownExtensions::task_list` | `deps/loom/examples/markdown/markdown_extensions.mbt` | Yes | Explicitly opts only Preview into the merged Loom extension |
| `MarkdownIRTask::checked` and list-item task metadata | `deps/loom/examples/markdown/markdown_ir.mbt` | Yes | Uses Loom-owned task semantics instead of inferring marker text in the renderer |
| `@html.input`, `@html.Checkbox`, `Attrs::disabled` | `deps/rabbita/rabbita/html` | Yes | Reuses the native accessible checkbox affordance |
| `Array::mapi`, `copy`, and `append` | MoonBit core `Array` | Yes | Places the checkbox inside only the first task paragraph while preserving returned ownership |
| `Option` pattern matching | MoonBit core | Yes | Handles optional task metadata without sentinel state |
| `String`/`StringView`, `Map`, `Set`, `Bytes`/`BytesView`, `Buffer` | MoonBit core | No | No new text parsing, lookup, byte processing, or string building belongs in this renderer integration |

New helpers added: none. The existing list-item child renderer was deepened to own task-prefix placement. Its only mutation appends into a fresh local output array; no external collection or application state is mutated.

## Validation scope

Boundary matrix / first failing regression:

- unchecked first-paragraph marker → disabled unchecked checkbox; marker removed from visible content
- checked first-paragraph marker → disabled checked checkbox; marker removed from visible content
- invalid marker → no checkbox
- later-paragraph marker → no checkbox and literal content retained
- tight task item → checkbox and content remain in the unwrapped item flow
- loose task item → checkbox is inside the first paragraph, not on a separate line

Target packages:

- `dowdiness/loomark/internal/preview`
- Loom submodule pointer `6b758b16` → merged `e4dfc541`

Additional conditional gates:

- Preview debug tests: 13/13
- Preview release JS tests: 13/13
- Loomark module release tests: 7466/7466
- production standalone Playwright E2E: 17/17, including both 10 ms Text input gates
- independent MoonBit review and post-loose-list re-review: PASS
- desktop and narrow production-browser inspection: PASS

## Push and CI readiness

```bash
git fetch origin main
git push
```

- [x] The branch contains the fetched `origin/main`, and the normal push completed without bypassing Lefthook's affected local checks.
- [x] No committed `.mbti` diff exists against `origin/main`.
- [x] The changed Loom commit is merged on and reachable from its configured origin.
- [x] The branch was pushed after the final commit and submodule-pointer change.
- [x] Independent review findings were resolved before the final validation.
- [x] GitHub CI's `All Checks Passed` gate is green before merge.
