### PR TITLE
feat(loomark): add multi-document repository operations

### DIFF
--- a/apps/loomark/app/model.mbt
+++ b/apps/loomark/app/model.mbt
@@ -15,8 +15,7 @@ priv struct EditingState {
   focused_mode : EditorMode
   compact : Bool
   preview : PreviewState
-  catalog : @source_repository.Catalog
-  repository_issues : Array[@source_repository.RepositoryIssue]
+  repository : @source_repository.RepositorySnapshot
 } derive(Eq)
 
 ///|

--- a/apps/loomark/app/update.mbt
+++ b/apps/loomark/app/update.mbt
@@ -80,27 +80,6 @@ fn select_mode(
 }
 
 ///|
-fn update_repository_issues(
-  existing : Array[@source_repository.RepositoryIssue],
-  document_id : String,
-  added : ArrayView[@source_repository.RepositoryIssue],
-) -> Array[@source_repository.RepositoryIssue] {
-  let retained = existing.filter(issue => {
-    match issue {
-      @source_repository.RepositoryIssue::NameDerivationFailed(issue_id) =>
-        issue_id != document_id
-      _ => true
-    }
-  })
-  for issue in added {
-    if !retained.contains(issue) {
-      retained.push(issue)
-    }
-  }
-  retained
-}
-
-///|
 fn initial_state(
   emit : @rabbita.Emit[Msg],
   compact : Bool,
@@ -136,8 +115,7 @@ fn update(
                   focused_mode: Text,
                   compact,
                   preview: Unrequested,
-                  catalog: snapshot.catalog(),
-                  repository_issues: snapshot.issues().to_owned(),
+                  repository: snapshot,
                 }),
                 text_area.initialize(text),
               )
