### PR TITLE
fix(loomark): keep parser recovery out of Preview

### DIFF
--- a/apps/loomark/CONTEXT.md
+++ b/apps/loomark/CONTEXT.md
@@ -26,6 +26,8 @@ _Avoid_: source mode, raw mode
 A read-only parse-derived view of Document text. It may lag behind Document text
 and never determines editing or saving. Loomark explicitly enables GFM task-list
 semantics here; task checkboxes display Document text state and remain disabled.
+Ordinary unresolved reference candidates render as text. Genuine raw/recovered
+regions render escaped author source without parser labels or inline diagnostics.
 _Avoid_: rendered document, accepted text
 
 **Preview mode**:
@@ -44,10 +46,11 @@ the first time. Preparation is skipped when a document remains in Text mode.
 _Avoid_: warm-up, preloading
 
 **Preview refresh**:
-Reading one coherent syntax snapshot, lowering it directly to MarkdownIR, and
-replacing Preview from the latest committed Document text. After the Parser
-transition, lowering waits for a 24 ms candidate-text quiet window so rapid
-changes normally produce one visible update.
+Reading one coherent syntax snapshot, lowering its captured source directly to
+MarkdownIR without reconstructing the document from CST tokens, and replacing
+Preview from the latest committed Document text. After the Parser transition,
+lowering waits for a 24 ms candidate-text quiet window so rapid changes normally
+produce one visible update.
 _Avoid_: projection refresh, render loop
 
 **Stale Preview**:

--- a/apps/loomark/examples/vanilla/tests/standalone.spec.ts
+++ b/apps/loomark/examples/vanilla/tests/standalone.spec.ts
@@ -256,6 +256,27 @@ test("Preview prepares after its status paints and refreshes typed Markdown", as
   await expect(page.getByRole("heading", { name: "Preview heading" })).toHaveCount(0)
 })
 
