### PR TITLE
perf(loomark): reduce Source save preparation

### DIFF
--- a/apps/loomark/internal/source_repository/derived_name.mbt
+++ b/apps/loomark/internal/source_repository/derived_name.mbt
@@ -10,9 +10,20 @@ priv struct NameDerivation {
 }
 
 ///|
-fn reusable_node_prefix_end(source : String, node : @seam.SyntaxNode) -> Int? {
-  let end = node.end()
-  guard node.start() == 0 && end > 0 && end <= source.length() else {
+fn certify_reusable_name_prefix(
+  source : String,
+  root : @seam.SyntaxNode,
+  diagnostics : @loom.DiagnosticSet,
+  candidate : @seam.SyntaxNode,
+) -> Int? {
+  guard diagnostics.is_empty() &&
+    root.first_child() is Some(first) &&
+    first.cst_node() == candidate.cst_node() &&
+    !candidate.cst_node().has_any_error() else {
+    return None
+  }
+  let end = candidate.end()
+  guard candidate.start() == 0 && end > 0 && end <= source.length() else {
     return None
   }
   let terminator = source.view(start_offset=end - 1, end_offset=end)
@@ -27,7 +38,7 @@ fn reusable_node_prefix_end(source : String, node : @seam.SyntaxNode) -> Int? {
 fn derive_name_with_certificate(
   source : String,
 ) -> Result[NameDerivation, Unit] {
-  let (cst, _) = @markdown.parse_cst(name_source_id, source) catch {
+  let (cst, diagnostics) = @markdown.parse_cst(name_source_id, source) catch {
     _ => return Err(())
   }
   let root = @seam.SyntaxNode::from_cst(cst)
@@ -42,7 +53,9 @@ fn derive_name_with_certificate(
       } else {
         Ok({
           name: Some(name),
-          reusable_prefix_end: reusable_node_prefix_end(source, node),
+          reusable_prefix_end: certify_reusable_name_prefix(
+            source, root, diagnostics, node,
+          ),
         })
       }
     }

--- a/apps/loomark/internal/source_repository/derived_name.mbt
+++ b/apps/loomark/internal/source_repository/derived_name.mbt
@@ -4,28 +4,90 @@ let name_source_id : @loom.SourceId = @loom.SourceId(
 )
 
 ///|
-fn derive_name(source : String) -> Result[String?, Unit] {
+priv struct NameDerivation {
+  name : String?
+  reusable_prefix_end : Int?
+}
+
+///|
+fn reusable_node_prefix_end(source : String, node : @seam.SyntaxNode) -> Int? {
+  let end = node.end()
+  guard node.start() == 0 && end > 0 && end <= source.length() else {
+    return None
+  }
+  let terminator = source.view(start_offset=end - 1, end_offset=end)
+  if terminator.equal_to_string("\n") || terminator.equal_to_string("\r") {
+    Some(end)
+  } else {
+    None
+  }
+}
+
+///|
+fn derive_name_with_certificate(
+  source : String,
+) -> Result[NameDerivation, Unit] {
   let (cst, _) = @markdown.parse_cst(name_source_id, source) catch {
     _ => return Err(())
   }
   let root = @seam.SyntaxNode::from_cst(cst)
   match first_atx_h1(root) {
-    None => Ok(None)
-    Some(inlines) => {
+    None => Ok({ name: None, reusable_prefix_end: None })
+    Some((node, inlines)) => {
       let builder = StringBuilder()
       guard append_inlines(inlines, builder) else { return Err(()) }
       let name = builder.to_string().trim().to_owned()
       if name == "" {
-        Ok(None)
+        Ok({ name: None, reusable_prefix_end: None })
       } else {
-        Ok(Some(name))
+        Ok({
+          name: Some(name),
+          reusable_prefix_end: reusable_node_prefix_end(source, node),
+        })
       }
     }
   }
 }
 
 ///|
-fn first_atx_h1(node : @seam.SyntaxNode) -> Array[@markdown.Inline]? {
+fn derive_name(source : String) -> Result[String?, Unit] {
+  derive_name_with_certificate(source).map(derivation => derivation.name)
+}
+
+///|
+fn first_line_end(source : String) -> Int? {
+  let terminator_start = match (source.find("\n"), source.find("\r")) {
+    (None, None) => return None
+    (Some(lf), None) => lf
+    (None, Some(cr)) => cr
+    (Some(lf), Some(cr)) => lf.min(cr)
+  }
+  let after_cr = (terminator_start + 2).min(source.length())
+  if source
+    .view(start_offset=terminator_start, end_offset=after_cr)
+    .equal_to_string("\r\n") {
+    Some(terminator_start + 2)
+  } else {
+    Some(terminator_start + 1)
+  }
+}
+
+///|
+fn certified_name_prefix_end(source : String, expected_name : String?) -> Int? {
+  guard first_line_end(source) is Some(end) else { return None }
+  let prefix = source.view(end_offset=end).to_owned()
+  guard derive_name_with_certificate(prefix) is Ok(derivation) &&
+    derivation.name == expected_name &&
+    derivation.reusable_prefix_end == Some(end) else {
+    return None
+  }
+  Some(end)
+}
+
+///|
+fn first_atx_h1(
+  node : @seam.SyntaxNode,
+) -> (@seam.SyntaxNode, Array[@markdown.Inline])? {
   let kind : @markdown.SyntaxKind = @seam.FromRawKind::from_raw(node.kind())
   if kind is HeadingNode &&
     node.has_direct_token_of_kind(
@@ -33,13 +95,13 @@ fn first_atx_h1(node : @seam.SyntaxNode) -> Array[@markdown.Inline]? {
     ) {
     let fold = @loom.CstFold::new(@markdown.markdown_fold_node)
     match fold.fold(node) {
-      Heading(1, inlines) => return Some(inlines)
+      Heading(1, inlines) => return Some((node, inlines))
       _ => ()
     }
   }
   for child in node.children() {
     match first_atx_h1(child) {
-      Some(inlines) => return Some(inlines)
+      Some(result) => return Some(result)
       None => ()
     }
   }

--- a/apps/loomark/internal/source_repository/derived_name_wbtest.mbt
+++ b/apps/loomark/internal/source_repository/derived_name_wbtest.mbt
@@ -39,6 +39,24 @@ test "name derivation certifies only a line-terminated top-level first H1" {
 }
 
 ///|
+test "recovered top-level heading derives a name but cannot certify reuse" {
+  let source = "# )bad\n"
+  let (cst, diagnostics) = try! @markdown.parse_cst(name_source_id, source)
+  let root = @seam.SyntaxNode::from_cst(cst)
+  guard root.first_child() is Some(heading) else {
+    fail("expected recovered heading")
+  }
+  assert_true(diagnostics.is_empty())
+  assert_true(heading.cst_node().has_any_error())
+  guard derive_name_with_certificate(source) is Ok(derivation) else {
+    fail("expected recovered heading name")
+  }
+  assert_eq(derivation.name, Some(")bad"))
+  assert_eq(derivation.reusable_prefix_end, None)
+  assert_eq(certified_name_prefix_end(source, derivation.name), None)
+}
+
+///|
 test "derived name uses the first ATX H1 in document order" {
   guard derive_name_with_certificate("## Skip\n\n> # Quoted\n\n# Later\n")
     is Ok(quoted_derivation) &&

--- a/apps/loomark/internal/source_repository/derived_name_wbtest.mbt
+++ b/apps/loomark/internal/source_repository/derived_name_wbtest.mbt
@@ -1,10 +1,54 @@
 ///|
+test "name derivation certifies only a line-terminated top-level first H1" {
+  guard derive_name_with_certificate("# Stable\n\nBody\n") is Ok(terminated) else {
+    fail("expected derived top-level name")
+  }
+  assert_eq(terminated.name, Some("Stable"))
+  assert_eq(terminated.reusable_prefix_end, Some(9))
+
+  for
+    fixture in [
+      ("# Stable\r\nBody\r\n", 10),
+      ("# Stable\rBody\r", 9),
+      ("# 😀\nBody\n", 5),
+    ] {
+    let (source, expected_end) = fixture
+    guard derive_name_with_certificate(source) is Ok(line_terminated) else {
+      fail("expected line-terminated derived name")
+    }
+    assert_eq(line_terminated.reusable_prefix_end, Some(expected_end))
+    assert_eq(
+      certified_name_prefix_end(source, line_terminated.name),
+      Some(expected_end),
+    )
+  }
+
+  guard derive_name_with_certificate("# Stable") is Ok(eof) else {
+    fail("expected EOF-derived name")
+  }
+  assert_eq(eof.name, Some("Stable"))
+  assert_eq(eof.reusable_prefix_end, None)
+
+  for source in ["> # Quoted\n", "- item\n  # Listed\n"] {
+    guard derive_name_with_certificate(source) is Ok(nested) else {
+      fail("expected nested derived name")
+    }
+    assert_eq(nested.reusable_prefix_end, None)
+    assert_eq(certified_name_prefix_end(source, nested.name), None)
+  }
+}
+
+///|
 test "derived name uses the first ATX H1 in document order" {
-  guard derive_name("## Skip\n\n> # Quoted\n\n# Later\n") is Ok(Some(quoted)) else {
+  guard derive_name_with_certificate("## Skip\n\n> # Quoted\n\n# Later\n")
+    is Ok(quoted_derivation) &&
+    quoted_derivation.name is Some(quoted) else {
     fail("expected quoted ATX H1")
   }
   assert_eq(quoted, "Quoted")
-  guard derive_name("- item\n  # Listed\n\n# Later\n") is Ok(Some(listed)) else {
+  assert_eq(quoted_derivation.reusable_prefix_end, None)
+  guard derive_name_with_certificate("- item\n  # Listed\n\n# Later\n")
+    is Ok({ name: Some(listed), .. }) else {
     fail("expected listed ATX H1")
   }
   assert_eq(listed, "Listed")
@@ -12,8 +56,10 @@ test "derived name uses the first ATX H1 in document order" {
 
 ///|
 test "derived name flattens supported inline content" {
-  guard derive_name("# **Bold** *italic* `code` [link](https://example.com)\n")
-    is Ok(Some(name)) else {
+  guard derive_name_with_certificate(
+      "# **Bold** *italic* `code` [link](https://example.com)\n",
+    )
+    is Ok({ name: Some(name), .. }) else {
     fail("expected flattened ATX H1")
   }
   assert_eq(name, "Bold italic code link")
@@ -36,6 +82,6 @@ test "derived name excludes non-ATX-H1 forms" {
     source in [
       "No heading\n", "Setext\n======\n", "## H2\n", "```md\n# Fenced\n```\n", "#   \n",
     ] {
-    assert_true(derive_name(source) is Ok(None))
+    assert_true(derive_name_with_certificate(source) is Ok({ name: None, .. }))
   }
 }

--- a/apps/loomark/internal/source_repository/reconciliation.mbt
+++ b/apps/loomark/internal/source_repository/reconciliation.mbt
@@ -96,3 +96,29 @@ fn next_catalog(
   entries.push(CatalogEntry::new(document_id, name).unwrap())
   (Catalog::from_entries(entries).unwrap(), issues)
 }
+
+///|
+fn next_catalog_after_source(
+  current : Catalog,
+  document_id : String,
+  previous_source : String?,
+  source : String,
+) -> (Catalog, Array[RepositoryIssue]) {
+  guard previous_source is Some(previous_source) &&
+    current.entries().search_by(entry => entry.document_id() == document_id)
+    is Some(index) else {
+    return next_catalog(current, document_id, source)
+  }
+  let current_entry = current.entries()[index]
+  guard certified_name_prefix_end(previous_source, current_entry.name())
+    is Some(end) &&
+    end <= source.length() &&
+    previous_source.view(end_offset=end).equal(source.view(end_offset=end)) else {
+    return next_catalog(current, document_id, source)
+  }
+  let entries = current
+    .entries()
+    .filter(entry => entry.document_id() != document_id)
+  entries.push(current_entry)
+  (Catalog::from_entries(entries).unwrap(), [])
+}

--- a/apps/loomark/internal/source_repository/reconciliation_benchmark_wbtest.mbt
+++ b/apps/loomark/internal/source_repository/reconciliation_benchmark_wbtest.mbt
@@ -91,7 +91,9 @@ test "bench: encode 1000 Source records with large-document mix" (b : @bench.T) 
 ///|
 test "bench: derive 1000 names with large-document mix" (b : @bench.T) {
   let sources = reconciliation_bench_sources(1000, true)
-  b.bench(fn() { b.keep(sources.map(source => derive_name(source.text()))) })
+  b.bench(fn() {
+    b.keep(sources.map(source => derive_name_with_certificate(source.text())))
+  })
 }
 
 ///|

--- a/apps/loomark/internal/source_repository/reconciliation_wbtest.mbt
+++ b/apps/loomark/internal/source_repository/reconciliation_wbtest.mbt
@@ -163,6 +163,27 @@ test "accepted suffix edit reuses certified Catalog name" {
 }
 
 ///|
+test "accepted recovered heading suffix edit cannot use certified reuse" {
+  let original = RepositorySnapshot::from_sources([
+    test_source("document-a", "# )bad\n\nOld body\n"),
+  ]).unwrap()
+  assert_eq(original.catalog().entries()[0].name(), Some(")bad"))
+  assert_eq(
+    certified_name_prefix_end(
+      original.source("document-a").unwrap().text(),
+      original.catalog().entries()[0].name(),
+    ),
+    None,
+  )
+
+  let accepted = accepted_source(
+    original,
+    test_source("document-a", "# )bad\n\nNew body\n"),
+  )
+  assert_eq(accepted.catalog().entries()[0].name(), Some(")bad"))
+}
+
+///|
 test "snapshot orders unequal-length identities lexically" {
   let snapshot = RepositorySnapshot::from_sources([
     test_source("z", "# Z\n"),

--- a/apps/loomark/internal/source_repository/reconciliation_wbtest.mbt
+++ b/apps/loomark/internal/source_repository/reconciliation_wbtest.mbt
@@ -123,6 +123,46 @@ test "snapshot source and accepted Source transition preserve repository state" 
 }
 
 ///|
+test "accepted suffix edit reuses certified Catalog name" {
+  let original = RepositorySnapshot::from_sources([
+    test_source("document-a", "# Stable\n\nOld body\n"),
+  ]).unwrap()
+  assert_eq(
+    certified_name_prefix_end(
+      original.source("document-a").unwrap().text(),
+      original.catalog().entries()[0].name(),
+    ),
+    Some(9),
+  )
+
+  let suffix = accepted_source(
+    original,
+    test_source("document-a", "# Stable\n\nNew body with # Later\n"),
+  )
+  assert_eq(suffix.catalog().entries()[0].name(), Some("Stable"))
+  assert_eq(
+    certified_name_prefix_end(
+      suffix.source("document-a").unwrap().text(),
+      suffix.catalog().entries()[0].name(),
+    ),
+    Some(9),
+  )
+
+  let changed = accepted_source(
+    suffix,
+    test_source("document-a", "# Changed\n\nNew body\n"),
+  )
+  assert_eq(changed.catalog().entries()[0].name(), Some("Changed"))
+  assert_eq(
+    certified_name_prefix_end(
+      changed.source("document-a").unwrap().text(),
+      changed.catalog().entries()[0].name(),
+    ),
+    Some(10),
+  )
+}
+
+///|
 test "snapshot orders unequal-length identities lexically" {
   let snapshot = RepositorySnapshot::from_sources([
     test_source("z", "# Z\n"),

--- a/apps/loomark/internal/source_repository/source_codec.mbt
+++ b/apps/loomark/internal/source_repository/source_codec.mbt
@@ -33,12 +33,8 @@ fn decode_source(
 }
 
 ///|
-fn encode_document(document_id : String, text : String) -> String {
-  Json::object({
-    "document_id": Json::string(document_id),
-    "text": Json::string(text),
-  }).stringify()
-}
+extern "js" fn encode_document(document_id : String, text : String) -> String =
+  #| (document_id, text) => JSON.stringify({ document_id, text })
 
 ///|
 fn decode_source_value(

--- a/apps/loomark/internal/source_repository/source_codec_wbtest.mbt
+++ b/apps/loomark/internal/source_repository/source_codec_wbtest.mbt
@@ -30,6 +30,22 @@ test "source encoder round-trips valid browser text through strict decoder" {
 }
 
 ///|
+test "source encoder exactly round-trips a 1 MiB Source" {
+  let prefix = "# Stable\r\n"
+  let text = prefix + String::make(1024 * 1024 - prefix.length(), 'x')
+  assert_eq(text.length(), 1024 * 1024)
+  let source = SourceRecord::new("document-1-mib", text).unwrap()
+  guard decode_source(
+      source_key(source.document_id()).unwrap(),
+      encode_source(source),
+    )
+    is Ok(decoded) else {
+    fail("expected exact 1 MiB Source round-trip")
+  }
+  assert_eq(decoded, source)
+}
+
+///|
 test "source key and payload identity must match" {
   let source = SourceRecord::new("document-1", "# Text\n").unwrap()
   assert_eq(source_key(""), None)

--- a/apps/loomark/internal/source_repository/source_codec_wbtest.mbt
+++ b/apps/loomark/internal/source_repository/source_codec_wbtest.mbt
@@ -10,6 +10,26 @@ test "source key and strict codec preserve identity and exact text" {
 }
 
 ///|
+test "source encoder round-trips valid browser text through strict decoder" {
+  for
+    text in [
+      "", "plain text", "quote: \" reverse solidus: \\ solidus: /", "controls: \u{0000}\b\t\n\r",
+      "line endings: LF\nCRLF\r\nCR\r", "日本語 café e\u{0301} 😀 \u{2028} \u{2029}",
+      "</script><script>alert(1)</script>",
+    ] {
+    let source = SourceRecord::new("document-\"-日本語", text).unwrap()
+    guard decode_source(
+        source_key(source.document_id()).unwrap(),
+        encode_source(source),
+      )
+      is Ok(decoded) else {
+      fail("expected strict Source round-trip")
+    }
+    assert_eq(decoded, source)
+  }
+}
+
+///|
 test "source key and payload identity must match" {
   let source = SourceRecord::new("document-1", "# Text\n").unwrap()
   assert_eq(source_key(""), None)

--- a/apps/loomark/internal/source_repository/source_preparation_benchmark_wbtest.mbt
+++ b/apps/loomark/internal/source_repository/source_preparation_benchmark_wbtest.mbt
@@ -1,0 +1,74 @@
+///|
+fn source_preparation_bench_sources(size : Int) -> Array[SourceRecord] {
+  Array::makei(8, index => {
+    SourceRecord::new(
+      "bench-document",
+      "# Stable\n" + String::make(size - 1, 'x') + "\{index}",
+    ).unwrap()
+  })
+}
+
+///|
+fn benchmark_source_encoding(b : @bench.T, size : Int) -> Unit {
+  let sources = source_preparation_bench_sources(size)
+  let mut index = 0
+  b.bench(fn() {
+    let encoded = encode_source(sources[index])
+    index = (index + 1) % sources.length()
+    b.keep(encoded)
+  })
+}
+
+///|
+test "bench: encode Source 64 KiB" (b : @bench.T) {
+  benchmark_source_encoding(b, 64 * 1024)
+}
+
+///|
+test "bench: encode Source 256 KiB" (b : @bench.T) {
+  benchmark_source_encoding(b, 256 * 1024)
+}
+
+///|
+test "bench: encode Source 1 MiB" (b : @bench.T) {
+  benchmark_source_encoding(b, 1024 * 1024)
+}
+
+///|
+test "bench: accept 1 MiB Source with unchanged certified title" (b : @bench.T) {
+  let snapshot = RepositorySnapshot::from_sources([
+    SourceRecord::new(
+      "bench-document",
+      "# Stable\n" + String::make(1024 * 1024, 'x'),
+    ).unwrap(),
+  ]).unwrap()
+  let sources = source_preparation_bench_sources(1024 * 1024)
+  let mut index = 0
+  b.bench(fn() {
+    let accepted = accepted_source(snapshot, sources[index])
+    index = (index + 1) % sources.length()
+    b.keep(accepted)
+  })
+}
+
+///|
+test "bench: accept 1 MiB Source after title change" (b : @bench.T) {
+  let snapshot = RepositorySnapshot::from_sources([
+    SourceRecord::new(
+      "bench-document",
+      "# Stable\n" + String::make(1024 * 1024, 'x'),
+    ).unwrap(),
+  ]).unwrap()
+  let sources = Array::makei(8, index => {
+    SourceRecord::new(
+      "bench-document",
+      "# Changed \{index}\n" + String::make(1024 * 1024, 'x'),
+    ).unwrap()
+  })
+  let mut index = 0
+  b.bench(fn() {
+    let accepted = accepted_source(snapshot, sources[index])
+    index = (index + 1) % sources.length()
+    b.keep(accepted)
+  })
+}

--- a/apps/loomark/internal/source_repository/types.mbt
+++ b/apps/loomark/internal/source_repository/types.mbt
@@ -210,9 +210,13 @@ fn accepted_source(
         _ => true
       }
     })
-  let (catalog, current_issues) = next_catalog(
+  let previous_source = snapshot
+    .source(document_id)
+    .map(source => source.text())
+  let (catalog, current_issues) = next_catalog_after_source(
     snapshot.catalog(),
     document_id,
+    previous_source,
     source.text(),
   )
   for issue in current_issues {

--- a/docs/decisions/2026-08-29-loomark-source-repository.md
+++ b/docs/decisions/2026-08-29-loomark-source-repository.md
@@ -67,8 +67,11 @@ hash contract.
 
 A normal save may parse only the previous Source's first terminated line to
 derive an ephemeral prefix certificate. It reuses the current Catalog name only
-when that prefix is a line-terminated top-level ATX H1 at offset zero, derives
-the same name, and is exactly equal in the new Source. Every other case runs the
+when that prefix parses without diagnostics or CST error/incomplete metadata,
+its first direct Document child is a line-terminated ATX H1 at offset zero, it
+derives the same name, and it is exactly equal in the new Source. Name
+derivation remains independent: recovered headings may still produce the same
+Catalog name while receiving no certificate. Every uncertified case runs the
 complete Markdown derivation and preserves its fail-closed behavior. No
 certificate is retained or persisted, so it cannot become Source authority.
 

--- a/docs/decisions/2026-08-29-loomark-source-repository.md
+++ b/docs/decisions/2026-08-29-loomark-source-repository.md
@@ -60,6 +60,18 @@ observed by that Snapshot; concurrent-tab coordination remains out of scope.
 Save completions are fenced by Document ID and exact Source candidate before
 they update active durability state.
 
+The JS-only repository uses the browser's native JSON encoder for the fixed
+`document_id`/`text` Source object. The strict MoonBit decoder remains the schema
+and identity authority; serialized byte spelling is not a public or canonical
+hash contract.
+
+A normal save may parse only the previous Source's first terminated line to
+derive an ephemeral prefix certificate. It reuses the current Catalog name only
+when that prefix is a line-terminated top-level ATX H1 at offset zero, derives
+the same name, and is exactly equal in the new Source. Every other case runs the
+complete Markdown derivation and preserves its fail-closed behavior. No
+certificate is retained or persisted, so it cannot become Source authority.
+
 Repository issues describe currently observed conditions rather than an
 append-only incident history. A name-derivation issue for a document disappears
 after a later committed Source derives safely. Storage failures remain operation
@@ -73,6 +85,11 @@ results rather than permanent repository issues.
   authority path.
 - No missing, stale, malformed, or unwritable metadata record can hide a Source.
 - The open path still pays the essential complete-scan and name-derivation cost.
+- Suffix-only saves after a certified first-line title avoid redundant complete
+  Markdown name derivation; changed, nested, missing, recovered, or EOF titles
+  retain the full path.
+- Fixed-schema Source encoding uses the deployment target's mature JSON escaping
+  while strict decode and exact text round trips remain covered in MoonBit.
 - The legacy record cannot shadow a successfully migrated Source indefinitely.
 - A blocked migration may open a fresh baseline while preserving both collision
   records for later recovery.

--- a/docs/performance/2026-08-29-loomark-source-reconciliation.md
+++ b/docs/performance/2026-08-29-loomark-source-reconciliation.md
@@ -81,8 +81,9 @@ eight distinct operands and retains every result.
 The encoder keeps the exact two-field Source schema and strict decoder but uses
 native JSON serialization in this JS-only package. Catalog reuse is deliberately
 narrow: each save reparses only the previous first terminated line, then reuses
-the name when that line certifies an unchanged, offset-zero, top-level ATX H1.
-No certificate is stored. Title changes and all uncertified forms continue
+the name when the first direct Document child is an unchanged ATX H1 and both
+parse diagnostics and CST error/incomplete metadata are empty. No certificate
+is stored. Title changes, recovered headings, and all uncertified forms continue
 through the existing complete parser.
 
 Production Chromium then exercised 30 saves across three fresh launches per

--- a/docs/performance/2026-08-29-loomark-source-reconciliation.md
+++ b/docs/performance/2026-08-29-loomark-source-reconciliation.md
@@ -63,6 +63,51 @@ Command:
 | Source put through transaction completion | small Source | 0.400 ms |
 | Source put through transaction completion | 1 MiB Source | 2.100 ms |
 
+## Normal-save preparation follow-up
+
+Issue [#1347](https://github.com/dowdiness/canopy/issues/1347) later measured
+selected 1 MiB normal saves and found complete Source encoding and repeated
+Catalog name derivation on that path. A release-JavaScript benchmark rotates
+eight distinct operands and retains every result.
+
+| Operation | Workload | Previous mean | Current mean |
+| --- | --- | ---: | ---: |
+| Strict Source encode | 64 KiB | 0.614 ms | 38.97 µs |
+| Strict Source encode | 256 KiB | 2.81 ms | 303.99 µs |
+| Strict Source encode | 1 MiB | 50.78 ms | 1.12 ms |
+| Accept Source with unchanged certified title | 1 MiB suffix edit | 58.68 ms | 2.10 ms |
+| Accept Source after title change | 1 MiB | full derivation required | 49.84 ms |
+
+The encoder keeps the exact two-field Source schema and strict decoder but uses
+native JSON serialization in this JS-only package. Catalog reuse is deliberately
+narrow: each save reparses only the previous first terminated line, then reuses
+the name when that line certifies an unchanged, offset-zero, top-level ATX H1.
+No certificate is stored. Title changes and all uncertified forms continue
+through the existing complete parser.
+
+Production Chromium then exercised 30 saves across three fresh launches per
+fixture. Put and acknowledgment offsets include the 250 ms quiet interval.
+
+| Fixture | Previous put p95 | Current put p95 | Previous ack p95 | Current ack p95 |
+| --- | ---: | ---: | ---: | ---: |
+| Practical 500-block Preview | 280.1 ms | 256.1 ms | 301.2 ms | 270.3 ms |
+| 64 KiB Text | 260.4 ms | 256.1 ms | 269.9 ms | 268.7 ms |
+| 256 KiB Text | 276.6 ms | 258.6 ms | 286.2 ms | 271.9 ms |
+| 1 MiB Text | 354.9 ms | 267.1 ms | 368.5 ms | 292.2 ms |
+
+The selected 1 MiB save-phase long task fell from 30/30 samples at 105 ms p95
+to 0/30. A separate post-input long task remained in 30/30 samples and varied
+by launch up to 230 ms p95; this change does not claim to make 1 MiB textarea
+input frame-responsive.
+
+Command:
+
+```bash
+NEW_MOON_MOD=0 moon bench --release --target js \
+  -p dowdiness/loomark/internal/source_repository \
+  -f source_preparation_benchmark_wbtest.mbt --no-parallelize
+```
+
 ## Interpretation
 
 At 1,000 mixed Sources, Markdown name derivation accounts for most pure


### PR DESCRIPTION
## Summary

- encode Loomark's fixed `source/v1` record with native `JSON.stringify` while retaining the strict existing decoder and Source schema
- reuse an existing Catalog name only after an ephemeral, fail-closed proof that the previous terminated first-line ATX H1 prefix is direct, unchanged, diagnostic-free, and free of CST recovery metadata
- reduce measured 1 MiB Source encoding from 50.78 ms to about 1.1 ms and suffix-only acceptance from 58.68 ms to about 2.1 ms, removing the measured save-phase long task

This is the Source-preparation prerequisite for #1347. It does not implement the pending-checkpoint scheduler or close the issue.

## UI and review evidence

N/A — no UI or visual behavior changed.

- [x] Any claimed Canopy rule cites its repository source; external guidance, recommendations, and preferences are labeled as such

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `parse_cst` | `dowdiness/markdown` | Yes | Reuses the authoritative Markdown grammar for full name derivation and the ephemeral first-line proof. |
| `SyntaxNode::{start,end,first_child}` and token queries | `dowdiness/loom/seam` | Yes | Certifies direct Document ownership plus the offset-zero, line-terminated ATX H1 shape without a second Markdown recognizer. |
| `DiagnosticSet::is_empty` / `CstNode::has_any_error` | `dowdiness/loom` / `dowdiness/loom/seam` | Yes | Refuses proof when parser diagnostics or formal CST error/incomplete metadata indicate recovery. |
| `String::{find,view}` / `StringView::equal_to_string` | MoonBit core | Yes | Finds CR/LF/CRLF boundaries and compares prefixes without scanning the complete new Source. |
| `StringBuilder` | MoonBit core | Yes | Retains the existing inline-title derivation. |
| `Option` / `Result` | MoonBit core | Yes | Represents unavailable certificates and fail-closed parser outcomes. |
| `Json::stringify` | MoonBit core | No | The measured generic serializer was the dominant 1 MiB preparation cost; this JS-only fixed-schema boundary uses native `JSON.stringify` and differential round-trip tests instead. |
| `Map` / `Set` | MoonBit core | No | The change performs no keyed membership, deduplication, or aggregation. |

New private helpers added:

- `certify_reusable_name_prefix`: is the sole proof issuer and requires clean diagnostics, direct first-child CST identity, no error/incomplete metadata, and a terminated offset-zero prefix
- `derive_name_with_certificate`: keeps ordinary derived-name output independent from the optional ephemeral proof boundary
- `first_line_end`: recognizes LF, CR, and CRLF without scanning beyond the first terminator
- `certified_name_prefix_end`: reparses only the previous first line and fails closed unless its name and boundary match the existing Catalog entry

No certificate is stored or exposed. `CatalogEntry`, its derived `Eq`/`Debug`, and the generated public interface remain unchanged.

## Validation scope

Boundary matrix / first failing regression:

- strict Source encode/decode: quotes, backslashes, control characters, LF/CR/CRLF, U+2028/U+2029, astral Unicode, and script-like text
- name reuse: LF/CR/CRLF-terminated top-level ATX H1 at offset zero, including astral titles
- fail-closed fallback: title edits, unterminated headings, nested/list/quote headings, empty names, parser recovery, and mismatched Catalog names
- actual recovery fixture `# )bad\n`: still derives `Some(")bad")`, has empty diagnostics but formal CST error metadata, receives no proof, and cannot enter certified reuse
- Source reconciliation: suffix-only edits reuse the proven name; heading edits and recovered headings run complete derivation
- exact 1 MiB Source encode/strict-decode round-trip equality

Target packages:

- `dowdiness/loomark/internal/source_repository`
- downstream validation: `dowdiness/loomark/app`, `dowdiness/loomark/internal/preview`

Additional conditional gates:

- targeted JS release tests: 66 passed
- workspace JS release tests: 7,565 passed
- production Chromium standalone E2E: 33 passed
- production Chromium measurement: 1 MiB put p95 354.9 ms → 267.1 ms; acknowledgment p95 368.5 ms → 292.2 ms; save-phase long tasks 30/30 → 0/30
- source-preparation release benchmarks at 64 KiB, 256 KiB, and 1 MiB
- documentation lifecycle contract and `git diff --check`
- independent MoonBit review, including the recovery-proof remediation: PASS

The separate 1 MiB post-input textarea/browser long task remains and is not claimed as fixed here.

## Push and CI readiness

```bash
git fetch origin main
git push
```

- [x] The branch contains the fetched `origin/main`, and the normal push completed without bypassing Lefthook's affected local checks.
- [x] The committed `.mbti` diff against `origin/main` was reviewed for unintended API or trait-bound changes; there is no `.mbti` change.
- [x] No submodule pointer changed; recorded recursive submodule commits passed the pre-push reachability gate.
- [x] The branch was pushed after the final commit.
- [x] Independent review findings were resolved before the final validation.
- [ ] GitHub CI's `All Checks Passed` gate is green before merge.