@@ -359,7 +337,7 @@ fn update(
             (
               Editing({ ..editing, save: Saving(candidate) }),
               @source_repository.save(
-                editing.catalog,
+                editing.repository,
                 document_id,
                 candidate,
                 result=emit.map(result => {
@@ -377,15 +355,7 @@ fn update(
       } else {
         match result {
           @source_repository.SaveResult::Stored(success) => {
-            let completed = {
-              ..editing,
-              catalog: success.catalog(),
-              repository_issues: update_repository_issues(
-                editing.repository_issues,
-                document_id,
-                success.issues(),
-              ),
-            }
+            let completed = { ..editing, repository: success }
             if candidate == editing.text {
               (Editing({ ..completed, save: Saved }), @cmd.none)
             } else if editing.composing {
@@ -395,7 +365,7 @@ fn update(
               (
                 Editing({ ..completed, save: Saving(latest) }),
                 @source_repository.save(
-                  completed.catalog,
+                  completed.repository,
                   document_id,
                   latest,
                   result=emit.map(result => {
@@ -417,7 +387,7 @@ fn update(
           (
             Editing({ ..editing, save: Saving(latest) }),
             @source_repository.save(
-              editing.catalog,
+              editing.repository,
               document_id,
               latest,
               result=emit.map(result => {

--- a/apps/loomark/app/update_wbtest.mbt
+++ b/apps/loomark/app/update_wbtest.mbt
@@ -1,10 +1,7 @@
 ///|
-fn test_app_catalog(
-  document_id : String,
-  name : String?,
-) -> @source_repository.Catalog {
-  @source_repository.Catalog::from_entries([
-    @source_repository.CatalogEntry::new(document_id, name).unwrap(),
+fn test_repository() -> @source_repository.RepositorySnapshot {
+  @source_repository.RepositorySnapshot::from_sources([
+    @source_repository.SourceRecord::new("document-1", "# Old\n").unwrap(),
   ]).unwrap()
 }
 
@@ -19,8 +16,7 @@ fn test_editing_state(text : String, save : SaveState) -> EditingState {
     focused_mode: Text,
     compact: false,
     preview: Unrequested,
-    catalog: test_app_catalog("document-1", Some("Old")),
-    repository_issues: [],
+    repository: test_repository(),
   }
 }
 
@@ -36,7 +32,7 @@ fn test_update(model : Model, msg : Msg) -> (Model, @cmd.Cmd) {
 }
 
 ///|
-test "opened snapshot selects the first lexical Document ID" {
+test "opened snapshot installs repository" {
   let snapshot = @source_repository.RepositorySnapshot::from_sources([
     @source_repository.SourceRecord::new("document-b", "# B\n").unwrap(),
     @source_repository.SourceRecord::new("document-a", "# A\n").unwrap(),
@@ -47,9 +43,7 @@ test "opened snapshot selects the first lexical Document ID" {
   )
   guard model is Editing(editing) else { fail("expected Editing") }
   assert_eq(editing.document_id, "document-a")
-  assert_eq(editing.text, "# A\n")
-  assert_true(editing.save == Saved)
-  assert_eq(editing.catalog, snapshot.catalog())
+  assert_eq(editing.repository, snapshot)
 }
 
 ///|
@@ -65,100 +59,71 @@ test "TextChanged remains free of repository IO" {
 }
 
 ///|
-test "SaveRequested starts a Source record transaction" {
+test "SaveRequested uses the repository snapshot" {
   let (model, command) = test_update(
     Editing(test_editing_state("# New\n", Waiting)),
     SaveRequested("# New\n"),
   )
   guard model is Editing(editing) else { fail("expected Editing") }
   assert_true(editing.save == Saving("# New\n"))
-  let rendered = @debug.to_string(command)
-  assert_true(rendered.contains("IndexedDBPut"))
-  assert_true(rendered.contains("source/v1/document-1"))
+  assert_true(@debug.to_string(command).contains("IndexedDBPut"))
 }
 
 ///|
-test "successful Source save installs catalog and retains name issues" {
-  let initial = {
-    ..test_editing_state("# New\n", Saving("# New\n")),
-    repository_issues: [
-      @source_repository.RepositoryIssue::UnknownRecord("other"),
-    ],
-  }
-  let next = test_app_catalog("document-1", Some("New"))
-  let success = @source_repository.SaveSuccess::new(next, [
-    @source_repository.RepositoryIssue::NameDerivationFailed("document-1"),
-  ])
+test "successful save installs returned snapshot" {
+  let initial = test_editing_state("# New\n", Saving("# New\n"))
+  let next = @source_repository.RepositorySnapshot::from_sources([
+    @source_repository.SourceRecord::new("document-1", "# New\n").unwrap(),
+  ]).unwrap()
   let (model, _) = test_update(
     Editing(initial),
     SaveCompleted(
       "document-1",
       "# New\n",
-      @source_repository.SaveResult::Stored(success),
+      @source_repository.SaveResult::Stored(next),
     ),
   )
   guard model is Editing(editing) else { fail("expected Editing") }
   assert_true(editing.save == Saved)
-  assert_eq(editing.catalog, next)
-  assert_eq(editing.repository_issues, [
-    @source_repository.RepositoryIssue::UnknownRecord("other"),
-    @source_repository.RepositoryIssue::NameDerivationFailed("document-1"),
-  ])
+  assert_eq(editing.repository, next)
 }
 
 ///|
-test "successful name derivation resolves the saved Document name issue" {
-  let initial = {
-    ..test_editing_state("# New\n", Saving("# New\n")),
-    repository_issues: [
-      @source_repository.RepositoryIssue::UnknownRecord("other"),
-      @source_repository.RepositoryIssue::NameDerivationFailed("document-1"),
-      @source_repository.RepositoryIssue::NameDerivationFailed("document-2"),
-    ],
-  }
-  let next = test_app_catalog("document-1", Some("New"))
+test "stale completion remains fenced by identity and candidate" {
+  let initial = test_editing_state("# Latest\n", Saving("# Latest\n"))
   let (model, _) = test_update(
     Editing(initial),
     SaveCompleted(
       "document-1",
-      "# New\n",
-      @source_repository.SaveResult::Stored(
-        @source_repository.SaveSuccess::new(next, []),
-      ),
+      "# Old\n",
+      @source_repository.SaveResult::Stored(test_repository()),
     ),
   )
-  guard model is Editing(editing) else { fail("expected Editing") }
-  assert_eq(editing.repository_issues, [
-    @source_repository.RepositoryIssue::UnknownRecord("other"),
-    @source_repository.RepositoryIssue::NameDerivationFailed("document-2"),
-  ])
+  assert_true(model == Editing(initial))
 }
 
 ///|
-test "stale successful completion immediately saves the latest Source" {
+test "stale success immediately saves the latest text" {
   let initial = test_editing_state("# Latest\n", Saving("# Old\n"))
-  let completed_catalog = test_app_catalog("document-1", Some("Old"))
   let (model, command) = test_update(
     Editing(initial),
     SaveCompleted(
       "document-1",
       "# Old\n",
-      @source_repository.SaveResult::Stored(
-        @source_repository.SaveSuccess::new(completed_catalog, []),
-      ),
+      @source_repository.SaveResult::Stored(test_repository()),
     ),
   )
   guard model is Editing(editing) else { fail("expected Editing") }
   assert_true(editing.save == Saving("# Latest\n"))
   let rendered = @debug.to_string(command)
-  assert_true(rendered.contains("source/v1/document-1"))
+  assert_true(rendered.contains("IndexedDBPut"))
   assert_true(rendered.contains("# Latest"))
 }
 
 ///|
-test "Source failure and another Document completion cannot claim saved state" {
+test "failure handling and foreign completion preserve active state" {
   let initial = test_editing_state("# New\n", Saving("# New\n"))
-  let (failed_model, _) = test_update(
+  let (failed, _) = test_update(
     Editing(initial),
     SaveCompleted(
       "document-1",
@@ -168,39 +133,29 @@ test "Source failure and another Document completion cannot claim saved state" {
       ),
     ),
   )
-  guard failed_model is Editing(failed) else { fail("expected Editing") }
+  guard failed is Editing(editing) else { fail("expected Editing") }
   assert_true(
-    failed.save == Failed(@source_repository.SaveFailure::WriteFailed),
+    editing.save == Failed(@source_repository.SaveFailure::WriteFailed),
   )
-
-  let next = test_app_catalog("document-1", Some("New"))
-  let foreign = SaveCompleted(
-    "document-2",
-    "# New\n",
-    @source_repository.SaveResult::Stored(
-      @source_repository.SaveSuccess::new(next, []),
+  let (foreign, _) = test_update(
+    Editing(initial),
+    SaveCompleted(
+      "document-2",
+      "# New\n",
+      @source_repository.SaveResult::Stored(test_repository()),
     ),
   )
-  let (unchanged, _) = test_update(Editing(initial), foreign)
-  assert_true(unchanged == Editing(initial))
+  assert_true(foreign == Editing(initial))
 }
 
 ///|
-test "same-Document stale completions cannot replace the active save" {
+test "same-document stale success and failure cannot replace active save" {
   let initial = test_editing_state("# Latest\n", Saving("# Latest\n"))
-  let stale_catalog = test_app_catalog("document-1", Some("Old"))
   let stale_success = SaveCompleted(
     "document-1",
     "# Old\n",
-    @source_repository.SaveResult::Stored(
-      @source_repository.SaveSuccess::new(stale_catalog, [
-        @source_repository.RepositoryIssue::NameDerivationFailed("document-1"),
-      ]),
-    ),
+    @source_repository.SaveResult::Stored(test_repository()),
   )
-  let (after_success, _) = test_update(Editing(initial), stale_success)
-  assert_true(after_success == Editing(initial))
-
   let stale_failure = SaveCompleted(
     "document-1",
     "# Old\n",
@@ -208,6 +163,8 @@ test "same-Document stale completions cannot replace the active save" {
       @source_repository.SaveFailure::WriteFailed,
     ),
   )
+  let (after_success, _) = test_update(Editing(initial), stale_success)
   let (after_failure, _) = test_update(Editing(initial), stale_failure)
+  assert_true(after_success == Editing(initial))
   assert_true(after_failure == Editing(initial))
 }

--- a/apps/loomark/internal/source_repository/moon.pkg
+++ b/apps/loomark/internal/source_repository/moon.pkg
@@ -9,6 +9,7 @@ import {
 
 import {
   "moonbitlang/core/bench",
+  "moonbitlang/core/debug",
 } for "wbtest"
 
 supported_targets = "js"

--- a/apps/loomark/internal/source_repository/pkg.generated.mbti
+++ b/apps/loomark/internal/source_repository/pkg.generated.mbti
@@ -7,9 +7,11 @@ import {
 }
 
 // Values
+pub fn create(RepositorySnapshot, result~ : @cmd.Emit[CreateResult]) -> @cmd.Cmd
+
 pub fn open(result~ : @cmd.Emit[OpenResult]) -> @cmd.Cmd
 
-pub fn save(Catalog, String, String, result~ : @cmd.Emit[SaveResult]) -> @cmd.Cmd
+pub fn save(RepositorySnapshot, String, String, result~ : @cmd.Emit[SaveResult]) -> @cmd.Cmd
 
 // Errors
 
@@ -22,6 +24,18 @@ type CatalogEntry derive(Eq, @debug.Debug)
 pub fn CatalogEntry::document_id(Self) -> String
 pub fn CatalogEntry::name(Self) -> String?
 pub fn CatalogEntry::new(String, String?) -> Self?
+
+pub(all) enum CreateFailure {
+  DocumentIdentityUnavailable
+  StorageUnavailable
+  QuotaExceeded
+  WriteFailed
+} derive(Eq, @debug.Debug)
+
+pub(all) enum CreateResult {
+  Created(RepositorySnapshot, String)
+  Failed(CreateFailure)
+} derive(Eq, @debug.Debug)
 
 pub(all) enum OpenFailure {
   StorageUnavailable
@@ -53,6 +67,7 @@ pub fn RepositorySnapshot::catalog(Self) -> Catalog
 pub fn RepositorySnapshot::from_sources(Array[SourceRecord]) -> Self?
 pub fn RepositorySnapshot::issues(Self) -> ArrayView[RepositoryIssue]
 pub fn RepositorySnapshot::selected(Self) -> SourceRecord?
+pub fn RepositorySnapshot::source(Self, String) -> SourceRecord?
 pub fn RepositorySnapshot::sources(Self) -> ArrayView[SourceRecord]
 
 pub(all) enum SaveFailure {
@@ -63,14 +78,9 @@ pub(all) enum SaveFailure {
 } derive(Eq, @debug.Debug)
 
 pub(all) enum SaveResult {
-  Stored(SaveSuccess)
+  Stored(RepositorySnapshot)
   Failed(SaveFailure)
 } derive(Eq, @debug.Debug)
-
-type SaveSuccess derive(Eq, @debug.Debug)
-pub fn SaveSuccess::catalog(Self) -> Catalog
-pub fn SaveSuccess::issues(Self) -> ArrayView[RepositoryIssue]
-pub fn SaveSuccess::new(Catalog, Array[RepositoryIssue]) -> Self
 
 type SourceRecord derive(Eq, @debug.Debug)
 pub fn SourceRecord::document_id(Self) -> String

--- a/apps/loomark/internal/source_repository/reconciliation.mbt
+++ b/apps/loomark/internal/source_repository/reconciliation.mbt
@@ -69,7 +69,8 @@ fn reconcile_scan(entries : Array[@indexed_db.ScanEntry]) -> Reconciliation {
     }
     None => ()
   }
-  guard snapshot_from_sources(sources, issues) is Some(snapshot) else {
+  guard snapshot_from_sources(sources, issues, raw_source_keys.to_array())
+    is Some(snapshot) else {
     return Empty(issues, raw_source_keys.to_array())
   }
   Ready(snapshot)

--- a/apps/loomark/internal/source_repository/reconciliation_wbtest.mbt
+++ b/apps/loomark/internal/source_repository/reconciliation_wbtest.mbt
@@ -31,6 +31,9 @@ test "reconciliation isolates corrupt and unsupported records" {
     fail("expected ready snapshot")
   }
   assert_eq(snapshot.sources().to_owned(), [valid])
+  assert_eq(snapshot.occupied_source_keys().to_owned(), [
+    "source/v1/broken", "source/v1/document-b", "source/v1/wrong-key",
+  ])
   assert_eq(snapshot.catalog().entries().to_owned(), [
     CatalogEntry::new("document-b", Some("Same")).unwrap(),
   ])
@@ -94,6 +97,102 @@ test "invalid legacy is preserved and an empty repository stays empty" {
   }
   assert_eq(occupied, [])
   assert_eq(issues, [RepositoryIssue::InvalidLegacyRecord])
+}
+
+///|
+test "snapshot source and accepted Source transition preserve repository state" {
+  let original = RepositorySnapshot::from_sources([
+    SourceRecord::new("document-b", "# B\n").unwrap(),
+    SourceRecord::new("document-a", "plain text\n").unwrap(),
+  ]).unwrap()
+  let accepted = accepted_source(
+    original,
+    SourceRecord::new("document-b", "# New B\n").unwrap(),
+  )
+  assert_eq(accepted.source("document-b").unwrap().text(), "# New B\n")
+  assert_eq(accepted.source("missing"), None)
+  assert_eq(accepted.sources().to_owned(), [
+    SourceRecord::new("document-a", "plain text\n").unwrap(),
+    SourceRecord::new("document-b", "# New B\n").unwrap(),
+  ])
+  assert_eq(accepted.catalog().entries().to_owned(), [
+    CatalogEntry::new("document-a", None).unwrap(),
+    CatalogEntry::new("document-b", Some("New B")).unwrap(),
+  ])
+  assert_eq(accepted.issues().to_owned(), [])
+}
+
+///|
+test "snapshot orders unequal-length identities lexically" {
+  let snapshot = RepositorySnapshot::from_sources([
+    test_source("z", "# Z\n"),
+    test_source("aa", "# AA\n"),
+    test_source("m", "# M\n"),
+  ]).unwrap()
+  assert_eq(snapshot.sources().to_owned(), [
+    test_source("aa", "# AA\n"),
+    test_source("m", "# M\n"),
+    test_source("z", "# Z\n"),
+  ])
+  assert_eq(snapshot.catalog().entries().to_owned(), [
+    CatalogEntry::new("aa", Some("AA")).unwrap(),
+    CatalogEntry::new("m", Some("M")).unwrap(),
+    CatalogEntry::new("z", Some("Z")).unwrap(),
+  ])
+}
+
+///|
+test "accepted sources preserve lexical catalog and unrelated issues" {
+  let original = RepositorySnapshot::new(
+    [test_source("b", "# B\n"), test_source("a", "# A\n")],
+    Catalog::from_entries([
+      CatalogEntry::new("a", Some("A")).unwrap(),
+      CatalogEntry::new("b", Some("B")).unwrap(),
+    ]).unwrap(),
+    [RepositoryIssue::UnknownRecord("other"), NameDerivationFailed("b")],
+    ["source/v1/a", "source/v1/b", "source/v1/corrupt"],
+  )
+  let with_c = accepted_source(original, test_source("c", "# C\n"))
+  assert_eq(with_c.catalog().entries().to_owned(), [
+    CatalogEntry::new("a", Some("A")).unwrap(),
+    CatalogEntry::new("b", Some("B")).unwrap(),
+    CatalogEntry::new("c", Some("C")).unwrap(),
+  ])
+  assert_eq(with_c.issues().to_owned(), [
+    RepositoryIssue::UnknownRecord("other"),
+    NameDerivationFailed("b"),
+  ])
+  assert_eq(with_c.occupied_source_keys().to_owned(), [
+    "source/v1/a", "source/v1/b", "source/v1/c", "source/v1/corrupt",
+  ])
+  let with_d = accepted_source(with_c, test_source("d", "# C\n"))
+  assert_eq(with_d.catalog().entries().to_owned(), [
+    CatalogEntry::new("a", Some("A")).unwrap(),
+    CatalogEntry::new("b", Some("B")).unwrap(),
+    CatalogEntry::new("c", Some("C")).unwrap(),
+    CatalogEntry::new("d", Some("C")).unwrap(),
+  ])
+  let with_a = accepted_source(with_c, test_source("a", "# A2\n"))
+  assert_eq(with_a.sources().to_owned(), [
+    test_source("a", "# A2\n"),
+    test_source("b", "# B\n"),
+    test_source("c", "# C\n"),
+  ])
+}
+
+///|
+test "accepted source does not duplicate current name issues" {
+  let original = RepositorySnapshot::new(
+    [test_source("a", "# A\n")],
+    Catalog::from_entries([CatalogEntry::new("a", Some("A")).unwrap()]).unwrap(),
+    [NameDerivationFailed("a")],
+    ["source/v1/a"],
+  )
+  let accepted = accepted_source(original, test_source("a", "# New\n"))
+  assert_eq(accepted.issues().to_owned(), [])
+  assert_eq(accepted.catalog().entries().to_owned(), [
+    CatalogEntry::new("a", Some("New")).unwrap(),
+  ])
 }
 
 ///|

--- a/apps/loomark/internal/source_repository/repository_command_wbtest.mbt
+++ b/apps/loomark/internal/source_repository/repository_command_wbtest.mbt
@@ -23,23 +23,47 @@ test "repository open routes legacy migration through one atomic mutation" {
 }
 
 ///|
-test "repository save begins by committing the Source record" {
-  let catalog = Catalog::from_entries([]).unwrap()
+test "repository save commits one Source record" {
+  let snapshot = RepositorySnapshot::from_sources([
+    SourceRecord::new("document-1", "# Old\n").unwrap(),
+  ]).unwrap()
   inspect(
-    Repr(save(catalog, "document-1", "# Saved\n", result=_ => @cmd.none)),
+    Repr(save(snapshot, "document-1", "# Saved\n", result=_ => @cmd.none)),
     content="IndexedDBPut(\n  { name: \"loomark\", version: 1, store_name: \"documents\" },\n  \"source/v1/document-1\",\n  \"{\\\"document_id\\\":\\\"document-1\\\",\\\"text\\\":\\\"# Saved\\\\n\\\"}\",\n)",
   )
 }
 
 ///|
-test "repository save rejects an invalid identity before storage" {
-  let catalog = Catalog::from_entries([]).unwrap()
+test "repository save rejects missing identity before storage" {
+  let snapshot = RepositorySnapshot::from_sources([
+    SourceRecord::new("document-1", "# Old\n").unwrap(),
+  ]).unwrap()
   let emitted : Array[SaveResult] = []
-  let _ = save(catalog, "", "# Invalid\n", result=result => {
+  let command = save(snapshot, "missing", "# Invalid\n", result=result => {
     emitted.push(result)
     @cmd.none
   })
   assert_eq(emitted, [SaveResult::Failed(SaveFailure::InvalidSource)])
+  assert_false(@debug.to_string(command).contains("IndexedDBPut"))
+}
+
+///|
+test "save completion publishes the next snapshot after storage completes" {
+  let snapshot = RepositorySnapshot::from_sources([
+    SourceRecord::new("document-1", "# Old\n").unwrap(),
+    SourceRecord::new("document-2", "# Other\n").unwrap(),
+  ]).unwrap()
+  let source = SourceRecord::new("document-1", "# Saved\n").unwrap()
+  let emitted : Array[SaveResult] = []
+  let _ = finish_save(snapshot, source, @indexed_db.WriteResult::Stored, result => {
+    emitted.push(result)
+    @cmd.none
+  })
+  guard emitted.get(0) is Some(SaveResult::Stored(next)) else {
+    fail("stored completion did not publish a snapshot")
+  }
+  assert_eq(next.source("document-1").unwrap().text(), "# Saved\n")
+  assert_eq(next.source("document-2").unwrap().text(), "# Other\n")
 }
 
 ///|
@@ -65,4 +89,84 @@ test "open write completion rescans and preserves failure classifications" {
     OpenResult::Failed(OpenFailure::QuotaExceeded),
     OpenResult::Failed(OpenFailure::WriteFailed),
   ])
+}
+
+///|
+test "create rejects an observed occupied key before storage" {
+  let source = SourceRecord::new("document-1", "# One\n").unwrap()
+  let snapshot = RepositorySnapshot::new(
+    [source],
+    Catalog::from_entries([
+      CatalogEntry::new("document-1", Some("One")).unwrap(),
+    ]).unwrap(),
+    [],
+    ["source/v1/document-1", "source/v1/corrupt"],
+  )
+  let emitted : Array[CreateResult] = []
+  let command = create_with_document_id(snapshot, "", result => {
+    emitted.push(result)
+    @cmd.none
+  })
+  assert_eq(emitted, [
+    CreateResult::Failed(CreateFailure::DocumentIdentityUnavailable),
+  ])
+  assert_false(@debug.to_string(command).contains("IndexedDBPut"))
+  let emitted : Array[CreateResult] = []
+  let command = create_with_document_id(snapshot, "corrupt", result => {
+    emitted.push(result)
+    @cmd.none
+  })
+  assert_eq(emitted, [
+    CreateResult::Failed(CreateFailure::DocumentIdentityUnavailable),
+  ])
+  assert_false(@debug.to_string(command).contains("IndexedDBPut"))
+}
+
+///|
+test "create prepares one put for a valid identity" {
+  let snapshot = RepositorySnapshot::from_sources([
+    SourceRecord::new("document-1", "# One\n").unwrap(),
+  ]).unwrap()
+  inspect(
+    Repr(create_with_document_id(snapshot, "document-2", _ => @cmd.none)),
+    content="IndexedDBPut(\n  { name: \"loomark\", version: 1, store_name: \"documents\" },\n  \"source/v1/document-2\",\n  \"{\\\"document_id\\\":\\\"document-2\\\",\\\"text\\\":\\\"# Untitled\\\\n\\\"}\",\n)",
+  )
+}
+
+///|
+test "create completion maps stored and write failures" {
+  let snapshot = RepositorySnapshot::from_sources([
+    SourceRecord::new("document-1", "# One\n").unwrap(),
+  ]).unwrap()
+  let source = SourceRecord::new("document-2", "# Untitled\n").unwrap()
+  let emitted : Array[CreateResult] = []
+  for
+    stored in [
+      @indexed_db.WriteResult::Stored,
+      @indexed_db.WriteResult::Unavailable,
+      @indexed_db.WriteResult::QuotaExceeded,
+      @indexed_db.WriteResult::Failed,
+    ] {
+    let _ = finish_create(snapshot, source, stored, result => {
+      emitted.push(result)
+      @cmd.none
+    })
+  }
+  guard emitted.get(0) is Some(CreateResult::Created(created, "document-2")) else {
+    fail("stored not created")
+  }
+  assert_eq(created.source("document-1").unwrap().text(), "# One\n")
+  assert_eq(created.source("document-2").unwrap().text(), "# Untitled\n")
+  assert_eq(
+    emitted.get(1),
+    Some(CreateResult::Failed(CreateFailure::StorageUnavailable)),
+  )
+  assert_eq(
+    emitted.get(2),
+    Some(CreateResult::Failed(CreateFailure::QuotaExceeded)),
+  )
+  assert_eq(
+    emitted.get(3),
+    Some(CreateResult::Failed(CreateFailure::WriteFailed)),
+  )
 }

--- a/apps/loomark/internal/source_repository/repository_command_wbtest.mbt
+++ b/apps/loomark/internal/source_repository/repository_command_wbtest.mbt
@@ -54,16 +54,32 @@ test "save completion publishes the next snapshot after storage completes" {
     SourceRecord::new("document-2", "# Other\n").unwrap(),
   ]).unwrap()
   let source = SourceRecord::new("document-1", "# Saved\n").unwrap()
+  let next = accepted_source(snapshot, source)
   let emitted : Array[SaveResult] = []
-  let _ = finish_save(snapshot, source, @indexed_db.WriteResult::Stored, result => {
-    emitted.push(result)
-    @cmd.none
-  })
-  guard emitted.get(0) is Some(SaveResult::Stored(next)) else {
-    fail("stored completion did not publish a snapshot")
+  for
+    stored in [
+      @indexed_db.WriteResult::Stored,
+      @indexed_db.WriteResult::Unavailable,
+      @indexed_db.WriteResult::QuotaExceeded,
+      @indexed_db.WriteResult::Failed,
+    ] {
+    let _ = finish_save(next, stored, result => {
+      emitted.push(result)
+      @cmd.none
+    })
   }
+  assert_eq(emitted.get(0), Some(SaveResult::Stored(next)))
   assert_eq(next.source("document-1").unwrap().text(), "# Saved\n")
   assert_eq(next.source("document-2").unwrap().text(), "# Other\n")
+  assert_eq(
+    emitted.get(1),
+    Some(SaveResult::Failed(SaveFailure::StorageUnavailable)),
+  )
+  assert_eq(
+    emitted.get(2),
+    Some(SaveResult::Failed(SaveFailure::QuotaExceeded)),
+  )
+  assert_eq(emitted.get(3), Some(SaveResult::Failed(SaveFailure::WriteFailed)))
 }
 
 ///|
@@ -139,6 +155,7 @@ test "create completion maps stored and write failures" {
     SourceRecord::new("document-1", "# One\n").unwrap(),
   ]).unwrap()
   let source = SourceRecord::new("document-2", "# Untitled\n").unwrap()
+  let next = accepted_source(snapshot, source)
   let emitted : Array[CreateResult] = []
   for
     stored in [
@@ -147,7 +164,7 @@ test "create completion maps stored and write failures" {
       @indexed_db.WriteResult::QuotaExceeded,
       @indexed_db.WriteResult::Failed,
     ] {
-    let _ = finish_create(snapshot, source, stored, result => {
+    let _ = finish_create(next, "document-2", stored, result => {
       emitted.push(result)
       @cmd.none
     })

--- a/apps/loomark/internal/source_repository/storage.mbt
+++ b/apps/loomark/internal/source_repository/storage.mbt
@@ -125,14 +125,12 @@ fn create_baseline(
 
 ///|
 fn finish_save(
-  snapshot : RepositorySnapshot,
-  source : SourceRecord,
+  next : RepositorySnapshot,
   stored : @indexed_db.WriteResult,
   result : @cmd.Emit[SaveResult],
 ) -> @cmd.Cmd {
   match stored {
-    @indexed_db.WriteResult::Stored =>
-      result(Stored(accepted_source(snapshot, source)))
+    @indexed_db.WriteResult::Stored => result(Stored(next))
     @indexed_db.WriteResult::Unavailable => result(Failed(StorageUnavailable))
     @indexed_db.WriteResult::QuotaExceeded => result(Failed(QuotaExceeded))
     @indexed_db.WriteResult::Failed => result(Failed(WriteFailed))
@@ -153,21 +151,21 @@ pub fn save(
     source_key(document_id) is Some(key) else {
     return result(Failed(InvalidSource))
   }
+  let next = accepted_source(snapshot, source)
   @indexed_db.put(document_store, key, encode_source(source), result=stored => {
-    finish_save(snapshot, source, stored, result)
+    finish_save(next, stored, result)
   })
 }
 
 ///|
 fn finish_create(
-  snapshot : RepositorySnapshot,
-  source : SourceRecord,
+  next : RepositorySnapshot,
+  document_id : String,
   stored : @indexed_db.WriteResult,
   result : @cmd.Emit[CreateResult],
 ) -> @cmd.Cmd {
   match stored {
-    @indexed_db.WriteResult::Stored =>
-      result(Created(accepted_source(snapshot, source), source.document_id()))
+    @indexed_db.WriteResult::Stored => result(Created(next, document_id))
     @indexed_db.WriteResult::Unavailable => result(Failed(StorageUnavailable))
     @indexed_db.WriteResult::QuotaExceeded => result(Failed(QuotaExceeded))
     @indexed_db.WriteResult::Failed => result(Failed(WriteFailed))
@@ -185,8 +183,9 @@ fn create_with_document_id(
     return result(Failed(DocumentIdentityUnavailable))
   }
   let source = SourceRecord::new(document_id, UNTITLED_SOURCE).unwrap()
+  let next = accepted_source(snapshot, source)
   @indexed_db.put(document_store, key, encode_source(source), result=stored => {
-    finish_create(snapshot, source, stored, result)
+    finish_create(next, document_id, stored, result)
   })
 }
 

--- a/apps/loomark/internal/source_repository/storage.mbt
+++ b/apps/loomark/internal/source_repository/storage.mbt
@@ -32,6 +32,14 @@ pub(all) enum SaveFailure {
 } derive(Eq, Debug)
 
 ///|
+pub(all) enum CreateFailure {
+  DocumentIdentityUnavailable
+  StorageUnavailable
+  QuotaExceeded
+  WriteFailed
+} derive(Eq, Debug)
+
+///|
 pub(all) enum OpenResult {
   Ready(RepositorySnapshot)
   Failed(OpenFailure)
@@ -39,8 +47,14 @@ pub(all) enum OpenResult {
 
 ///|
 pub(all) enum SaveResult {
-  Stored(SaveSuccess)
+  Stored(RepositorySnapshot)
   Failed(SaveFailure)
+} derive(Eq, Debug)
+
+///|
+pub(all) enum CreateResult {
+  Created(RepositorySnapshot, String)
+  Failed(CreateFailure)
 } derive(Eq, Debug)
 
 ///|
@@ -110,24 +124,79 @@ fn create_baseline(
 }
 
 ///|
+fn finish_save(
+  snapshot : RepositorySnapshot,
+  source : SourceRecord,
+  stored : @indexed_db.WriteResult,
+  result : @cmd.Emit[SaveResult],
+) -> @cmd.Cmd {
+  match stored {
+    @indexed_db.WriteResult::Stored =>
+      result(Stored(accepted_source(snapshot, source)))
+    @indexed_db.WriteResult::Unavailable => result(Failed(StorageUnavailable))
+    @indexed_db.WriteResult::QuotaExceeded => result(Failed(QuotaExceeded))
+    @indexed_db.WriteResult::Failed => result(Failed(WriteFailed))
+  }
+}
+
+///|
 pub fn save(
-  catalog : Catalog,
+  snapshot : RepositorySnapshot,
   document_id : String,
   text : String,
   result~ : @cmd.Emit[SaveResult],
 ) -> @cmd.Cmd {
+  guard snapshot.source(document_id) is Some(_) else {
+    return result(Failed(InvalidSource))
+  }
   guard SourceRecord::new(document_id, text) is Some(source) &&
     source_key(document_id) is Some(key) else {
     return result(Failed(InvalidSource))
   }
-  let (next, issues) = next_catalog(catalog, document_id, text)
   @indexed_db.put(document_store, key, encode_source(source), result=stored => {
-    match stored {
-      @indexed_db.WriteResult::Stored =>
-        result(Stored(SaveSuccess::new(next, issues)))
-      @indexed_db.WriteResult::Unavailable => result(Failed(StorageUnavailable))
-      @indexed_db.WriteResult::QuotaExceeded => result(Failed(QuotaExceeded))
-      @indexed_db.WriteResult::Failed => result(Failed(WriteFailed))
-    }
+    finish_save(snapshot, source, stored, result)
   })
+}
+
+///|
+fn finish_create(
+  snapshot : RepositorySnapshot,
+  source : SourceRecord,
+  stored : @indexed_db.WriteResult,
+  result : @cmd.Emit[CreateResult],
+) -> @cmd.Cmd {
+  match stored {
+    @indexed_db.WriteResult::Stored =>
+      result(Created(accepted_source(snapshot, source), source.document_id()))
+    @indexed_db.WriteResult::Unavailable => result(Failed(StorageUnavailable))
+    @indexed_db.WriteResult::QuotaExceeded => result(Failed(QuotaExceeded))
+    @indexed_db.WriteResult::Failed => result(Failed(WriteFailed))
+  }
+}
+
+///|
+fn create_with_document_id(
+  snapshot : RepositorySnapshot,
+  document_id : String,
+  result : @cmd.Emit[CreateResult],
+) -> @cmd.Cmd {
+  guard source_key(document_id) is Some(key) &&
+    !snapshot.occupied_source_keys().contains(key) else {
+    return result(Failed(DocumentIdentityUnavailable))
+  }
+  let source = SourceRecord::new(document_id, UNTITLED_SOURCE).unwrap()
+  @indexed_db.put(document_store, key, encode_source(source), result=stored => {
+    finish_create(snapshot, source, stored, result)
+  })
+}
+
+///|
+pub fn create(
+  snapshot : RepositorySnapshot,
+  result~ : @cmd.Emit[CreateResult],
+) -> @cmd.Cmd {
+  guard random_uuid_available() else {
+    return result(Failed(DocumentIdentityUnavailable))
+  }
+  create_with_document_id(snapshot, random_uuid(), result)
 }

--- a/apps/loomark/internal/source_repository/types.mbt
+++ b/apps/loomark/internal/source_repository/types.mbt
@@ -57,7 +57,9 @@ struct Catalog(Array[CatalogEntry]) derive(Eq, Debug)
 ///|
 pub fn Catalog::from_entries(entries : Array[CatalogEntry]) -> Self? {
   let ordered = entries.copy()
-  ordered.sort_by_key(entry => entry.document_id())
+  ordered.sort_by((left, right) => {
+    left.document_id().lexical_compare(right.document_id())
+  })
   catalog_from_sorted_entries(ordered)
 }
 
@@ -89,28 +91,40 @@ pub(all) enum RepositoryIssue {
 } derive(Eq, Debug)
 
 ///|
-struct RepositorySnapshot(Array[SourceRecord], Catalog, Array[RepositoryIssue]) derive (
-  Eq,
-  Debug,
-)
+struct RepositorySnapshot(
+  Array[SourceRecord],
+  Catalog,
+  Array[RepositoryIssue],
+  Array[String]
+) derive(Eq, Debug)
 
 ///|
 fn RepositorySnapshot::new(
   sources : Array[SourceRecord],
   catalog : Catalog,
   issues : Array[RepositoryIssue],
+  occupied_source_keys : Array[String],
 ) -> Self {
-  RepositorySnapshot(sources.copy(), catalog, issues.copy())
+  let occupied = Set::from_iter(occupied_source_keys.iter())
+  for source in sources {
+    occupied.add(source_key(source.document_id()).unwrap())
+  }
+  let occupied = occupied.to_array()
+  occupied.sort_by((left, right) => left.lexical_compare(right))
+  RepositorySnapshot(sources.copy(), catalog, issues.copy(), occupied)
 }
 
 ///|
 fn snapshot_from_sources(
   sources : Array[SourceRecord],
   initial_issues : Array[RepositoryIssue],
+  occupied_source_keys : Array[String],
 ) -> RepositorySnapshot? {
   guard !sources.is_empty() else { return None }
   let ordered = sources.copy()
-  ordered.sort_by_key(source => source.document_id())
+  ordered.sort_by((left, right) => {
+    left.document_id().lexical_compare(right.document_id())
+  })
   let identities = Set::from_iter(
     ordered.iter().map(source => source.document_id()),
   )
@@ -127,17 +141,28 @@ fn snapshot_from_sources(
     CatalogEntry::new(source.document_id(), name).unwrap()
   })
   guard Catalog::from_entries(entries) is Some(catalog) else { return None }
-  Some(RepositorySnapshot::new(ordered, catalog, issues))
+  Some(RepositorySnapshot::new(ordered, catalog, issues, occupied_source_keys))
 }
 
 ///|
 pub fn RepositorySnapshot::from_sources(sources : Array[SourceRecord]) -> Self? {
-  snapshot_from_sources(sources, [])
+  snapshot_from_sources(sources, [], [])
 }
 
 ///|
 pub fn RepositorySnapshot::sources(self : Self) -> ArrayView[SourceRecord] {
   self.0.view()
+}
+
+///|
+pub fn RepositorySnapshot::source(
+  self : Self,
+  document_id : String,
+) -> SourceRecord? {
+  match self.0.view().search_by(source => source.document_id() == document_id) {
+    Some(index) => self.0.view().get(index)
+    None => None
+  }
 }
 
 ///|
@@ -156,22 +181,49 @@ pub fn RepositorySnapshot::issues(self : Self) -> ArrayView[RepositoryIssue] {
 }
 
 ///|
-struct SaveSuccess(Catalog, Array[RepositoryIssue]) derive(Eq, Debug)
-
-///|
-pub fn SaveSuccess::new(
-  catalog : Catalog,
-  issues : Array[RepositoryIssue],
-) -> Self {
-  SaveSuccess(catalog, issues.copy())
+fn RepositorySnapshot::occupied_source_keys(self : Self) -> ArrayView[String] {
+  self.3.view()
 }
 
 ///|
-pub fn SaveSuccess::catalog(self : Self) -> Catalog {
-  self.0
-}
+fn accepted_source(
+  snapshot : RepositorySnapshot,
+  source : SourceRecord,
+) -> RepositorySnapshot {
+  let document_id = source.document_id()
+  let sources = snapshot
+    .sources()
+    .to_owned()
+    .filter(existing => existing.document_id() != document_id)
+  sources.push(source)
+  sources.sort_by((left, right) => {
+    left.document_id().lexical_compare(right.document_id())
+  })
 
-///|
-pub fn SaveSuccess::issues(self : Self) -> ArrayView[RepositoryIssue] {
-  self.1.view()
+  let issues = snapshot
+    .issues()
+    .to_owned()
+    .filter(issue => {
+      match issue {
+        RepositoryIssue::NameDerivationFailed(issue_id) =>
+          issue_id != document_id
+        _ => true
+      }
+    })
+  let (catalog, current_issues) = next_catalog(
+    snapshot.catalog(),
+    document_id,
+    source.text(),
+  )
+  for issue in current_issues {
+    if !issues.contains(issue) {
+      issues.push(issue)
+    }
+  }
+  RepositorySnapshot::new(
+    sources,
+    catalog,
+    issues,
+    snapshot.occupied_source_keys().to_owned(),
+  )
 }

--- a/docs/decisions/2026-08-29-loomark-source-repository.md
+++ b/docs/decisions/2026-08-29-loomark-source-repository.md
@@ -53,11 +53,12 @@ and only `active` is deleted. A corrupt target preserves both records and is
 reported as a migration collision. Mutation failure rolls back the target put
 and preserves `active`.
 
-A normal save derives the next in-memory Catalog outside the Raw input task and
-commits only the accepted Source. Transaction completion establishes the
-acknowledged browser-storage state. Only then does the application install the
-next Catalog. Save completions are fenced by Document ID and exact Source
-candidate before they update active durability state.
+A normal save or create derives the next immutable RepositorySnapshot outside
+Raw input. It commits only the accepted Source and installs that snapshot only
+after transaction completion. Occupied keys prevent overwrite of records
+observed by that Snapshot; concurrent-tab coordination remains out of scope.
+Save completions are fenced by Document ID and exact Source candidate before
+they update active durability state.
 
 Repository issues describe currently observed conditions rather than an
 append-only incident history. A name-derivation issue for a document disappears
@@ -78,6 +79,8 @@ results rather than permanent repository issues.
 - Text input continues to update only Browser-draft state; complete-source name
   derivation, serialization, and IndexedDB work begin at `SaveRequested`.
 - Persistent active-document selection remains deferred to #1305.
+- RepositorySnapshots retain the exact observed `source/v1` keys, including
+  malformed and unsupported records.
 - A persisted discovery accelerator requires a separate measured decision and a
   validation protocol that cannot become document authority.
 


### PR DESCRIPTION
## Summary

- Make `RepositorySnapshot` the single immutable state token for valid Sources, the derived Catalog, current repository issues, and observed occupied Source keys.
- Add update-only `save(snapshot, document_id, text)` and one-attempt `create(snapshot)` operations that publish the next Snapshot only after the Source transaction completes.
- Add total Source lookup, preserve stale-save fencing in the app, and use true lexical Document ID ordering instead of MoonBit's shortlex `Compare[String]` order.

This is the repository prerequisite for the create/list UI in #1304. It does not add document-list or switching UI.

## UI and review evidence

N/A — this change does not alter rendered UI or interaction paths.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `SourceRecord::new`, `source_key`, `encode_source` | `apps/loomark/internal/source_repository` | Yes | Existing Source identity and codec boundary |
| `next_catalog`, `derive_name`, `reconcile_scan` | `apps/loomark/internal/source_repository` | Yes | Existing derived-name and full-scan authority paths |
| `Array` / `ArrayView` lookup, filter, copy, and sort APIs | MoonBit core | Yes | Immutable Snapshot transitions and defensive views |
| `Set` | MoonBit core | Yes | Duplicate identity validation and occupied-key normalization |
| `String::lexical_compare` | MoonBit core | Yes | `Compare[String]` is shortlex and does not satisfy the documented lexical-order contract |
| `Option` / `Result` | MoonBit core | Yes | Total lookup and fail-closed validation |
| `Map` | MoonBit core | No | No measured keyed-lookup requirement justifies another representation |
| IndexedDB `add` | Web API / Rabbita | No | Would add conflict classification and cross-tab policy; concurrent-tab coordination remains out of scope |

New helpers added:

- `accepted_source` — the single pure transition that advances Sources, Catalog, current issues, and occupied keys together.
- `finish_save` / `finish_create` — map transaction-completion results to operation-specific typed results.
- `create_with_document_id` — keeps UUID acquisition outside the deterministic create admission and command seam.

Remaining imperative code is limited to local immutable-value construction, UUID acquisition, and IndexedDB command wiring.

## Validation scope

Boundary matrix / first failing regression:

- Snapshot lookup: existing and absent Document IDs.
- Transition: add second/third Sources, unequal-length lexical ordering, duplicate names with distinct IDs, one-Source update, derived-name update, unrelated Source/issue preservation, and occupied corrupt keys.
- Save: missing identity rejects before storage; valid update issues exactly one Source put; Stored completion publishes the next Snapshot; typed failures preserve the caller's prior Snapshot.
- Create: invalid or observed-occupied identity rejects before storage; valid identity issues exactly one `# Untitled\n` Source put; completion returns the next Snapshot and generated ID; storage, quota, and generic failures remain distinct.
- App: Raw `TextChanged` remains repository-I/O-free; exact Document ID plus candidate stale-completion fence remains intact.

Target packages:

- `apps/loomark/internal/source_repository`
- `apps/loomark/app`
- `apps/loomark/main`

Additional conditional gates:

- Targeted JS release tests: 34 passed.
- Workspace JS release tests: 7,535 passed.
- Source-repository benchmarks: 7 passed.
- Production Chromium standalone E2E: 28 passed.
- Targeted JS `--deny-warn` check passed.
- Workspace JS check and release build passed; output contains only existing workspace/vendored warnings.
- Standalone TypeScript typecheck passed.
- Documentation lifecycle and agent-document link checks passed.
- Independent review findings were resolved.

## Push and CI readiness

```bash
git fetch origin main
git push
```

- [x] The branch contains the fetched `origin/main`, and the normal push completed without bypassing Lefthook's affected local checks.
- [x] The committed `.mbti` diff against `origin/main` was reviewed for unintended API or trait-bound changes.
- [x] No submodule commit changed.
- [x] The branch was pushed after the candidate commit.
- [x] Independent review findings were resolved before the final validation.
- [ ] GitHub CI's `All Checks Passed` gate is green before merge.