+test("Preview keeps incomplete Markdown literal without parser chrome", async ({ page }) => {
+  await page.goto("/")
+  const text = page.getByRole("textbox", { name: "Text" })
+  await text.fill("𐐀[unclosed\n")
+  await page.getByRole("tab", { name: "Preview" }).click()
+
+  const preview = page.getByRole("region", { name: "Markdown preview" })
+  await expect(preview).toContainText("𐐀[unclosed")
+  await expect(preview).not.toContainText("Recovered Markdown")
+  await expect(preview).not.toContainText("Raw Markdown")
+  await expect(preview.locator('[data-loomark-preview-fallback]')).toHaveCount(0)
+  await expect(preview.locator('[data-loomark-preview-diagnostic]')).toHaveCount(0)
+  await expect(preview.locator("p > div")).toHaveCount(0)
+
+  await page.getByRole("tab", { name: "Text" }).click()
+  await text.fill("[text](\n")
+  await page.getByRole("tab", { name: "Preview" }).click()
+  await expect(preview).toContainText("[text](")
+  await expect(preview).not.toContainText("Diagnostic:")
+})
+
 test("Tailwind Preflight and utilities preserve the Loomark shell and compact text measure", async ({ page }) => {
   await page.setViewportSize({ width: 900, height: 700 })
   await page.goto("/")

--- a/apps/loomark/internal/preview/engine.mbt
+++ b/apps/loomark/internal/preview/engine.mbt
@@ -48,10 +48,8 @@ fn create_parser_state(source : String) -> Result[EngineState, PreviewFailure] {
 ///|
 fn output(parser : @loom.SyntaxParser) -> PreviewOutput {
   let snapshot = parser.snapshot().read_or_abort()
-  let document = @markdown.experimental_markdown_ir_from_syntax_with_diagnostics(
-    parser.source_id(),
-    snapshot.syntax,
-    snapshot.diagnostics,
+  let document = @markdown.experimental_markdown_ir_from_syntax_snapshot(
+    snapshot,
     extensions=@markdown.MarkdownExtensions::task_list(),
   )
   { html: render(document), empty: is_empty(document) }

--- a/apps/loomark/internal/preview/moon.pkg
+++ b/apps/loomark/internal/preview/moon.pkg
@@ -1,5 +1,4 @@
 import {
-  "dowdiness/diagnostic",
   "dowdiness/loom",
   "dowdiness/markdown",
   "dowdiness/text_change",

--- a/apps/loomark/internal/preview/renderer.mbt
+++ b/apps/loomark/internal/preview/renderer.mbt
@@ -1,4 +1,10 @@
 ///|
+priv enum RenderPosition {
+  Flow
+  Phrasing
+}
+
+///|
 fn plain_text(node : @markdown.MarkdownIR) -> String {
   match node.text_value() {
     Some(value) => return value
@@ -11,7 +17,8 @@ fn plain_text(node : @markdown.MarkdownIR) -> String {
     @markdown.Autolink(display~, ..) => display
     @markdown.InlineCode(value~) | @markdown.HtmlBlock(value~) => value
     @markdown.HardBreak(..) | @markdown.SoftBreak => "\n"
-    @markdown.Unsupported(message~) | @markdown.Recovered(message~) => message
+    @markdown.Unsupported(message~) => message
+    @markdown.Recovered(value~) => value
     @markdown.ThematicBreak => ""
     @markdown.CodeBlock(value~, ..) => value
     @markdown.Document
@@ -92,20 +99,26 @@ fn safe_destination(destination : String, image~ : Bool) -> String? {
 }
 
 ///|
-fn diagnostics(node : @markdown.MarkdownIR) -> Array[@rabbita.Html] {
-  node
-  .diagnostics()
-  .map(diagnostic => {
-    @html.li(
-      attrs=@html.Attrs::build().data_set("loomark-preview-diagnostic", ""),
-      "Diagnostic: " + diagnostic.format(),
-    )
-  })
+fn render_children(
+  node : @markdown.MarkdownIR,
+  position : RenderPosition,
+) -> Array[@rabbita.Html] {
+  node.children().map(child => render_node(child, position~))
 }
 
 ///|
-fn render_children(node : @markdown.MarkdownIR) -> Array[@rabbita.Html] {
-  node.children().map(child => render_node(child))
+fn render_opaque_source(
+  value : String,
+  position : RenderPosition,
+) -> @rabbita.Html {
+  match position {
+    Phrasing => @html.text(value)
+    Flow =>
+      @html.pre(
+        class="m-0 whitespace-pre-wrap font-lm-sans text-inherit",
+        value,
+      )
+  }
 }
 
 ///|
@@ -118,8 +131,8 @@ fn render_list_children(
   .map(child => {
     match child.view() {
       @markdown.ListItem(..) | @markdown.OrderedListItem(..) =>
-        render_node(child, list_parent_spread=parent_list_spread)
-      _ => render_node(child)
+        render_node(child, position=Flow, list_parent_spread=parent_list_spread)
+      _ => render_node(child, position=Flow)
     }
   })
 }
@@ -152,7 +165,7 @@ fn render_list_item_children(
   .mapi((index, child) => {
     match child.view() {
       @markdown.Paragraph => {
-        let children = render_children(child)
+        let children = render_children(child, Phrasing)
         let children = if index == 0 && task is Some(_) {
           let prefixed = task_prefix.copy()
           prefixed.append(children)
@@ -166,7 +179,7 @@ fn render_list_item_children(
           @html.fragment(children)
         }
       }
-      _ => render_node(child)
+      _ => render_node(child, position=Flow)
     }
   })
 }
@@ -193,17 +206,36 @@ fn render_heading(
 ///|
 fn render_node(
   node : @markdown.MarkdownIR,
+  position? : RenderPosition = Flow,
   list_parent_spread? : Bool = false,
   unwrap_list_item_paragraph? : Bool = false,
 ) -> @rabbita.Html {
   let node_view = node.view()
   let children = match node_view {
+    @markdown.Document | @markdown.BlockQuote => render_children(node, Flow)
     @markdown.UnorderedList(spread~, ..) | @markdown.OrderedList(spread~, ..) =>
       render_list_children(node, spread)
     @markdown.ListItem(spread~, task~, ..)
     | @markdown.OrderedListItem(spread~, task~, ..) =>
       render_list_item_children(node, spread || list_parent_spread, task)
-    _ => render_children(node)
+    @markdown.Heading(..)
+    | @markdown.Paragraph
+    | @markdown.Bold
+    | @markdown.Italic
+    | @markdown.Link(..) => render_children(node, Phrasing)
+    @markdown.Image(..)
+    | @markdown.CodeBlock(..)
+    | @markdown.HtmlBlock(..)
+    | @markdown.ThematicBreak
+    | @markdown.Text(..)
+    | @markdown.InlineCode(..)
+    | @markdown.Autolink(..)
+    | @markdown.InlineHtml(..)
+    | @markdown.SoftBreak
+    | @markdown.HardBreak(..)
+    | @markdown.Unsupported(..)
+    | @markdown.Raw(..)
+    | @markdown.Recovered(..) => []
   }
   match node_view {
     @markdown.Document => @html.fragment(children)
@@ -360,25 +392,8 @@ fn render_node(
         ),
         "Unsupported Markdown: " + message,
       )
-    @markdown.Raw(value~) =>
-      @html.div(
-        attrs=@html.Attrs::build().data_set("loomark-preview-fallback", "raw"),
-        [
-          @html.strong("Raw Markdown:"),
-          @html.pre(value),
-          @html.ul(diagnostics(node)),
-        ],
-      )
-    @markdown.Recovered(message~) =>
-      @html.div(
-        attrs=@html.Attrs::build().data_set(
-          "loomark-preview-fallback", "recovered",
-        ),
-        [
-          @html.strong("Recovered Markdown: " + message),
-          @html.ul(diagnostics(node)),
-        ],
-      )
+    @markdown.Raw(value~) => render_opaque_source(value, position)
+    @markdown.Recovered(value~) => render_opaque_source(value, position)
   }
 }
 

--- a/apps/loomark/internal/preview/renderer_wbtest.mbt
+++ b/apps/loomark/internal/preview/renderer_wbtest.mbt
@@ -5,11 +5,8 @@ fn preview_test_document(source : String) -> @markdown.MarkdownIR raise {
     source,
     @markdown.markdown_grammar.to_syntax_grammar(),
   )
-  let snapshot = parser.snapshot().read_or_abort()
-  @markdown.experimental_markdown_ir_from_syntax_with_diagnostics(
-    parser.source_id(),
-    snapshot.syntax,
-    snapshot.diagnostics,
+  @markdown.experimental_markdown_ir_from_syntax_snapshot(
+    parser.snapshot().read_or_abort(),
     extensions=@markdown.MarkdownExtensions::task_list(),
   )
 }
@@ -98,10 +95,20 @@ test "Preview renderer rejects unsafe destinations" {
 }
 
 ///|
-test "Preview renderer preserves syntax diagnostics during direct lowering" {
-  let rendered = render_preview("[unclosed\n")
-  assert_preview_contains(rendered, "Recovered Markdown: [")
-  assert_preview_contains(rendered, "data-loomark-preview-diagnostic")
+test "Preview renders unresolved and raw recovery source without parser chrome" {
+  let cases = ["[unclosed\n", "[text](\n", "𐐀[unclosed\n"]
+  for source in cases {
+    let rendered = render_preview(source)
+    assert_true(!rendered.contains("Recovered Markdown"))
+    assert_true(!rendered.contains("Raw Markdown"))
+    assert_true(!rendered.contains("Diagnostic:"))
+    assert_true(!rendered.contains("data-loomark-preview-fallback"))
+    assert_true(!rendered.contains("data-loomark-preview-diagnostic"))
+    assert_true(!rendered.contains("<p><div"))
+  }
+  assert_preview_contains(render_preview("[unclosed\n"), "[unclosed")
+  assert_preview_contains(render_preview("[text](\n"), "[text](")
+  assert_preview_contains(render_preview("𐐀[unclosed\n"), "𐐀[unclosed")
 }
 
 ///|

--- a/docs/plans/2026-08-26-loomark-preview-split-production.md
+++ b/docs/plans/2026-08-26-loomark-preview-split-production.md
@@ -178,8 +178,9 @@ Required behavior:
 - At the next allowed retry, create one replacement Parser from current Document
   text. Never keep two active Parsers.
 - An allowed refresh reads one coherent `SyntaxSnapshot`, lowers it with
-  `experimental_markdown_ir_from_syntax_with_diagnostics`, and builds typed
-  Html. No compatibility `Block` AST or retained semantic attachment is created.
+  `experimental_markdown_ir_from_syntax_snapshot`, and builds typed Html. The
+  lowering reuses snapshot source instead of reconstructing it from CST tokens.
+  No compatibility `Block` AST or retained semantic attachment is created.
 - Snapshot reading, direct MarkdownIR lowering, and typed rendering are total
   for a healthy Parser. Internal invariant aborts are not converted into
   `PreviewFailure`. The current app has one page-lifetime document and no
@@ -238,9 +239,11 @@ rather than old application machinery.
 The renderer must:
 
 - exhaustively handle all 24 current public `MarkdownIRView` variants;
-- use `MarkdownIR::children`, `text_value`, and `diagnostics`;
+- use `MarkdownIR::children` and `text_value`;
 - preserve tight and loose list behavior, ordered starts, break forms, code
-  info, link forms, and diagnostic fallbacks;
+  info, and link forms;
+- render Raw/Recovered author source contextually as escaped flow or phrasing
+  content without parser labels or inline diagnostic lists;
 - render block and inline Markdown HTML as inert text;
 - render long URLs with wrapping, code blocks with internal horizontal
   overflow, and images within the reading width;
@@ -325,8 +328,8 @@ completed Markdown is not a live region.
 | Incremental Parser change | `SyntaxParser::apply_edit` | Reuse for every healthy `ReplaceRange`. |
 | Complete replacement | `SyntaxParser::set_source` | Reuse for `ReplaceAll`; do not rebuild a healthy Parser. |
 | Parser construction | `@loom.new_syntax_parser` | Reuse to avoid constructing an unused compatibility `Block` AST. |
-| Coherent parse result | `SyntaxParser::snapshot` | Reuse one source/syntax/diagnostics snapshot. |
-| Semantic document | `experimental_markdown_ir_from_syntax_with_diagnostics` | Reuse for one stateless lowering at each allowed refresh. |
+| Coherent parse result | `SyntaxParser::snapshot` | Reuse one source-id/source/syntax/diagnostics snapshot. |
+| Semantic document | `experimental_markdown_ir_from_syntax_snapshot` | Reuse snapshot source for one stateless lowering at each allowed refresh. |
 | Retained semantic cache | `MarkdownSemanticAttachment` | Checked but not reused; measured boundary fallbacks make its structural-key read substantially slower in Loomark. |
 | Preview rendering | Historical direct typed-Html renderer | Restore the pure renderer only. |
 | Resizable layout | RUI resizable panel group, panels, handle | Reuse; RUI owns ratio and interaction. |

--- a/modules/canopy/lang/markdown/proj/sdeg_heading_side_table_wbtest.mbt
+++ b/modules/canopy/lang/markdown/proj/sdeg_heading_side_table_wbtest.mbt
@@ -926,7 +926,7 @@ test "sdeg phase1: production side table memo treats valid delete as absence evi
 }
 
 ///|
-test "sdeg phase1: production side table memo holds malformed snapshots" {
+test "sdeg phase1: unmatched reference opener remains a live heading" {
   let parser = @loom.new_parser(
     @loomcore.SourceId("canopy-test:markdown-heading-side-table:error-node"),
     "# A\n",
@@ -949,8 +949,8 @@ test "sdeg phase1: production side table memo holds malformed snapshots" {
     initial_row.last_live.id,
   ).unwrap()
 
-  inspect(invalid_row.status == HeadingMissing, content="true")
-  inspect(invalid_row.current_id is None, content="true")
+  inspect(invalid_row.status == HeadingLive, content="true")
+  inspect(invalid_row.current_id is Some(_), content="true")
   inspect(invalid_row.consecutive_absences, content="0")
   inspect(invalid.rows.length(), content="1")
   inspect(valid_missing_row.status == HeadingMissing, content="true")


### PR DESCRIPTION
## Summary

- consume Loom's source-aware `SyntaxSnapshot` lowering API so Loomark Preview no longer reconstructs the document source from the CST
- render opaque Raw/Recovered Markdown as escaped author source in the correct flow or phrasing context, without parser diagnostics or recovery chrome in the document body
- update Preview, standalone browser, and Markdown projection regressions for incomplete Markdown as ordinary live author text

dowdiness/loom#937 is merged. The parent gitlink now pins Loom merge commit `066772b5ef6a131f61a58988a29cf0f311e8f0d3` on `origin/main`; its source tree is identical to the reviewed PR head.

## UI and review evidence

- [x] Accessible names and the keyboard path were preserved; the Preview remains a labelled read-only region and task checkboxes remain disabled.
- [x] Desktop and 390px mobile layouts were inspected with incomplete and non-BMP Markdown; viewport reflow and existing controls remained usable.
- [x] The accessibility tree contains only author source for incomplete Markdown, with no `Recovered Markdown`, `Raw Markdown`, or `Diagnostic:` chrome.
- [x] Browser console and invalid paragraph/block nesting checks were clean.
- [x] No external visual rule is claimed as a Canopy requirement; `.impeccable.md` and the existing Loomark visual system were preserved.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `experimental_markdown_ir_from_syntax_snapshot` | `deps/loom/examples/markdown` | Yes | Keeps source, source identity, syntax, and diagnostics coherent without a second lowering model. |
| `MarkdownIRView::{Raw, Recovered}` and `MarkdownIR::{view,children,text_value}` | `deps/loom/examples/markdown` | Yes | Preserves the existing direct typed renderer and avoids a presentation IR or free `(IR, source)` pair. |
| Rabbita typed `Html` flow and phrasing elements | `deps/rabbita/rabbita/html` | Yes | Produces escaped author source while maintaining valid HTML context. |
| MoonBit `String`, `Option`, and `Array::{map,join}` | core | Yes | Existing text extraction and child traversal remain declarative; no new text scanner or collection loop was added. |
| `MarkdownSemanticReadNode` | `deps/loom/examples/markdown` | No | A per-node wrapper would add allocation and duplicate the direct Preview renderer's existing traversal. |

New helpers added:

- `RenderPosition` records the renderer's existing flow-versus-phrasing obligation without creating a public presentation type.
- `render_opaque_source` is the single boundary for rendering Raw/Recovered author source as valid escaped HTML in either context.

## Validation scope

Boundary matrix / first failing regression:

- unresolved `[unclosed` and incomplete `[text](` render as literal author text without recovery chrome
- non-BMP UTF-16 prefixes preserve exact source
- Raw/Recovered values render correctly in both flow and phrasing positions without invalid `<p><div>` nesting
- shortcut/full/collapsed/image references, task-list opt-in, and valid headings keep their existing semantics
- the Canopy heading side-table consumer now treats unmatched brackets as live heading text rather than malformed parser output

Target packages:

- `dowdiness/loomark/internal/preview`
- `dowdiness/loomark` workspace module
- `dowdiness/canopy/lang/markdown/proj`

Additional conditional gates:

- Preview targeted release JS tests: 13/13
- Loomark module debug and release JS tests: 7469/7469
- heading side-table regressions: 35/35
- standalone production Playwright E2E: 18/18
- strict checks for Preview and Markdown projection packages: PASS
- documentation lifecycle and agent-link checks: PASS
- independent integrated MoonBit review: PASS with no findings
- Impeccable mechanical detector: no findings
- release JS Preview cycle: approximately 4.6 ms for 500 blocks and 28 ms for 2,500 blocks
- release JS renderer: approximately 3.1 ms for 500 blocks and 21.8 ms for 2,500 blocks

## Push and CI readiness

```bash
git fetch origin main
git push
```

- [x] The branch contains the fetched `origin/main`, and the normal push completed with Lefthook's affected local checks.
- [x] The committed `.mbti` changes are confined to the Loom dependency and were reviewed for unintended API or trait-bound changes.
- [x] The Loom squash-merge commit is reachable from `origin/main`, and its tree matches the reviewed dependency commit.
- [x] The branch was pushed again after the post-merge submodule-pointer commit.
- [x] Independent review completed with no unresolved findings.
- [ ] GitHub CI's `All Checks Passed` gate must be green before merge.
