### PR TITLE
refactor(loomark): encapsulate Preview lifecycle

### DIFF
--- a/apps/loomark/app/app.mbt
+++ b/apps/loomark/app/app.mbt
@@ -78,7 +78,7 @@ pub fn app() -> @rabbita.Val[@rabbita.Html] {
                 } else {
                   ["display:none;overflow:hidden"]
                 },
-                preview_view(editing.preview),
+                editing.preview.view(),
               ),
             ]
           }

--- a/apps/loomark/app/model.mbt
+++ b/apps/loomark/app/model.mbt
@@ -20,7 +20,7 @@ priv struct EditingState {
   creation : DocumentCreation
   mode : EditorMode
   compact : Bool
-  preview : PreviewState
+  preview : @preview.State
   repository : @source_repository.RepositorySnapshot
 } derive(Eq)
 
@@ -29,21 +29,6 @@ priv enum EditorMode {
   Text
   Preview
   Split
-} derive(Eq)
-
-///|
-priv struct PreviewResult {
-  text : String
-  html : @rabbita.Html
-  empty : Bool
-} derive(Eq)
-
-///|
-priv enum PreviewState {
-  Unrequested
-  Preparing
-  Ready(PreviewResult)
-  Failed(PreviewResult?)
 } derive(Eq)
 
 ///|
