### PR TITLE
feat!: migrate Canopy to EGW text schema 2

### DIFF
--- a/apps/block-editor/moon.mod
+++ b/apps/block-editor/moon.mod
@@ -4,7 +4,7 @@ version = "0.1.0"
 
 import {
   "dowdiness/canopy@0.1.0",
-  "dowdiness/event-graph-walker@0.7.1",
+  "dowdiness/event-graph-walker@0.8.0",
 }
 
 preferred_target = "js"

--- a/apps/ideal/main/commands.mbt
+++ b/apps/ideal/main/commands.mbt
@@ -37,7 +37,7 @@ fn sync_after_local_model_change(model : Model, text : String) -> Cmd {
     @cm.set_doc(
       model.cm_id,
       text,
-      source_version=@ffi.get_version_json(model.handle),
+      source_version=Hash::hash(model.editor.get_version()).to_string(),
     ),
     @rabbita.effect(fn() { js_after_local_text_edit() }),
   ])
@@ -48,7 +48,7 @@ fn sync_after_external_crdt_change(model : Model) -> Cmd {
   @cm.set_doc(
     model.cm_id,
     model.editor.get_text(),
-    source_version=@ffi.get_version_json(model.handle),
+    source_version=Hash::hash(model.editor.get_version()).to_string(),
   )
 }
 

--- a/apps/ideal/main/crdt_reexport.mbt
+++ b/apps/ideal/main/crdt_reexport.mbt
@@ -71,12 +71,12 @@ pub fn delete_at(handle : Int, pos : Int, ts : Int) -> Bool raise {
 }
 
 ///|
