### PR TITLE
Loomark: resume the Editing Document after reload

### DIFF
--- a/apps/loomark/CONTEXT.md
+++ b/apps/loomark/CONTEXT.md
@@ -15,6 +15,17 @@ Loomark document when the user first changes its text; leaving it untouched does
 not add it to Recent documents.
 _Avoid_: blank record, draft
 
+**Editing Document**:
+The Loomark document currently shown in the Editor and owning its TextArea and
+Preview. A requested Document switch does not change the Editing Document until
+the requested document is ready and activated.
+_Avoid_: active document, open document, selected document
+
+**Selection target**:
+The Loomark document requested by a Document switch. It may differ temporarily
+from the Editing Document while the requested document is being prepared.
+_Avoid_: Editing Document, active document
+
 **Document text**:
 The current Markdown text. Text input updates it immediately.
 _Avoid_: canonical source, draft text, surface, surface text
@@ -189,6 +200,7 @@ _Avoid_: delete failure, timed-out deletion
 
 **Recovery**:
 The state shown for a Loomark document whose Browser storage record cannot be
-opened safely. Loomark preserves it as unavailable without preventing valid
-Loomark documents or a New document from opening.
+opened safely. That document cannot become the Editing Document, but Loomark
+preserves it as unavailable and opens another valid Loomark document or a New
+document.
 _Avoid_: automatic reset, save failure

--- a/apps/loomark/README.md
+++ b/apps/loomark/README.md
@@ -32,29 +32,33 @@ becomes processable, or when the page becomes hidden. The maximum is application
 policy rather than a wall-clock acknowledgment guarantee. IME composition
 defers persistence until its committed result.
 
-At most one Source write and one newer text-free checkpoint exist. Transaction
-completion starts a latest follow-up only when that checkpoint is already
-eligible. Checkpoint epoch and quiet revision reject delayed work even when
+For each document, at most one Source write and one newer text-free checkpoint
+exist; different documents may persist independently. Transaction completion
+starts a latest follow-up only when that checkpoint is already eligible. Checkpoint epoch and quiet revision reject delayed work even when
 text follows an equal-value ABA path. Exact return to the acknowledged Source
 restores `Saved` without a redundant write, including after a failed attempt;
 other failures require explicit Retry.
 
-Each `source/v1/<document-id>` record contains exactly `document_id` and `text`
-and is the durable authority for that document. Opening scans the complete
-store, isolates malformed or unsupported records, derives first-ATX-H1 names
-into an in-memory Catalog, and selects the first valid Document ID lexically.
-Unknown metadata remains stored but cannot hide or override a Source.
+Each `source/v1/<document-id>` record contains `document_id`, `text`, and its
+Change order and is the durable authority for that document. Opening scans the
+complete store, isolates malformed or unsupported records, derives first-ATX-H1
+names into an in-memory Catalog, and orders valid Sources by newest Change order
+with a Document ID tie break. The independent `editing-document` string record
+selects an exact valid Source after that reconciliation; a missing, malformed,
+or stale value uses the deterministic Catalog selection instead. Opening never
+repairs or rewrites it.
 
-An empty repository creates a UUID-backed Source with exact text
-`# Untitled\n`. The legacy `active` record is moved atomically when safe;
-collisions preserve both records. A normal save writes only the accepted Source
-and installs the next in-memory Catalog after that transaction completes. A
-Source save failure preserves current text and presents Retry. A confirmed
-Delete removes one known non-final Source in one transaction while document
-mutations are quiescent. The prepared Snapshot becomes visible only after
-transaction completion; deleting the final Source is rejected. Hidden-page
-persistence is best effort because the browser may freeze or terminate before
-IndexedDB completion.
+An empty repository opens an ephemeral New document without writing a Source.
+The legacy `active` record is moved atomically when safe; collisions preserve
+both records. A normal save writes only the accepted Source and applies its
+acknowledgment to the latest in-memory Snapshot. Activating a saved Source writes
+its Document ID to `editing-document` on a best-effort basis without adding
+application state, retry, or a Source durability claim. Source save failures
+preserve current text and present Retry. A confirmed Delete is ordered within
+the target document's persistence lane; deleting the Editing Document activates
+and remembers a saved fallback, or opens an ephemeral New document when none
+remains. Hidden-page persistence is best effort because the browser may freeze
+or terminate before IndexedDB completion.
 
 ## Development
 

--- a/apps/loomark/app/update.mbt
+++ b/apps/loomark/app/update.mbt
@@ -159,7 +159,7 @@ fn activate(
     document_id,
     generation: editing.activation.generation + 1,
   }
