### PR TITLE
feat(loomark): delete documents atomically

### DIFF
--- a/apps/loomark/README.md
+++ b/apps/loomark/README.md
@@ -13,8 +13,8 @@ pub fn app() -> @rabbita.Val[@rabbita.Html]
 
 `apps/loomark/main/main.mbt` mounts that application. Browser integration is
 split between `apps/loomark/internal/source_repository`, which reconciles
-versioned Source records and derives an in-memory Catalog through `open` and
-`save`, and `apps/loomark/internal/text_area`, which converts native textarea
+versioned Source records and derives an in-memory Catalog through `open`,
+`save`, and `delete`, and `apps/loomark/internal/text_area`, which converts native textarea
 input sequences into shared `TextChange` operations.
 
 See the [Standard Rabbita Text App plan](../../docs/plans/2026-08-24-loomark-standard-rabbita-text-app.md) and the accepted decisions:
@@ -22,6 +22,7 @@ See the [Standard Rabbita Text App plan](../../docs/plans/2026-08-24-loomark-sta
 - [Current and saved text](../../docs/decisions/2026-08-24-loomark-source-first-interactive-contract.md)
 - [Production E2E boundary](../../docs/decisions/2026-08-24-loomark-production-e2e-boundary.md)
 - [Textarea edit ownership](../../docs/decisions/2026-08-25-loomark-textarea-edit-boundary.md)
+- [Document deletion](../../docs/decisions/2026-08-31-loomark-document-deletion.md)
 
 ## Autosave and Recovery
 
@@ -48,7 +49,10 @@ An empty repository creates a UUID-backed Source with exact text
 `# Untitled\n`. The legacy `active` record is moved atomically when safe;
 collisions preserve both records. A normal save writes only the accepted Source
 and installs the next in-memory Catalog after that transaction completes. A
-Source save failure preserves current text and presents Retry. Hidden-page
+Source save failure preserves current text and presents Retry. A confirmed
+Delete removes one known non-final Source in one transaction while document
+mutations are quiescent. The prepared Snapshot becomes visible only after
+transaction completion; deleting the final Source is rejected. Hidden-page
 persistence is best effort because the browser may freeze or terminate before
 IndexedDB completion.
 

--- a/apps/loomark/app/app.mbt
+++ b/apps/loomark/app/app.mbt
@@ -1,4 +1,74 @@
 ///|
+fn delete_dialog(
+  model : @rabbita.Val[Model],
+  emit : @rabbita.Emit[Msg],
+) -> @rabbita.Val[@rabbita.Html] {
+  let target = model.map(model => {
+    match model {
+      Editing({ deletion: DeleteConfirmation(document_id), repository, .. }) => {
+        let entries = repository.catalog().entries()
+        match entries.search_by(entry => entry.document_id() == document_id) {
+          Some(index) =>
+            entries
+            .get(index)
+            .map(entry => {
+              (document_id, document_option_label(entries, index, entry))
+            })
+          None => None
+        }
+      }
+      Loading(_) | Editing(_) | Recovery(_, _) => None
+    }
+  })
+  target.switch_by(
+    target => {
+      match target {
+        None => @rabbita.Val::constant(@html.nothing)
+        Some((document_id, label)) =>
+          @rui.alert_dialog(
+            id="loomark-delete-document",
+            default_open=true,
+            on_open_change=@cmd.Emit(open => {
+              if open {
+                @cmd.none
+              } else {
+                emit(DeleteCancelled)
+              }
+            }),
+            scope => {
+              @rui.alert_dialog_portal([
+                @rui.alert_dialog_content(scope, [
+                  @rui.alert_dialog_header([
+                    @rui.alert_dialog_title(scope, "Delete \"\{label}\"?"),
+                    @rui.alert_dialog_description(
+                      scope, "This permanently removes the document from this browser.",
+                    ),
+                  ]),
+                  @rui.alert_dialog_footer([
+                    @rui.alert_dialog_cancel(scope, "Cancel"),
+                    @rui.alert_dialog_action(
+                      scope,
+                      on_click=emit(DeleteConfirmed(document_id)),
+                      class="[--rui-button-bg:var(--color-lm-danger)] [--rui-button-fg:white]",
+                      "Delete document",
+                    ),
+                  ]),
+                ]),
+              ])
+            },
+          )
+      }
+    },
+    by=target => {
+      match target {
+        Some((document_id, _)) => "confirm-\{document_id}"
+        None => "closed"
+      }
+    },
+  )
+}
+
+///|
 /// Prototype: manage and switch Loomark documents inside RUI Sidebar.
 pub fn app() -> @rabbita.Val[@rabbita.Html] {
   let text_area = @text_area.TextArea::TextArea("loomark-text")
@@ -50,16 +120,13 @@ pub fn app() -> @rabbita.Val[@rabbita.Html] {
                 } else {
                   ["display:none;overflow:hidden"]
                 },
-                if editing.creation == Creating {
-                  text_area_view(
-                    emit,
-                    text_area,
-                    editing.activation,
-                    disabled=true,
-                  )
-                } else {
-                  text_area_view(emit, text_area, editing.activation)
-                },
+                text_area_view(
+                  emit,
+                  text_area,
+                  editing.activation,
+                  disabled=editing.creation == Creating,
+                  read_only=deletion_blocks_document_changes(editing),
+                ),
               ),
               @rui.resizable_handle(
                 scope~,
@@ -116,16 +183,19 @@ pub fn app() -> @rabbita.Val[@rabbita.Html] {
     },
     by=compact => if compact { "compact" } else { "wide" },
   )
-  let layout_input = model.map2(selected_panels, (model, editor_panels) => {
-    (model, editor_panels)
-  })
+  let dialog = delete_dialog(model, emit)
+  let layout_input = model.map3(selected_panels, dialog, (
+    model,
+    editor_panels,
+    dialog,
+  ) => (model, editor_panels, dialog))
   @sidebar.sidebar_provider_with_input(
     input=layout_input,
     default_collapsed=initial_compact,
     class="h-dvh min-h-0 [--rui-sidebar-width:clamp(11rem,24vw,17rem)] [--rui-sidebar-width-icon:2.75rem]",
     (sidebar, layout) => {
-      let (model, editor_panels) = layout
-      view(sidebar, model, emit, editor_panels)
+      let (model, editor_panels, dialog) = layout
+      view(sidebar, model, emit, editor_panels, dialog)
     },
   )
 }