-pub fn export_all_json(handle : Int) -> String {
+pub fn export_all_json(handle : Int) -> String raise {
   @ffi.export_all_json(handle)
 }
 
 ///|
-pub fn export_since_json(handle : Int, peer_version : String) -> String {
+pub fn export_since_json(handle : Int, peer_version : String) -> String raise {
   @ffi.export_since_json(handle, peer_version)
 }
 

--- a/apps/ideal/main/crdt_reexport.mbt
+++ b/apps/ideal/main/crdt_reexport.mbt
@@ -56,7 +56,7 @@ pub fn get_errors_json(handle : Int) -> String raise Failure {
 }
 
 ///|
-pub fn get_version_json(handle : Int) -> String {
+pub fn get_version_json(handle : Int) -> String raise {
   @ffi.get_version_json(handle)
 }
 

--- a/apps/ideal/main/init.mbt
+++ b/apps/ideal/main/init.mbt
@@ -79,7 +79,7 @@ fn subscriptions(model : Model, emit : Emit[Msg]) -> Sub {
       model.cm_id,
       selection=emit.map(range => CmSelectionChanged(range)),
       on_change_with_doc=emit.map(event => CmChanges(event)),
-      source_version=() => @ffi.get_version_json(model.handle),
+      source_version=() => Hash::hash(model.editor.get_version()).to_string(),
     )
   } else {
     @sub.none

--- a/apps/ideal/main/pkg.generated.mbti
+++ b/apps/ideal/main/pkg.generated.mbti
@@ -39,9 +39,9 @@ pub fn ephemeral_set_presence(Int, String, String) -> Unit
 
 pub fn ephemeral_set_presence_with_selection(Int, String, String, Int, Int) -> Unit
 
-pub fn export_all_json(Int) -> String
+pub fn export_all_json(Int) -> String raise
 
-pub fn export_since_json(Int, String) -> String
+pub fn export_since_json(Int, String) -> String raise
 
 pub fn get_errors_json(Int) -> String raise Failure
 

--- a/apps/ideal/main/pkg.generated.mbti
+++ b/apps/ideal/main/pkg.generated.mbti
@@ -51,7 +51,7 @@ pub fn get_source_map_json(Int) -> String
 
 pub fn get_text(Int) -> String
 
-pub fn get_version_json(Int) -> String
+pub fn get_version_json(Int) -> String raise
 
 pub fn handle_redo(Int) -> Bool raise Failure
 

--- a/apps/ideal/main/update_codemirror.mbt
+++ b/apps/ideal/main/update_codemirror.mbt
@@ -48,7 +48,7 @@ fn handle_codemirror(
       // version still matches the source currently displayed in CodeMirror;
       // otherwise use the transaction's captured document snapshot fallback.
       let changes = event.changes
-      let current_source_version = @ffi.get_version_json(model.handle)
+      let current_source_version = Hash::hash(model.editor.get_version()).to_string()
       js_perf_begin("cmDocChangedHandler")
       js_perf_begin("syncEditorApply")
       let timestamp_ms = js_now_ms()
@@ -91,7 +91,7 @@ fn handle_codemirror(
         }
       }
       let actual_text = new_model.editor.get_text()
-      let source_version = @ffi.get_version_json(model.handle)
+      let source_version = Hash::hash(model.editor.get_version()).to_string()
       js_perf_begin("publicationPrepare")
       let sync_cmd = match fallback_text {
         Some(text) =>

--- a/apps/ideal/moon.mod
+++ b/apps/ideal/moon.mod
@@ -16,7 +16,7 @@ import {
   "dowdiness/text_change@0.1.0",
   "dowdiness/graphviz@0.1.0",
   "dowdiness/lambda@0.1.0",
-  "dowdiness/event-graph-walker@0.7.1",
+  "dowdiness/event-graph-walker@0.8.0",
   "dowdiness/visualizer@0.1.0",
   "dowdiness/canvas-spatial@0.1.0",
   "dowdiness/incr@0.15.1",

--- a/apps/ideal/web/e2e/editor-features.spec.ts
+++ b/apps/ideal/web/e2e/editor-features.spec.ts
@@ -150,6 +150,39 @@ test.describe('Persistence', () => {
       return text.includes('add5') && !text.includes('apply id 42');
     });
   });
+
+  test('rejects and removes stored text schema 1 state', async ({ page }) => {
+    const room = `schema-1-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const key = `canopy-doc-${room}`;
+    await page.addInitScript(({ storageKey }) => {
+      localStorage.setItem(
+        storageKey,
+        '{"schema":1,"format":"event-graph-walker/text-sync","operations":[],"heads":[]}',
+      );
+    }, { storageKey: key });
+
+    await waitForEditor(page, `/#${room}`);
+    expect(
+      await page.evaluate((storageKey) => localStorage.getItem(storageKey), key),
+    ).toBeNull();
+    expect(
+      await page.evaluate(() => {
+        const bridge = (globalThis as any).__canopy_bridge;
+        try {
+          bridge.crdt.export_since_json(
+            bridge.crdtHandle,
+            '{"schema":1,"format":"event-graph-walker/text-version","entries":[]}',
+          );
+          return false;
+        } catch {
+          return true;
+        }
+      }),
+    ).toBe(true);
+
+    await page.getByRole('button', { name: 'Basics' }).click();
+    await expect(page.locator('#canopy-text-editor .cm-content')).toContainText('double');
+  });
 });
 
 // ── CodeMirror Rendering ─────────────────────────────────────

--- a/modules/canopy/editor/editor_test.mbt
+++ b/modules/canopy/editor/editor_test.mbt
@@ -123,12 +123,12 @@ test "cursor bounds checking" {
 test "pending sync clamps cursor after applying ready delete" {
   let editor = try! Editor::new("receiver")
   let initial = try! @text.SyncMessage::from_json_string(
-    "{\"schema\":1,\"format\":\"event-graph-walker/text-sync\",\"operations\":[{\"id\":{\"replica_id\":\"remote\",\"sequence\":0},\"parents\":[],\"kind\":\"insert\",\"content\":\"A\",\"origin_left\":null,\"origin_right\":null}],\"heads\":[{\"replica_id\":\"remote\",\"sequence\":0}]}",
+    "{\"schema\":2,\"format\":\"event-graph-walker/text-sync\",\"operations\":[{\"id\":{\"replica_id\":\"remote\",\"sequence\":0},\"parents\":[],\"kind\":\"insert\",\"content\":\"A\",\"origin_left\":null,\"origin_right\":null}],\"heads\":[{\"replica_id\":\"remote\",\"sequence\":0}]}",
   )
   try! editor.apply_sync(initial)
   editor.move_cursor(1)
   let mixed = try! @text.SyncMessage::from_json_string(
-    "{\"schema\":1,\"format\":\"event-graph-walker/text-sync\",\"operations\":[{\"id\":{\"replica_id\":\"remote\",\"sequence\":1},\"parents\":[{\"replica_id\":\"remote\",\"sequence\":0}],\"kind\":\"delete\",\"content\":null,\"origin_left\":{\"replica_id\":\"remote\",\"sequence\":0},\"origin_right\":null},{\"id\":{\"replica_id\":\"remote\",\"sequence\":3},\"parents\":[{\"replica_id\":\"remote\",\"sequence\":2}],\"kind\":\"insert\",\"content\":\"X\",\"origin_left\":null,\"origin_right\":null}],\"heads\":[{\"replica_id\":\"remote\",\"sequence\":3}]}",
+    "{\"schema\":2,\"format\":\"event-graph-walker/text-sync\",\"operations\":[{\"id\":{\"replica_id\":\"remote\",\"sequence\":1},\"parents\":[{\"replica_id\":\"remote\",\"sequence\":0}],\"kind\":\"delete\",\"content\":null,\"origin_left\":{\"replica_id\":\"remote\",\"sequence\":0},\"origin_right\":null},{\"id\":{\"replica_id\":\"remote\",\"sequence\":3},\"parents\":[{\"replica_id\":\"remote\",\"sequence\":2}],\"kind\":\"insert\",\"content\":\"X\",\"origin_left\":null,\"origin_right\":null}],\"heads\":[{\"replica_id\":\"remote\",\"sequence\":3}]}",
   )
   let result : Result[Unit, Error] = Ok(editor.apply_sync(mixed)) catch {
     error => Err(error)
@@ -207,7 +207,7 @@ test "concurrent inserts at same position" {
   // With FugueMax: Both X and Y are inserted between A and C with origin_left=A, origin_right=C
   // Since A is ancestor of C, both become left children of C
   // With agent tiebreaking, alice < bob alphabetically, so X comes before Y
-  inspect(alice_text, content="AYXC")
+  inspect(alice_text, content="AXYC")
 
   // Verify both contributions are present
   inspect(alice_text.contains("A"), content="true")

--- a/modules/canopy/editor/markdown/editor.mbt
+++ b/modules/canopy/editor/markdown/editor.mbt
@@ -452,7 +452,9 @@ pub struct MarkdownDocumentVersion {
 
 ///|
 /// Encode this causal frontier as the canonical portable text-version token.
-pub fn MarkdownDocumentVersion::to_json_string(self : Self) -> String {
+pub fn MarkdownDocumentVersion::to_json_string(
+  self : Self,
+) -> String raise @text.TextError {
   self.value.to_json_string()
 }
 

--- a/modules/canopy/editor/markdown/markdown_editor_wbtest.mbt
+++ b/modules/canopy/editor/markdown/markdown_editor_wbtest.mbt
@@ -2176,6 +2176,18 @@ test "history codec round-trips through the Markdown façade" {
 }
 
 ///|
+test "history codec rejects persisted text schema 1" {
+  let result = Ok(
+    MarkdownDocumentHistory::from_json_string(
+      "{\"schema\":1,\"format\":\"event-graph-walker/text-sync\",\"operations\":[],\"heads\":[]}",
+    ),
+  ) catch {
+    error => Err(error)
+  }
+  assert_true(result is Err(MarkdownHistoryCodecError::Malformed(_)))
+}
+
+///|
 test "portable Markdown delegates façade sentinel export" {
   let editor = try! MarkdownEditor(
     agent_id="portable-markdown-facade",

--- a/modules/canopy/editor/markdown/pkg.generated.mbti
+++ b/modules/canopy/editor/markdown/pkg.generated.mbti
@@ -2,6 +2,7 @@
 package "dowdiness/canopy/editor/markdown"
 
 import {
+  "dowdiness/event-graph-walker/text",
   "moonbitlang/core/debug",
   "moonbitlang/core/immut/vector",
 }
@@ -138,7 +139,7 @@ pub fn MarkdownDocumentUtf16Selection::range_start(Self) -> Int
 pub struct MarkdownDocumentVersion {
   // private fields
 } derive(Eq, @debug.Debug)
-pub fn MarkdownDocumentVersion::to_json_string(Self) -> String
+pub fn MarkdownDocumentVersion::to_json_string(Self) -> String raise @text.TextError
 
 pub(all) enum MarkdownEditRequest {
   ReplaceSource(String)

--- a/modules/canopy/editor/sync_editor_test.mbt
+++ b/modules/canopy/editor/sync_editor_test.mbt
@@ -505,8 +505,8 @@ test "SyncEditor: concurrent middle inserts converge with parser state" {
   try! alice.apply_sync(try! bob.export_all())
   try! bob.apply_sync(try! alice.export_all())
 
-  inspect(alice.get_text(), content="abBAcd")
-  inspect(bob.get_text(), content="abBAcd")
+  inspect(alice.get_text(), content="abABcd")
+  inspect(bob.get_text(), content="abABcd")
   inspect(
     @probe.get_test_ast(alice) == @probe.get_test_ast(bob),
     content="true",

--- a/modules/canopy/editor/sync_editor_ws.mbt
+++ b/modules/canopy/editor/sync_editor_ws.mbt
@@ -8,8 +8,8 @@
 ///|
 /// Narrow IO record for the retry/send paths (no `Eq` bound required).
 fn[T] SyncEditor::sync_io(self : SyncEditor[T]) -> @sync_session.SyncIo {
-  @sync_session.SyncIo::SyncIo(send=data => self.interaction.ws_send(data), current_version=() => {
-    self.get_version()
+  @sync_session.SyncIo::SyncIo(send=data => self.interaction.ws_send(data), current_version_json=() => {
+    self.get_version().to_json_string()
   })
 }
 

--- a/modules/canopy/ffi/lambda/analysis.mbt
+++ b/modules/canopy/ffi/lambda/analysis.mbt
@@ -74,7 +74,7 @@ fn LambdaHandle::pattern_source_snapshot(
 ) -> @facts.SourceSnapshot {
   @facts.SourceSnapshot::SourceSnapshot(
     doc_id=self.editor_id.0.to_string(),
-    version=self.editor.get_version().to_json_string().hash(),
+    version=Hash::hash(self.editor.get_version()),
     source~,
   )
 }

--- a/modules/canopy/ffi/lambda/canopy_test.mbt
+++ b/modules/canopy/ffi/lambda/canopy_test.mbt
@@ -12,11 +12,29 @@ test "editor creation rejects an empty agent identifier before registration" {
 }
 
 ///|
-test "sync JSON fallback is a valid empty v0.5 envelope" {
-  let all = @text.SyncMessage::from_json_string(export_all_json(-1))
-  let since = @text.SyncMessage::from_json_string(export_since_json(-1, ""))
-  inspect(all.op_count(), content="0")
-  inspect(since.op_count(), content="0")
+test "sync JSON export rejects an invalid editor handle" {
+  let all : Result[String, Error] = Ok(export_all_json(-1)) catch {
+    error => Err(error)
+  }
+  let since : Result[String, Error] = Ok(export_since_json(-1, "")) catch {
+    error => Err(error)
+  }
+  inspect(all is Err(_), content="true")
+  inspect(since is Err(_), content="true")
+}
+
+///|
+test "schema-1 peer Version is rejected across the Lambda FFI" {
+  let handle = create_editor("schema-2-version-boundary")
+  let result : Result[String, Error] = Ok(
+    export_since_json(
+      handle, "{\"schema\":1,\"format\":\"event-graph-walker/text-version\",\"entries\":[]}",
+    ),
+  ) catch {
+    error => Err(error)
+  }
+  inspect(result is Err(@text.TextError::SyncFailed(_)), content="true")
+  destroy_editor(handle)
 }
 
 ///|

--- a/modules/canopy/ffi/lambda/canopy_test.mbt
+++ b/modules/canopy/ffi/lambda/canopy_test.mbt
@@ -19,8 +19,12 @@ test "sync JSON export rejects an invalid editor handle" {
   let since : Result[String, Error] = Ok(export_since_json(-1, "")) catch {
     error => Err(error)
   }
+  let version : Result[String, Error] = Ok(get_version_json(-1)) catch {
+    error => Err(error)
+  }
   inspect(all is Err(_), content="true")
   inspect(since is Err(_), content="true")
+  inspect(version is Err(_), content="true")
 }
 
 ///|

--- a/modules/canopy/ffi/lambda/diagnostics.mbt
+++ b/modules/canopy/ffi/lambda/diagnostics.mbt
@@ -159,10 +159,10 @@ pub fn apply_sync_json(handle : Int, sync_json : String) -> String {
 
 ///|
 /// Get the current version as a JSON string.
-pub fn get_version_json(handle : Int) -> String {
+pub fn get_version_json(handle : Int) -> String raise {
   match lambda_registry.get(handle) {
     Some(h) => h.editor.get_version().to_json_string()
-    None => "\"\""
+    None => fail("invalid editor handle")
   }
 }
 

--- a/modules/canopy/ffi/lambda/diagnostics.mbt
+++ b/modules/canopy/ffi/lambda/diagnostics.mbt
@@ -118,32 +118,26 @@ pub fn get_diagnostics_json(handle : Int) -> String {
 }
 
 ///|
-const EMPTY_SYNC_JSON : String = "{\"schema\":1,\"format\":\"event-graph-walker/text-sync\",\"operations\":[],\"heads\":[]}"
-
-///|
 /// Export all operations as a SyncMessage JSON string.
-pub fn export_all_json(handle : Int) -> String {
+pub fn export_all_json(handle : Int) -> String raise {
   match lambda_registry.get(handle) {
-    Some(h) =>
-      h.editor.export_all().to_json_string() catch {
-        _ => EMPTY_SYNC_JSON
-      }
-    None => EMPTY_SYNC_JSON
+    Some(h) => h.editor.export_all().to_json_string()
+    None => fail("invalid editor handle")
   }
 }
 
 ///|
 /// Export operations since a peer's version as a SyncMessage JSON string.
-pub fn export_since_json(handle : Int, peer_version_json : String) -> String {
+pub fn export_since_json(
+  handle : Int,
+  peer_version_json : String,
+) -> String raise {
   match lambda_registry.get(handle) {
-    Some(h) =>
-      try {
-        let ver = @text.Version::from_json_string(peer_version_json)
-        h.editor.export_since(ver).to_json_string()
-      } catch {
-        _ => EMPTY_SYNC_JSON
-      }
-    None => EMPTY_SYNC_JSON
+    Some(h) => {
+      let version = @text.Version::from_json_string(peer_version_json)
+      h.editor.export_since(version).to_json_string()
+    }
+    None => fail("invalid editor handle")
   }
 }
 

--- a/modules/canopy/ffi/lambda/pkg.generated.mbti
+++ b/modules/canopy/ffi/lambda/pkg.generated.mbti
@@ -79,7 +79,7 @@ pub fn get_sync_editor() -> @editor.SyncEditor[@ast.Term]?
 
 pub fn get_text(Int) -> String
 
-pub fn get_version_json(Int) -> String
+pub fn get_version_json(Int) -> String raise
 
 pub fn get_view_tree_json(Int) -> String raise Failure
 

--- a/modules/canopy/ffi/lambda/pkg.generated.mbti
+++ b/modules/canopy/ffi/lambda/pkg.generated.mbti
@@ -51,9 +51,9 @@ pub fn ephemeral_set_presence(Int, String, String) -> Unit
 
 pub fn ephemeral_set_presence_with_selection(Int, String, String, Int, Int) -> Unit
 
-pub fn export_all_json(Int) -> String
+pub fn export_all_json(Int) -> String raise
 
-pub fn export_since_json(Int, String) -> String
+pub fn export_since_json(Int, String) -> String raise
 
 pub fn get_ast_dot_resolved(Int) -> String raise Failure
 

--- a/modules/canopy/ffi/lambda/ws.mbt
+++ b/modules/canopy/ffi/lambda/ws.mbt
@@ -73,12 +73,14 @@ pub fn ws_enable_watchdog(handle : Int, timeout_ms : Int) -> Unit {
 ///|
 /// Register a JS callback that receives SyncStatus transitions.
 /// The callback payload is a JSON string; the JS host `JSON.parse`s it
-/// and reads the shape { tag, peer_id?, attempt?, reason? }:
+/// and reads the shape { tag, peer_id?, attempt?, reason?, kind?, limit?, actual? }:
 ///   {"tag":"disconnected"}
 ///   {"tag":"idle"}
 ///   {"tag":"recovering","peer_id":"<id>","attempt":<n>}
 ///   {"tag":"error","reason":"exhausted","peer_id":"<id>"}
 ///   {"tag":"error","reason":"target_left","peer_id":"<id>"}
+///   {"tag":"error","reason":"local_version_limit","kind":"DecodedOperations","limit":4096,"actual":4097}
+///   {"tag":"error","reason":"local_version_encoding"}
 /// JSON (vs. a delimited string) avoids ambiguity when peer_id contains
 /// characters that would otherwise need escaping at the boundary.
 /// Host JS wires delivery via `globalThis.__canopy_bridge.onStatusChange`.
@@ -130,6 +132,19 @@ fn encode_sync_status(status : @editor.SyncStatus) -> String {
             "tag": Json::string("error"),
             "reason": Json::string("target_left"),
             "peer_id": Json::string(peer_id),
+          })
+        LocalVersionLimitExceeded(kind~, limit~, actual~) =>
+          Json::object({
+            "tag": Json::string("error"),
+            "reason": Json::string("local_version_limit"),
+            "kind": Json::string(kind.to_string()),
+            "limit": Json::number(limit.to_double()),
+            "actual": Json::number(actual.to_double()),
+          })
+        LocalVersionEncodingFailed =>
+          Json::object({
+            "tag": Json::string("error"),
+            "reason": Json::string("local_version_encoding"),
           })
       }
   }

--- a/modules/canopy/moon.mod
+++ b/modules/canopy/moon.mod
@@ -8,7 +8,7 @@ import {
   "moonbitlang/async@0.20.1",
   "dowdiness/incr@0.15.1",
   "dowdiness/diagnostic@0.1.0",
-  "dowdiness/event-graph-walker@0.7.1",
+  "dowdiness/event-graph-walker@0.8.0",
   "dowdiness/byte_codec@0.1.0",
   "dowdiness/text_change@0.1.0",
   "dowdiness/moji@0.1.0",

--- a/modules/canopy/sync_session/README.md
+++ b/modules/canopy/sync_session/README.md
@@ -18,7 +18,8 @@ deprecation idiom with at least one release cycle.
   checked *before* advancing, so retries 0–2 each send and 3 surfaces
   `Error(Exhausted)`), deferred-message buffering capped at 32 with
   drop-oldest, stale request-id / watchdog-epoch discard, 1 MB SyncResponse
-  cap on the responder side.
+  cap on the responder side, and terminal local Version encoding failures that
+  send neither a frame nor a watchdog.
 - `SyncTransport` — the transport seam (trait); `InMemoryRoom` /
   `InMemoryTransport` — the in-process reference implementation used by
   tests and local collaboration probes.
@@ -28,8 +29,9 @@ deprecation idiom with at least one release cycle.
 Document state, parsing, and presence. The owning editor supplies those
 per call through two closure records:
 
-- `SyncIo` — `send` + `current_version`; enough for the retry/send paths
-  (`on_watchdog_fire`). Kept narrow because the editor's watchdog surface
+- `SyncIo` — `send` + fallible `current_version_json`; enough for the
+  retry/send paths (`on_watchdog_fire`). Encoding stays in the editor adapter,
+  while this package owns the no-send/error transition. Kept narrow because the editor's watchdog surface
   has no `Eq` bound and cannot build the full host.
 - `SyncHost` — `SyncIo` plus `apply_sync` / `export_all` / `export_since`
   and ephemeral routing closures; consumed only by `on_message`.

--- a/modules/canopy/sync_session/payloads.mbt
+++ b/modules/canopy/sync_session/payloads.mbt
@@ -59,6 +59,7 @@ fn should_retry_sync_error(err : Error) -> Bool {
   match err {
     @text.TextError::SyncFailed(@sync.Failure::MissingDependency(..)) => true
     @text.TextError::VersionNotFound => true
+    @text.TextError::ProjectionRecoveryRequired => true
     _ => false
   }
 }

--- a/modules/canopy/sync_session/pkg.generated.mbti
+++ b/modules/canopy/sync_session/pkg.generated.mbti
@@ -3,6 +3,7 @@ package "dowdiness/canopy/sync_session"
 
 import {
   "dowdiness/canopy/protocol/wire",
+  "dowdiness/event-graph-walker/sync",
   "dowdiness/event-graph-walker/text",
   "moonbitlang/core/debug",
 }
@@ -29,6 +30,8 @@ type RecoveryContext
 pub enum SyncErrorReason {
   Exhausted(peer_id~ : String)
   TargetLeft(peer_id~ : String)
+  LocalVersionLimitExceeded(kind~ : @sync.LimitKind, limit~ : Int, actual~ : Int)
+  LocalVersionEncodingFailed
 } derive(Eq, @debug.Debug)
 pub impl Show for SyncErrorReason
 
@@ -45,9 +48,9 @@ pub fn SyncHost::SyncHost(io~ : SyncIo, apply_sync~ : (@text.SyncMessage) -> Uni
 
 pub struct SyncIo {
   send : (Bytes) -> Unit
-  current_version : () -> @text.Version
+  current_version_json : () -> String raise @text.TextError
 }
-pub fn SyncIo::SyncIo(send~ : (Bytes) -> Unit, current_version~ : () -> @text.Version) -> Self
+pub fn SyncIo::SyncIo(send~ : (Bytes) -> Unit, current_version_json~ : () -> String raise @text.TextError) -> Self
 
 pub struct SyncSession {
   // private fields

--- a/modules/canopy/sync_session/session_wbtest.mbt
+++ b/modules/canopy/sync_session/session_wbtest.mbt
@@ -48,6 +48,7 @@ test "SyncSession: retries only causal dependency failures" {
         ),
       ),
       should_retry_sync_error(@text.TextError::VersionNotFound),
+      should_retry_sync_error(@text.TextError::ProjectionRecoveryRequired),
       should_retry_sync_error(
         @text.TextError::SyncFailed(
           @sync.Failure::MalformedMessage(detail="bad envelope"),
@@ -73,7 +74,7 @@ test "SyncSession: retries only causal dependency failures" {
         ),
       ),
     ],
-    content="[true, true, false, false, false, false]",
+    content="[true, true, true, false, false, false, false]",
   )
 }
 
@@ -104,6 +105,74 @@ test "SyncStatus: Show impl" {
 }
 
 // Dispatch: recovery buffering and response staleness
+
+///|
+test "SyncSession: projection recovery failure starts peer recovery" {
+  let session = SyncSession()
+  session.on_open()
+  let message = empty_msg_or_fail()
+  let sent : Array[Bytes] = []
+  let host = SyncHost(
+    io=test_io(sent),
+    apply_sync=_ => raise @text.TextError::ProjectionRecoveryRequired,
+    export_all=() => empty_msg_or_fail(),
+    export_since=_ => empty_msg_or_fail(),
+    apply_ephemeral=(_, _) => (),
+    encode_ephemeral=_ => Bytes::new(0),
+    on_peer_leave=_ => (),
+  )
+  let payload = Buffer()
+  payload.write_string_utf16le(message.to_json_string().view())
+  session.on_message(
+    @wire.encode_relayed_crdt_ops("alice", payload.to_bytes()),
+    host,
+  )
+  inspect(session.recovery is Some(_), content="true")
+  inspect(sent.length(), content="1")
+  inspect(
+    session.get_status(),
+    content=(
+      #|Recovering(peer_id="alice", attempt=1)
+    ),
+  )
+}
+
+///|
+test "SyncSession: projection recovery during delta consumes retry" {
+  let session = SyncSession()
+  session.on_open()
+  let message = empty_msg_or_fail()
+  session.recovery_epoch = 1
+  session.recovery = Some(RecoveryContext::new("alice", message, 1))
+  session.set_status(Recovering(peer_id="alice", attempt=1))
+  let sent : Array[Bytes] = []
+  let host = SyncHost(
+    io=test_io(sent),
+    apply_sync=_ => raise @text.TextError::ProjectionRecoveryRequired,
+    export_all=() => empty_msg_or_fail(),
+    export_since=_ => empty_msg_or_fail(),
+    apply_ephemeral=(_, _) => (),
+    encode_ephemeral=_ => Bytes::new(0),
+    on_peer_leave=_ => (),
+  )
+  session.on_message(
+    @wire.encode_sync_response(
+      target="alice",
+      request_id="1",
+      sync_json=message.to_json_string(),
+    ),
+    host,
+  )
+  inspect(session.recovery is Some(_), content="true")
+  inspect(session.recovery.unwrap().retries, content="1")
+  inspect(sent.length(), content="1")
+  inspect(
+    session.get_status(),
+    content=(
+      #|Recovering(peer_id="alice", attempt=2)
+    ),
+  )
+}
 
 ///|
 test "SyncSession: RelayedCrdtOps buffers during recovery" {

--- a/modules/canopy/sync_session/session_wbtest.mbt
+++ b/modules/canopy/sync_session/session_wbtest.mbt
@@ -13,10 +13,23 @@ fn empty_msg_or_fail() -> @text.SyncMessage raise {
 }
 
 ///|
-/// Fake IO: records sent frames, serves a fresh empty version.
+/// Fake IO: records sent frames, serves a fresh empty Version token.
 fn test_io(sent : Array[Bytes]) -> SyncIo {
-  SyncIo(send=data => sent.push(data), current_version=() => {
-    try! @text.TextState::new("io-peer").version()
+  SyncIo(send=data => sent.push(data), current_version_json=() => {
+    @text.TextState::new("io-peer").version().to_json_string()
+  })
+}
+
+///|
+fn version_limit_io(sent : Array[Bytes]) -> SyncIo {
+  SyncIo(send=data => sent.push(data), current_version_json=() => {
+    raise @text.TextError::SyncFailed(
+      @sync.Failure::LimitExceeded(
+        kind=@sync.LimitKind::DecodedOperations,
+        limit=4096,
+        actual=4097,
+      ),
+    )
   })
 }
 
@@ -24,6 +37,39 @@ fn test_io(sent : Array[Bytes]) -> SyncIo {
 /// Fake host whose document closures are inert: apply_sync succeeds,
 /// exports return an empty SyncMessage, ephemeral payloads vanish.
 /// `left` records on_peer_leave calls.
+test "local Version limit ends recovery without sending or scheduling" {
+  let sent : Array[Bytes] = []
+  let scheduled : Array[(Int, Int)] = []
+  let statuses : Array[SyncStatus] = []
+  let session = SyncSession::SyncSession()
+  session.set_on_status_change(Some(status => statuses.push(status)))
+  session.set_watchdog_scheduler(
+    Some((request_id, timeout) => scheduled.push((request_id, timeout))),
+  )
+  session.enter_recovery(
+    "peer",
+    try! empty_msg_or_fail(),
+    version_limit_io(sent),
+  )
+  inspect(sent.length(), content="0")
+  inspect(scheduled.length(), content="0")
+  inspect(session.recovery is None, content="true")
+  inspect(
+    session.get_status(),
+    content=(
+      #|Error(
+      #|  reason=LocalVersionLimitExceeded(
+      #|    kind=DecodedOperations,
+      #|    limit=4096,
+      #|    actual=4097,
+      #|  ),
+      #|)
+    ),
+  )
+  inspect(statuses.length(), content="2")
+}
+
+///|
 fn test_host(sent : Array[Bytes], left : Array[String]) -> SyncHost {
   SyncHost(
     io=test_io(sent),

--- a/modules/canopy/sync_session/sync_session.mbt
+++ b/modules/canopy/sync_session/sync_session.mbt
@@ -17,15 +17,15 @@ const DEFAULT_WATCHDOG_MS : Int = 5000
 /// apply_sync closure requires it).
 pub struct SyncIo {
   send : (Bytes) -> Unit
-  current_version : () -> @text.Version
+  current_version_json : () -> String raise @text.TextError
 }
 
 ///|
 pub fn SyncIo::SyncIo(
   send~ : (Bytes) -> Unit,
-  current_version~ : () -> @text.Version,
+  current_version_json~ : () -> String raise @text.TextError,
 ) -> SyncIo {
-  { send, current_version }
+  { send, current_version_json }
 }
 
 ///|
@@ -378,15 +378,32 @@ fn SyncSession::enter_recovery(
 }
 
 ///|
+fn local_version_encoding_reason(error : @text.TextError) -> SyncErrorReason {
+  match error {
+    @text.TextError::SyncFailed(
+      @sync.Failure::LimitExceeded(kind~, limit~, actual~)
+    ) => LocalVersionLimitExceeded(kind~, limit~, actual~)
+    _ => LocalVersionEncodingFailed
+  }
+}
+
+///|
 /// Send a SyncRequest to a specific peer via the relay.
 /// Always uses the current version (not stale from recovery entry).
+/// A local encoding failure ends recovery before any frame or watchdog is sent.
 fn SyncSession::send_sync_request(
   self : SyncSession,
   target : String,
   request_id : Int,
   io : SyncIo,
 ) -> Unit {
-  let version_json = (io.current_version)().to_json_string()
+  let version_json = (io.current_version_json)() catch {
+    error => {
+      self.recovery = None
+      self.set_status(Error(reason=local_version_encoding_reason(error)))
+      return
+    }
+  }
   let wire = @wire.encode_sync_request(
     target~,
     request_id=request_id.to_string(),

--- a/modules/canopy/sync_session/sync_status.mbt
+++ b/modules/canopy/sync_session/sync_status.mbt
@@ -24,6 +24,14 @@ pub enum SyncErrorReason {
   Exhausted(peer_id~ : String)
   /// The target peer disconnected while recovery was in progress.
   TargetLeft(peer_id~ : String)
+  /// The current local Version exceeded the fixed text wire envelope.
+  LocalVersionLimitExceeded(
+    kind~ : @sync.LimitKind,
+    limit~ : Int,
+    actual~ : Int
+  )
+  /// Local Version serialization failed for a reason outside its limit contract.
+  LocalVersionEncodingFailed
 } derive(Debug, Eq)
 
 ///|

--- a/tools/verification/sync_session/main.mbt
+++ b/tools/verification/sync_session/main.mbt
@@ -33,6 +33,9 @@ fn status_text(status : @sync_session.SyncStatus) -> String {
       match reason {
         TargetLeft(peer_id~) => "Error(TargetLeft(peer_id=\{peer_id}))"
         Exhausted(peer_id~) => "Error(Exhausted(peer_id=\{peer_id}))"
+        LocalVersionLimitExceeded(kind~, limit~, actual~) =>
+          "Error(LocalVersionLimitExceeded(kind=\{kind},limit=\{limit},actual=\{actual}))"
+        LocalVersionEncodingFailed => "Error(LocalVersionEncodingFailed)"
       }
   }
 }
@@ -93,8 +96,8 @@ fn Driver::send(self : Driver, bytes : Bytes) -> Unit {
 
 ///|
 fn Driver::host(self : Driver) -> @sync_session.SyncHost raise {
-  let io = @sync_session.SyncIo::SyncIo(send=bytes => self.send(bytes), current_version=() => {
-    @text.Version::empty()
+  let io = @sync_session.SyncIo::SyncIo(send=bytes => self.send(bytes), current_version_json=() => {
+    @text.Version::empty().to_json_string()
   })
   let apply = fn(msg : @text.SyncMessage) raise {
     self.apply_count[0] += 1
@@ -122,8 +125,8 @@ fn Driver::host(self : Driver) -> @sync_session.SyncHost raise {
 fn Driver::watchdog(self : Driver, id : Int) -> Unit {
   self.session.on_watchdog_fire(
     id,
-    @sync_session.SyncIo::SyncIo(send=bytes => self.send(bytes), current_version=() => {
-      @text.Version::empty()
+    @sync_session.SyncIo::SyncIo(send=bytes => self.send(bytes), current_version_json=() => {
+      @text.Version::empty().to_json_string()
     }),
   )
 }

--- a/tools/verification/sync_session/moon.mod
+++ b/tools/verification/sync_session/moon.mod
@@ -6,7 +6,7 @@ import {
   "mizchi/quint_connect@0.1.0",
   "moonbitlang/async@0.20.3",
   "dowdiness/canopy@0.1.0",
-  "dowdiness/event-graph-walker@0.7.1",
+  "dowdiness/event-graph-walker@0.8.0",
 }
 
 preferred_target = "native"


### PR DESCRIPTION
## Summary

- pin Event Graph Walker `0.8.0` at merged commit `5334d7884705c8bcbfa23d1a95099480aa9cfe78` and migrate Canopy text collaboration to the breaking exact schema-2 wire contract
- reject persisted or peer-provided schema-1 state instead of synthesizing, downgrading, or silently accepting it
- propagate local Version encoding limits through `SyncIo`, editor, Markdown, Lambda FFI, and status callbacks; local failure ends recovery before sending a frame or scheduling a watchdog
- use opaque `Version` hashing for local cache/change tracking instead of fallible wire JSON serialization

Upstream: dowdiness/event-graph-walker#129, released as `v0.8.0` at `5334d7884705c8bcbfa23d1a95099480aa9cfe78`. Loom PR dowdiness/loom#938 updates its Lambda registry pin and is included through merged commit `4c264db8e19dfd0ae9721ffa359fb4bb8cf249ec`.

This is a coordinated breaking migration. Text schema 1 has no compatibility decoder or downgrade path. Browser persistence removes rejected schema-1 state and starts from a valid local document rather than converting incomplete causal knowledge.

## UI and review evidence

N/A — no visual design or interaction behavior changes. The Ideal browser E2E suite validates persistence rejection and the existing editor interaction surface.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `Version::to_json_string` / `Version::from_json_string` | `deps/event-graph-walker/text` | Yes | Canonical fallible schema-2 Version wire boundary |
| `SyncMessage::from_json_string` | `deps/event-graph-walker/text` | Yes | Strict schema-2 history/message decoder |
| `Hash::hash` | MoonBit core | Yes | Local revision/cache token without invoking the wire codec |
| `TextError::SyncFailed` and `LimitExceeded` | `deps/event-graph-walker/text` and `sync` | Yes | Preserves typed local limit details at the session boundary |
| `Json` constructors | MoonBit core | Yes | Existing Lambda status callback envelope |
| `Option` / raised error boundary | MoonBit core and existing Canopy APIs | Yes | Existing session/FFI style; no parallel `Result` wrapper introduced |
| `Map`, `Set`, `Array`, `Iter`, `StringView`, `BytesView`, `Buffer` | MoonBit core | No | This migration adds no collection transformation or owning codec; graph/range authority remains upstream in EGW |

New helpers added (if any):

None. The change extends existing session error variants and replaces the existing `SyncIo.current_version` capability with a fallible JSON capability.

## Validation scope

Boundary matrix / first failing regression:

- schema-1 peer Version: rejected through Lambda FFI
- schema-1 persisted SyncMessage: rejected and removed by the Ideal browser adapter
- schema-1 Markdown history: rejected through the public Markdown façade
- malformed/operational sync failure: propagated instead of converted to empty Version, SyncMessage, or string
- `ProjectionRecoveryRequired`: classified as retryable
- local Version cardinality/byte limit: recovery cleared, terminal typed status emitted, zero frames sent, zero watchdogs scheduled
- generic local Version encoding failure: distinct terminal status
- successful schema-2 Version/history: round-trips through editor, Markdown, FFI, and browser consumers
- local source/cache identity: derived from opaque `Version` Hash rather than wire encoding

Target packages:

- `modules/canopy/sync_session`
- `modules/canopy/editor`
- `modules/canopy/editor/markdown`
- `modules/canopy/ffi/lambda`
- `apps/ideal/main`
- `apps/ideal/web`
- `tools/verification/sync_session`
- `deps/event-graph-walker` gitlink and dependent module manifests

Additional conditional gates:

```text
moon check: 342 warnings, 0 errors
moon test:
  wasm:   4853/4853
  js:     2508/2508
  native: 109/109
moon build --target js: PASS
apps/web production/SSG build: PASS
apps/ideal/web production build: PASS
Ideal Playwright E2E: 124/124
SyncSession verification:
  flat and distributed symbolic verification: PASS
  500 raw distributed traces: PASS
  200 randomized Choreo traces / 4,155 states: PASS
  mutation controls: PASS
Markdown targeted native release tests after review follow-up: 91/91
independent MoonBit review: PASS, no blockers
```

## Push and CI readiness

```bash
git fetch origin main
git push
```

- [x] The branch contains the fetched `origin/main`, and the normal push completed without bypassing Lefthook's affected local checks.
- [x] The committed `.mbti` diff against `origin/main` was reviewed for unintended API or trait-bound changes.
- [x] The changed EGW and Loom submodule commits are merged and reachable from their remote `main` branches.
- [x] The branch was pushed after every final commit, submodule-pointer change, and history rewrite.
- [x] Independent review findings were resolved before the final validation.
- [x] GitHub CI's `All Checks Passed` gate is green before merge.