-  let (preview, command) = activate_surface(
+  let (preview, surface) = activate_surface(
     activation,
     text,
     editing.mode,
@@ -167,7 +167,11 @@ fn activate(
     text_area,
     preview_engine,
   )
-  ({ ..editing, activation, preview }, command)
+  let remember = @source_repository.remember_editing_document(
+    editing.documents.snapshot(),
+    document_id,
+  )
+  ({ ..editing, activation, preview }, @cmd.batch([surface, remember]))
 }
 
 ///|
@@ -207,8 +211,8 @@ fn update(
   preview_engine : @preview.PreviewEngine,
 ) -> (Model, @rabbita.Cmd) {
   match (model, msg) {
-    (Loading(compact), Opened(Ready(snapshot))) =>
-      match snapshot.selected() {
+    (Loading(compact), Opened(Ready(snapshot, initial))) =>
+      match initial {
         Some(source) => {
           let documents = initial_documents(snapshot)
           let activation = { document_id: source.document_id(), generation: 0 }

--- a/apps/loomark/app/update_wbtest.mbt
+++ b/apps/loomark/app/update_wbtest.mbt
@@ -48,6 +48,18 @@ test "loading and recovery ignore document lifecycle feedback" {
 }
 
 ///|
+test "repository open activates its resolved initial Document" {
+  let snapshot = test_snapshot()
+  let initial = snapshot.source("two").unwrap()
+  let (model, _) = test_update(
+    Loading(false),
+    Opened(Ready(snapshot, Some(initial))),
+  )
+  guard model is Editing(editing) else { fail("editing") }
+  assert_eq(editing.activation.document_id, "two")
+}
+
+///|
 test "active delete is accepted and composition defers confirmation" {
   let initial = test_editing()
   let (model, _) = test_update(Editing(initial), DeleteRequested("one"))
@@ -77,6 +89,17 @@ test "same document selection is a no-op" {
 }
 
 ///|
+test "only saved Document activation is remembered" {
+  let saved = test_update(Editing(test_editing()), DocumentSelected("two")).1
+  let ephemeral = test_update(
+      Editing({ ..test_editing(), creation: Creating }),
+      CreateCompleted("one", Created("new")),
+    ).1
+  assert_true(@debug.to_string(saved).contains("editing-document"))
+  assert_false(@debug.to_string(ephemeral).contains("editing-document"))
+}
+
+///|
 test "stale create completion is ignored" {
   let initial = { ..test_editing(), creation: Creating }
   let (model, _) = test_update(
@@ -98,6 +121,25 @@ test "pending target cannot be selected" {
   )
   guard model is Editing(editing) else { fail("editing") }
   assert_eq(editing.activation.document_id, "one")
+}
+
+///|
+test "deleting the Editing Document remembers its saved fallback" {
+  let initial = { ..test_editing(), deletion: DeleteConfirmation("one") }
+  let (model, _) = test_update(Editing(initial), DeleteConfirmed("one"))
+  guard model is Editing(deleting) else { fail("deleting") }
+  guard deleting.documents.delete_status("one") is Some(Deleting(operation)) else {
+    fail("delete operation")
+  }
+  let (model, command) = test_update(
+    Editing(deleting),
+    DocumentsLifecycle(DeleteCompleted(operation, Deleted("one"))),
+  )
+  guard model is Editing(editing) else { fail("fallback") }
+  assert_eq(editing.activation.document_id, "two")
+  let command = @debug.to_string(command)
+  assert_true(command.contains("editing-document"))
+  assert_true(command.contains("two"))
 }
 
 ///|

--- a/apps/loomark/examples/vanilla/tests/standalone.spec.ts
+++ b/apps/loomark/examples/vanilla/tests/standalone.spec.ts
@@ -4,6 +4,7 @@ const DOCUMENT_DATABASE_NAME = "loomark"
 const DOCUMENT_DATABASE_VERSION = 1
 const DOCUMENT_STORE_NAME = "documents"
 const LEGACY_ACTIVE_KEY = "active"
+const EDITING_DOCUMENT_KEY = "editing-document"
 const SOURCE_KEY_PREFIX = "source/v1/"
 const CATALOG_KEY = "catalog/v1"
 
@@ -258,8 +259,11 @@ async function replaceStoreRecords(page: Page, records: StoreRecord[]): Promise<
   })
 }
 
-function encodeStoredDocument(document: StoredDocument): string {
-  return JSON.stringify({ ...document, change_order: 0 })
+function encodeStoredDocument(
+  document: StoredDocument,
+  changeOrder = 0,
+): string {
+  return JSON.stringify({ ...document, change_order: changeOrder })
 }
 
 async function expectStoredDocument(
@@ -456,6 +460,41 @@ async function readDocumentPutLog(page: Page): Promise<PutObservation[]> {
   ))
 }
 
+type StoreMutationObservation = {
+  method: "put" | "delete"
+  key?: IDBValidKey
+}
+
+function installStoreMutationLog(): void {
+  const state = globalThis as typeof globalThis & {
+    __loomarkStoreMutationLog?: StoreMutationObservation[]
+  }
+  const prototype = IDBObjectStore.prototype as any
+  const originalPut = prototype.put
+  const originalDelete = prototype.delete
+  state.__loomarkStoreMutationLog = []
+  prototype.put = function(
+    this: IDBObjectStore,
+    value: unknown,
+    recordKey?: IDBValidKey,
+  ) {
+    state.__loomarkStoreMutationLog?.push({ method: "put", key: recordKey })
+    return originalPut.call(this, value, recordKey)
+  }
+  prototype.delete = function(this: IDBObjectStore, recordKey: IDBValidKey) {
+    state.__loomarkStoreMutationLog?.push({ method: "delete", key: recordKey })
+    return originalDelete.call(this, recordKey)
+  }
+}
+
+async function readStoreMutationLog(page: Page): Promise<StoreMutationObservation[]> {
+  return page.evaluate(() => (
+    (globalThis as typeof globalThis & {
+      __loomarkStoreMutationLog?: StoreMutationObservation[]
+    }).__loomarkStoreMutationLog ?? []
+  ))
+}
+
 test("fresh production opens Text mode and preserves its textarea and undo history across modes", async ({ page }) => {
   const workerUrls: string[] = []
   page.on("worker", worker => workerUrls.push(worker.url()))
@@ -561,7 +600,7 @@ test("opening and saving persist only authoritative Source records", async ({ pa
   expect(JSON.parse(savedRaw as string).change_order).toEqual(expect.any(Number))
 })
 
-test("several Sources select the first lexical Document ID without writing metadata", async ({ page }) => {
+test("several Sources select the first lexical Document ID", async ({ page }) => {
   await page.goto("/")
   await waitForRepositoryOpen(page)
   const documentA = { document_id: "document-a", text: "# Same\n" }
@@ -591,7 +630,42 @@ test("several Sources select the first lexical Document ID without writing metad
   }))
     .toBeVisible()
   expect(await readStoredDocumentRaw(page, CATALOG_KEY)).toBeUndefined()
+  expect(await readStoredDocumentRaw(page, EDITING_DOCUMENT_KEY)).toBeUndefined()
   expect(await readStoredDocumentRaw(page, "source/v2/future")).toBe("future")
+})
+
+test("startup is read-only and restores an accepted Editing Document", async ({ page }) => {
+  await page.goto("/")
+  await waitForRepositoryOpen(page)
+  const documentA = { document_id: "document-a", text: "# A\n" }
+  const documentB = { document_id: "document-b", text: "# B\n" }
+  await replaceStoreRecords(page, [
+    { key: sourceKey(documentA.document_id), value: encodeStoredDocument(documentA) },
+    { key: sourceKey(documentB.document_id), value: encodeStoredDocument(documentB) },
+    { key: EDITING_DOCUMENT_KEY, value: documentB.document_id },
+  ])
+
+  await page.addInitScript(installStoreMutationLog)
+  await page.reload()
+  const documents = page.getByRole("complementary", { name: "Documents" })
+  await expect(page.getByRole("textbox", { name: "Text" })).toHaveValue(documentB.text)
+  await expect(documents.getByRole("button", { name: "B", exact: true }))
+    .toHaveAttribute("data-state", "active")
+  expect(await readStoreMutationLog(page)).toEqual([])
+})
+
+test("a non-string Editing Document is equivalent to no Editing Document", async ({ page }) => {
+  await page.goto("/")
+  await waitForRepositoryOpen(page)
+  const documentA = { document_id: "document-a", text: "# A\n" }
+  await replaceStoreRecords(page, [
+    { key: sourceKey(documentA.document_id), value: encodeStoredDocument(documentA) },
+    { key: EDITING_DOCUMENT_KEY, value: { unsupported: true } },
+  ])
+
+  await page.reload()
+  await expect(page.getByRole("textbox", { name: "Text" })).toHaveValue(documentA.text)
+  await expect(page.getByRole("heading", { name: "Document recovery" })).toHaveCount(0)
 })
 
 test("Document Sidebar switches saved Sources A to B to A without cross-document undo", async ({ page }) => {
@@ -619,6 +693,8 @@ test("Document Sidebar switches saved Sources A to B to A without cross-document
 
   await documents.getByRole("button", { name: "B", exact: true }).click()
   await expect(text).toHaveValue(documentB.text)
+  await expect.poll(() => readStoredDocumentRaw(page, EDITING_DOCUMENT_KEY))
+    .toBe(documentB.document_id)
   await expect(page.getByRole("tab", { name: "Split" })).toHaveAttribute(
     "aria-selected",
     "true",
@@ -631,20 +707,79 @@ test("Document Sidebar switches saved Sources A to B to A without cross-document
 
   await documents.getByRole("button", { name: "A edited", exact: true }).click()
   await expect(text).toHaveValue("# A edited\n")
+  await expect.poll(() => readStoredDocumentRaw(page, EDITING_DOCUMENT_KEY))
+    .toBe(documentA.document_id)
   await expect(page.getByRole("heading", { name: "A edited" })).toBeVisible()
   expect(await readStoredDocumentRaw(page, sourceKey(documentB.document_id)))
     .toBe(encodeStoredDocument(documentB))
+  await page.reload()
+  await expect(text).toHaveValue("# A edited\n")
 })
 
-test("New Document activates an empty ephemeral document and persists on first edit", async ({ page }) => {
+test("Editing Document writes are last-invocation-wins", async ({ page }) => {
+  await page.goto("/")
+  await waitForRepositoryOpen(page)
+  const documentA = { document_id: "document-a", text: "# A\n" }
+  const documentB = { document_id: "document-b", text: "# B\n" }
+  await replaceStoreRecords(page, [
+    { key: sourceKey(documentA.document_id), value: encodeStoredDocument(documentA) },
+    { key: sourceKey(documentB.document_id), value: encodeStoredDocument(documentB) },
+  ])
+
+  await page.reload()
+  await page.evaluate(installDelayedDocumentCommit, EDITING_DOCUMENT_KEY)
+  const documents = page.getByRole("complementary", { name: "Documents" })
+  const text = page.getByRole("textbox", { name: "Text" })
+  await documents.getByRole("button", { name: "B", exact: true }).click()
+  await documents.getByRole("button", { name: "A", exact: true }).click()
+  await expect(text).toHaveValue(documentA.text)
+  await expect.poll(() => page.evaluate(() => (
+    (globalThis as typeof globalThis & {
+      __loomarkDelayedCommitCompletions?: number
+    }).__loomarkDelayedCommitCompletions ?? 0
+  ))).toBe(2)
+  await expect.poll(() => readStoredDocumentRaw(page, EDITING_DOCUMENT_KEY))
+    .toBe(documentA.document_id)
+
+  await page.reload()
+  await expect(text).toHaveValue(documentA.text)
+})
+
+test("remember failure cannot affect editing or Source recovery", async ({ page }) => {
+  await page.addInitScript(installDocumentPutFailure, EDITING_DOCUMENT_KEY)
+  await page.goto("/")
+  await waitForRepositoryOpen(page)
+  const documentA = { document_id: "document-a", text: "# A\n" }
+  const documentB = { document_id: "document-b", text: "# B\n" }
+  await replaceStoreRecords(page, [
+    { key: sourceKey(documentA.document_id), value: encodeStoredDocument(documentA) },
+    { key: sourceKey(documentB.document_id), value: encodeStoredDocument(documentB) },
+  ])
+
+  await page.reload()
+  const documents = page.getByRole("complementary", { name: "Documents" })
+  const text = page.getByRole("textbox", { name: "Text" })
+  await documents.getByRole("button", { name: "B", exact: true }).click()
+  await expect(text).toHaveValue(documentB.text)
+  await expect(page.getByRole("heading", { name: "Document recovery" })).toHaveCount(0)
+  expect(await readStoredDocumentRaw(page, EDITING_DOCUMENT_KEY)).toBeUndefined()
+
+  await page.reload()
+  await expect(text).toHaveValue(documentA.text)
+  await expect(page.getByRole("heading", { name: "Document recovery" })).toHaveCount(0)
+})
+
+test("New stays ephemeral and its first Source save is not remembered", async ({ page }) => {
   await page.goto("/")
   await waitForRepositoryOpen(page)
   const before = await readStoredDocuments(page)
   expect(before).toHaveLength(1)
 
   const documents = page.getByRole("complementary", { name: "Documents" })
+  await page.evaluate(installStoreMutationLog)
   await page.getByRole("button", { name: "New document" }).click()
   await expect.poll(() => readStoredDocuments(page).then(documents => documents.length)).toBe(1)
+  expect(await readStoreMutationLog(page)).toEqual([])
   const after = await readStoredDocuments(page)
   expect(after).toEqual(before)
   await expect(page.getByRole("textbox", { name: "Text" })).toHaveValue("")
@@ -659,13 +794,20 @@ test("New Document activates an empty ephemeral document and persists on first e
   if (!created) throw new Error("created Source missing")
   await expectStoredDocument(page, { ...created, text: "# Project notes\n" })
   await expect(documents.locator('[data-state="active"]')).toContainText("Project notes")
+  const mutations = await readStoreMutationLog(page)
+  expect(mutations.some(mutation => mutation.key === sourceKey(created.document_id)))
+    .toBe(true)
+  expect(mutations.some(mutation => mutation.key === EDITING_DOCUMENT_KEY))
+    .toBe(false)
+  expect(await readStoredDocumentRaw(page, EDITING_DOCUMENT_KEY)).toBeUndefined()
   const renamed = await readStoredDocuments(page)
 
   await page.reload()
   await expect(documents.getByRole("button", { name: "Untitled", exact: true }))
     .toBeVisible()
   await expect(documents.getByRole("button", { name: "Project notes", exact: true }))
-    .toBeVisible()
+    .toHaveAttribute("data-state", "active")
+  expect(await readStoredDocumentRaw(page, EDITING_DOCUMENT_KEY)).toBeUndefined()
   expect(await readStoredDocuments(page)).toEqual(renamed)
 })
 
@@ -695,14 +837,17 @@ test("Delete document removes a non-active Source without moving the editor", as
   await expect(page.getByRole("button", { name: "B", exact: true })).toHaveCount(0)
 })
 
-test("Delete document activates the lexical fallback only after commit", async ({ page }) => {
+test("Delete document activates and remembers the newest fallback", async ({ page }) => {
   await page.goto("/")
   await waitForRepositoryOpen(page)
   const documentA = { document_id: "document-a", text: "# A\n" }
   const documentB = { document_id: "document-b", text: "# B\n" }
+  const documentC = { document_id: "document-c", text: "# C\n" }
   await replaceStoreRecords(page, [
-    { key: sourceKey(documentA.document_id), value: encodeStoredDocument(documentA) },
-    { key: sourceKey(documentB.document_id), value: encodeStoredDocument(documentB) },
+    { key: sourceKey(documentA.document_id), value: encodeStoredDocument(documentA, 5) },
+    { key: sourceKey(documentB.document_id), value: encodeStoredDocument(documentB, 10) },
+    { key: sourceKey(documentC.document_id), value: encodeStoredDocument(documentC, 20) },
+    { key: EDITING_DOCUMENT_KEY, value: documentA.document_id },
   ])
   await page.reload()
 
@@ -711,11 +856,13 @@ test("Delete document activates the lexical fallback only after commit", async (
   await dialog.getByRole("button", { name: "Delete document" }).click()
 
   const text = page.getByRole("textbox", { name: "Text" })
-  await expect(text).toHaveValue(documentB.text)
+  await expect(text).toHaveValue(documentC.text)
+  await expect.poll(() => readStoredDocumentRaw(page, EDITING_DOCUMENT_KEY))
+    .toBe(documentC.document_id)
   await expect.poll(() => readStoredDocumentRaw(page, sourceKey(documentA.document_id)))
     .toBeUndefined()
   await page.reload()
-  await expect(text).toHaveValue(documentB.text)
+  await expect(text).toHaveValue(documentC.text)
 })
 
 test("Delete document cancellation preserves the Source and editor", async ({ page }) => {

--- a/apps/loomark/internal/source_repository/pkg.generated.mbti
+++ b/apps/loomark/internal/source_repository/pkg.generated.mbti
@@ -15,6 +15,8 @@ pub fn open(result~ : @cmd.Emit[OpenResult]) -> @cmd.Cmd
 
 pub fn probe(RepositorySnapshot, String, result~ : @cmd.Emit[ProbeResult]) -> @cmd.Cmd
 
+pub fn remember_editing_document(RepositorySnapshot, String) -> @cmd.Cmd
+
 pub fn save(RepositorySnapshot, String, String, change_order? : ChangeOrder, result~ : @cmd.Emit[SaveResult]) -> @cmd.Cmd
 
 pub fn store_new(RepositorySnapshot, String, String, ChangeOrder, result~ : @cmd.Emit[SaveResult]) -> @cmd.Cmd
@@ -76,7 +78,7 @@ pub(all) enum OpenFailure {
 } derive(Eq, @debug.Debug)
 
 pub(all) enum OpenResult {
-  Ready(RepositorySnapshot)
+  Ready(RepositorySnapshot, SourceRecord?)
   Failed(OpenFailure)
 } derive(Eq, @debug.Debug)
 

--- a/apps/loomark/internal/source_repository/reconciliation.mbt
+++ b/apps/loomark/internal/source_repository/reconciliation.mbt
@@ -2,8 +2,11 @@
 const LEGACY_ACTIVE_KEY : String = "active"
 
 ///|
+const EDITING_DOCUMENT_KEY : String = "editing-document"
+
+///|
 priv enum Reconciliation {
-  Ready(RepositorySnapshot)
+  Ready(RepositorySnapshot, SourceRecord?)
   Migrate(Array[@indexed_db.Mutation])
 }
 
@@ -14,10 +17,13 @@ fn reconcile_scan(entries : Array[@indexed_db.ScanEntry]) -> Reconciliation {
   let raw_source_keys : Set[String] = Set([])
   let valid_source_ids : Set[String] = Set([])
   let mut legacy : (String, SourceRecord)? = None
+  let mut editing_document_id : String? = None
   for entry in entries {
     match entry {
       StringRecord(key, encoded) =>
-        if key == LEGACY_ACTIVE_KEY {
+        if key == EDITING_DOCUMENT_KEY {
+          editing_document_id = Some(encoded)
+        } else if key == LEGACY_ACTIVE_KEY {
           match decode_source_value(encoded) {
             Ok(source) => legacy = Some((encoded, source))
             Err(_) => issues.push(InvalidLegacyRecord)
@@ -42,7 +48,9 @@ fn reconcile_scan(entries : Array[@indexed_db.ScanEntry]) -> Reconciliation {
         if key.strip_prefix(SOURCE_KEY_PREFIX) is Some(_) {
           raw_source_keys.add(key)
         }
-        if key == LEGACY_ACTIVE_KEY {
+        if key == EDITING_DOCUMENT_KEY {
+          ()
+        } else if key == LEGACY_ACTIVE_KEY {
           issues.push(InvalidLegacyRecord)
         } else {
           issues.push(UnsupportedRecord(key))
@@ -69,13 +77,21 @@ fn reconcile_scan(entries : Array[@indexed_db.ScanEntry]) -> Reconciliation {
     }
     None => ()
   }
-  match snapshot_from_sources(sources, issues, raw_source_keys.to_array()) {
-    Some(snapshot) => Ready(snapshot)
+  let snapshot = match
+    snapshot_from_sources(sources, issues, raw_source_keys.to_array()) {
+    Some(snapshot) => snapshot
     None =>
-      Ready(
-        snapshot_from_sources([], issues, raw_source_keys.to_array()).unwrap(),
-      )
+      snapshot_from_sources([], issues, raw_source_keys.to_array()).unwrap()
   }
+  let initial = match editing_document_id {
+    Some(document_id) =>
+      match snapshot.source(document_id) {
+        Some(source) => Some(source)
+        None => snapshot.selected()
+      }
+    None => snapshot.selected()
+  }
+  Ready(snapshot, initial)
 }
 
 ///|

--- a/apps/loomark/internal/source_repository/reconciliation_wbtest.mbt
+++ b/apps/loomark/internal/source_repository/reconciliation_wbtest.mbt
@@ -30,9 +30,10 @@ test "reconciliation isolates corrupt and unsupported records" {
     @indexed_db.ScanEntry::UnsupportedValue("binary"),
     @indexed_db.ScanEntry::UnsupportedKey(6),
   ])
-  guard result is Reconciliation::Ready(snapshot) else {
+  guard result is Reconciliation::Ready(snapshot, Some(initial)) else {
     fail("expected ready snapshot")
   }
+  assert_eq(initial, valid)
   assert_eq(snapshot.sources().to_owned(), [valid])
   assert_eq(snapshot.occupied_source_keys().to_owned(), [
     "source/v1/broken", "source/v1/document-b", "source/v1/old", "source/v1/wrong-key",
@@ -50,6 +51,47 @@ test "reconciliation isolates corrupt and unsupported records" {
     RepositoryIssue::UnsupportedRecord("binary"),
     RepositoryIssue::UnsupportedKey(6),
   ])
+}
+
+///|
+test "initial Document is the accepted Editing Document or deterministic fallback" {
+  let selected = SourceRecord::new(
+    "document-a",
+    "# A\n",
+    change_order=ChangeOrder::from_int64(20L).unwrap(),
+  ).unwrap()
+  let editing = SourceRecord::new(
+    "document-b",
+    "# B\n",
+    change_order=ChangeOrder::from_int64(10L).unwrap(),
+  ).unwrap()
+  let sources = [
+    @indexed_db.ScanEntry::StringRecord(
+      source_key("document-a").unwrap(),
+      encode_source(selected),
+    ),
+    @indexed_db.ScanEntry::StringRecord(
+      source_key("document-b").unwrap(),
+      encode_source(editing),
+    ),
+  ]
+  let cases : Array[(Array[@indexed_db.ScanEntry], SourceRecord)] = [
+    ([], selected),
+    ([StringRecord(EDITING_DOCUMENT_KEY, "document-b")], editing),
+    ([StringRecord(EDITING_DOCUMENT_KEY, "")], selected),
+    ([StringRecord(EDITING_DOCUMENT_KEY, "missing")], selected),
+    ([UnsupportedValue(EDITING_DOCUMENT_KEY)], selected),
+  ]
+  for case in cases {
+    let (metadata, expected) = case
+    guard reconcile_scan(metadata + sources)
+      is Reconciliation::Ready(snapshot, Some(initial)) else {
+      fail("expected ready repository")
+    }
+    assert_eq(initial, expected)
+    assert_eq(snapshot.selected(), Some(selected))
+    assert_eq(snapshot.issues(), [])
+  }
 }
 
 ///|
@@ -82,7 +124,7 @@ test "legacy migration decisions preserve collision safety" {
       @indexed_db.ScanEntry::StringRecord(LEGACY_ACTIVE_KEY, active),
       @indexed_db.ScanEntry::StringRecord("source/v1/legacy-id", "corrupt"),
     ])
-    is Reconciliation::Ready(snapshot) else {
+    is Reconciliation::Ready(snapshot, _) else {
     fail("expected ready collision snapshot without mutation")
   }
   assert_eq(snapshot.sources().length(), 0)
@@ -99,7 +141,7 @@ test "invalid legacy is preserved in a ready empty repository" {
   guard reconcile_scan([
       @indexed_db.ScanEntry::StringRecord(LEGACY_ACTIVE_KEY, "not-json"),
     ])
-    is Reconciliation::Ready(snapshot) else {
+    is Reconciliation::Ready(snapshot, _) else {
     fail("expected ready empty repository")
   }
   assert_eq(snapshot.sources().length(), 0)
@@ -109,7 +151,7 @@ test "invalid legacy is preserved in a ready empty repository" {
 
 ///|
 test "empty scan is directly ready with an empty snapshot" {
-  guard reconcile_scan([]) is Reconciliation::Ready(snapshot) else {
+  guard reconcile_scan([]) is Reconciliation::Ready(snapshot, None) else {
     fail("expected ready empty repository")
   }
   assert_eq(snapshot.sources(), [])

--- a/apps/loomark/internal/source_repository/repository_command_wbtest.mbt
+++ b/apps/loomark/internal/source_repository/repository_command_wbtest.mbt
@@ -7,18 +7,15 @@ test "repository open begins with a complete store scan" {
 }
 
 ///|
-test "repository open returns an empty snapshot without storage repair" {
+test "repository open returns the accepted Snapshot and initial document without repair" {
+  let source = SourceRecord::new("document-1", "# One\n").unwrap()
+  let snapshot = RepositorySnapshot::from_sources([source]).unwrap()
   let emitted : Array[OpenResult] = []
-  let command = continue_open(
-    Reconciliation::Ready(RepositorySnapshot::from_sources([]).unwrap()),
-    result => {
-      emitted.push(result)
-      @cmd.none
-    },
-  )
-  assert_eq(emitted, [
-    OpenResult::Ready(RepositorySnapshot::from_sources([]).unwrap()),
-  ])
+  let command = continue_open(Reconciliation::Ready(snapshot, Some(source)), result => {
+    emitted.push(result)
+    @cmd.none
+  })
+  assert_eq(emitted, [OpenResult::Ready(snapshot, Some(source))])
   assert_false(@debug.to_string(command).contains("IndexedDBPut"))
 }
 
@@ -36,6 +33,19 @@ test "repository open routes legacy migration through one atomic mutation" {
     ),
     content="IndexedDBMutate(\n  { name: \"loomark\", version: 1, store_name: \"documents\" },\n  [Put(\"source/v1/document-1\", \"encoded\"), Delete(\"active\")],\n)",
   )
+}
+
+///|
+test "repository remembers only an accepted Editing Document" {
+  let snapshot = RepositorySnapshot::from_sources([
+    SourceRecord::new("document-1", "# One\n").unwrap(),
+  ]).unwrap()
+  inspect(
+    Repr(remember_editing_document(snapshot, "document-1")),
+    content="IndexedDBPut(\n  { name: \"loomark\", version: 1, store_name: \"documents\" },\n  \"editing-document\",\n  \"document-1\",\n)",
+  )
+  let unknown = remember_editing_document(snapshot, "missing")
+  assert_false(@debug.to_string(unknown).contains("IndexedDBPut"))
 }
 
 ///|

--- a/apps/loomark/internal/source_repository/storage.mbt
+++ b/apps/loomark/internal/source_repository/storage.mbt
@@ -54,7 +54,7 @@ pub(all) enum ProbeFailure {
 
 ///|
 pub(all) enum OpenResult {
-  Ready(RepositorySnapshot)
+  Ready(RepositorySnapshot, SourceRecord?)
   Failed(OpenFailure)
 } derive(Eq, Debug)
 
@@ -90,6 +90,18 @@ pub fn open(result~ : @cmd.Emit[OpenResult]) -> @cmd.Cmd {
 }
 
 ///|
+/// Best-effort memory of the current saved Editing Document.
+pub fn remember_editing_document(
+  snapshot : RepositorySnapshot,
+  document_id : String,
+) -> @cmd.Cmd {
+  guard snapshot.source(document_id) is Some(_) else { return @cmd.none }
+  @indexed_db.put(document_store, EDITING_DOCUMENT_KEY, document_id, result=_ => {
+    @cmd.none
+  })
+}
+
+///|
 fn scan_repository(result : @cmd.Emit[OpenResult]) -> @cmd.Cmd {
   @indexed_db.scan(document_store, result=scanned => {
     match scanned {
@@ -120,7 +132,7 @@ fn continue_open(
   result : @cmd.Emit[OpenResult],
 ) -> @cmd.Cmd {
   match reconciliation {
-    Ready(snapshot) => result(Ready(snapshot))
+    Ready(snapshot, initial) => result(Ready(snapshot, initial))
     Migrate(mutations) =>
       @indexed_db.mutate(document_store, mutations, result=stored => {
         finish_open_write(stored, result)

--- a/docs/decisions/2026-08-29-loomark-source-repository.md
+++ b/docs/decisions/2026-08-29-loomark-source-repository.md
@@ -2,15 +2,17 @@
 
 **Date:** 2026-08-29
 
-**Status:** Accepted; Source shape, empty-repository behavior, Catalog order,
-and write-completion policy are partially superseded by
-[Loomark document deletion](2026-08-31-loomark-document-deletion.md).
+**Status:** Accepted; amended by
+[Loomark document deletion](2026-08-31-loomark-document-deletion.md) and
+[#1305](https://github.com/dowdiness/canopy/issues/1305) for the Editing
+Document convenience record.
 
 **Issue:** [#1303](https://github.com/dowdiness/canopy/issues/1303)
 
 **Related:**
 
 - [Loomark document deletion](2026-08-31-loomark-document-deletion.md)
+- [Resume the Editing Document](https://github.com/dowdiness/canopy/issues/1305)
 - [Loomark separates current and saved text](2026-08-24-loomark-source-first-interactive-contract.md)
 - [Loomark standard Rabbita Text app](../plans/2026-08-24-loomark-standard-rabbita-text-app.md)
 
@@ -34,21 +36,25 @@ The `loomark` IndexedDB database remains at version `1` with object store
 `documents`. Versioned keys inside that store define the repository:
 
 - `source/v1/<document-id>` is one independently authoritative Source;
+- `editing-document` is an optional Document ID string used only to choose the
+  initial Editing Document after Source reconciliation;
 - `active` is read only as the legacy migration source;
 - every other key is preserved and reported as unknown or unsupported.
 
-No Catalog record is persisted. A Source value contains exactly the fields
-`document_id` and `text`, and the key suffix must equal the payload identity.
-Opening scans the complete store through Rabbita's IndexedDB cursor provider,
-decodes each Source independently, derives the first usable ATX H1 name, sorts
-valid Sources lexically by Document ID, and returns a deterministic in-memory
-Catalog. Malformed values, identity mismatches, unsupported schemas, unknown
-records, and unsupported key or value types remain stored and cannot hide valid
-Sources.
+No Catalog record is persisted. A Source value contains `document_id`, `text`,
+and Change order, and the key suffix must equal the payload identity. Opening
+scans the complete store through Rabbita's IndexedDB cursor provider, decodes
+each Source independently, derives the first usable ATX H1 name, sorts valid
+Sources by newest Change order with a Document ID tie break, and returns a
+deterministic in-memory Catalog. Only after that Snapshot is accepted does a
+valid `editing-document` value select its exact Source. Missing, empty,
+non-string, stale, or unknown values use the deterministic first Source without
+repair or storage writes. Malformed values, identity mismatches, unsupported
+schemas, unknown records, and unsupported key or value types remain stored and
+cannot hide valid Sources.
 
-An empty repository creates a UUID-backed Source whose exact text is
-`# Untitled\n`. Loomark reports it ready only after the Source transaction
-completes.
+An empty repository opens an ephemeral New document and writes no Source until
+its first Document text change is accepted by Browser storage.
 
 A valid legacy `active` value is moved with one atomic transaction containing a
 Source put and legacy delete. If a valid target Source exists, that Source wins
@@ -56,12 +62,17 @@ and only `active` is deleted. A corrupt target preserves both records and is
 reported as a migration collision. Mutation failure rolls back the target put
 and preserves `active`.
 
-A normal save or create derives the next immutable RepositorySnapshot outside
-Raw input. It commits only the accepted Source and installs that snapshot only
-after transaction completion. Occupied keys prevent overwrite of records
-observed by that Snapshot; concurrent-tab coordination remains out of scope.
-Save completions are fenced by Document ID and exact Source candidate before
-they update active durability state.
+A normal save commits only the accepted Source and applies its acknowledged
+change to the latest immutable RepositorySnapshot after transaction completion.
+New document creation reserves an identity without storage. Occupied keys
+prevent overwrite of records observed by the Snapshot; concurrent-tab
+coordination remains out of scope. Save completions are fenced by Document ID
+and exact Source candidate before they update durability state.
+
+Activating a saved Source separately replaces `editing-document` with its
+Document ID. The write has no application state, queue, retry, or completion
+message and makes no Source durability claim. Startup, ephemeral New document
+activation, and the first save of a New document do not write the record.
 
 The JS-only repository uses the browser's native JSON encoder for the fixed
 `document_id`/`text` Source object. The strict MoonBit decoder remains the schema
@@ -101,7 +112,8 @@ results rather than permanent repository issues.
   records for later recovery.
 - Text input continues to update only Browser-draft state; complete-source name
   derivation, serialization, and IndexedDB work begin at `SaveRequested`.
-- Persistent active-document selection remains deferred to #1305.
+- The best-effort Editing Document record cannot become a second in-memory
+  selection authority or a Source durability claim.
 - RepositorySnapshots retain the exact observed `source/v1` keys, including
   malformed and unsupported records.
 - A persisted discovery accelerator requires a separate measured decision and a
@@ -130,9 +142,9 @@ Rejected because no measured product target requires a second validation or
 schema-migration mechanism.
 
 **Introduce a mutable repository actor or generic storage port.** Rejected
-because the application already owns one-write-in-flight scheduling and Rabbita
-already owns the only production adapter, FIFO execution, transaction lifecycle,
-and failure classification.
+because the application reducer already owns per-document operation ordering and
+completion fencing, while Rabbita owns the only production adapter, transaction
+admission and lifecycle, and failure classification.
 
 **Implement IndexedDB scanning in Canopy.** Rejected because Rabbita owns
 connection lifecycle, cursor progression, transaction completion, abort

--- a/docs/plans/2026-08-28-loomark-multi-document-v1.md
+++ b/docs/plans/2026-08-28-loomark-multi-document-v1.md
@@ -1,9 +1,11 @@
 # Loomark multi-document v1 release contract
 
-**Status:** Proposed for the first multi-document release. This is a deliberately
-small, temporary v1 contract, not permanent Loomark architecture. Revisit each
-choice after the v1 product is complete and measured rather than extending this
-plan by assumption.
+**Status:** Product contract for the first multi-document release. The accepted
+Source repository, Autosave, and Delete decisions supersede this plan's earlier
+physical storage, cold-read, and persistence-lifecycle sketches; use those
+decisions and current code for implementation mechanics. The remaining product
+choices are deliberately small and temporary, not permanent Loomark
+architecture.
 
 **Issues:** [#1300](https://github.com/dowdiness/canopy/issues/1300),
 [#1303](https://github.com/dowdiness/canopy/issues/1303),
@@ -35,23 +37,21 @@ list preparation outside the ordinary Text input task.
 
 ### IndexedDB shape
 
-- Each document is one structured IndexedDB record containing its identity,
-  Document text, most-recent-change value, and the bounded information needed to
-  display its first content in Recent documents.
-- Document text and list information are replaced together. V1 does not keep a
-  separate catalog, manifest, Header record, or Source record.
-- The Recent documents view reads a browser-maintained index without
-  materializing every Document text. Opening a document reads that document's
-  complete record.
-- One malformed document record is preserved and shown as unavailable without
-  blocking valid documents. V1 does not hide, delete, repair, or replace it.
-- The latest selected DocumentId is small session data outside document records.
-  Reopening Loomark loads that document in Text mode. If it no longer exists,
-  Loomark selects the most recently changed remaining document; if none exists,
-  it shows an unstored New document. A malformed selected document is reported
-  rather than silently replaced by another document.
-- Export writes only Document text; IndexedDB list and session fields never enter
-  the Markdown file.
+- Each `source/v1/<document-id>` record contains the Document identity, Document
+  text, and Change order. It contains no separate current-document field.
+- Opening scans and validates every Source independently, derives Recent
+  documents in memory, and preserves malformed or unsupported records without
+  letting them hide valid Sources. V1 persists no Catalog or list index.
+- The independent `editing-document` string record contains only the Document ID
+  written after a saved Source becomes the Editing Document. Reopening applies
+  it only after Source reconciliation. Missing, malformed, stale, or unknown
+  values select the most recently changed valid Source, or an unstored New
+  document when none exists.
+- Opening, New document creation, and the first save of a New document do not
+  write `editing-document`; its write is best effort and has no application
+  state, retry, or Source durability claim.
+- Export writes only Document text; Browser storage fields never enter the
+  Markdown file.
 
 ### Create and identify
 


### PR DESCRIPTION
## Summary

- restore the last saved Editing Document from an independent `editing-document` string in the existing Loomark IndexedDB store
- resolve the convenience value only after Source reconciliation, with the existing deterministic Source or New document fallback
- remember only saved-Source activations while keeping startup, ephemeral New, first save, and write failure outside application state and Source durability

Closes #1305

## UI and review evidence

N/A — no visual or interaction design changed. Production Chromium verifies the existing Documents UI reflects the resolved Editing Document.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `RepositorySnapshot::source` / `selected` | `apps/loomark/internal/source_repository` | Yes | validates a stored ID and supplies the existing deterministic fallback |
| `@indexed_db.scan` / `put` | `deps/rabbita/rabbita/indexed_db` | Yes | reuses the existing store scan and best-effort replacement command |
| existing `Activation` and activation seam | `apps/loomark/app` | Yes | remains the only in-memory Editing Document authority |
| `String` and `Option` pattern matching | MoonBit core | Yes | stores the ID directly and represents accepted/missing initial Sources |
| `Array::add` | MoonBit core | Yes | builds the reconciliation invariant table without a custom collection helper |
| `Map`, `Set`, JSON, `Bytes` / `Buffer` | MoonBit core / existing repository code | No | Snapshot already owns lookup; the value is one direct string and needs no envelope or byte processing |

New helpers added (if any):

- `remember_editing_document`: the Source repository-owned effect boundary that rejects IDs absent from the accepted Snapshot and emits one best-effort IndexedDB replacement. No application queue, completion message, retry, or Model state is added.

## Validation scope

Boundary matrix / first failing regression:

- accepted stored ID → exact Source; absent, empty, stale, and non-string values → `RepositorySnapshot::selected()`; empty repository → existing New path
- startup is read-only; saved activation writes; ephemeral New and first Source save do not write
- automatic fallback after deleting the Editing Document writes the saved fallback
- delayed rapid activations are last-invocation-wins; remember failure cannot affect editing, Source recovery, or durability

Target packages:

- `apps/loomark/internal/source_repository`
- `apps/loomark/app`
- `apps/loomark/examples/vanilla`

Additional conditional gates:

- `moon check apps/loomark --warn-list +73`
- `moon test apps/loomark/internal/source_repository apps/loomark/app --release` — 96 passed
- `npm run typecheck` in `apps/loomark/examples/vanilla`
- `./scripts/test-loomark-standalone-e2e.sh` — 49 production Chromium tests passed
- Lefthook pre-push affected validation — 50 source-repository tests and 46 app tests passed
- independent MoonBit latest-base review — PASS

No new ADR is needed: this is disposable convenience data within the existing Source repository decision, which was updated in place.

## Push and CI readiness

```bash
git fetch origin main
git push
```

- [x] The branch contains the fetched `origin/main`, and the normal push completed without bypassing Lefthook's affected local checks.
- [x] The committed `.mbti` diff against `origin/main` was reviewed for unintended API or trait-bound changes.
- [x] No submodule pointer changed; recorded submodule commits passed the reachability gate.
- [x] The branch was pushed after the current commit.
- [x] Independent review findings were resolved before the final validation.
- [ ] GitHub CI's `All Checks Passed` gate is green before merge.