--- a/apps/loomark/app/model.mbt
+++ b/apps/loomark/app/model.mbt
@@ -19,6 +19,8 @@ priv struct EditingState {
   save : SaveState
   last_checkpoint_epoch : Int
   creation : DocumentCreation
+  deletion : DocumentDeletion
+  last_delete_request : Int
   mode : EditorMode
   compact : Bool
   preview : @preview.State
@@ -61,6 +63,14 @@ priv enum DocumentCreation {
 } derive(Eq)
 
 ///|
+priv enum DocumentDeletion {
+  NoDeletion
+  DeleteConfirmation(String)
+  Deleting(Int, String)
+  DeleteFailed(String, @source_repository.DeleteFailure)
+} derive(Eq)
+
+///|
 priv enum Msg {
   Opened(@source_repository.OpenResult)
   ExampleSelected(Activation, String)
@@ -78,4 +88,9 @@ priv enum Msg {
   DocumentSelected(String)
   CreateRequested
   CreateCompleted(Activation, @source_repository.CreateResult)
+  DeleteRequested(String)
+  DeleteCancelled
+  DeleteConfirmed(String)
+  DeleteCompleted(Int, @source_repository.DeleteResult)
+  DismissDeleteFailure
 }

--- a/apps/loomark/app/update.mbt
+++ b/apps/loomark/app/update.mbt
@@ -39,8 +39,19 @@ fn select_mode(
 }
 
 ///|
+fn deletion_blocks_document_changes(editing : EditingState) -> Bool {
+  match editing.deletion {
+    DeleteConfirmation(_) | Deleting(_, _) => true
+    NoDeletion | DeleteFailed(_, _) => false
+  }
+}
+
+///|
 fn can_activate(editing : EditingState) -> Bool {
-  editing.save == Saved && !editing.composing && editing.creation != Creating
+  editing.save == Saved &&
+  !editing.composing &&
+  editing.creation != Creating &&
+  !deletion_blocks_document_changes(editing)
 }
 
 ///|
@@ -157,6 +168,8 @@ fn update(
                   save: Saved,
                   last_checkpoint_epoch: 0,
                   creation: Idle,
+                  deletion: NoDeletion,
+                  last_delete_request: 0,
                   mode: Text,
                   compact,
                   preview,
@@ -177,7 +190,8 @@ fn update(
     (Editing(editing), ExampleSelected(owner, text)) =>
       if owner != editing.activation {
         (model, @cmd.none)
-      } else if editing.creation == Creating {
+      } else if editing.creation == Creating ||
+        deletion_blocks_document_changes(editing) {
         (model, text_area.initialize(editing.text))
       } else {
         (
@@ -196,7 +210,8 @@ fn update(
     (Editing(editing), TextChanged(owner, change)) =>
       if owner != editing.activation {
         (model, @cmd.none)
-      } else if editing.creation == Creating {
+      } else if editing.creation == Creating ||
+        deletion_blocks_document_changes(editing) {
         (model, text_area.initialize(editing.text))
       } else {
         match change.apply(editing.text) {
@@ -227,7 +242,9 @@ fn update(
         }
       }
     (Editing(editing), CompositionStarted(owner)) =>
-      if owner != editing.activation || editing.creation == Creating {
+      if owner != editing.activation ||
+        editing.creation == Creating ||
+        deletion_blocks_document_changes(editing) {
         (model, @cmd.none)
       } else {
         (Editing({ ..editing, composing: true }), @cmd.none)
@@ -235,7 +252,8 @@ fn update(
     (Editing(editing), CompositionEnded(owner)) =>
       if owner != editing.activation {
         (model, @cmd.none)
-      } else if editing.creation == Creating {
+      } else if editing.creation == Creating ||
+        deletion_blocks_document_changes(editing) {
         (model, text_area.initialize(editing.text))
       } else {
         let (editing, save_effect) = save_after_composition_ended(editing)
@@ -316,6 +334,85 @@ fn update(
             (Editing(editing), command)
           }
         }
+      }
+    (Editing(editing), DeleteRequested(document_id)) =>
+      if !can_activate(editing) ||
+        editing.repository.source(document_id) is None ||
+        editing.repository.sources().length() <= 1 {
+        (model, @cmd.none)
+      } else {
+        (
+          Editing({ ..editing, deletion: DeleteConfirmation(document_id) }),
+          @cmd.none,
+        )
+      }
+    (Editing(editing), DeleteCancelled) =>
+      match editing.deletion {
+        DeleteConfirmation(_) =>
+          (Editing({ ..editing, deletion: NoDeletion }), @cmd.none)
+        NoDeletion | Deleting(_, _) | DeleteFailed(_, _) => (model, @cmd.none)
+      }
+    (Editing(editing), DeleteConfirmed(document_id)) =>
+      if editing.deletion != DeleteConfirmation(document_id) ||
+        editing.save != Saved ||
+        editing.composing ||
+        editing.creation == Creating ||
+        editing.repository.source(document_id) is None ||
+        editing.repository.sources().length() <= 1 {
+        (model, @cmd.none)
+      } else {
+        let request = editing.last_delete_request + 1
+        (
+          Editing({
+            ..editing,
+            deletion: Deleting(request, document_id),
+            last_delete_request: request,
+          }),
+          @source_repository.delete(
+            editing.repository,
+            document_id,
+            result=emit.map(result => DeleteCompleted(request, result)),
+          ),
+        )
+      }
+    (Editing(editing), DeleteCompleted(request, result)) =>
+      match editing.deletion {
+        Deleting(active_request, document_id) if active_request == request =>
+          match result {
+            @source_repository.DeleteResult::Failed(failure) =>
+              (
+                Editing({
+                  ..editing,
+                  deletion: DeleteFailed(document_id, failure),
+                }),
+                @cmd.none,
+              )
+            @source_repository.DeleteResult::Deleted(repository) =>
+              if document_id != editing.activation.document_id {
+                (
+                  Editing({ ..editing, repository, deletion: NoDeletion }),
+                  @cmd.none,
+                )
+              } else {
+                let source = repository.selected().unwrap()
+                let prepared = { ..editing, repository, deletion: NoDeletion }
+                let (editing, command) = activate_document(
+                  prepared, source, emit, text_area, preview_engine,
+                )
+                (Editing(editing), command)
+              }
+          }
+        NoDeletion
+        | DeleteConfirmation(_)
+        | DeleteFailed(_, _)
+        | Deleting(_, _) => (model, @cmd.none)
+      }
+    (Editing(editing), DismissDeleteFailure) =>
+      match editing.deletion {
+        DeleteFailed(_, _) =>
+          (Editing({ ..editing, deletion: NoDeletion }), @cmd.none)
+        NoDeletion | DeleteConfirmation(_) | Deleting(_, _) =>
+          (model, @cmd.none)
       }
     (Editing(editing), ViewportChanged(width)) =>
       (Editing({ ..editing, compact: compact_viewport(width) }), @cmd.none)

--- a/apps/loomark/app/update_wbtest.mbt
+++ b/apps/loomark/app/update_wbtest.mbt
@@ -30,6 +30,8 @@ fn test_editing_state(text : String, save : SaveState) -> EditingState {
     save,
     last_checkpoint_epoch: 0,
     creation: Idle,
+    deletion: NoDeletion,
+    last_delete_request: 0,
     mode: Text,
     compact: false,
     preview: test_preview_state(text),
@@ -102,6 +104,142 @@ test "saved document selection activates its exact Source without writing" {
   assert_eq(editing.text, "# Second\n")
   assert_true(editing.save == Saved)
   assert_true(editing.preview == test_preview_state("# Second\n"))
+  assert_false(@debug.to_string(command).contains("IndexedDB"))
+}
+
+///|
+test "confirmed non-active deletion starts from a quiescent repository" {
+  let snapshot = @source_repository.RepositorySnapshot::from_sources([
+    @source_repository.SourceRecord::new("document-1", "# One\n").unwrap(),
+    @source_repository.SourceRecord::new("document-2", "# Two\n").unwrap(),
+  ]).unwrap()
+  let initial = { ..test_editing_state("# One\n", Saved), repository: snapshot }
+  let (confirming, _) = test_update(
+    Editing(initial),
+    DeleteRequested("document-2"),
+  )
+  guard confirming is Editing(confirming) else { fail("expected Editing") }
+  assert_true(confirming.deletion == DeleteConfirmation("document-2"))
+  let (model, command) = test_update(
+    Editing(confirming),
+    DeleteConfirmed("document-2"),
+  )
+  guard model is Editing(editing) else { fail("expected Editing") }
+  assert_true(editing.deletion == Deleting(1, "document-2"))
+  assert_eq(editing.last_delete_request, 1)
+  assert_true(editing.activation == initial.activation)
+  assert_eq(editing.text, initial.text)
+  assert_eq(editing.repository, initial.repository)
+  assert_true(
+    @debug.to_string(command).contains("Delete(\"source/v1/document-2\")"),
+  )
+}
+
+///|
+test "acknowledged non-active deletion changes only repository state" {
+  let original = @source_repository.RepositorySnapshot::from_sources([
+    @source_repository.SourceRecord::new("document-1", "# One\n").unwrap(),
+    @source_repository.SourceRecord::new("document-2", "# Two\n").unwrap(),
+  ]).unwrap()
+  let next = @source_repository.RepositorySnapshot::from_sources([
+    @source_repository.SourceRecord::new("document-1", "# One\n").unwrap(),
+  ]).unwrap()
+  let initial = {
+    ..test_editing_state("# One\n", Saved),
+    repository: original,
+    deletion: Deleting(1, "document-2"),
+    last_delete_request: 1,
+  }
+  let (model, command) = test_update(
+    Editing(initial),
+    DeleteCompleted(1, @source_repository.DeleteResult::Deleted(next)),
+  )
+  guard model is Editing(editing) else { fail("expected Editing") }
+  assert_true(editing == { ..initial, repository: next, deletion: NoDeletion })
+  assert_false(@debug.to_string(command).contains("IndexedDB"))
+}
+
+///|
+test "acknowledged active deletion activates deterministic fallback" {
+  let original = @source_repository.RepositorySnapshot::from_sources([
+    @source_repository.SourceRecord::new("document-1", "# One\n").unwrap(),
+    @source_repository.SourceRecord::new("document-2", "# Two\n").unwrap(),
+  ]).unwrap()
+  let next = @source_repository.RepositorySnapshot::from_sources([
+    @source_repository.SourceRecord::new("document-2", "# Two\n").unwrap(),
+  ]).unwrap()
+  let initial = {
+    ..test_editing_state("# One\n", Saved),
+    repository: original,
+    deletion: Deleting(1, "document-1"),
+    last_delete_request: 1,
+  }
+  let (model, _) = test_update(
+    Editing(initial),
+    DeleteCompleted(1, @source_repository.DeleteResult::Deleted(next)),
+  )
+  guard model is Editing(editing) else { fail("expected Editing") }
+  assert_eq(editing.repository, next)
+  assert_eq(editing.activation.document_id, "document-2")
+  assert_eq(editing.activation.generation, 1)
+  assert_eq(editing.text, "# Two\n")
+  assert_true(editing.deletion == NoDeletion)
+}
+
+///|
+test "delete failure and stale completion preserve document state" {
+  let initial = {
+    ..test_editing_state("# One\n", Saved),
+    deletion: Deleting(2, "document-1"),
+    last_delete_request: 2,
+  }
+  let (stale, _) = test_update(
+    Editing(initial),
+    DeleteCompleted(
+      1,
+      @source_repository.DeleteResult::Failed(
+        @source_repository.DeleteFailure::WriteFailed,
+      ),
+    ),
+  )
+  assert_true(stale == Editing(initial))
+  let (failed, _) = test_update(
+    Editing(initial),
+    DeleteCompleted(
+      2,
+      @source_repository.DeleteResult::Failed(
+        @source_repository.DeleteFailure::WriteFailed,
+      ),
+    ),
+  )
+  guard failed is Editing(editing) else { fail("expected Editing") }
+  assert_true(
+    editing ==
+    {
+      ..initial,
+      deletion: DeleteFailed(
+        "document-1",
+        @source_repository.DeleteFailure::WriteFailed,
+      ),
+    },
+  )
+}
+
+///|
+test "document text cannot change while deletion is in flight" {
+  let initial = {
+    ..test_editing_state("# One\n", Saved),
+    deletion: Deleting(1, "document-1"),
+    last_delete_request: 1,
+  }
+  let (model, command) = test_update(
+    Editing(initial),
+    TextChanged(
+      initial.activation,
+      @text_change.TextChange::ReplaceAll("# Changed\n"),
+    ),
+  )
+  assert_true(model == Editing(initial))
   assert_false(@debug.to_string(command).contains("IndexedDB"))
 }
 

--- a/apps/loomark/app/view.mbt
+++ b/apps/loomark/app/view.mbt
@@ -19,6 +19,11 @@ fn mode_tab(
   emit : @rabbita.Emit[Msg],
 ) -> @rabbita.Html {
   let name = mode_name(mode)
+  let icon_class = match mode {
+    Text => "i-lucide-align-left"
+    Preview => "i-lucide-eye"
+    Split => "i-lucide-columns-2"
+  }
   @rui.tabs_trigger(
     value=name.to_lower(),
     selected=mode == selected_mode,
@@ -32,10 +37,8 @@ fn mode_tab(
       "width:1.75rem;height:1.75rem;min-height:1.75rem;flex:none;padding:0",
     ],
     @html.span(
-      class="pointer-events-none relative block size-4.5 transition-colors duration-150 group-hover:text-[oklch(0.145_0_0)]",
-      attrs=@html.Attrs::build()
-        .data_set("mode", name.to_lower())
-        .aria_hidden("true"),
+      class="pointer-events-none block size-4.5 \{icon_class} transition-colors duration-150 group-hover:text-[oklch(0.145_0_0)]",
+      attrs=@html.Attrs::build().aria_hidden("true"),
       @html.nothing,
     ),
   )
@@ -80,10 +83,8 @@ fn document_option_label(
 ///|
 fn sidebar_panel_icon() -> @rabbita.Html {
   @html.span(
-    class="relative block size-4 shrink-0",
-    attrs=@html.Attrs::build()
-      .data_set("loomark-icon", "sidebar")
-      .aria_hidden("true"),
+    class="i-lucide-panel-left block size-4 shrink-0",
+    attrs=@html.Attrs::build().aria_hidden("true"),
     @html.nothing,
   )
 }
@@ -91,10 +92,8 @@ fn sidebar_panel_icon() -> @rabbita.Html {
 ///|
 fn sidebar_folder_icon() -> @rabbita.Html {
   @html.span(
-    class="relative block size-4 shrink-0",
-    attrs=@html.Attrs::build()
-      .data_set("loomark-icon", "folder")
-      .aria_hidden("true"),
+    class="i-lucide-folder block size-4 shrink-0",
+    attrs=@html.Attrs::build().aria_hidden("true"),
     @html.nothing,
   )
 }
@@ -102,10 +101,8 @@ fn sidebar_folder_icon() -> @rabbita.Html {
 ///|
 fn sidebar_new_icon() -> @rabbita.Html {
   @html.span(
-    class="relative block size-4 shrink-0",
-    attrs=@html.Attrs::build()
-      .data_set("loomark-icon", "new-document")
-      .aria_hidden("true"),
+    class="i-lucide-plus block size-4 shrink-0 transition-transform duration-[120ms] active:scale-[0.86] motion-reduce:duration-[80ms]",
+    attrs=@html.Attrs::build().aria_hidden("true"),
     @html.nothing,
   )
 }
@@ -113,10 +110,8 @@ fn sidebar_new_icon() -> @rabbita.Html {
 ///|
 fn sidebar_delete_icon() -> @rabbita.Html {
   @html.span(
-    class="relative block size-4 shrink-0",
-    attrs=@html.Attrs::build()
-      .data_set("loomark-icon", "delete-document")
-      .aria_hidden("true"),
+    class="i-lucide-trash-2 block size-4 shrink-0",
+    attrs=@html.Attrs::build().aria_hidden("true"),
     @html.nothing,
   )
 }

--- a/apps/loomark/app/view.mbt
+++ b/apps/loomark/app/view.mbt
@@ -111,6 +111,17 @@ fn sidebar_new_icon() -> @rabbita.Html {
 }
 
 ///|
+fn sidebar_delete_icon() -> @rabbita.Html {
+  @html.span(
+    class="relative block size-4 shrink-0",
+    attrs=@html.Attrs::build()
+      .data_set("loomark-icon", "delete-document")
+      .aria_hidden("true"),
+    @html.nothing,
+  )
+}
+
+///|
 fn document_sidebar(
   scope : @sidebar.SidebarScope,
   editing : EditingState,
@@ -163,13 +174,13 @@ fn document_sidebar(
                   let document_id = entry.document_id()
                   let selected = document_id == editing.activation.document_id
                   let label = document_option_label(entries, index, entry)
-                  @sidebar.sidebar_menu_sub_item(
+                  @sidebar.sidebar_menu_sub_item([
                     @sidebar.sidebar_menu_sub_button(
                       is_active=selected,
                       disabled=!available && !selected,
                       aria_label=label,
                       title=label,
-                      class="hover:opacity-70 active:opacity-50",
+                      class="pr-8 hover:opacity-70 active:opacity-50",
                       on_click=@cmd.batch([
                         emit(DocumentSelected(document_id)),
                         close_after_action,
@@ -182,7 +193,16 @@ fn document_sidebar(
                         label,
                       ),
                     ),
-                  )
+                    @sidebar.sidebar_menu_action(
+                      disabled=!available || entries.length() <= 1,
+                      aria_label="Delete \"\{label}\"",
+                      title="Delete \"\{label}\"",
+                      class="text-lm-danger active:opacity-50",
+                      style=["width:1.5rem;height:1.5rem"],
+                      on_click=emit(DeleteRequested(document_id)),
+                      sidebar_delete_icon(),
+                    ),
+                  ])
                 }),
               ),
             ]),
@@ -241,6 +261,7 @@ fn text_area_view(
   text_area : @text_area.TextArea,
   activation : Activation,
   disabled? : Bool,
+  read_only? : Bool,
 ) -> @rabbita.Html {
   @html.div(
     class="h-full min-h-0 w-full min-w-0",
@@ -251,6 +272,7 @@ fn text_area_view(
           rows=24,
           autofocus=true,
           disabled?,
+          read_only?,
           class="m-0 block h-full min-h-0 w-full min-w-0 resize-none rounded-none border-0 bg-transparent px-[max(3rem,calc((100%_-_44rem)_/_2))] pt-8 pb-16 font-lm-mono text-base leading-[1.65] text-lm-ink caret-lm-accent outline-0 [tab-size:2] max-[641px]:px-3 max-[641px]:pt-6 max-[641px]:pb-12",
           attrs=text_area.attach(
             @html.Attrs::build().aria_label("Text"),
@@ -302,6 +324,45 @@ fn creation_failure_view(
 }
 
 ///|
+fn delete_failure_view(
+  document_id : String,
+  failure : @source_repository.DeleteFailure,
+  emit : @rabbita.Emit[Msg],
+) -> @rabbita.Html {
+  let reason = match failure {
+    @source_repository.DeleteFailure::InvalidSource =>
+      "The document is no longer available."
+    @source_repository.DeleteFailure::LastSource =>
+      "The last document cannot be deleted."
+    @source_repository.DeleteFailure::StorageUnavailable =>
+      "Browser storage is unavailable."
+    @source_repository.DeleteFailure::QuotaExceeded =>
+      "Browser storage could not complete the deletion."
+    @source_repository.DeleteFailure::WriteFailed =>
+      "Browser storage failed while deleting the document."
+  }
+  @html.div(
+    class="flex min-h-12 shrink-0 items-center justify-between gap-4 border-t border-[oklch(0.78_0.07_25)] bg-lm-danger-soft px-4 py-2.5 text-sm text-lm-danger opacity-100 transition-opacity duration-[160ms] ease-[cubic-bezier(0.23,1,0.32,1)] starting:opacity-0 motion-reduce:duration-[80ms] motion-reduce:ease-[ease] max-[641px]:items-start [&_p]:m-0",
+    attrs=@html.Attrs::build().role("alert"),
+    [
+      @html.p("The document was not deleted. " + reason),
+      @html.div(class="flex shrink-0 gap-2", [
+        @html.button(
+          class="min-h-8 cursor-pointer rounded-md border border-current bg-transparent px-2.5 py-1 text-inherit focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-lm-danger",
+          on_click=emit(DeleteRequested(document_id)),
+          "Try again",
+        ),
+        @html.button(
+          class="min-h-8 cursor-pointer rounded-md border border-current bg-transparent px-2.5 py-1 text-inherit focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-lm-danger",
+          on_click=emit(DismissDeleteFailure),
+          "Dismiss",
+        ),
+      ]),
+    ],
+  )
+}
+
+///|
 fn save_failure_view(
   failure : @source_repository.SaveFailure,
   emit : @rabbita.Emit[Msg],
@@ -335,6 +396,7 @@ fn view(
   model : Model,
   emit : @rabbita.Emit[Msg],
   editor_panels : @rabbita.Html,
+  delete_dialog : @rabbita.Html,
 ) -> @rabbita.Html {
   @html.div(
     id="loomark-root",
@@ -342,51 +404,65 @@ fn view(
     attrs=@html.Attrs::build()
       .role("region")
       .aria_label("Loomark Markdown Editor"),
-    match model {
-      Loading(_) =>
-        @html.div(
-          class="grid min-h-dvh place-items-center text-lm-muted [&_p]:m-0",
-          [@html.p("Loading document")],
-        )
-      Recovery(failure, _) => {
-        let message = match failure {
-          @source_repository.OpenFailure::StorageUnavailable =>
-            "Browser storage is unavailable."
-          @source_repository.OpenFailure::ReadFailed =>
-            "Browser storage failed while reading the document."
-          @source_repository.OpenFailure::DocumentIdentityUnavailable =>
-            "This browser cannot create a document identity."
-          @source_repository.OpenFailure::QuotaExceeded =>
-            "Browser storage is full."
-          @source_repository.OpenFailure::WriteFailed =>
-            "Browser storage failed while preparing the document."
+    [
+      match model {
+        Loading(_) =>
+          @html.div(
+            class="grid min-h-dvh place-items-center text-lm-muted [&_p]:m-0",
+            [@html.p("Loading document")],
+          )
+        Recovery(failure, _) => {
+          let message = match failure {
+            @source_repository.OpenFailure::StorageUnavailable =>
+              "Browser storage is unavailable."
+            @source_repository.OpenFailure::ReadFailed =>
+              "Browser storage failed while reading the document."
+            @source_repository.OpenFailure::DocumentIdentityUnavailable =>
+              "This browser cannot create a document identity."
+            @source_repository.OpenFailure::QuotaExceeded =>
+              "Browser storage is full."
+            @source_repository.OpenFailure::WriteFailed =>
+              "Browser storage failed while preparing the document."
+          }
+          @html.div(
+            class="mx-auto w-[min(calc(100%-2rem),36rem)] pt-[max(4rem,20vh)] pb-8 [&_h1]:mt-0 [&_h1]:mb-3 [&_h1]:text-xl [&_h1]:leading-[1.3] [&_p]:m-0 [&_p]:leading-[1.6] [&_p]:text-lm-muted",
+            [@html.h1("Document recovery"), @html.p(message)],
+          )
         }
-        @html.div(
-          class="mx-auto w-[min(calc(100%-2rem),36rem)] pt-[max(4rem,20vh)] pb-8 [&_h1]:mt-0 [&_h1]:mb-3 [&_h1]:text-xl [&_h1]:leading-[1.3] [&_p]:m-0 [&_p]:leading-[1.6] [&_p]:text-lm-muted",
-          [@html.h1("Document recovery"), @html.p(message)],
-        )
-      }
-      Editing(editing) =>
-        @html.div(
-          class="flex h-full min-h-0 min-w-0 flex-1 opacity-100 transition-opacity duration-[140ms] ease-[cubic-bezier(0.23,1,0.32,1)] starting:opacity-[0.92] motion-reduce:duration-[80ms] motion-reduce:ease-[ease]",
-          [
-            document_sidebar(sidebar, editing, emit),
-            @html.div(
-              class="flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-lm-paper",
-              [
-                mode_bar(sidebar, editing, emit),
-                mode_content(editing.mode, editor_panels),
-                match (editing.save, editing.creation) {
-                  (Failed(failure, _), _) => save_failure_view(failure, emit)
-                  (_, CreationFailed(failure)) =>
-                    creation_failure_view(failure, emit)
-                  (Saved | Waiting(_) | Saving(_, _), Idle | Creating) =>
-                    @html.nothing
-                },
-              ],
-            ),
-          ],
-        )
-    },
+        Editing(editing) =>
+          @html.div(
+            class="flex h-full min-h-0 min-w-0 flex-1 opacity-100 transition-opacity duration-[140ms] ease-[cubic-bezier(0.23,1,0.32,1)] starting:opacity-[0.92] motion-reduce:duration-[80ms] motion-reduce:ease-[ease]",
+            [
+              document_sidebar(sidebar, editing, emit),
+              @html.div(
+                class="flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-lm-paper",
+                [
+                  mode_bar(sidebar, editing, emit),
+                  mode_content(editing.mode, editor_panels),
+                  match (editing.save, editing.creation, editing.deletion) {
+                    (Failed(failure, _), _, _) =>
+                      save_failure_view(failure, emit)
+                    (_, CreationFailed(failure), _) =>
+                      creation_failure_view(failure, emit)
+                    (_, _, DeleteFailed(document_id, failure)) =>
+                      delete_failure_view(document_id, failure, emit)
+                    (
+                      Saved
+                      | Waiting(_)
+                      | Saving(_, _),
+                      Idle
+                      | Creating,
+                      NoDeletion
+                      | DeleteConfirmation(_)
+                      | Deleting(_, _),
+                    ) => @html.nothing
+                  },
+                ],
+              ),
+            ],
+          )
+      },
+      delete_dialog,
+    ],
   )
 }

--- a/apps/loomark/app/view.mbt
+++ b/apps/loomark/app/view.mbt
@@ -33,9 +33,7 @@ fn mode_tab(
     title=name,
     class="group",
     attrs=@html.Attrs::build().aria_label(name),
-    style=[
-      "width:1.75rem;height:1.75rem;min-height:1.75rem;flex:none;padding:0",
-    ],
+    style=["width:2rem;height:2rem;min-height:2rem;flex:none;padding:0"],
     @html.span(
       class="pointer-events-none block size-4.5 \{icon_class} transition-colors duration-150 group-hover:text-[oklch(0.145_0_0)]",
       attrs=@html.Attrs::build().aria_hidden("true"),
@@ -101,7 +99,7 @@ fn sidebar_folder_icon() -> @rabbita.Html {
 ///|
 fn sidebar_new_icon() -> @rabbita.Html {
   @html.span(
-    class="i-lucide-plus block size-4 shrink-0 transition-transform duration-[120ms] active:scale-[0.86] motion-reduce:duration-[80ms]",
+    class="i-lucide-plus block size-4 shrink-0",
     attrs=@html.Attrs::build().aria_hidden("true"),
     @html.nothing,
   )
@@ -159,8 +157,8 @@ fn document_sidebar(
                 disabled=!available,
                 aria_label="New document",
                 title="New document",
-                class="active:opacity-50",
-                style=["width:1.5rem;height:1.5rem"],
+                class="loomark-sidebar-action",
+                style=["width:2rem;height:2rem"],
                 on_click=@cmd.batch([emit(CreateRequested), close_after_action]),
                 sidebar_new_icon(),
               ),
@@ -175,13 +173,13 @@ fn document_sidebar(
                       disabled=!available && !selected,
                       aria_label=label,
                       title=label,
-                      class="pr-8 hover:opacity-70 active:opacity-50",
+                      class="pr-10 hover:opacity-70 active:opacity-50",
                       on_click=@cmd.batch([
                         emit(DocumentSelected(document_id)),
                         close_after_action,
                       ]),
                       style=[
-                        "height:auto;min-height:2.25rem;align-items:flex-start;padding-block:0.375rem",
+                        "height:auto;min-height:2.5rem;align-items:flex-start;padding-block:0.5rem",
                       ],
                       @html.span(
                         class="min-w-0 overflow-hidden text-ellipsis whitespace-normal [display:-webkit-box] [-webkit-box-orient:vertical] [-webkit-line-clamp:2]",
@@ -191,9 +189,13 @@ fn document_sidebar(
                     @sidebar.sidebar_menu_action(
                       disabled=!available || entries.length() <= 1,
                       aria_label="Delete \"\{label}\"",
-                      title="Delete \"\{label}\"",
-                      class="text-lm-danger active:opacity-50",
-                      style=["width:1.5rem;height:1.5rem"],
+                      title=if entries.length() <= 1 {
+                        "Keep at least one document"
+                      } else {
+                        "Delete \"\{label}\""
+                      },
+                      class="loomark-sidebar-action loomark-delete-action",
+                      style=["width:2rem;height:2rem"],
                       on_click=emit(DeleteRequested(document_id)),
                       sidebar_delete_icon(),
                     ),

--- a/apps/loomark/examples/vanilla/tests/standalone.spec.ts
+++ b/apps/loomark/examples/vanilla/tests/standalone.spec.ts
@@ -540,11 +540,18 @@ test("several Sources select the first lexical Document ID without writing metad
   await page.reload()
   await expect(page.getByRole("textbox", { name: "Text" })).toHaveValue(documentA.text)
   const documents = page.getByRole("complementary", { name: "Documents" })
-  await expect(documents.getByRole("button", { name: "Same (1 of 2)" }))
-    .toBeVisible()
-  await expect(documents.getByRole("button", { name: "Same (2 of 2)" }))
-    .toBeVisible()
-  await expect(documents.getByRole("button", { name: "Unnamed document" }))
+  await expect(documents.getByRole("button", {
+    name: "Same (1 of 2)",
+    exact: true,
+  })).toBeVisible()
+  await expect(documents.getByRole("button", {
+    name: "Same (2 of 2)",
+    exact: true,
+  })).toBeVisible()
+  await expect(documents.getByRole("button", {
+    name: "Unnamed document",
+    exact: true,
+  }))
     .toBeVisible()
   expect(await readStoredDocumentRaw(page, CATALOG_KEY)).toBeUndefined()
   expect(await readStoredDocumentRaw(page, "source/v2/future")).toBe("future")
@@ -623,6 +630,84 @@ test("New Document commits one baseline Source before activating it", async ({ p
   await expect(documents.getByRole("button", { name: "Project notes", exact: true }))
     .toBeVisible()
   expect(await readStoredDocuments(page)).toEqual(renamed)
+})
+
+test("Delete document removes a non-active Source without moving the editor", async ({ page }) => {
+  await page.goto("/")
+  await waitForRepositoryOpen(page)
+  const documentA = { document_id: "document-a", text: "# A\n" }
+  const documentB = { document_id: "document-b", text: "# B\n" }
+  await replaceStoreRecords(page, [
+    { key: sourceKey(documentA.document_id), value: encodeStoredDocument(documentA) },
+    { key: sourceKey(documentB.document_id), value: encodeStoredDocument(documentB) },
+  ])
+  await page.reload()
+
+  const text = page.getByRole("textbox", { name: "Text" })
+  await expect(text).toHaveValue(documentA.text)
+  await page.getByRole("button", { name: 'Delete "B"' }).click()
+  const dialog = page.getByRole("alertdialog")
+  await expect(dialog).toContainText('Delete "B"?')
+  await dialog.getByRole("button", { name: "Delete document" }).click()
+
+  await expect.poll(() => readStoredDocumentRaw(page, sourceKey(documentB.document_id)))
+    .toBeUndefined()
+  await expect(text).toHaveValue(documentA.text)
+  await page.reload()
+  await expect(text).toHaveValue(documentA.text)
+  await expect(page.getByRole("button", { name: "B", exact: true })).toHaveCount(0)
+})
+
+test("Delete document activates the lexical fallback only after commit", async ({ page }) => {
+  await page.goto("/")
+  await waitForRepositoryOpen(page)
+  const documentA = { document_id: "document-a", text: "# A\n" }
+  const documentB = { document_id: "document-b", text: "# B\n" }
+  await replaceStoreRecords(page, [
+    { key: sourceKey(documentA.document_id), value: encodeStoredDocument(documentA) },
+    { key: sourceKey(documentB.document_id), value: encodeStoredDocument(documentB) },
+  ])
+  await page.reload()
+
+  await page.getByRole("button", { name: 'Delete "A"' }).click()
+  const dialog = page.getByRole("alertdialog")
+  await dialog.getByRole("button", { name: "Delete document" }).click()
+
+  const text = page.getByRole("textbox", { name: "Text" })
+  await expect(text).toHaveValue(documentB.text)
+  await expect.poll(() => readStoredDocumentRaw(page, sourceKey(documentA.document_id)))
+    .toBeUndefined()
+  await page.reload()
+  await expect(text).toHaveValue(documentB.text)
+})
+
+test("Delete document cancellation preserves the Source and editor", async ({ page }) => {
+  await page.goto("/")
+  await waitForRepositoryOpen(page)
+  const documentA = { document_id: "document-a", text: "# A\n" }
+  const documentB = { document_id: "document-b", text: "# B\n" }
+  await replaceStoreRecords(page, [
+    { key: sourceKey(documentA.document_id), value: encodeStoredDocument(documentA) },
+    { key: sourceKey(documentB.document_id), value: encodeStoredDocument(documentB) },
+  ])
+  await page.reload()
+
+  await page.getByRole("button", { name: 'Delete "B"' }).click()
+  const dialog = page.getByRole("alertdialog")
+  await dialog.getByRole("button", { name: "Cancel" }).click()
+
+  await expect(dialog).toHaveCount(0)
+  await expect.poll(() => readStoredDocumentRaw(page, sourceKey(documentB.document_id)))
+    .toBe(encodeStoredDocument(documentB))
+  const text = page.getByRole("textbox", { name: "Text" })
+  await text.fill("# Still editable\n")
+  await expect(text).toHaveValue("# Still editable\n")
+})
+
+test("Delete document rejects deleting the final Source", async ({ page }) => {
+  await page.goto("/")
+  await waitForRepositoryOpen(page)
+  await expect(page.getByRole("button", { name: /^Delete "/ })).toBeDisabled()
 })
 
 test("creation failure preserves the active document and can retry", async ({ page }) => {

--- a/apps/loomark/internal/source_repository/pkg.generated.mbti
+++ b/apps/loomark/internal/source_repository/pkg.generated.mbti
@@ -9,6 +9,8 @@ import {
 // Values
 pub fn create(RepositorySnapshot, result~ : @cmd.Emit[CreateResult]) -> @cmd.Cmd
 
+pub fn delete(RepositorySnapshot, String, result~ : @cmd.Emit[DeleteResult]) -> @cmd.Cmd
+
 pub fn open(result~ : @cmd.Emit[OpenResult]) -> @cmd.Cmd
 
 pub fn save(RepositorySnapshot, String, String, result~ : @cmd.Emit[SaveResult]) -> @cmd.Cmd
@@ -35,6 +37,19 @@ pub(all) enum CreateFailure {
 pub(all) enum CreateResult {
   Created(RepositorySnapshot, String)
   Failed(CreateFailure)
+} derive(Eq, @debug.Debug)
+
+pub(all) enum DeleteFailure {
+  InvalidSource
+  LastSource
+  StorageUnavailable
+  QuotaExceeded
+  WriteFailed
+} derive(Eq, @debug.Debug)
+
+pub(all) enum DeleteResult {
+  Deleted(RepositorySnapshot)
+  Failed(DeleteFailure)
 } derive(Eq, @debug.Debug)
 
 pub(all) enum OpenFailure {

--- a/apps/loomark/internal/source_repository/repository_command_wbtest.mbt
+++ b/apps/loomark/internal/source_repository/repository_command_wbtest.mbt
@@ -83,6 +83,102 @@ test "save completion publishes the next snapshot after storage completes" {
 }
 
 ///|
+test "accepted deletion preserves unrelated repository observations" {
+  let snapshot = RepositorySnapshot::new(
+    [
+      SourceRecord::new("document-1", "# One\n").unwrap(),
+      SourceRecord::new("document-2", "# Two\n").unwrap(),
+    ],
+    Catalog::from_entries([
+      CatalogEntry::new("document-1", Some("One")).unwrap(),
+      CatalogEntry::new("document-2", Some("Two")).unwrap(),
+    ]).unwrap(),
+    [
+      RepositoryIssue::NameDerivationFailed("document-1"),
+      RepositoryIssue::UnknownRecord("metadata/future"),
+    ],
+    ["source/v1/document-1", "source/v1/document-2", "source/v1/corrupt"],
+  )
+  let next = accepted_deletion(snapshot, "document-1").unwrap()
+  assert_eq(next.sources().map(source => source.document_id()), ["document-2"])
+  assert_eq(next.issues(), [RepositoryIssue::UnknownRecord("metadata/future")])
+  assert_eq(next.occupied_source_keys(), [
+    "source/v1/corrupt", "source/v1/document-2",
+  ])
+}
+
+///|
+test "repository delete prepares one atomic Source deletion" {
+  let snapshot = RepositorySnapshot::from_sources([
+    SourceRecord::new("document-1", "# One\n").unwrap(),
+    SourceRecord::new("document-2", "# Two\n").unwrap(),
+  ]).unwrap()
+  inspect(
+    Repr(delete(snapshot, "document-2", result=_ => @cmd.none)),
+    content="IndexedDBMutate(\n  { name: \"loomark\", version: 1, store_name: \"documents\" },\n  [Delete(\"source/v1/document-2\")],\n)",
+  )
+}
+
+///|
+test "repository delete rejects unknown and final identities before storage" {
+  let snapshot = RepositorySnapshot::from_sources([
+    SourceRecord::new("document-1", "# One\n").unwrap(),
+  ]).unwrap()
+  let emitted : Array[DeleteResult] = []
+  let unknown = delete(snapshot, "missing", result=result => {
+    emitted.push(result)
+    @cmd.none
+  })
+  let last_source = delete(snapshot, "document-1", result=result => {
+    emitted.push(result)
+    @cmd.none
+  })
+  assert_eq(emitted, [
+    DeleteResult::Failed(DeleteFailure::InvalidSource),
+    DeleteResult::Failed(DeleteFailure::LastSource),
+  ])
+  assert_false(@debug.to_string(unknown).contains("IndexedDBMutate"))
+  assert_false(@debug.to_string(last_source).contains("IndexedDBMutate"))
+}
+
+///|
+test "delete completion publishes only its prepared snapshot" {
+  let original = RepositorySnapshot::from_sources([
+    SourceRecord::new("document-1", "# One\n").unwrap(),
+    SourceRecord::new("document-2", "# Two\n").unwrap(),
+  ]).unwrap()
+  let next = accepted_deletion(original, "document-1").unwrap()
+  let emitted : Array[DeleteResult] = []
+  for
+    stored in [
+      @indexed_db.WriteResult::Stored,
+      @indexed_db.WriteResult::Unavailable,
+      @indexed_db.WriteResult::QuotaExceeded,
+      @indexed_db.WriteResult::Failed,
+    ] {
+    let _ = finish_delete(next, stored, result => {
+      emitted.push(result)
+      @cmd.none
+    })
+  }
+  assert_eq(emitted.get(0), Some(DeleteResult::Deleted(next)))
+  assert_true(next.source("document-1") is None)
+  assert_eq(next.source("document-2").unwrap().text(), "# Two\n")
+  assert_eq(
+    emitted.get(1),
+    Some(DeleteResult::Failed(DeleteFailure::StorageUnavailable)),
+  )
+  assert_eq(
+    emitted.get(2),
+    Some(DeleteResult::Failed(DeleteFailure::QuotaExceeded)),
+  )
+  assert_eq(
+    emitted.get(3),
+    Some(DeleteResult::Failed(DeleteFailure::WriteFailed)),
+  )
+}
+
+///|
 test "open write completion rescans and preserves failure classifications" {
   inspect(
     Repr(finish_open_write(@indexed_db.WriteResult::Stored, _ => @cmd.none)),

--- a/apps/loomark/internal/source_repository/storage.mbt
+++ b/apps/loomark/internal/source_repository/storage.mbt
@@ -40,6 +40,15 @@ pub(all) enum CreateFailure {
 } derive(Eq, Debug)
 
 ///|
+pub(all) enum DeleteFailure {
+  InvalidSource
+  LastSource
+  StorageUnavailable
+  QuotaExceeded
+  WriteFailed
+} derive(Eq, Debug)
+
+///|
 pub(all) enum OpenResult {
   Ready(RepositorySnapshot)
   Failed(OpenFailure)
@@ -55,6 +64,12 @@ pub(all) enum SaveResult {
 pub(all) enum CreateResult {
   Created(RepositorySnapshot, String)
   Failed(CreateFailure)
+} derive(Eq, Debug)
+
+///|
+pub(all) enum DeleteResult {
+  Deleted(RepositorySnapshot)
+  Failed(DeleteFailure)
 } derive(Eq, Debug)
 
 ///|
@@ -154,6 +169,41 @@ pub fn save(
   let next = accepted_source(snapshot, source)
   @indexed_db.put(document_store, key, encode_source(source), result=stored => {
     finish_save(next, stored, result)
+  })
+}
+
+///|
+fn finish_delete(
+  next : RepositorySnapshot,
+  stored : @indexed_db.WriteResult,
+  result : @cmd.Emit[DeleteResult],
+) -> @cmd.Cmd {
+  match stored {
+    @indexed_db.WriteResult::Stored => result(Deleted(next))
+    @indexed_db.WriteResult::Unavailable => result(Failed(StorageUnavailable))
+    @indexed_db.WriteResult::QuotaExceeded => result(Failed(QuotaExceeded))
+    @indexed_db.WriteResult::Failed => result(Failed(WriteFailed))
+  }
+}
+
+///|
+pub fn delete(
+  snapshot : RepositorySnapshot,
+  document_id : String,
+  result~ : @cmd.Emit[DeleteResult],
+) -> @cmd.Cmd {
+  guard snapshot.source(document_id) is Some(_) else {
+    return result(Failed(InvalidSource))
+  }
+  guard snapshot.sources().length() > 1 else {
+    return result(Failed(LastSource))
+  }
+  guard accepted_deletion(snapshot, document_id) is Some(next) &&
+    source_key(document_id) is Some(key) else {
+    return result(Failed(InvalidSource))
+  }
+  @indexed_db.mutate(document_store, [@indexed_db.Mutation::Delete(key)], result=stored => {
+    finish_delete(next, stored, result)
   })
 }
 

--- a/apps/loomark/internal/source_repository/types.mbt
+++ b/apps/loomark/internal/source_repository/types.mbt
@@ -186,6 +186,39 @@ fn RepositorySnapshot::occupied_source_keys(self : Self) -> ArrayView[String] {
 }
 
 ///|
+fn accepted_deletion(
+  snapshot : RepositorySnapshot,
+  document_id : String,
+) -> RepositorySnapshot? {
+  guard snapshot.source(document_id) is Some(_) &&
+    snapshot.sources().length() > 1 else {
+    return None
+  }
+  let key = source_key(document_id).unwrap()
+  let sources = snapshot
+    .sources()
+    .filter(source => source.document_id() != document_id)
+  let entries = snapshot
+    .catalog()
+    .entries()
+    .filter(entry => entry.document_id() != document_id)
+  let issues = snapshot
+    .issues()
+    .filter(issue => {
+      match issue {
+        RepositoryIssue::NameDerivationFailed(issue_id) =>
+          issue_id != document_id
+        _ => true
+      }
+    })
+  let occupied_source_keys = snapshot
+    .occupied_source_keys()
+    .filter(occupied => occupied != key)
+  guard Catalog::from_entries(entries) is Some(catalog) else { return None }
+  Some(RepositorySnapshot::new(sources, catalog, issues, occupied_source_keys))
+}
+
+///|
 fn accepted_source(
   snapshot : RepositorySnapshot,
   source : SourceRecord,

--- a/apps/loomark/package-lock.json
+++ b/apps/loomark/package-lock.json
@@ -6,9 +6,67 @@
     "": {
       "name": "loomark-web",
       "devDependencies": {
+        "@egoist/tailwindcss-icons": "^1.9.2",
+        "@iconify-json/lucide": "^1.2.127",
         "@tailwindcss/cli": "4.3.3",
         "@tailwindcss/typography": "0.5.20",
         "tailwindcss": "4.3.3"
+      }
+    },
+    "node_modules/@antfu/install-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "package-manager-detector": "^1.3.0",
+        "tinyexec": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@egoist/tailwindcss-icons": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@egoist/tailwindcss-icons/-/tailwindcss-icons-1.9.2.tgz",
+      "integrity": "sha512-I6XsSykmhu2cASg5Hp/ICLsJ/K/1aXPaSKjgbWaNp2xYnb4We/arWMmkhhV+9CglOFCUbqx0A3mM2kWV32ZIhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@iconify/utils": "^3.1.0"
+      },
+      "peerDependencies": {
+        "tailwindcss": "*"
+      }
+    },
+    "node_modules/@iconify-json/lucide": {
+      "version": "1.2.127",
+      "resolved": "https://registry.npmjs.org/@iconify-json/lucide/-/lucide-1.2.127.tgz",
+      "integrity": "sha512-7KuCCpkly00kefna4wEnCr8l2HFRkbn4mD4zRib8wCSbrBmnR/l57ExpU6j5jv/Bo+qHpWuHpDtcqceQ0ptArw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@iconify/types": "*"
+      }
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@iconify/utils": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.4.tgz",
+      "integrity": "sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@antfu/install-pkg": "^1.1.0",
+        "@iconify/types": "^2.0.0",
+        "import-meta-resolve": "^4.2.0"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -828,6 +886,17 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -1195,6 +1264,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/package-manager-detector": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
+      "integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1258,6 +1334,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/to-regex-range": {

--- a/apps/loomark/package.json
+++ b/apps/loomark/package.json
@@ -6,6 +6,8 @@
     "dev:styles": "tailwindcss -i ./styles/tailwind.css -o ./public/styles.css --watch"
   },
   "devDependencies": {
+    "@egoist/tailwindcss-icons": "^1.9.2",
+    "@iconify-json/lucide": "^1.2.127",
     "@tailwindcss/cli": "4.3.3",
     "@tailwindcss/typography": "0.5.20",
     "tailwindcss": "4.3.3"

--- a/apps/loomark/styles/tailwind.css
+++ b/apps/loomark/styles/tailwind.css
@@ -162,6 +162,27 @@
   transform: rotate(90deg);
 }
 
+[data-loomark-icon="delete-document"]::before {
+  position: absolute;
+  inset: 0.2rem 0.25rem 0.15rem;
+  border: 1.25px solid currentColor;
+  border-top: 0;
+  border-radius: 0 0 0.1rem 0.1rem;
+  content: "";
+}
+
+[data-loomark-icon="delete-document"]::after {
+  position: absolute;
+  top: 0.1rem;
+  left: 0.2rem;
+  width: 0.6rem;
+  height: 1.25px;
+  border-radius: 1px;
+  background: currentColor;
+  box-shadow: 0.16rem -0.1rem 0 -0.03rem currentColor;
+  content: "";
+}
+
 [data-mode="text"]::before {
   position: absolute;
   top: 0.25rem;

--- a/apps/loomark/styles/tailwind.css
+++ b/apps/loomark/styles/tailwind.css
@@ -1,5 +1,6 @@
 @import "tailwindcss" source(none);
 @plugin "@tailwindcss/typography";
+@plugin "@egoist/tailwindcss-icons";
 @source "../app";
 @source not "../app/example_documents";
 @source not "../app/example_*.g.mbt";
@@ -80,25 +81,6 @@
   margin-bottom: 0;
 }
 
-/* Small navigation glyphs are authored geometry; utilities own their controls. */
-[data-loomark-icon="sidebar"] {
-  border: 1.5px solid currentColor;
-  border-radius: 0.1875rem;
-}
-
-[data-loomark-icon="sidebar"]::before {
-  position: absolute;
-  inset-block: 0;
-  left: 0.3rem;
-  width: 1.5px;
-  background: currentColor;
-  content: "";
-}
-
-[data-slot="sidebar-menu-action"] [data-loomark-icon="new-document"] {
-  transition: transform 120ms ease-out;
-}
-
 @media (hover: hover) and (pointer: fine) {
   [data-slot="sidebar-trigger"]:hover {
     --rui-button-bg: var(--color-lm-accent-soft);
@@ -109,124 +91,4 @@
     --rui-sidebar-action-bg: var(--color-lm-accent-soft);
     --rui-sidebar-action-fg: var(--color-lm-accent);
   }
-}
-
-[data-slot="sidebar-menu-action"]:active
-  [data-loomark-icon="new-document"] {
-  transform: scale(0.86);
-}
-
-@media (prefers-reduced-motion: reduce) {
-  [data-slot="sidebar-menu-action"] [data-loomark-icon="new-document"] {
-    transition-duration: 80ms;
-  }
-}
-
-[data-loomark-icon="folder"]::before,
-[data-loomark-icon="folder"]::after {
-  position: absolute;
-  border: 1.25px solid currentColor;
-  content: "";
-}
-
-[data-loomark-icon="folder"]::before {
-  top: 0.1875rem;
-  left: 0.125rem;
-  width: 0.4375rem;
-  height: 0.25rem;
-  border-bottom: 0;
-  border-radius: 0.125rem 0.125rem 0 0;
-}
-
-[data-loomark-icon="folder"]::after {
-  top: 0.375rem;
-  left: 0.0625rem;
-  width: 0.875rem;
-  height: 0.5625rem;
-  border-radius: 0.125rem;
-}
-
-[data-loomark-icon="new-document"]::before,
-[data-loomark-icon="new-document"]::after {
-  position: absolute;
-  top: calc(50% - 0.75px);
-  left: 0.1875rem;
-  width: 0.625rem;
-  height: 1.5px;
-  border-radius: 1px;
-  background: currentColor;
-  content: "";
-}
-
-[data-loomark-icon="new-document"]::after {
-  transform: rotate(90deg);
-}
-
-[data-loomark-icon="delete-document"]::before {
-  position: absolute;
-  inset: 0.2rem 0.25rem 0.15rem;
-  border: 1.25px solid currentColor;
-  border-top: 0;
-  border-radius: 0 0 0.1rem 0.1rem;
-  content: "";
-}
-
-[data-loomark-icon="delete-document"]::after {
-  position: absolute;
-  top: 0.1rem;
-  left: 0.2rem;
-  width: 0.6rem;
-  height: 1.25px;
-  border-radius: 1px;
-  background: currentColor;
-  box-shadow: 0.16rem -0.1rem 0 -0.03rem currentColor;
-  content: "";
-}
-
-[data-mode="text"]::before {
-  position: absolute;
-  top: 0.25rem;
-  left: 0.1875rem;
-  width: 0.75rem;
-  height: 1px;
-  background: currentColor;
-  box-shadow: 0 0.25rem 0 currentColor, 0 0.5rem 0 currentColor;
-  content: "";
-}
-
-[data-mode="preview"]::before {
-  position: absolute;
-  top: 0.1875rem;
-  left: 0.1875rem;
-  width: 0.6875rem;
-  height: 0.6875rem;
-  border: 1.5px solid currentColor;
-  border-radius: 75% 0;
-  content: "";
-  transform: rotate(45deg);
-}
-
-[data-mode="preview"]::after {
-  position: absolute;
-  top: 0.4375rem;
-  left: 0.4375rem;
-  width: 0.25rem;
-  height: 0.25rem;
-  border-radius: 50%;
-  background: currentColor;
-  content: "";
-}
-
-[data-mode="split"] {
-  border: 1.5px solid currentColor;
-  border-radius: 0.125rem;
-}
-
-[data-mode="split"]::after {
-  position: absolute;
-  inset-block: 0;
-  left: calc(50% - 0.75px);
-  width: 1.5px;
-  background: currentColor;
-  content: "";
 }

--- a/apps/loomark/styles/tailwind.css
+++ b/apps/loomark/styles/tailwind.css
@@ -81,6 +81,25 @@
   margin-bottom: 0;
 }
 
+.loomark-delete-action {
+  --rui-sidebar-action-fg: var(--color-lm-muted);
+}
+
+.loomark-delete-action:focus-visible {
+  --rui-sidebar-action-bg: var(--color-lm-danger-soft);
+  --rui-sidebar-action-fg: var(--color-lm-danger);
+}
+
+.loomark-sidebar-action[aria-disabled="true"] {
+  --rui-sidebar-action-fg: var(--color-lm-muted);
+  --rui-sidebar-action-opacity: 0.3;
+}
+
+.loomark-sidebar-action:active:not([aria-disabled="true"]) {
+  --rui-sidebar-action-opacity: 0.65;
+  --rui-sidebar-action-press-offset: 1px;
+}
+
 @media (hover: hover) and (pointer: fine) {
   [data-slot="sidebar-trigger"]:hover {
     --rui-button-bg: var(--color-lm-accent-soft);
@@ -90,5 +109,10 @@
   [data-slot="sidebar-menu-action"]:hover {
     --rui-sidebar-action-bg: var(--color-lm-accent-soft);
     --rui-sidebar-action-fg: var(--color-lm-accent);
+  }
+
+  .loomark-delete-action:hover:not([aria-disabled="true"]) {
+    --rui-sidebar-action-bg: var(--color-lm-danger-soft);
+    --rui-sidebar-action-fg: var(--color-lm-danger);
   }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -252,6 +252,9 @@ behavior** — check the code before relying on any specific detail.
   — makes versioned Source records independently authoritative, derives the
   Catalog in memory, atomically migrates `active`, and keeps normal saves to one
   Source transaction.
+- [Loomark document deletion](decisions/2026-08-31-loomark-document-deletion.md)
+  — deletes one known non-final Source from a quiescent document state and
+  publishes its prepared Snapshot only after transaction completion.
 
 ## Historical / Archive
 

--- a/docs/decisions/2026-08-31-loomark-document-deletion.md
+++ b/docs/decisions/2026-08-31-loomark-document-deletion.md
@@ -1,0 +1,90 @@
+# Loomark deletes Sources only from a quiescent document state
+
+**Date:** 2026-08-31
+
+**Status:** Accepted
+
+**Issue:** [#1306](https://github.com/dowdiness/canopy/issues/1306)
+
+**Related:**
+
+- [Loomark Source repository](2026-08-29-loomark-source-repository.md)
+- [Loomark separates current and saved text](2026-08-24-loomark-source-first-interactive-contract.md)
+
+## Context
+
+Deleting a Source must not publish a Catalog that disagrees with IndexedDB or
+overwrite a Snapshot accepted by another repository operation. Loomark already
+admits document switching and creation only while the active document is Saved,
+not composing, and not creating. Only the active document can Autosave.
+
+Allowing edits or another repository mutation during deletion would create a
+Save/Delete ordering problem that the product does not otherwise need. Solving
+that self-created concurrency with per-document queues, Snapshot deltas,
+watchdogs, or a new persisted ordering field would make permanent deletion
+substantially deeper than its product behavior.
+
+Issue #1306 also requires a policy for the final valid Source. Replacing it with
+a newly generated Source would add identity generation and a second mutation to
+an operation whose purpose is deleting one Source.
+
+## Decision
+
+Loomark permits deletion only from the existing quiescent document boundary:
+the active document is Saved, composition is inactive, and creation is idle.
+Confirmation and an in-flight Delete temporarily block text mutation, document
+switching, creation, and another Delete. Preview and Editor mode remain usable
+because they do not mutate the Source repository.
+
+The repository validates that the target belongs to the supplied immutable
+`RepositorySnapshot` and that at least two valid Sources remain. Unknown targets
+and the final Source fail before IndexedDB work.
+
+The repository computes the next Snapshot and derived Catalog before issuing
+one transaction. That transaction contains only
+`Mutation::Delete(source_key)`. Only transaction completion publishes the
+prepared Snapshot. Abort, unavailability, quota, or another write failure
+preserves the prior Snapshot.
+
+Delete attempts carry an app-private monotonic request ID. A completion changes
+state only when it matches the single in-flight attempt.
+
+Deleting the active Source activates `RepositorySnapshot::selected()` after
+commit. Its existing lexical Document ID order is the deterministic fallback.
+Deleting a non-active Source changes only the acknowledged repository Snapshot.
+
+The final valid Source cannot be deleted. The UI disables that action and the
+repository independently enforces the policy.
+
+The `source/v1` value remains exactly `document_id` and `text`. Delete adds no
+persisted Catalog, ordering field, tombstone, replacement Source, empty
+repository state, or Rabbita provider behavior.
+
+## Consequences
+
+- Delete has one in-flight state rather than a persistence queue.
+- A stalled transaction can temporarily make document mutations unavailable;
+  no timeout may claim whether an unacknowledged transaction committed.
+- Closing the page needs no special recovery. The next complete Source scan
+  reflects whichever IndexedDB state became durable.
+- Most-recently-changed fallback and deleting the final Source remain separate
+  product decisions requiring their own evidence and storage contracts.
+
+## Rejected alternatives
+
+**Delete the final Source and open an ephemeral replacement.** Rejected because
+it changes the existing non-empty repository invariant and introduces identity
+reservation and first-write promotion unrelated to deleting one Source.
+
+**Atomically replace the final Source with `# Untitled\n`.** Rejected because it
+adds UUID failure and a Source put to the smallest deletion contract.
+
+**Allow Save and Delete concurrently and merge acknowledged deltas.** Rejected
+because the existing Saved-only admission boundary can prevent that race.
+
+**Add per-document persistence lanes.** Rejected because Loomark edits and saves
+only one active document, while Delete is a rare confirmed operation.
+
+**Probe after a watchdog timeout.** Rejected because IndexedDB transaction
+completion or abort already defines the operation result; page termination is
+resolved by the next repository scan.


### PR DESCRIPTION
## Summary

- add quiescent document deletion for any known non-final Loomark Source
- commit one IndexedDB delete transaction before publishing the prepared immutable repository snapshot
- add an accessible Sidebar action and confirmation dialog, with Lucide icons and explicit failure/retry states

Closes #1306.

## UI and review evidence

- [x] Visible-label removal preserves accessible names, visible focus, and the keyboard path
- [x] Interactive bounds, pointer feedback, and viewport reflow were checked in the rendered UI
- [x] Any claimed Canopy rule cites its repository source; external guidance, recommendations, and preferences are labeled as such

Rendered checks covered desktop and 390 px layouts, confirmation/cancellation, active and non-active deletion, disabled final-Source deletion, keyboard focus, and reload persistence.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `can_activate` | `apps/loomark/app/update.mbt` | Yes | Admits deletion only from the existing Saved, non-composing, non-Creating boundary. |
| `RepositorySnapshot::source` / `RepositorySnapshot::selected` | `apps/loomark/internal/source_repository/types.mbt` | Yes | Validates identities and selects the existing lexical fallback after active deletion. |
| `@indexed_db.mutate` / `Mutation::Delete` | Rabbita IndexedDB | Yes | Executes exactly one delete mutation and acknowledges only transaction completion. |
| `@rui.alert_dialog` / Sidebar actions | Rabbita RUI | Yes | Provides the confirmation and accessible document actions without new UI primitives. |
| `ArrayView::filter`, `Option`, and pattern matching | MoonBit core | Yes | Constructs the next immutable collection and handles source lookup/results declaratively. |
| `Map` / `Set` | MoonBit core | Indirectly | Existing repository constructors already own catalog and occupied-key reconstruction; no new collection layer was needed. |
| `Result` | MoonBit core | No | Domain-specific `DeleteResult` must distinguish acknowledged deletion from storage and validation failures. |

New helpers added (if any):

- `accepted_deletion`: pure pre-I/O validation and next-Snapshot preparation.
- `deletion_blocks_document_changes`: central guard for the temporary mutation freeze.
- `finish_delete`: thin command-shell adapter that attaches the request ID.
- `delete_dialog`, `delete_failure_view`, and `sidebar_delete_icon`: local rendering helpers that keep the main view structure readable.

## Validation scope

Boundary matrix / first failing regression:

- repository: known/non-final, unknown, final Source, exact one-key mutation, transaction failure, catalog/issues/occupied-key reconstruction
- reducer: active and non-active success, full state preservation on failure, stale completion fencing, retry, and blocked Text/Create/Switch/Delete operations
- browser: confirmation, cancellation, active/non-active deletion, final-Source rejection, reload persistence, and 390 px controls

Target packages:

- `apps/loomark/app`
- `apps/loomark/internal/source_repository`

Additional conditional gates:

- Loomark app tests: 41 passed
- Source repository tests: 35 passed
- production standalone Playwright suite: 46 passed
- Tailwind production style build and TypeScript standalone typecheck passed
- `git diff --check` passed

## Push and CI readiness

```bash
git fetch origin main
git push
```

- [x] The branch contains the fetched `origin/main`, and the normal push
      completed without bypassing Lefthook's affected local checks.
- [x] The committed `.mbti` diff against `origin/main` was reviewed for
      unintended API or trait-bound changes.
- [x] Any changed submodule commit is pushed and reachable from its remote.
- [x] The branch was pushed again after every commit, amend, rebase,
      cherry-pick, submodule-pointer, manifest, or generated-interface change.
- [x] Independent review findings were resolved before the final validation.
- [ ] GitHub CI's `All Checks Passed` gate is green before merge.
