### PR TITLE
feat(loomark): style Preview with Tailwind Typography

### DIFF
--- a/apps/loomark/app/view.mbt
+++ b/apps/loomark/app/view.mbt
@@ -164,7 +164,7 @@ fn preview_view(state : PreviewState) -> @rabbita.Html {
     [
       alert,
       @html.div(
-        class="mx-auto grid w-[min(calc(100%-4rem),46rem)] min-w-0 auto-rows-max gap-4 px-4 pt-8 pb-16 text-base leading-[1.7] max-[641px]:w-full max-[641px]:px-3 max-[641px]:pt-6 max-[641px]:pb-12 [&>*]:min-w-0 [&>*]:break-words [&_a]:text-lm-accent [&_a]:underline-offset-[0.18em] [&_img]:h-auto [&_img]:max-w-full [&_ol]:m-0 [&_ol]:list-decimal [&_ol]:ps-6 [&_pre]:max-w-full [&_pre]:overflow-x-auto [&_pre]:whitespace-pre-wrap [&_ul]:m-0 [&_ul]:list-disc [&_ul]:ps-6",
+        class="prose loomark-prose lg:prose-lg mx-auto w-[min(calc(100%-4rem),46rem)] max-w-none min-w-0 px-4 pt-8 pb-16 font-lm-ui max-[641px]:w-full max-[641px]:px-3 max-[641px]:pt-6 max-[641px]:pb-12 [&>*]:min-w-0 [&>*]:break-words",
         content,
       ),
     ],

--- a/apps/loomark/app/view_wbtest.mbt
+++ b/apps/loomark/app/view_wbtest.mbt
@@ -9,6 +9,7 @@ test "Preview view distinguishes preparing initial failure and stale result" {
   let preparing = render_preview_state(Preparing)
   assert_true(preparing.contains("role=\"status\""))
   assert_true(preparing.contains("Preparing preview…"))
+  assert_true(preparing.contains("prose loomark-prose"))
 
   let initial_failure = render_preview_state(Failed(None))
   assert_true(initial_failure.contains("role=\"alert\""))

--- a/apps/loomark/examples/vanilla/tests/standalone.spec.ts
+++ b/apps/loomark/examples/vanilla/tests/standalone.spec.ts
@@ -244,6 +244,16 @@ test("Preview prepares after its status paints and refreshes typed Markdown", as
   await expect(link).toHaveAttribute("href", "https://example.test")
   await expect(link).toHaveAttribute("target", "_blank")
   await expect(link).toHaveAttribute("rel", "noopener noreferrer")
+  await page.context().route("https://example.test/", route => route.fulfill({
+    status: 200,
+    contentType: "text/html",
+    body: "External preview link opened",
+  }))
+  const popupPromise = page.waitForEvent("popup")
+  await link.click()
+  const popup = await popupPromise
+  await expect.poll(() => popup.url()).toBe("https://example.test/")
+  await popup.close()
   await expect(page.getByText('<div id="unsafe-preview">raw HTML</div>')).toBeVisible()
   await expect(page.locator("#unsafe-preview")).toHaveCount(0)
 
@@ -277,7 +287,7 @@ test("Preview keeps incomplete Markdown literal without parser chrome", async ({
   await expect(preview).not.toContainText("Diagnostic:")
 })
 
-test("Tailwind Preflight and utilities preserve the Loomark shell and compact text measure", async ({ page }) => {
+test("Tailwind Typography and utilities preserve the Loomark shell and reading measure", async ({ page }) => {
   await page.setViewportSize({ width: 900, height: 700 })
   await page.goto("/")
   await expect(page.getByRole("textbox", { name: "Text" })).toBeVisible()
@@ -324,8 +334,26 @@ test("Tailwind Preflight and utilities preserve the Loomark shell and compact te
   expect(await preview.locator("hr").first().evaluate(element => (
     Number.parseFloat(getComputedStyle(element).width)
   ))).toBeGreaterThan(500)
-  expect(await preview.locator("pre code").first()
-    .evaluate(element => getComputedStyle(element).lineHeight)).toBe("21px")
+  expect(Number.parseFloat(await preview.locator("pre code").first()
+    .evaluate(element => getComputedStyle(element).lineHeight))).toBeCloseTo(24, 1)
+  expect(await preview.locator("p code").first().evaluate(element => ({
+    before: getComputedStyle(element, "::before").content,
+    after: getComputedStyle(element, "::after").content,
+  }))).toEqual({ before: "none", after: "none" })
+  await expect.poll(() => preview.locator("p").first().evaluate(element => (
+    getComputedStyle(element).fontSize
+  ))).toBe("16px")
+  expect(await preview.locator("p").first().evaluate(element => (
+    getComputedStyle(element).marginTop
+  ))).toBe("18px")
+  expect(await preview.locator("h2").first().evaluate(element => (
+    getComputedStyle(element).marginTop
+  ))).toBe("28px")
+
+  await page.setViewportSize({ width: 1200, height: 700 })
+  await expect.poll(() => preview.locator("p").first().evaluate(element => (
+    getComputedStyle(element).fontSize
+  ))).toBe("18px")
 })
 
 test("mode tabs move focus without activation and activate with Enter or Space", async ({ page }) => {

--- a/apps/loomark/internal/preview/moon.pkg
+++ b/apps/loomark/internal/preview/moon.pkg
@@ -6,7 +6,6 @@ import {
   "moonbit-community/rabbita/cmd",
   "moonbit-community/rabbita/dom",
   "moonbit-community/rabbita/html",
-  "Yoorkin/rui",
 }
 
 import {

--- a/apps/loomark/internal/preview/renderer.mbt
+++ b/apps/loomark/internal/preview/renderer.mbt
@@ -114,10 +114,7 @@ fn render_opaque_source(
   match position {
     Phrasing => @html.text(value)
     Flow =>
-      @html.pre(
-        class="m-0 whitespace-pre-wrap font-lm-sans text-inherit",
-        value,
-      )
+      @html.pre(class="m-0 whitespace-pre-wrap font-lm-ui text-inherit", value)
   }
 }
 
@@ -174,7 +171,7 @@ fn render_list_item_children(
           children
         }
         if render_paragraphs {
-          @rui.typography_p(children)
+          @html.p(children)
         } else {
           @html.fragment(children)
         }
@@ -190,16 +187,12 @@ fn render_heading(
   children : Array[@rabbita.Html],
 ) -> @rabbita.Html {
   match depth {
-    1 => @rui.typography_h1(style=["text-align:start"], children)
-    2 =>
-      @rui.typography_h2(
-        style=["border-bottom:none;padding-bottom:0"],
-        children,
-      )
-    3 => @rui.typography_h3(children)
-    4 => @rui.typography_h4(children)
-    5 => @html.h5(class="m-0 text-base font-semibold leading-6", children)
-    _ => @html.h6(class="m-0 text-sm font-semibold leading-[1.4]", children)
+    1 => @html.h1(children)
+    2 => @html.h2(children)
+    3 => @html.h3(children)
+    4 => @html.h4(children)
+    5 => @html.h5(children)
+    _ => @html.h6(children)
   }
 }
 
@@ -244,9 +237,9 @@ fn render_node(
       if unwrap_list_item_paragraph {
         @html.fragment(children)
       } else {
-        @rui.typography_p(children)
+        @html.p(children)
       }
-    @markdown.BlockQuote => @rui.typography_blockquote(children)
+    @markdown.BlockQuote => @html.blockquote(children)
     @markdown.UnorderedList(spread~, marker~) =>
       @html.ul(
         attrs=@html.Attrs::build()
@@ -285,7 +278,6 @@ fn render_node(
       )
     @markdown.CodeBlock(info~, value~) =>
       @html.pre(
-        class="m-0 whitespace-pre rounded-lg bg-[oklch(0.95_0.003_255)] p-4 [&_code]:font-lm-mono [&_code]:text-sm [&_code]:leading-[1.5]",
         @html.code(
           attrs=@html.Attrs::build().data_set("loomark-code-info", info),
           value,
@@ -308,6 +300,7 @@ fn render_node(
             href=destination,
             target=@html.Blank,
             rel="noopener noreferrer",
+            escape=true,
             title?,
             attrs=@html.Attrs::build().data_set(
               "loomark-link-reference-form",
@@ -352,6 +345,7 @@ fn render_node(
             href=destination,
             target=@html.Blank,
             rel="noopener noreferrer",
+            escape=true,
             attrs=@html.Attrs::build().data_set(
               "loomark-autolink-kind",
               match kind {

--- a/apps/loomark/internal/preview/renderer_wbtest.mbt
+++ b/apps/loomark/internal/preview/renderer_wbtest.mbt
@@ -112,6 +112,14 @@ test "Preview renders unresolved and raw recovery source without parser chrome" 
 }
 
 ///|
+test "Preview flow recovery keeps the Loomark UI font" {
+  let rendered = @rabbita_testing.server_side_render(() => {
+    render_opaque_source("unresolved", Flow)
+  })
+  assert_preview_contains(rendered, "font-lm-ui")
+}
+
+///|
 test "Preview renders GFM task markers as disabled checkboxes" {
   let unchecked = render_preview("- [ ] todo\n")
   let checked = render_preview("- [x] done\n")

--- a/apps/loomark/package-lock.json
+++ b/apps/loomark/package-lock.json
@@ -7,6 +7,7 @@
       "name": "loomark-web",
       "devDependencies": {
         "@tailwindcss/cli": "4.3.3",
+        "@tailwindcss/typography": "0.5.20",
         "tailwindcss": "4.3.3"
       }
     },
@@ -741,6 +742,19 @@
         "node": ">= 20"
       }
     },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.20",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.20.tgz",
+      "integrity": "sha512-hwbzQuNUfcPvbegQFatVPl/MY/tcM9KLl963hQ5laJKPh81TEZ1+dNG9PirGvcaDBkp+BCshExAyKVPW91dozw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || >=4.0.0 || insiders"
+      }
+    },
     "node_modules/braces": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
@@ -752,6 +766,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/detect-libc": {
@@ -1188,6 +1215,20 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1231,6 +1272,13 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/apps/loomark/package.json
+++ b/apps/loomark/package.json
@@ -7,6 +7,7 @@
   },
   "devDependencies": {
     "@tailwindcss/cli": "4.3.3",
+    "@tailwindcss/typography": "0.5.20",
     "tailwindcss": "4.3.3"
   }
 }

--- a/apps/loomark/styles/tailwind.css
+++ b/apps/loomark/styles/tailwind.css
@@ -1,4 +1,5 @@
 @import "tailwindcss" source(none);
+@plugin "@tailwindcss/typography";
 @source "../app";
 @source not "../app/example_documents";
 @source not "../app/example_*.g.mbt";
@@ -19,6 +20,64 @@
   --color-lm-danger-soft: oklch(0.94 0.025 25);
   --font-lm-ui: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   --font-lm-mono: ui-monospace, "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+}
+
+/* Typography owns Markdown rhythm while Loomark keeps the established palette. */
+.loomark-prose {
+  --tw-prose-body: var(--color-lm-ink);
+  --tw-prose-headings: var(--color-lm-ink);
+  --tw-prose-lead: var(--color-lm-muted);
+  --tw-prose-links: var(--color-lm-accent);
+  --tw-prose-bold: var(--color-lm-ink);
+  --tw-prose-counters: var(--color-lm-muted);
+  --tw-prose-bullets: var(--color-lm-muted);
+  --tw-prose-hr: var(--color-lm-rule);
+  --tw-prose-quotes: var(--color-lm-ink);
+  --tw-prose-quote-borders: var(--color-lm-rule);
+  --tw-prose-captions: var(--color-lm-muted);
+  --tw-prose-code: var(--color-lm-ink);
+  --tw-prose-pre-code: var(--color-lm-ink);
+  --tw-prose-pre-bg: oklch(0.95 0.003 255);
+  --tw-prose-th-borders: var(--color-lm-rule);
+  --tw-prose-td-borders: var(--color-lm-rule);
+}
+
+.loomark-prose :where(code):not(:where(pre code))::before,
+.loomark-prose :where(code):not(:where(pre code))::after {
+  content: none;
+}
+
+/* Keep Typography's hierarchy, but stay close to Loomark's former 1rem rhythm. */
+.loomark-prose :where(p) {
+  margin-block: 1.125rem;
+}
+
+.loomark-prose :where(ul, ol, pre, blockquote, figure, table) {
+  margin-block: 1.25rem;
+}
+
+.loomark-prose :where(h1) {
+  margin-block: 0 1.25rem;
+}
+
+.loomark-prose :where(h2) {
+  margin-block: 1.75rem 1rem;
+}
+
+.loomark-prose :where(h3, h4, h5, h6) {
+  margin-block: 1.5rem 0.875rem;
+}
+
+.loomark-prose :where(hr) {
+  margin-block: 1.75rem;
+}
+
+.loomark-prose :where(:first-child) {
+  margin-top: 0;
+}
+
+.loomark-prose :where(:last-child) {
+  margin-bottom: 0;
 }
 
 /* The mode glyphs are authored geometry; utilities own the surrounding control. */


### PR DESCRIPTION
## Summary

- style Loomark's Markdown Preview with `@tailwindcss/typography` while preserving the existing Loomark palette and semantic renderer output
- use responsive prose sizing and a compact vertical rhythm that stays close to the previous Preview spacing
- preserve browser-native Preview link navigation and cover typography, recovery text, and popup behavior in browser tests

## UI and review evidence

- [x] No visible labels were removed; accessible names, focus behavior, and keyboard paths remain unchanged
- [x] Preview reflow and typography were checked at mobile and desktop widths; normal link activation was checked in a real browser
- [x] No new Canopy-rule claim is made; the implementation follows `.impeccable.md` and the existing Loomark visual tokens

Rendered evidence:

- mobile Preview uses 16px prose text
- wide Preview uses `lg:prose-lg` with 18px prose text
- paragraphs use 18px vertical margins and section headings use the compact Loomark rhythm
- independent `moonbit-reviewer` review passed after its missing font-utility finding was fixed

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `@html.h1` through `@html.h6`, `@html.p`, `@html.blockquote`, `@html.pre` | `deps/rabbita/rabbita/html` | Yes | Keeps the renderer semantic and lets the Preview composition own prose styling |
| `@html.a(..., escape=true)` | `deps/rabbita/rabbita/html/html.mbt` | Yes | Uses Rabbita's supported native-navigation escape instead of adding DOM or JavaScript handling |
| `@rui.typography_*` | `deps/rabbita/rui/typography.mbt` | No | Its inline per-element styles prevent Tailwind Typography from owning Markdown document rhythm |
| Tailwind Typography prose variables | `@tailwindcss/typography` | Yes | Reuses the plugin's supported theme surface and maps it to Loomark tokens |

No new MoonBit functions, methods, helpers, or types were added. No new collection or data-shape manipulation was introduced, so no additional MoonBit core API candidate applies.

New helpers added (if any):

None.

Remaining imperative code:

None added. Preview rendering remains a deterministic MarkdownIR-to-HTML transformation; browser navigation remains owned by Rabbita and the browser shell.

## Validation scope

Boundary matrix / first failing regression:

- Preview structure: headings, paragraphs, tight/loose lists, blockquotes, code, links, images, raw/recovered text
- viewport: 640px Preview stays at 16px; 1200px Preview uses 18px responsive prose
- typography: list markers, rule width, code line-height, compact margins, and removal of decorative inline-code backticks
- navigation: the regression first failed because a normal Preview-link click produced no popup; it now opens the safe destination in a new page
- safety: rejected unsafe destinations remain non-links; safe links retain `noopener noreferrer`

Target packages:

- `apps/loomark/app`
- `apps/loomark/internal/preview`

Additional conditional gates:

- `NEW_MOON_MOD=0 moon check apps/loomark/app --target js`
- `NEW_MOON_MOD=0 moon check apps/loomark/internal/preview --target js`
- `NEW_MOON_MOD=0 moon test apps/loomark/app --target js` — 1/1 passed
- `NEW_MOON_MOD=0 moon test apps/loomark/internal/preview --target js` — 14/14 passed
- `./scripts/test-loomark-standalone-e2e.sh` — 18/18 passed
- `git diff --check`
- Impeccable detector — no findings

## Push and CI readiness

```bash
git fetch origin main
git push
```

- [x] The branch contains the fetched `origin/main`, and the normal push completed without bypassing Lefthook's affected local checks.
- [x] The committed `.mbti` diff against `origin/main` was reviewed; there is no `.mbti` change.
- [x] No submodule pointer changed.
- [x] The branch was pushed after the final commit.
- [x] Independent review findings were resolved before the final validation.
- [ ] GitHub CI's `All Checks Passed` gate is green before merge.