@@ -69,24 +54,7 @@ priv enum Msg {
   CompositionStarted(Activation)
   CompositionEnded(Activation)
   ModeSelected(EditorMode)
-  BeginPreviewPreparation(Activation)
-  PreviewPrepared(
-    Activation,
-    String,
-    Result[@preview.PreviewOutput, @preview.PreviewFailure]
-  )
-  ParserAdvanced(
-    Activation,
-    String,
-    Bool,
-    Result[Unit, @preview.PreviewFailure]
-  )
-  PreviewRefreshRequested(Activation, String)
-  PreviewRefreshed(
-    Activation,
-    String,
-    Result[@preview.PreviewOutput, @preview.PreviewFailure]
-  )
+  PreviewEvent(@preview.Event)
   ViewportChanged(Int)
   SaveRequested(Activation, String)
   SaveCompleted(Activation, String, @source_repository.SaveResult)

--- a/apps/loomark/app/update.mbt
+++ b/apps/loomark/app/update.mbt
@@ -2,9 +2,6 @@
 const AUTOSAVE_QUIET_MS : Int = 250
 
 ///|
-const PREVIEW_QUIET_MS : Int = 24
-
-///|
 const COMPACT_MAX_WIDTH : Int = 640
 
 ///|
@@ -13,20 +10,8 @@ fn compact_viewport(width : Int) -> Bool {
 }
 
 ///|
-fn preview_last(state : PreviewState) -> PreviewResult? {
-  match state {
-    Ready(result) => Some(result)
-    Failed(result) => result
-    Unrequested | Preparing => None
-  }
-}
-
-///|
-fn completed_preview(
-  text : String,
-  output : @preview.PreviewOutput,
-) -> PreviewResult {
-  { text, html: output.html, empty: output.empty }
+fn preview_input(editing : EditingState) -> @preview.Input {
+  @preview.Input(editing.activation.generation, editing.text)
 }
 
 ///|
@@ -37,26 +22,16 @@ fn select_mode(
   preview_engine : @preview.PreviewEngine,
 ) -> (EditingState, @rabbita.Cmd) {
   let entering_preview = editing.mode == Text && mode != Text
-  match editing.preview {
-    Unrequested if mode != Text =>
-      (
-        { ..editing, mode, preview: Preparing },
-        @preview.after_paint(emit(BeginPreviewPreparation(editing.activation))),
-      )
-    Failed(_) if entering_preview =>
-      (
-        { ..editing, mode, },
-        @preview.refresh_cmd(
-          preview_engine,
-          editing.activation.generation,
-          editing.text,
-          result=emit.map(result => {
-            PreviewRefreshed(editing.activation, editing.text, result)
-          }),
-        ),
-      )
-    Unrequested | Preparing | Ready(_) | Failed(_) =>
-      ({ ..editing, mode, }, @cmd.none)
+  let editing = { ..editing, mode, }
+  if entering_preview {
+    let (preview, command) = preview_engine.request(
+      editing.preview,
+      preview_input(editing),
+      emit.map(event => PreviewEvent(event)),
+    )
+    ({ ..editing, preview, }, command)
+  } else {
+    (editing, @cmd.none)
   }
 }
 
@@ -77,27 +52,31 @@ fn activate_document(
     document_id: source.document_id(),
     generation: editing.activation.generation + 1,
   }
-  let preview = if editing.mode == Text { Unrequested } else { Preparing }
-  let prepare_command = if editing.mode == Text {
-    @cmd.none
+  let input = @preview.Input(activation.generation, source.text())
+  let (preview, activate_command) = preview_engine.activate(input)
+  let (preview, request_command) = if editing.mode == Text {
+    (preview, @cmd.none)
   } else {
-    @preview.after_paint(emit(BeginPreviewPreparation(activation)))
-  }
-  let next = {
-    ..editing,
-    activation,
-    text: source.text(),
-    composing: false,
-    save: Saved,
-    creation: Idle,
-    preview,
+    preview_engine.request(
+      preview,
+      input,
+      emit.map(event => PreviewEvent(event)),
+    )
   }
   (
-    next,
+    {
+      ..editing,
+      activation,
+      text: source.text(),
+      composing: false,
+      save: Saved,
+      creation: Idle,
+      preview,
+    },
     @cmd.batch([
       text_area.initialize(source.text()),
-      @preview.activate_cmd(preview_engine, activation.generation),
-      prepare_command,
+      activate_command,
+      request_command,
     ]),
   )
 }
@@ -128,6 +107,9 @@ fn update(
           match snapshot.selected() {
             Some(source) => {
               let text = source.text()
+              let (preview, preview_command) = preview_engine.activate(
+                @preview.Input(0, text),
+              )
               (
                 Editing({
                   activation: {
@@ -140,13 +122,10 @@ fn update(
                   creation: Idle,
                   mode: Text,
                   compact,
-                  preview: Unrequested,
+                  preview,
                   repository: snapshot,
                 }),
-                @cmd.batch([
-                  text_area.initialize(text),
-                  @preview.activate_cmd(preview_engine, 0),
-                ]),
+                @cmd.batch([text_area.initialize(text), preview_command]),
               )
             }
             None =>
@@ -204,31 +183,15 @@ fn update(
             } else {
               @cmd.delay(emit(SaveRequested(owner, text)), AUTOSAVE_QUIET_MS)
             }
-            let preview_command = match editing.preview {
-              Unrequested | Preparing => @cmd.none
-              Ready(_) =>
-                @preview.apply_cmd(
-                  preview_engine,
-                  owner.generation,
-                  change,
-                  text,
-                  result=emit.map(result => {
-                    ParserAdvanced(owner, text, false, result)
-                  }),
-                )
-              Failed(_) =>
-                @preview.apply_cmd(
-                  preview_engine,
-                  owner.generation,
-                  change,
-                  text,
-                  result=emit.map(result => {
-                    ParserAdvanced(owner, text, true, result)
-                  }),
-                )
-            }
+            let editing = { ..editing, text, save }
+            let (preview, preview_command) = preview_engine.document_changed(
+              editing.preview,
+              preview_input(editing),
+              change,
+              emit.map(event => PreviewEvent(event)),
+            )
             (
-              Editing({ ..editing, text, save }),
+              Editing({ ..editing, preview, }),
               @cmd.batch([save_command, preview_command]),
             )
           }
@@ -260,130 +223,15 @@ fn update(
       let (editing, command) = select_mode(editing, mode, emit, preview_engine)
       (Editing(editing), command)
     }
-    (Editing(editing), BeginPreviewPreparation(owner)) =>
-      if owner != editing.activation {
-        (model, @cmd.none)
-      } else {
-        match editing.preview {
-          Preparing =>
-            (
-              model,
-              @preview.prepare_cmd(
-                preview_engine,
-                owner.generation,
-                editing.text,
-                result=emit.map(result => {
-                  PreviewPrepared(owner, editing.text, result)
-                }),
-              ),
-            )
-          Unrequested | Ready(_) | Failed(_) => (model, @cmd.none)
-        }
-      }
-    (Editing(editing), PreviewPrepared(owner, candidate, result)) =>
-      if owner != editing.activation {
-        (model, @cmd.none)
-      } else if candidate != editing.text {
-        (
-          Editing({ ..editing, preview: Failed(None) }),
-          @cmd.batch([
-            @preview.discard_cmd(preview_engine, owner.generation),
-            @cmd.delay(
-              emit(PreviewRefreshRequested(owner, editing.text)),
-              PREVIEW_QUIET_MS,
-            ),
-          ]),
-        )
-      } else {
-        match result {
-          Ok(output) if preview_engine.accept(output) =>
-            (
-              Editing({
-                ..editing,
-                preview: Ready(completed_preview(candidate, output)),
-              }),
-              @cmd.none,
-            )
-          Ok(_) | Err(_) =>
-            (Editing({ ..editing, preview: Failed(None) }), @cmd.none)
-        }
-      }
-    (Editing(editing), ParserAdvanced(owner, candidate, retry, result)) =>
-      if owner != editing.activation {
-        (model, @cmd.none)
-      } else {
-        match result {
-          Ok(_) =>
-            (
-              model,
-              @cmd.delay(
-                emit(PreviewRefreshRequested(owner, candidate)),
-                PREVIEW_QUIET_MS,
-              ),
-            )
-          Err(_) => {
-            let command = if retry {
-              @cmd.delay(
-                emit(PreviewRefreshRequested(owner, candidate)),
-                PREVIEW_QUIET_MS,
-              )
-            } else {
-              @cmd.none
-            }
-            (
-              Editing({
-                ..editing,
-                preview: Failed(preview_last(editing.preview)),
-              }),
-              command,
-            )
-          }
-        }
-      }
-    (Editing(editing), PreviewRefreshRequested(owner, candidate)) =>
-      if owner != editing.activation || candidate != editing.text {
-        (model, @cmd.none)
-      } else {
-        match editing.preview {
-          Unrequested | Preparing => (model, @cmd.none)
-          Ready(_) | Failed(_) =>
-            (
-              model,
-              @preview.refresh_cmd(
-                preview_engine,
-                owner.generation,
-                candidate,
-                result=emit.map(result => {
-                  PreviewRefreshed(owner, candidate, result)
-                }),
-              ),
-            )
-        }
-      }
-    (Editing(editing), PreviewRefreshed(owner, candidate, result)) =>
-      if owner != editing.activation || candidate != editing.text {
-        (model, @cmd.none)
-      } else {
-        match result {
-          Ok(output) if preview_engine.accept(output) =>
-            (
-              Editing({
-                ..editing,
-                preview: Ready(completed_preview(candidate, output)),
-              }),
-              @cmd.none,
-            )
-          Ok(_) => (model, @cmd.none)
-          Err(_) =>
-            (
-              Editing({
-                ..editing,
-                preview: Failed(preview_last(editing.preview)),
-              }),
-              @cmd.none,
-            )
-        }
-      }
+    (Editing(editing), PreviewEvent(event)) => {
+      let (preview, command) = preview_engine.update(
+        editing.preview,
+        preview_input(editing),
+        event,
+        emit.map(event => PreviewEvent(event)),
+      )
+      (Editing({ ..editing, preview, }), command)
+    }
     (Loading(_), ViewportChanged(width)) =>
       (Loading(compact_viewport(width)), @cmd.none)
     (Editing(editing), CreateRequested) =>

--- a/apps/loomark/app/update_wbtest.mbt
+++ b/apps/loomark/app/update_wbtest.mbt
@@ -6,6 +6,13 @@ fn test_repository() -> @source_repository.RepositorySnapshot {
 }
 
 ///|
+fn test_preview_state(text : String) -> @preview.State {
+  let engine = @preview.PreviewEngine::PreviewEngine()
+  let (state, _) = engine.activate(@preview.Input(0, text))
+  state
+}
+
+///|
 fn test_editing_state(text : String, save : SaveState) -> EditingState {
   {
     activation: { document_id: "document-1", generation: 0 },
@@ -15,7 +22,7 @@ fn test_editing_state(text : String, save : SaveState) -> EditingState {
     creation: Idle,
     mode: Text,
     compact: false,
-    preview: Unrequested,
+    preview: test_preview_state(text),
     repository: test_repository(),
   }
 }
@@ -65,7 +72,7 @@ test "saved document selection activates its exact Source without writing" {
   assert_eq(editing.activation.generation, 1)
   assert_eq(editing.text, "# Second\n")
   assert_true(editing.save == Saved)
-  assert_true(editing.preview == Unrequested)
+  assert_true(editing.preview == test_preview_state("# Second\n"))
   assert_false(@debug.to_string(command).contains("IndexedDB"))
 }
 
@@ -79,21 +86,6 @@ test "stale activation cannot change current text" {
   let (model, _) = test_update(
     Editing(initial),
     TextChanged(stale, @text_change.TextChange::ReplaceAll("# Stale\n")),
-  )
-  assert_true(model == Editing(initial))
-}
-
-///|
-test "stale activation cannot process a prepared Preview result" {
-  let initial = {
-    ..test_editing_state("# Current\n", Saved),
-    activation: { document_id: "document-1", generation: 1 },
-    preview: Preparing,
-  }
-  let stale : Activation = { document_id: "document-1", generation: 0 }
-  let (model, _) = test_update(
-    Editing(initial),
-    PreviewPrepared(stale, initial.text, Err(OutOfSync)),
   )
   assert_true(model == Editing(initial))
 }

--- a/apps/loomark/app/view.mbt
+++ b/apps/loomark/app/view.mbt
@@ -271,67 +271,6 @@ fn text_area_view(
 }
 
 ///|
-fn preview_result_view(result : PreviewResult) -> @rabbita.Html {
-  if result.empty {
-    @html.p(
-      class="m-0 text-lm-muted",
-      attrs=@html.Attrs::build().role("status"),
-      "Nothing to preview",
-    )
-  } else {
-    result.html
-  }
-}
-
-///|
-fn preview_view(state : PreviewState) -> @rabbita.Html {
-  let (alert, content) = match state {
-    Unrequested => (@html.nothing, @html.nothing)
-    Preparing =>
-      (
-        @html.nothing,
-        @html.p(
-          class="m-0 text-lm-muted",
-          attrs=@html.Attrs::build().role("status"),
-          "Preparing preview…",
-        ),
-      )
-    Ready(result) => (@html.nothing, preview_result_view(result))
-    Failed(None) =>
-      (
-        @html.nothing,
-        @html.p(
-          class="m-0 opacity-100 text-lm-danger transition-opacity duration-[160ms] ease-[cubic-bezier(0.23,1,0.32,1)] starting:opacity-0 motion-reduce:duration-[80ms] motion-reduce:ease-[ease]",
-          attrs=@html.Attrs::build().role("alert"),
-          "Preview could not be prepared.",
-        ),
-      )
-    Failed(Some(result)) =>
-      (
-        @html.div(
-          class="sticky top-0 z-2 border-b border-[oklch(0.78_0.07_25)] bg-lm-danger-soft px-4 py-2.5 text-sm leading-[1.4] text-lm-danger opacity-100 transition-opacity duration-[160ms] ease-[cubic-bezier(0.23,1,0.32,1)] starting:opacity-0 motion-reduce:duration-[80ms] motion-reduce:ease-[ease] max-[641px]:px-3",
-          attrs=@html.Attrs::build().role("alert"),
-          "Preview could not be updated. Showing the last completed preview.",
-        ),
-        preview_result_view(result),
-      )
-  }
-  @html.div(
-    id="loomark-preview-scroll",
-    class="h-full min-h-0 w-full min-w-0 overflow-auto outline-0 focus-visible:shadow-[inset_0_0_0_2px_var(--color-lm-accent)]",
-    attrs=@html.Attrs::build()
-      .role("region")
-      .aria_label("Markdown preview")
-      .tabindex(0),
-    [
-      alert,
-      @html.div(
-        class="prose prose-sm loomark-prose md:prose-base xl:prose-lg mx-auto w-[min(calc(100%-4rem),46rem)] max-w-none min-w-0 px-4 pt-8 pb-16 font-lm-ui max-[641px]:w-full max-[641px]:px-3 max-[641px]:pt-6 max-[641px]:pb-12 [&>*]:min-w-0 [&>*]:break-words",
-        content,
-      ),
-    ],
-  )
-}
 
 ///|
 fn creation_failure_view(

--- a/apps/loomark/app/view_wbtest.mbt
+++ b/apps/loomark/app/view_wbtest.mbt
@@ -1,10 +1,4 @@
 ///|
-#warnings("-alert_unstable")
-fn render_preview_state(state : PreviewState) -> String {
-  @rabbita_testing.server_side_render(() => preview_view(state))
-}
-
-///|
 test "Mode tabs use the RUI Tabs trigger contract" {
   let rendered = @rabbita_testing.server_side_render(() => {
     mode_tab(Text, Preview, @cmd.Emit(_ => @cmd.none))
@@ -49,26 +43,4 @@ test "creation failure explains the result and exposes retry" {
   assert_true(rendered.contains("role=\"alert\""))
   assert_true(rendered.contains("Browser storage is full."))
   assert_true(rendered.contains("Retry creating"))
-}
-
-///|
-test "Preview view distinguishes preparing initial failure and stale result" {
-  let preparing = render_preview_state(Preparing)
-  assert_true(preparing.contains("role=\"status\""))
-  assert_true(preparing.contains("Preparing preview…"))
-  assert_true(
-    preparing.contains("prose prose-sm loomark-prose md:prose-base xl:prose-lg"),
-  )
-
-  let initial_failure = render_preview_state(Failed(None))
-  assert_true(initial_failure.contains("role=\"alert\""))
-  assert_true(initial_failure.contains("Preview could not be prepared."))
-
-  let stale = render_preview_state(
-    Failed(
-      Some({ text: "# Last good\n", html: @html.h1("Last good"), empty: false }),
-    ),
-  )
-  assert_true(stale.contains("Showing the last completed preview."))
-  assert_true(stale.contains(">Last good</h1>"))
 }

--- a/apps/loomark/internal/preview/engine.mbt
+++ b/apps/loomark/internal/preview/engine.mbt
@@ -1,5 +1,6 @@
 ///|
-pub(all) enum PreviewFailure {
+#warnings("-unused_value")
+priv enum PreviewFailure {
   InitializationFailed
   TransitionFailed
   OutOfSync
@@ -31,10 +32,11 @@ priv struct PendingMarkdownRender {
 }
 
 ///|
-pub(all) struct PreviewOutput {
+#warnings("-unused_value")
+priv struct PreviewOutput {
   html : @rabbita.Html
   empty : Bool
-  priv acceptance : PreviewAcceptance
+  acceptance : PreviewAcceptance
 } derive(Eq)
 
 ///|
@@ -74,7 +76,10 @@ pub fn PreviewEngine::PreviewEngine() -> PreviewEngine {
 }
 
 ///|
-fn PreviewEngine::activate(self : PreviewEngine, generation : Int) -> Bool {
+fn PreviewEngine::activate_generation(
+  self : PreviewEngine,
+  generation : Int,
+) -> Bool {
   match self.owner_generation {
     Some(current) if generation <= current => false
     None | Some(_) => {
@@ -182,11 +187,8 @@ fn PreviewEngine::output(
 }
 
 ///|
-/// Accept renderer state only after the app accepts this exact output.
-pub fn PreviewEngine::accept(
-  self : PreviewEngine,
-  output : PreviewOutput,
-) -> Bool {
+/// Accept renderer state only after the Preview lifecycle admits this output.
+fn PreviewEngine::accept(self : PreviewEngine, output : PreviewOutput) -> Bool {
   guard self.pending_render is Some(pending) else { return false }
   guard physical_equal(output.acceptance.domain, self.acceptance_domain) &&
     output.acceptance.sequence == pending.acceptance.sequence &&
@@ -338,71 +340,4 @@ fn PreviewEngine::discard_owned(self : PreviewEngine, generation : Int) -> Bool 
   guard self.owns(generation) else { return false }
   self.discard()
   true
-}
-
-///|
-/// Emit a command after DOM patching and one animation-frame boundary. The
-/// zero-delay task after the frame gives the patched Preparing state a paint
-/// opportunity before synchronous Parser construction starts.
-pub fn after_paint(command : @cmd.Cmd) -> @cmd.Cmd {
-  @cmd.custom_cmd(kind=@cmd.after_render, scheduler => {
-    ignore(
-      @dom.window().request_animation_frame(_ => {
-        ignore(@dom.window().set_timeout(() => scheduler.add(command), 0))
-      }),
-    )
-  })
-}
-
-///|
-pub fn activate_cmd(engine : PreviewEngine, generation : Int) -> @cmd.Cmd {
-  @cmd.custom_cmd(_ => ignore(engine.activate(generation)))
-}
-
-///|
-pub fn prepare_cmd(
-  engine : PreviewEngine,
-  generation : Int,
-  source : String,
-  result~ : @cmd.Emit[Result[PreviewOutput, PreviewFailure]],
-) -> @cmd.Cmd {
-  @cmd.custom_cmd(scheduler => {
-    if engine.prepare_owned(generation, source) is Some(output) {
-      scheduler.add(result(output))
-    }
-  })
-}
-
-///|
-pub fn apply_cmd(
-  engine : PreviewEngine,
-  generation : Int,
-  change : @text_change.TextChange,
-  source : String,
-  result~ : @cmd.Emit[Result[Unit, PreviewFailure]],
-) -> @cmd.Cmd {
-  @cmd.custom_cmd(scheduler => {
-    if engine.apply_owned(generation, change, source) is Some(output) {
-      scheduler.add(result(output))
-    }
-  })
-}
-
-///|
-pub fn refresh_cmd(
-  engine : PreviewEngine,
-  generation : Int,
-  source : String,
-  result~ : @cmd.Emit[Result[PreviewOutput, PreviewFailure]],
-) -> @cmd.Cmd {
-  @cmd.custom_cmd(scheduler => {
-    if engine.refresh_owned(generation, source) is Some(output) {
-      scheduler.add(result(output))
-    }
-  })
-}
-
-///|
-pub fn discard_cmd(engine : PreviewEngine, generation : Int) -> @cmd.Cmd {
-  @cmd.custom_cmd(_ => ignore(engine.discard_owned(generation)))
 }

--- a/apps/loomark/internal/preview/engine_wbtest.mbt
+++ b/apps/loomark/internal/preview/engine_wbtest.mbt
@@ -1,13 +1,13 @@
 ///|
 test "PreviewEngine rejects an operation owned by an older activation" {
   let engine = PreviewEngine::PreviewEngine()
-  assert_true(engine.activate(1))
+  assert_true(engine.activate_generation(1))
   guard engine.prepare_owned(1, "# First\n") is Some(Ok(first)) else {
     fail("current activation should prepare")
   }
   assert_true(engine.accept(first))
   let next_lazy_key_floor = engine.next_lazy_key
-  assert_true(engine.activate(2))
+  assert_true(engine.activate_generation(2))
   guard engine.prepare_owned(1, "# Stale\n") is None else {
     fail("stale activation should not prepare")
   }
@@ -34,7 +34,7 @@ test "PreviewEngine rejects an operation owned by an older activation" {
     Healthy(source~, ..) => assert_eq(source, "# Current\n")
     NoPair | Broken => fail("stale operation changed current parser")
   }
-  assert_false(engine.activate(1))
+  assert_false(engine.activate_generation(1))
 }
 
 ///|

--- a/apps/loomark/internal/preview/lifecycle.mbt
+++ b/apps/loomark/internal/preview/lifecycle.mbt
@@ -1,0 +1,251 @@
+///|
+const PREVIEW_QUIET_MS : Int = 24
+
+///|
+/// Current app-owned facts needed by the Preview lifecycle.
+///
+/// Document text remains owned by the app Model. A captured Input identifies
+/// the activation and text from which one Preview operation was requested; it
+/// is not a request identity or a second text authority.
+pub struct Input {
+  priv generation : Int
+  priv document_text : String
+} derive(Eq)
+
+///|
+pub fn Input::Input(generation : Int, document_text : String) -> Input {
+  { generation, document_text }
+}
+
+///|
+priv struct RenderedPreview {
+  document_text : String
+  html : @rabbita.Html
+  empty : Bool
+} derive(Eq)
+
+///|
+priv enum Phase {
+  Unrequested
+  Preparing
+  Ready(RenderedPreview)
+  Failed(RenderedPreview?)
+} derive(Eq)
+
+///|
+/// Plain Preview presentation state retained in the Rabbita Model.
+pub struct State {
+  priv phase : Phase
+} derive(Eq)
+
+///|
+priv enum EventKind {
+  BeginPreparation(Int)
+  Prepared(Input, Result[PreviewOutput, PreviewFailure])
+  ParserAdvanced(Input, Bool, Result[Unit, PreviewFailure])
+  RefreshRequested(Input)
+  Refreshed(Input, Result[PreviewOutput, PreviewFailure])
+}
+
+///|
+/// Opaque completion from Preview commands back into the Rabbita update loop.
+pub struct Event {
+  priv kind : EventKind
+}
+
+///|
+fn PreviewEngine::activate_command(
+  self : PreviewEngine,
+  generation : Int,
+) -> @cmd.Cmd {
+  @cmd.custom_cmd(_ => ignore(self.activate_generation(generation)))
+}
+
+///|
+fn after_paint(command : @cmd.Cmd) -> @cmd.Cmd {
+  @cmd.custom_cmd(kind=@cmd.after_render, scheduler => {
+    ignore(
+      @dom.window().request_animation_frame(_ => {
+        ignore(@dom.window().set_timeout(() => scheduler.add(command), 0))
+      }),
+    )
+  })
+}
+
+///|
+fn PreviewEngine::prepare_command(
+  self : PreviewEngine,
+  input : Input,
+  emit : @cmd.Emit[Event],
+) -> @cmd.Cmd {
+  @cmd.custom_cmd(scheduler => {
+    if self.prepare_owned(input.generation, input.document_text) is Some(result) {
+      scheduler.add(emit({ kind: Prepared(input, result) }))
+    }
+  })
+}
+
+///|
+fn PreviewEngine::apply_command(
+  self : PreviewEngine,
+  input : Input,
+  change : @text_change.TextChange,
+  retry : Bool,
+  emit : @cmd.Emit[Event],
+) -> @cmd.Cmd {
+  @cmd.custom_cmd(scheduler => {
+    if self.apply_owned(input.generation, change, input.document_text)
+      is Some(result) {
+      scheduler.add(emit({ kind: ParserAdvanced(input, retry, result) }))
+    }
+  })
+}
+
+///|
+fn PreviewEngine::refresh_command(
+  self : PreviewEngine,
+  input : Input,
+  emit : @cmd.Emit[Event],
+) -> @cmd.Cmd {
+  @cmd.custom_cmd(scheduler => {
+    if self.refresh_owned(input.generation, input.document_text) is Some(result) {
+      scheduler.add(emit({ kind: Refreshed(input, result) }))
+    }
+  })
+}
+
+///|
+fn PreviewEngine::discard_command(
+  self : PreviewEngine,
+  generation : Int,
+) -> @cmd.Cmd {
+  @cmd.custom_cmd(_ => ignore(self.discard_owned(generation)))
+}
+
+///|
+/// Activate Preview ownership for a selected Loomark document.
+pub fn PreviewEngine::activate(
+  self : PreviewEngine,
+  input : Input,
+) -> (State, @cmd.Cmd) {
+  ({ phase: Unrequested }, self.activate_command(input.generation))
+}
+
+///|
+/// Request Preview after Preview or Split becomes visible.
+pub fn PreviewEngine::request(
+  self : PreviewEngine,
+  state : State,
+  input : Input,
+  emit : @cmd.Emit[Event],
+) -> (State, @cmd.Cmd) {
+  match state.phase {
+    Unrequested =>
+      (
+        { phase: Preparing },
+        after_paint(emit({ kind: BeginPreparation(input.generation) })),
+      )
+    Failed(_) => (state, self.refresh_command(input, emit))
+    Preparing | Ready(_) => (state, @cmd.none)
+  }
+}
+
+///|
+/// Advance the long-lived Parser immediately after one committed Document edit.
+pub fn PreviewEngine::document_changed(
+  self : PreviewEngine,
+  state : State,
+  input : Input,
+  change : @text_change.TextChange,
+  emit : @cmd.Emit[Event],
+) -> (State, @cmd.Cmd) {
+  match state.phase {
+    Unrequested | Preparing => (state, @cmd.none)
+    Ready(_) => (state, self.apply_command(input, change, false, emit))
+    Failed(_) => (state, self.apply_command(input, change, true, emit))
+  }
+}
+
+///|
+/// Admit one Preview completion against the current app-owned Input.
+pub fn PreviewEngine::update(
+  self : PreviewEngine,
+  state : State,
+  current : Input,
+  event : Event,
+  emit : @cmd.Emit[Event],
+) -> (State, @cmd.Cmd) {
+  match event.kind {
+    BeginPreparation(generation) if generation == current.generation &&
+      state.phase is Preparing => (state, self.prepare_command(current, emit))
+    Prepared(input, result) if input.generation == current.generation &&
+      state.phase is Preparing =>
+      if input.document_text != current.document_text {
+        (
+          { phase: Failed(None) },
+          @cmd.batch([
+            self.discard_command(current.generation),
+            @cmd.delay(
+              emit({ kind: RefreshRequested(current) }),
+              PREVIEW_QUIET_MS,
+            ),
+          ]),
+        )
+      } else {
+        match result {
+          Ok(output) if self.accept(output) =>
+            ({ phase: Ready(completed_preview(input, output)) }, @cmd.none)
+          Ok(_) | Err(_) => ({ phase: Failed(None) }, @cmd.none)
+        }
+      }
+    ParserAdvanced(input, retry, result) if input == current =>
+      match result {
+        Ok(_) =>
+          (
+            state,
+            @cmd.delay(
+              emit({ kind: RefreshRequested(input) }),
+              PREVIEW_QUIET_MS,
+            ),
+          )
+        Err(_) => {
+          let command = if retry {
+            @cmd.delay(
+              emit({ kind: RefreshRequested(input) }),
+              PREVIEW_QUIET_MS,
+            )
+          } else {
+            @cmd.none
+          }
+          ({ phase: Failed(last_preview(state.phase)) }, command)
+        }
+      }
+    RefreshRequested(input) if input == current =>
+      match state.phase {
+        Ready(_) | Failed(_) => (state, self.refresh_command(input, emit))
+        Unrequested | Preparing => (state, @cmd.none)
+      }
+    Refreshed(input, result) if input == current =>
+      match result {
+        Ok(output) if self.accept(output) =>
+          ({ phase: Ready(completed_preview(input, output)) }, @cmd.none)
+        Ok(_) => (state, @cmd.none)
+        Err(_) => ({ phase: Failed(last_preview(state.phase)) }, @cmd.none)
+      }
+    _ => (state, @cmd.none)
+  }
+}
+
+///|
+fn completed_preview(input : Input, output : PreviewOutput) -> RenderedPreview {
+  { document_text: input.document_text, html: output.html, empty: output.empty }
+}
+
+///|
+fn last_preview(phase : Phase) -> RenderedPreview? {
+  match phase {
+    Ready(preview) => Some(preview)
+    Failed(preview) => preview
+    Unrequested | Preparing => None
+  }
+}

--- a/apps/loomark/internal/preview/lifecycle.mbt
+++ b/apps/loomark/internal/preview/lifecycle.mbt
@@ -54,6 +54,131 @@ pub struct Event {
 }
 
 ///|
+/// Inputs accepted by the deterministic Preview lifecycle core.
+priv enum PreviewInputEvent {
+  Activated
+  Requested
+  DocumentChanged(@text_change.TextChange)
+  Complete(EventKind)
+}
+
+///|
+/// Domain-specific work selected by the pure lifecycle core for the imperative
+/// PreviewEngine shell. Rabbita Cmd remains the sole effect representation.
+priv enum PreviewDecision {
+  NoCommand
+  ActivateGeneration(Int)
+  BeginPreparationAfterPaint(Int)
+  Prepare(Input)
+  Apply(Input, @text_change.TextChange, Bool)
+  DiscardAndScheduleRefresh(Input)
+  ScheduleRefresh(Input)
+  Refresh(Input)
+  Admit(PreviewOutput, State, State)
+}
+
+///|
+priv struct PreviewTransition {
+  state : State
+  decision : PreviewDecision
+}
+
+///|
+/// Deterministically select the next Preview state and shell work.
+///
+/// This boundary neither reads nor mutates PreviewEngine and performs no I/O.
+fn preview_transition(
+  state : State,
+  current : Input,
+  event : PreviewInputEvent,
+) -> PreviewTransition {
+  match event {
+    Activated =>
+      {
+        state: { phase: Unrequested },
+        decision: ActivateGeneration(current.generation),
+      }
+    Requested =>
+      match state.phase {
+        Unrequested =>
+          {
+            state: { phase: Preparing },
+            decision: BeginPreparationAfterPaint(current.generation),
+          }
+        Failed(_) => { state, decision: Refresh(current) }
+        Preparing | Ready(_) => { state, decision: NoCommand }
+      }
+    DocumentChanged(change) =>
+      match state.phase {
+        Unrequested | Preparing => { state, decision: NoCommand }
+        Ready(_) => { state, decision: Apply(current, change, false) }
+        Failed(_) => { state, decision: Apply(current, change, true) }
+      }
+    Complete(completion) =>
+      match completion {
+        BeginPreparation(generation) if generation == current.generation &&
+          state.phase is Preparing => { state, decision: Prepare(current) }
+        Prepared(input, _) if input.generation == current.generation &&
+          state.phase is Preparing &&
+          input.document_text != current.document_text =>
+          {
+            state: { phase: Failed(None) },
+            decision: DiscardAndScheduleRefresh(current),
+          }
+        Prepared(input, result) if input == current && state.phase is Preparing =>
+          match result {
+            Ok(output) =>
+              {
+                state,
+                decision: Admit(
+                  output,
+                  { phase: Ready(completed_preview(input, output)) },
+                  { phase: Failed(None) },
+                ),
+              }
+            Err(_) => { state: { phase: Failed(None) }, decision: NoCommand }
+          }
+        ParserAdvanced(input, retry, result) if input == current =>
+          match result {
+            Ok(_) => { state, decision: ScheduleRefresh(input) }
+            Err(_) =>
+              {
+                state: { phase: Failed(last_preview(state.phase)) },
+                decision: if retry {
+                  ScheduleRefresh(input)
+                } else {
+                  NoCommand
+                },
+              }
+          }
+        RefreshRequested(input) if input == current =>
+          match state.phase {
+            Ready(_) | Failed(_) => { state, decision: Refresh(input) }
+            Unrequested | Preparing => { state, decision: NoCommand }
+          }
+        Refreshed(input, result) if input == current =>
+          match result {
+            Ok(output) =>
+              {
+                state,
+                decision: Admit(
+                  output,
+                  { phase: Ready(completed_preview(input, output)) },
+                  state,
+                ),
+              }
+            Err(_) =>
+              {
+                state: { phase: Failed(last_preview(state.phase)) },
+                decision: NoCommand,
+              }
+          }
+        _ => { state, decision: NoCommand }
+      }
+  }
+}
+
+///|
 fn PreviewEngine::activate_command(
   self : PreviewEngine,
   generation : Int,
@@ -123,12 +248,55 @@ fn PreviewEngine::discard_command(
 }
 
 ///|
+/// Interpret one pure lifecycle decision in the imperative PreviewEngine shell.
+fn PreviewEngine::execute(
+  self : PreviewEngine,
+  transition : PreviewTransition,
+  emit : @cmd.Emit[Event],
+) -> (State, @cmd.Cmd) {
+  match transition.decision {
+    NoCommand => (transition.state, @cmd.none)
+    ActivateGeneration(generation) =>
+      (transition.state, self.activate_command(generation))
+    BeginPreparationAfterPaint(generation) =>
+      (
+        transition.state,
+        after_paint(emit({ kind: BeginPreparation(generation) })),
+      )
+    Prepare(input) => (transition.state, self.prepare_command(input, emit))
+    Apply(input, change, retry) =>
+      (transition.state, self.apply_command(input, change, retry, emit))
+    DiscardAndScheduleRefresh(input) =>
+      (
+        transition.state,
+        @cmd.batch([
+          self.discard_command(input.generation),
+          @cmd.delay(emit({ kind: RefreshRequested(input) }), PREVIEW_QUIET_MS),
+        ]),
+      )
+    ScheduleRefresh(input) =>
+      (
+        transition.state,
+        @cmd.delay(emit({ kind: RefreshRequested(input) }), PREVIEW_QUIET_MS),
+      )
+    Refresh(input) => (transition.state, self.refresh_command(input, emit))
+    Admit(output, accepted, rejected) =>
+      (if self.accept(output) { accepted } else { rejected }, @cmd.none)
+  }
+}
+
+///|
 /// Activate Preview ownership for a selected Loomark document.
 pub fn PreviewEngine::activate(
   self : PreviewEngine,
   input : Input,
 ) -> (State, @cmd.Cmd) {
-  ({ phase: Unrequested }, self.activate_command(input.generation))
+  let transition = preview_transition({ phase: Unrequested }, input, Activated)
+  match transition.decision {
+    ActivateGeneration(generation) =>
+      (transition.state, self.activate_command(generation))
+    _ => (transition.state, @cmd.none)
+  }
 }
 
 ///|
@@ -139,15 +307,7 @@ pub fn PreviewEngine::request(
   input : Input,
   emit : @cmd.Emit[Event],
 ) -> (State, @cmd.Cmd) {
-  match state.phase {
-    Unrequested =>
-      (
-        { phase: Preparing },
-        after_paint(emit({ kind: BeginPreparation(input.generation) })),
-      )
-    Failed(_) => (state, self.refresh_command(input, emit))
-    Preparing | Ready(_) => (state, @cmd.none)
-  }
+  self.execute(preview_transition(state, input, Requested), emit)
 }
 
 ///|
@@ -159,11 +319,7 @@ pub fn PreviewEngine::document_changed(
   change : @text_change.TextChange,
   emit : @cmd.Emit[Event],
 ) -> (State, @cmd.Cmd) {
-  match state.phase {
-    Unrequested | Preparing => (state, @cmd.none)
-    Ready(_) => (state, self.apply_command(input, change, false, emit))
-    Failed(_) => (state, self.apply_command(input, change, true, emit))
-  }
+  self.execute(preview_transition(state, input, DocumentChanged(change)), emit)
 }
 
 ///|
@@ -175,65 +331,7 @@ pub fn PreviewEngine::update(
   event : Event,
   emit : @cmd.Emit[Event],
 ) -> (State, @cmd.Cmd) {
-  match event.kind {
-    BeginPreparation(generation) if generation == current.generation &&
-      state.phase is Preparing => (state, self.prepare_command(current, emit))
-    Prepared(input, result) if input.generation == current.generation &&
-      state.phase is Preparing =>
-      if input.document_text != current.document_text {
-        (
-          { phase: Failed(None) },
-          @cmd.batch([
-            self.discard_command(current.generation),
-            @cmd.delay(
-              emit({ kind: RefreshRequested(current) }),
-              PREVIEW_QUIET_MS,
-            ),
-          ]),
-        )
-      } else {
-        match result {
-          Ok(output) if self.accept(output) =>
-            ({ phase: Ready(completed_preview(input, output)) }, @cmd.none)
-          Ok(_) | Err(_) => ({ phase: Failed(None) }, @cmd.none)
-        }
-      }
-    ParserAdvanced(input, retry, result) if input == current =>
-      match result {
-        Ok(_) =>
-          (
-            state,
-            @cmd.delay(
-              emit({ kind: RefreshRequested(input) }),
-              PREVIEW_QUIET_MS,
-            ),
-          )
-        Err(_) => {
-          let command = if retry {
-            @cmd.delay(
-              emit({ kind: RefreshRequested(input) }),
-              PREVIEW_QUIET_MS,
-            )
-          } else {
-            @cmd.none
-          }
-          ({ phase: Failed(last_preview(state.phase)) }, command)
-        }
-      }
-    RefreshRequested(input) if input == current =>
-      match state.phase {
-        Ready(_) | Failed(_) => (state, self.refresh_command(input, emit))
-        Unrequested | Preparing => (state, @cmd.none)
-      }
-    Refreshed(input, result) if input == current =>
-      match result {
-        Ok(output) if self.accept(output) =>
-          ({ phase: Ready(completed_preview(input, output)) }, @cmd.none)
-        Ok(_) => (state, @cmd.none)
-        Err(_) => ({ phase: Failed(last_preview(state.phase)) }, @cmd.none)
-      }
-    _ => (state, @cmd.none)
-  }
+  self.execute(preview_transition(state, current, Complete(event.kind)), emit)
 }
 
 ///|

--- a/apps/loomark/internal/preview/lifecycle_wbtest.mbt
+++ b/apps/loomark/internal/preview/lifecycle_wbtest.mbt
@@ -1,0 +1,150 @@
+///|
+fn lifecycle_emit() -> @cmd.Emit[Event] {
+  @cmd.Emit(_ => @cmd.none)
+}
+
+///|
+#warnings("-alert_unstable")
+fn render_lifecycle_state(state : State) -> String {
+  @rabbita_testing.server_side_render(() => state.view())
+}
+
+///|
+test "request exposes Preparing before cold preparation" {
+  let engine = PreviewEngine::PreviewEngine()
+  let input = Input(1, "# Current\n")
+  let (initial, _) = engine.activate(input)
+  let (preparing, command) = engine.request(initial, input, lifecycle_emit())
+  let rendered = render_lifecycle_state(preparing)
+  assert_true(rendered.contains("role=\"status\""))
+  assert_true(rendered.contains("Preparing preview…"))
+  ignore(command)
+}
+
+///|
+test "older activation completion cannot affect current Preview state" {
+  let engine = PreviewEngine::PreviewEngine()
+  let state : State = { phase: Preparing }
+  let stale = Input(1, "# Old document\n")
+  let current = Input(2, "# Current document\n")
+  let (after, _) = engine.update(
+    state,
+    current,
+    { kind: Prepared(stale, Err(OutOfSync)) },
+    lifecycle_emit(),
+  )
+  assert_true(after == state)
+}
+
+///|
+test "same-activation stale Parser completion cannot affect current Input" {
+  let engine = PreviewEngine::PreviewEngine()
+  assert_true(engine.activate_generation(1))
+  let input_a = Input(1, "# Candidate A\n")
+  guard engine.prepare_owned(1, input_a.document_text) is Some(Ok(output)) else {
+    fail("candidate A should prepare")
+  }
+  let (ready, _) = engine.update(
+    { phase: Preparing },
+    input_a,
+    { kind: Prepared(input_a, Ok(output)) },
+    lifecycle_emit(),
+  )
+  let input_b = Input(1, "# Current B\n")
+  for result in [Ok(()), Err(Unusable)] {
+    let (after, _) = engine.update(
+      ready,
+      input_b,
+      { kind: ParserAdvanced(input_a, true, result) },
+      lifecycle_emit(),
+    )
+    assert_true(after == ready)
+  }
+}
+
+///|
+test "A-B-A admits an equal-input preparation and Parser completion" {
+  let engine = PreviewEngine::PreviewEngine()
+  assert_true(engine.activate_generation(1))
+  let first_a = Input(1, "# A\n")
+  guard engine.prepare_owned(1, first_a.document_text) is Some(Ok(output)) else {
+    fail("first A should prepare")
+  }
+  let preparing : State = { phase: Preparing }
+  let input_b = Input(1, "# B\n")
+  let (after_b, _) = engine.document_changed(
+    preparing,
+    input_b,
+    @text_change.ReplaceAll(input_b.document_text),
+    lifecycle_emit(),
+  )
+  let current_a = Input(1, "# A\n")
+  let (after_a, _) = engine.document_changed(
+    after_b,
+    current_a,
+    @text_change.ReplaceAll(current_a.document_text),
+    lifecycle_emit(),
+  )
+  assert_true(first_a != input_b)
+  assert_true(first_a == current_a)
+  let (ready, _) = engine.update(
+    after_a,
+    current_a,
+    { kind: Prepared(first_a, Ok(output)) },
+    lifecycle_emit(),
+  )
+  assert_true(ready.phase is Ready(_))
+
+  let (after_success, _) = engine.update(
+    ready,
+    current_a,
+    { kind: ParserAdvanced(first_a, false, Ok(())) },
+    lifecycle_emit(),
+  )
+  assert_true(after_success == ready)
+
+  let (after_failure, _) = engine.update(
+    ready,
+    current_a,
+    { kind: ParserAdvanced(first_a, false, Err(TransitionFailed)) },
+    lifecycle_emit(),
+  )
+  assert_true(after_failure.phase is Failed(Some(_)))
+}
+
+///|
+test "preparation completed for stale text converges on current Input" {
+  let engine = PreviewEngine::PreviewEngine()
+  assert_true(engine.activate_generation(1))
+  let input_a = Input(1, "# Candidate A\n")
+  guard engine.prepare_owned(1, input_a.document_text) is Some(Ok(output)) else {
+    fail("candidate A should prepare")
+  }
+  let input_b = Input(1, "# Current B\n")
+  let (state, _) = engine.update(
+    { phase: Preparing },
+    input_b,
+    { kind: Prepared(input_a, Ok(output)) },
+    lifecycle_emit(),
+  )
+  assert_true(state.phase is Failed(None))
+}
+
+///|
+test "Preview view distinguishes initial failure and retained stale Preview" {
+  let failed = render_lifecycle_state({ phase: Failed(None) })
+  assert_true(failed.contains("role=\"alert\""))
+  assert_true(failed.contains("Preview could not be prepared."))
+
+  let stale = render_lifecycle_state({
+    phase: Failed(
+      Some({
+        document_text: "# Previous\n",
+        html: @html.p("Previous preview"),
+        empty: false,
+      }),
+    ),
+  })
+  assert_true(stale.contains("Showing the last completed preview."))
+  assert_true(stale.contains("Previous preview"))
+}

--- a/apps/loomark/internal/preview/lifecycle_wbtest.mbt
+++ b/apps/loomark/internal/preview/lifecycle_wbtest.mbt
@@ -131,6 +131,78 @@ test "preparation completed for stale text converges on current Input" {
 }
 
 ///|
+test "pure reducer decides stale preparation recovery without PreviewEngine" {
+  let input_a = Input(1, "# Candidate A\n")
+  let current_b = Input(1, "# Current B\n")
+  let transition = preview_transition(
+    { phase: Preparing },
+    current_b,
+    Complete(Prepared(input_a, Err(OutOfSync))),
+  )
+  assert_true(transition.state.phase is Failed(None))
+  assert_true(
+    transition.decision is DiscardAndScheduleRefresh(input) &&
+    input == current_b,
+  )
+}
+
+///|
+priv struct LifecycleCmdHarness {
+  engine : PreviewEngine
+  mut state : State
+  mut current : Input
+}
+
+///|
+fn LifecycleCmdHarness::emit(self : LifecycleCmdHarness) -> @cmd.Emit[Event] {
+  @cmd.Emit(event => {
+    @cmd.custom_cmd(scheduler => {
+      let (state, command) = self.engine.update(
+        self.state,
+        self.current,
+        event,
+        self.emit(),
+      )
+      self.state = state
+      scheduler.add(command)
+    })
+  })
+}
+
+///|
+async test "stale preparation command converges current Preview to Ready" {
+  let engine = PreviewEngine::PreviewEngine()
+  let input_a = Input(1, "# Candidate A\n")
+  let (initial, activate_command) = engine.activate(input_a)
+  @rabbita_testing.run_cmd(activate_command)
+  let harness = LifecycleCmdHarness::{
+    engine,
+    state: initial,
+    current: input_a,
+  }
+  let (preparing, _) = engine.request(initial, input_a, harness.emit())
+  harness.state = preparing
+  let (still_preparing, preparation_command) = engine.update(
+    harness.state,
+    harness.current,
+    { kind: BeginPreparation(input_a.generation) },
+    harness.emit(),
+  )
+  harness.state = still_preparing
+  let current_b = Input(1, "# Current B\n")
+  let make_preparation_stale = @cmd.custom_cmd(_ => harness.current = current_b)
+
+  @rabbita_testing.run_cmd(
+    @cmd.batch([preparation_command, make_preparation_stale]),
+  )
+
+  assert_true(harness.state.phase is Ready(_))
+  let rendered = render_lifecycle_state(harness.state)
+  assert_true(rendered.contains("Current B"))
+  assert_false(rendered.contains("Candidate A"))
+}
+
+///|
 test "Preview view distinguishes initial failure and retained stale Preview" {
   let failed = render_lifecycle_state({ phase: Failed(None) })
   assert_true(failed.contains("role=\"alert\""))

--- a/apps/loomark/internal/preview/moon.pkg
+++ b/apps/loomark/internal/preview/moon.pkg
@@ -10,6 +10,7 @@ import {
 
 import {
   "moonbit-community/rabbita/testing" @rabbita_testing,
+  "moonbitlang/async",
   "moonbitlang/core/bench",
 } for "wbtest"
 

--- a/apps/loomark/internal/preview/pkg.generated.mbti
+++ b/apps/loomark/internal/preview/pkg.generated.mbti
@@ -2,51 +2,38 @@
 package "dowdiness/loomark/internal/preview"
 
 import {
-  "dowdiness/markdown",
   "dowdiness/text_change",
   "moonbit-community/rabbita/cmd",
   "moonbit-community/rabbita/html",
-  "moonbitlang/core/debug",
 }
 
 // Values
-pub fn activate_cmd(PreviewEngine, Int) -> @cmd.Cmd
-
-pub fn after_paint(@cmd.Cmd) -> @cmd.Cmd
-
-pub fn apply_cmd(PreviewEngine, Int, @text_change.TextChange, String, result~ : @cmd.Emit[Result[Unit, PreviewFailure]]) -> @cmd.Cmd
-
-pub fn discard_cmd(PreviewEngine, Int) -> @cmd.Cmd
-
-pub fn is_empty(@markdown.MarkdownNode) -> Bool
-
-pub fn prepare_cmd(PreviewEngine, Int, String, result~ : @cmd.Emit[Result[PreviewOutput, PreviewFailure]]) -> @cmd.Cmd
-
-pub fn refresh_cmd(PreviewEngine, Int, String, result~ : @cmd.Emit[Result[PreviewOutput, PreviewFailure]]) -> @cmd.Cmd
-
-pub fn render(@markdown.MarkdownNode) -> @html.Html
 
 // Errors
 
 // Types and methods
+pub struct Event {
+  // private fields
+}
+
+pub struct Input {
+  // private fields
+} derive(Eq)
+pub fn Input::Input(Int, String) -> Self
+
 pub struct PreviewEngine {
   // private fields
 }
 pub fn PreviewEngine::PreviewEngine() -> Self
-pub fn PreviewEngine::accept(Self, PreviewOutput) -> Bool
+pub fn PreviewEngine::activate(Self, Input) -> (State, @cmd.Cmd)
+pub fn PreviewEngine::document_changed(Self, State, Input, @text_change.TextChange, @cmd.Emit[Event]) -> (State, @cmd.Cmd)
+pub fn PreviewEngine::request(Self, State, Input, @cmd.Emit[Event]) -> (State, @cmd.Cmd)
+pub fn PreviewEngine::update(Self, State, Input, Event, @cmd.Emit[Event]) -> (State, @cmd.Cmd)
 
-pub(all) enum PreviewFailure {
-  InitializationFailed
-  TransitionFailed
-  OutOfSync
-  Unusable
-} derive(Eq, @debug.Debug)
-
-pub(all) struct PreviewOutput {
-  html : @html.Html
-  empty : Bool
+pub struct State {
   // private fields
 } derive(Eq)
+pub fn State::view(Self) -> @html.Html
 
 // Type aliases
 

--- a/apps/loomark/internal/preview/renderer.mbt
+++ b/apps/loomark/internal/preview/renderer.mbt
@@ -393,7 +393,8 @@ fn render_node(
 
 ///|
 /// Render one opaque semantic Markdown root as typed Rabbita Html.
-pub fn render(root : @markdown.MarkdownNode) -> @rabbita.Html {
+#warnings("-unused_value")
+fn render(root : @markdown.MarkdownNode) -> @rabbita.Html {
   render_node(root)
 }
 
@@ -416,6 +417,7 @@ fn render_top_level_blocks(
 
 ///|
 /// Report whether a semantic root has no renderable top-level children.
-pub fn is_empty(root : @markdown.MarkdownNode) -> Bool {
+#warnings("-unused_value")
+fn is_empty(root : @markdown.MarkdownNode) -> Bool {
   root.children().is_empty()
 }

--- a/apps/loomark/internal/preview/view.mbt
+++ b/apps/loomark/internal/preview/view.mbt
@@ -1,0 +1,65 @@
+///|
+fn preview_result_view(preview : RenderedPreview) -> @rabbita.Html {
+  if preview.empty {
+    @html.p(
+      class="m-0 text-lm-muted",
+      attrs=@html.Attrs::build().role("status"),
+      "Nothing to preview",
+    )
+  } else {
+    preview.html
+  }
+}
+
+///|
+pub fn State::view(self : State) -> @rabbita.Html {
+  let (alert, content) = match self.phase {
+    Unrequested | Preparing =>
+      (
+        @html.nothing,
+        if self.phase is Preparing {
+          @html.p(
+            class="m-0 text-lm-muted",
+            attrs=@html.Attrs::build().role("status"),
+            "Preparing preview…",
+          )
+        } else {
+          @html.nothing
+        },
+      )
+    Ready(output) => (@html.nothing, preview_result_view(output))
+    Failed(None) =>
+      (
+        @html.nothing,
+        @html.p(
+          class="m-0 opacity-100 text-lm-danger transition-opacity duration-[160ms] ease-[cubic-bezier(0.23,1,0.32,1)] starting:opacity-0 motion-reduce:duration-[80ms] motion-reduce:ease-[ease]",
+          attrs=@html.Attrs::build().role("alert"),
+          "Preview could not be prepared.",
+        ),
+      )
+    Failed(Some(output)) =>
+      (
+        @html.div(
+          class="sticky top-0 z-2 border-b border-[oklch(0.78_0.07_25)] bg-lm-danger-soft px-4 py-2.5 text-sm leading-[1.4] text-lm-danger opacity-100 transition-opacity duration-[160ms] ease-[cubic-bezier(0.23,1,0.32,1)] starting:opacity-0 motion-reduce:duration-[80ms] motion-reduce:ease-[ease] max-[641px]:px-3",
+          attrs=@html.Attrs::build().role("alert"),
+          "Preview could not be updated. Showing the last completed preview.",
+        ),
+        preview_result_view(output),
+      )
+  }
+  @html.div(
+    id="loomark-preview-scroll",
+    class="h-full min-h-0 w-full min-w-0 overflow-auto outline-0 focus-visible:shadow-[inset_0_0_0_2px_var(--color-lm-accent)]",
+    attrs=@html.Attrs::build()
+      .role("region")
+      .aria_label("Markdown preview")
+      .tabindex(0),
+    [
+      alert,
+      @html.div(
+        class="prose prose-sm loomark-prose md:prose-base xl:prose-lg mx-auto w-[min(calc(100%-4rem),46rem)] max-w-none min-w-0 px-4 pt-8 pb-16 font-lm-ui max-[641px]:w-full max-[641px]:px-3 max-[641px]:pt-6 max-[641px]:pb-12 [&>*]:min-w-0 [&>*]:break-words",
+        content,
+      ),
+    ],
+  )
+}

--- a/apps/loomark/moon.mod
+++ b/apps/loomark/moon.mod
@@ -4,6 +4,7 @@ version = "0.1.0"
 
 import {
   "moonbit-community/rabbita@0.15.4",
+  "moonbitlang/async@0.21.0",
   "Yoorkin/rui@0.1.1",
   "dowdiness/diagnostic@0.1.0",
   "dowdiness/loom@0.1.0",


### PR DESCRIPTION
## Summary

- Move Preview presentation state, view rendering, retry scheduling, Parser completion admission, and renderer publication into a deep `internal/preview` facade.
- Replace five app-level Preview protocol messages with one opaque `PreviewEvent`, while retaining one Rabbita root state machine and app-owned Document text.
- Use a completely deterministic `State + Input + Event -> State + PreviewDecision` reducer; keep Parser, DOM, scheduling, delay, and renderer acceptance in the imperative `PreviewEngine` shell.
- Fence completions by activation generation and captured text, then atomically admit the exact pending renderer output before publishing `Ready`.

## UI and review evidence

No intended visual or interaction changes. The production Loomark Playwright suite passed all 33 tests, including first-paint Preview preparation, mode switching, textarea identity, rapid input, IME, and the 10 ms input-processing contracts.

- [x] Visible-label removal preserves accessible names, visible focus, and the keyboard path — N/A; no label was removed
- [x] Interactive bounds, pointer feedback, and viewport reflow were checked in the rendered UI — N/A for changed behavior; existing production browser coverage passed
- [x] Any claimed Canopy rule cites its repository source; external guidance, recommendations, and preferences are labeled as such

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `Cmd`, `Emit`, `batch`, `delay`, `after_render` | Rabbita `cmd` | Yes | Preserve Rabbita's existing explicit effect model instead of adding another abstraction. |
| `TextChange::apply` | `dowdiness/text_change` | Yes | Validate each committed edit against authoritative Document text before advancing the Parser. |
| `SyntaxParser::apply_edit` / `set_source` | Loom | Yes | Retain the existing long-lived incremental Parser. |
| `MarkdownDocumentUpdates` and top-level block matching | `dowdiness/markdown` | Yes | Preserve semantic block identity and lazy VDOM reuse. |
| `Option`, `Result`, `String`, `Set`, `ArrayView` | MoonBit core | Yes | Model fallibility and optional accepted state, compare captured text, and validate reusable block indexes without new collection mechanisms. |
| `create_state_with_input` | Rabbita incremental API | No | A second child state would not process each parent input change synchronously and would duplicate lifecycle ownership. |
| Incr Query | `dowdiness/incr/incr_query` | No | It is a pull/query cache, not a reducer, scheduler, or mutable Parser owner. |

New helpers added:

- `Input`: opaque projection of activation generation and current Document text; it is not a second text authority or request identity.
- `State`: opaque Preview presentation state stored in the root Rabbita Model.
- `Event`: opaque completion envelope that hides the prepare/apply/refresh protocol from the app.
- Private `PreviewInputEvent`, `PreviewTransition`, and `PreviewDecision`: domain-specific functional-core values that keep all state decisions deterministic; they do not replace Rabbita `Cmd` as the effect representation.
- Private command helpers in `lifecycle.mbt`: adapt the existing imperative `PreviewEngine` to Rabbita `Cmd` without exposing Parser or renderer mechanics.
- `RenderedPreview`, `completed_preview`, and `last_preview`: keep accepted presentation data and stale-preview fallback local to Preview.

## Validation scope

Boundary matrix / first failing regression:

- Cold Preview request paints `Preparing` before Parser preparation.
- Older activation completions cannot change the current Preview.
- Same-activation completions captured from stale text cannot update state or schedule refresh for current text.
- A→B→A equal-input admission remains valid.
- Preparation completed for stale text discards the obsolete Parser and enters the retry path for current text.
- A deterministic command-host integration test executes the stale preparation command, makes A stale before its queued completion, drains discard/delay/refresh/completion commands, and proves current B reaches `Ready`.
- Parser transitions occur immediately after each committed edit; only display refresh uses the 24 ms quiet window.
- Initial failure and retained-last-preview failure remain visually distinct.
- Renderer output is published only after the matching private acceptance capability is admitted.

Target packages:

- `dowdiness/loomark/app`
- `dowdiness/loomark/internal/preview`

Additional conditional gates:

- Targeted JS check passed.
- Targeted debug tests: 46 passed.
- Targeted release tests: 46 passed.
- Workspace validation passed: 4,884 wasm, 2,580 JS, and 109 native tests.
- `./scripts/test-loomark-standalone-e2e.sh`: 33 Playwright tests passed; standalone TypeScript typecheck passed.
- `moon fmt`, `moon info`, and `git diff --check` passed.
- Independent MoonBit review found no high-confidence correctness or API-boundary defect; requested A→B→A and activation-fence coverage was added.
- A second independent review confirmed the reducer is pure and the stale-preparation integration test genuinely exercises FIFO command delivery and recursive recovery to current B.
- No proof package, TypeScript source, documentation, or submodule pointer changed.

## Push and CI readiness

```bash
git fetch origin main
git push
```

- [x] The branch contains the fetched `origin/main`, and the normal push completed without bypassing Lefthook's affected local checks.
- [x] The committed `.mbti` diff against `origin/main` was reviewed for unintended API or trait-bound changes.
- [x] Any changed submodule commit is pushed and reachable from its remote — N/A; no submodule pointer changed.
- [x] The branch was pushed again after every commit, amend, rebase, cherry-pick, submodule-pointer, manifest, or generated-interface change.
- [x] Independent review findings were resolved before the final validation.
- [ ] GitHub CI's `All Checks Passed` gate is green before merge.
