### PR TITLE
refactor(ideal): route text history through Rabbita

### DIFF
--- a/apps/ideal/main/bridge_ffi.mbt
+++ b/apps/ideal/main/bridge_ffi.mbt
@@ -25,17 +25,6 @@ extern "js" fn js_make_ideal_cm_extension_raw(
   cm : @js_value.Value,
 ) -> @js_value.Value =
   #| function(cm) {
-  #|   const CANOPY_EVENT_REQUEST_UNDO = "request-undo";
-  #|   const CANOPY_EVENT_REQUEST_REDO = "request-redo";
-  #|   const dispatchTextEditorEvent = (eventType) => {
-  #|     const target = document.getElementById("canopy-text-editor");
-  #|     if (target && typeof target.dispatchEvent === "function") {
-  #|       target.dispatchEvent(new CustomEvent(eventType, {
-  #|         bubbles: true,
-  #|         composed: true,
-  #|       }));
-  #|     }
-  #|   };
   #|   const normalizeExtensions = (factory) => {
   #|     const provided = typeof factory === 'function' ? factory(cm) : [];
   #|     return Array.isArray(provided) ? provided : [provided];
@@ -102,30 +91,7 @@ extern "js" fn js_make_ideal_cm_extension_raw(
   #|     },
   #|   });
   #|   const defaultKeymap = Array.isArray(cm.defaultKeymap) ? cm.defaultKeymap : [];
-  #|   const keymap = cm.keymap.of([
-  #|     {
-  #|       key: "Mod-z",
-  #|       run: () => {
-  #|         dispatchTextEditorEvent(CANOPY_EVENT_REQUEST_UNDO);
-  #|         return true;
-  #|       },
-  #|     },
-  #|     {
-  #|       key: "Mod-Shift-z",
-  #|       run: () => {
-  #|         dispatchTextEditorEvent(CANOPY_EVENT_REQUEST_REDO);
-  #|         return true;
-  #|       },
-  #|     },
-  #|     {
-  #|       key: "Mod-y",
-  #|       run: () => {
-  #|         dispatchTextEditorEvent(CANOPY_EVENT_REQUEST_REDO);
-  #|         return true;
-  #|       },
-  #|     },
-  #|     ...defaultKeymap,
-  #|   ]);
+  #|   const keymap = cm.keymap.of(defaultKeymap);
   #|   const languageExtensions = normalizeExtensions(
   #|     globalThis.__canopy_bridge?.createLambdaExtensions,
   #|   );

--- a/apps/ideal/main/init.mbt
+++ b/apps/ideal/main/init.mbt
@@ -79,6 +79,10 @@ fn subscriptions(model : Model, emit : Emit[Msg]) -> Sub {
       model.cm_id,
       selection=emit.map(range => CmSelectionChanged(range)),
       on_change_with_doc=emit.map(event => CmChanges(event)),
+      shortcuts=[
+        @cm.Shortcut::new("Mod-z", emit(Undo), shift=emit(Redo)),
+        @cm.Shortcut::new("Mod-y", emit(Redo)),
+      ],
       source_version=() => Hash::hash(model.editor.get_version()).to_string(),
     )
   } else {

--- a/apps/ideal/main/main_wbtest.mbt
+++ b/apps/ideal/main/main_wbtest.mbt
@@ -412,8 +412,6 @@ test "event names are centralized" {
   inspect(ExternalCrdtChange.event_type(), content="external-crdt-changed")
   inspect(LongPress.event_type(), content="long-press")
   inspect(NodeSelected.event_type(), content="node-selected")
-  inspect(RequestUndo.event_type(), content="request-undo")
-  inspect(RequestRedo.event_type(), content="request-redo")
   inspect(StructuralEditApplied.event_type(), content="structural-edit-applied")
   inspect(SyncStatus.event_type(), content="sync-status")
 }

--- a/apps/ideal/main/rabbita_dom_sub.mbt
+++ b/apps/ideal/main/rabbita_dom_sub.mbt
@@ -12,8 +12,6 @@ priv enum EventName {
   FileOpened
   LongPress
   NodeSelected
-  RequestRedo
-  RequestUndo
   StructuralEditApplied
   SyncStatus
 }
@@ -43,8 +41,6 @@ fn EventName::event_type(self : EventName) -> String {
     FileOpened => "file-loaded"
     LongPress => "long-press"
     NodeSelected => "node-selected"
-    RequestRedo => "request-redo"
-    RequestUndo => "request-undo"
     StructuralEditApplied => "structural-edit-applied"
     SyncStatus => "sync-status"
   }
@@ -59,8 +55,6 @@ fn EventName::key(self : EventName) -> String {
     FileOpened => "file-loaded"
     LongPress => "long-press"
     NodeSelected => "node-selected"
-    RequestRedo => "request-redo"
-    RequestUndo => "request-undo"
     StructuralEditApplied => "structural-edit-applied"
     SyncStatus => "sync-status"
   }
@@ -168,8 +162,6 @@ fn editor_dom_event_subscriptions(emit : @rabbita.Emit[Msg]) -> @sub.Sub {
       NodeSelected,
       emit.map(detail => StructureNodeSelected(event_detail_node_id(detail))),
     ),
-    custom_event_sub(TextEditor, RequestUndo, emit.map(_ => Undo)),
-    custom_event_sub(TextEditor, RequestRedo, emit.map(_ => Redo)),
     // The host dispatches "file-loaded" on #canopy-text-editor with the chosen
     // file's text as the (plain-string) event detail; deliver it as FileLoaded.
     custom_event_sub(

--- a/apps/ideal/web/e2e/editor-features.spec.ts
+++ b/apps/ideal/web/e2e/editor-features.spec.ts
@@ -449,6 +449,72 @@ test.describe('Sync Status', () => {
 // ── Undo / Redo ──────────────────────────────────────────────
 
 test.describe('Undo / Redo', () => {
+  test('text shortcut undoes exactly one CRDT history group', async ({ page }) => {
+    await waitForEditor(page);
+
+    const before = await page.evaluate(() => {
+      const testWindow = window as any;
+      testWindow.__textUndoDomEvents = 0;
+      testWindow.__textRedoDomEvents = 0;
+      document.addEventListener('request-undo', () => {
+        testWindow.__textUndoDomEvents += 1;
+      });
+      document.addEventListener('request-redo', () => {
+        testWindow.__textRedoDomEvents += 1;
+      });
+      const bridge = testWindow.__canopy_bridge;
+      return bridge.crdt.get_text(bridge.crdtHandle);
+    });
+    await page.evaluate(() => {
+      const content = document.querySelector(
+        '#canopy-text-editor .cm-content',
+      ) as HTMLElement;
+      content?.focus();
+    });
+    await page.keyboard.press('Control+End');
+    await page.keyboard.type('x');
+    await page.waitForTimeout(600);
+    await page.keyboard.type('y');
+
+    await page.waitForFunction((expected) => {
+      const bridge = (window as any).__canopy_bridge;
+      return bridge?.crdt?.get_text(bridge.crdtHandle) === expected;
+    }, `${before}xy`);
+
+    await page.keyboard.press('Control+z');
+
+    await page.waitForFunction((expected) => {
+      const bridge = (window as any).__canopy_bridge;
+      return bridge?.crdt?.get_text(bridge.crdtHandle) === expected;
+    }, `${before}x`);
+    await page.waitForTimeout(100);
+    const afterUndo = await page.evaluate(() => {
+      const bridge = (window as any).__canopy_bridge;
+      return bridge.crdt.get_text(bridge.crdtHandle);
+    });
+    expect(afterUndo).toBe(`${before}x`);
+    expect(await page.evaluate(() => (window as any).__textUndoDomEvents)).toBe(0);
+
+    await page.keyboard.press('Control+Shift+Z');
+    await page.waitForFunction((expected) => {
+      const bridge = (window as any).__canopy_bridge;
+      return bridge?.crdt?.get_text(bridge.crdtHandle) === expected;
+    }, `${before}xy`);
+    expect(await page.evaluate(() => (window as any).__textRedoDomEvents)).toBe(0);
+
+    await page.keyboard.press('Control+z');
+    await page.waitForFunction((expected) => {
+      const bridge = (window as any).__canopy_bridge;
+      return bridge?.crdt?.get_text(bridge.crdtHandle) === expected;
+    }, `${before}x`);
+    await page.keyboard.press('Control+y');
+    await page.waitForFunction((expected) => {
+      const bridge = (window as any).__canopy_bridge;
+      return bridge?.crdt?.get_text(bridge.crdtHandle) === expected;
+    }, `${before}xy`);
+    expect(await page.evaluate(() => (window as any).__textRedoDomEvents)).toBe(0);
+  });
+
   test('undo button does not crash with no history', async ({ page }) => {
     await waitForEditor(page);
     // Clicking undo with no edit history should not error

--- a/modules/rabbita_codemirror/codemirror.mbt
+++ b/modules/rabbita_codemirror/codemirror.mbt
@@ -71,8 +71,34 @@ pub fn ChangeEvent::new(
 }
 
 ///|
+/// A focused CodeMirror shortcut that schedules a Rabbita command.
+///
+/// Construct shortcuts in `subscriptions`; do not store them in application
+/// Models. Array order defines precedence when keys overlap.
+pub struct Shortcut {
+  key : String
+  command : @cmd.Cmd
+  shift_command : @cmd.Cmd?
+}
+
+///|
+/// Associate a CodeMirror key name such as `Mod-z` with a Rabbita command.
+///
+/// `shift` uses CodeMirror's native shifted-command slot. For example,
+/// `Mod-z` with a redo `shift` handles both undo and `Mod-Shift-z` without
+/// allowing the shifted key to fall through to CodeMirror's local history.
+pub fn Shortcut::new(
+  key : String,
+  command : @cmd.Cmd,
+  shift? : @cmd.Cmd,
+) -> Shortcut {
+  { key, command, shift_command: shift }
+}
+
+///|
 #cfg(target="js")
 priv struct CmEntry {
+  generation : Int
   view : @js_ffi.CmView
   theme_comp : @js_ffi.Compartment
   readonly_comp : @js_ffi.Compartment
@@ -81,7 +107,9 @@ priv struct CmEntry {
   line_wrapping_comp : @js_ffi.Compartment
   extension_comp : @js_ffi.Compartment
   listener_comp : @js_ffi.Compartment
+  shortcut_comp : @js_ffi.Compartment
   update_disposable : @js_ffi.Disposable
+  shortcut_disposable : @js_ffi.Disposable
 }
 
 ///|
@@ -89,9 +117,16 @@ priv struct CmEntry {
 let editors : Map[String, CmEntry] = Map([])
 
 ///|
+/// Monotonic mount generations keep retained Rabbita subscriptions from
+/// targeting a replaced CodeMirror view without retaining retired editor ids.
+#cfg(target="js")
+let next_editor_generation : Ref[Int] = { val: 0 }
+
+///|
 priv suberror CmSubscription {
   CmListen(
     String,
+    Array[Shortcut],
     doc~ : @cmd.Emit[String]?,
     selection~ : @cmd.Emit[SelRange]?,
     focus~ : @cmd.Emit[Bool]?,
@@ -229,6 +264,7 @@ fn no_op_update_listener(
 #cfg(target="js")
 fn dispose_entry(entry : CmEntry) -> Unit {
   entry.update_disposable.dispose()
+  entry.shortcut_disposable.dispose()
   @js_ffi.js_view_destroy(entry.view)
 }
 
@@ -333,6 +369,7 @@ fn build_initial_extension(
   line_wrapping_comp : @js_ffi.Compartment,
   extension_comp : @js_ffi.Compartment,
   listener_comp : @js_ffi.Compartment,
+  shortcut_comp : @js_ffi.Compartment,
   initial_theme : @theme.Theme?,
   initial_readonly : Bool,
   initial_keymap : @keymap.Keymap?,
@@ -357,7 +394,19 @@ fn build_initial_extension(
     ),
     @js_ffi.js_compartment_of(extension_comp, initial_extension),
     @js_ffi.js_compartment_of(listener_comp, empty_extension()),
+    @js_ffi.js_compartment_of(shortcut_comp, empty_extension()),
   ])
+}
+
+///|
+#cfg(target="js")
+fn build_shortcut_signature(shortcuts : Array[Shortcut]) -> String {
+  let encoded = shortcuts.map(shortcut => {
+    let has_shift = if shortcut.shift_command is Some(_) { "1" } else { "0" }
+    "\{shortcut.key.length()}:\{shortcut.key}:\{has_shift}"
+  })
+  let joined = encoded.join("")
+  "\{shortcuts.length()}:\{joined}"
 }
 
 ///|
@@ -382,6 +431,7 @@ fn cm_sub_loader(
   match payload {
     CmListen(
       id,
+      shortcuts,
       doc~,
       selection~,
       focus~,
@@ -397,6 +447,7 @@ fn cm_sub_loader(
       let mut changes_tagger = changes
       let mut changes_with_doc_tagger = changes_with_doc
       let mut source_version_tagger = source_version
+      let mut current_shortcuts = shortcuts
       let include_doc = doc is Some(_)
       let include_change_doc = changes_with_doc is Some(_)
 
@@ -411,6 +462,15 @@ fn cm_sub_loader(
       fn on_focus(value : @js_value.Value) {
         guard focus_tagger is Some(msg) else { return }
         scheduler.add(msg(value.cast()))
+      }
+      fn on_shortcut(index : Int, shifted : Bool) {
+        guard current_shortcuts.get(index) is Some(shortcut) else { return }
+        if shifted {
+          guard shortcut.shift_command is Some(command) else { return }
+          scheduler.add(command)
+        } else {
+          scheduler.add(shortcut.command)
+        }
       }
       fn on_changes(value : @js_value.Value) {
         if include_change_doc {
@@ -432,6 +492,7 @@ fn cm_sub_loader(
       }
 
       entry.update_disposable.dispose()
+      entry.shortcut_disposable.dispose()
       let disposable = @js_ffi.js_add_update_listener(
         entry.view,
         entry.listener_comp,
@@ -443,14 +504,29 @@ fn cm_sub_loader(
         include_doc~,
         include_change_doc~,
       )
-      editors[id] = { ..entry, update_disposable: disposable }
+      let shortcut_disposable = @js_ffi.js_add_shortcuts(
+        entry.view,
+        entry.shortcut_comp,
+        shortcuts.map(shortcut => shortcut.key),
+        shortcuts.map(shortcut => shortcut.shift_command is Some(_)),
+        on_shortcut,
+      )
+      editors[id] = {
+        ..entry,
+        update_disposable: disposable,
+        shortcut_disposable,
+      }
 
       Some({
-        unload: fn(_) { disposable.dispose() },
+        unload: fn(_) {
+          disposable.dispose()
+          shortcut_disposable.dispose()
+        },
         update_tagger: fn(payload) {
           guard payload
             is CmListen(
               _,
+              shortcuts,
               doc~,
               selection~,
               focus~,
@@ -466,6 +542,7 @@ fn cm_sub_loader(
           changes_tagger = changes
           changes_with_doc_tagger = changes_with_doc
           source_version_tagger = source_version
+          current_shortcuts = shortcuts
         },
       })
     }
@@ -525,6 +602,8 @@ pub fn mount(
       }
       guard custom_extension is Some(custom_extension) else { return }
 
+      let generation = next_editor_generation.val
+      next_editor_generation.val = generation + 1
       if editors.get(id) is Some(old_entry) {
         dispose_entry(old_entry)
         editors.remove(id)
@@ -537,14 +616,23 @@ pub fn mount(
       let line_wrapping_comp = @js_ffi.js_compartment_new(cm)
       let extension_comp = @js_ffi.js_compartment_new(cm)
       let listener_comp = @js_ffi.js_compartment_new(cm)
+      let shortcut_comp = @js_ffi.js_compartment_new(cm)
       let extension = build_initial_extension(
         cm_value, theme_comp, readonly_comp, keymap_comp, line_numbers_comp, line_wrapping_comp,
-        extension_comp, listener_comp, initial_theme, initial_readonly, initial_keymap,
-        initial_line_numbers, initial_line_wrapping, custom_extension,
+        extension_comp, listener_comp, shortcut_comp, initial_theme, initial_readonly,
+        initial_keymap, initial_line_numbers, initial_line_wrapping, custom_extension,
       )
       let view = @js_ffi.js_create_view(cm, host_id, init_doc, extension)
       let update_disposable = no_op_update_listener(view, listener_comp)
+      let shortcut_disposable = @js_ffi.js_add_shortcuts(
+        view,
+        shortcut_comp,
+        [],
+        [],
+        (_, _) => (),
+      )
       editors[id] = {
+        generation,
         view,
         theme_comp,
         readonly_comp,
@@ -553,7 +641,9 @@ pub fn mount(
         line_wrapping_comp,
         extension_comp,
         listener_comp,
+        shortcut_comp,
         update_disposable,
+        shortcut_disposable,
       }
       match on_mounted {
         Some(cmd) => scheduler.add(cmd)
@@ -785,7 +875,11 @@ pub fn set_line_wrapping(
 }
 
 ///|
-/// Subscribe to CodeMirror document, selection, focus, and per-change changes.
+/// Subscribe to CodeMirror events and focused shortcuts.
+///
+/// Mount the editor with an `on_mounted` command and subscribe after that
+/// command updates application state. A per-id mount generation then forces
+/// Rabbita to attach this subscription to any replacement view.
 ///
 /// `on_change` is additive: it delivers every replaced range of a transaction
 /// as an ordered `Array[ChangeDelta]` in pre-transaction coordinates, leaving
@@ -808,29 +902,39 @@ pub fn listen(
   focus? : @cmd.Emit[Bool],
   on_change? : @cmd.Emit[Array[ChangeDelta]],
   on_change_with_doc? : @cmd.Emit[ChangeEvent],
+  shortcuts? : Array[Shortcut] = [],
   source_version? : () -> String = () => "",
 ) -> @sub.Sub {
+  let shortcuts = shortcuts.copy()
   let has_doc = doc is Some(_)
   let has_selection = selection is Some(_)
   let has_focus = focus is Some(_)
   let has_changes = on_change is Some(_)
   let has_changes_with_doc = on_change_with_doc is Some(_)
+  let has_shortcuts = shortcuts.length() > 0
 
   guard has_doc ||
     has_selection ||
     has_focus ||
     has_changes ||
-    has_changes_with_doc else {
+    has_changes_with_doc ||
+    has_shortcuts else {
     @sub.none
   }
-  let key = build_listen_key(
+  let event_key = build_listen_key(
     id, has_doc, has_selection, has_focus, has_changes, has_changes_with_doc,
   )
+  let generation = match editors.get(id) {
+    Some(entry) => entry.generation
+    None => -1
+  }
+  let key = "\{event_key};generation=\{generation};shortcuts=\{build_shortcut_signature(shortcuts)}"
   @sub.custom_sub(
     key,
     Local,
     CmListen(
       id,
+      shortcuts,
       doc~,
       selection~,
       focus~,

--- a/modules/rabbita_codemirror/codemirror_wbtest.mbt
+++ b/modules/rabbita_codemirror/codemirror_wbtest.mbt
@@ -1,4 +1,36 @@
 ///|
+test "shortcut signature preserves order and boundaries" {
+  inspect(
+    build_shortcut_signature([
+      Shortcut::new("a", @cmd.none),
+      Shortcut::new("bc", @cmd.none),
+    ]),
+    content="2:1:a:02:bc:0",
+  )
+}
+
+///|
+test "shortcut signature preserves duplicate occurrences" {
+  inspect(
+    build_shortcut_signature([
+      Shortcut::new("Mod-z", @cmd.none),
+      Shortcut::new("Mod-z", @cmd.none),
+    ]),
+    content="2:5:Mod-z:05:Mod-z:0",
+  )
+}
+
+///|
+test "shortcut signature includes shifted command shape" {
+  inspect(
+    build_shortcut_signature([
+      Shortcut::new("Mod-z", @cmd.none, shift=@cmd.none),
+    ]),
+    content="1:5:Mod-z:1",
+  )
+}
+
+///|
 test "listen key format" {
   inspect(
     build_listen_key("a", true, true, false, true, false),

--- a/modules/rabbita_codemirror/js/codemirror.mbt
+++ b/modules/rabbita_codemirror/js/codemirror.mbt
@@ -476,3 +476,61 @@ pub fn js_add_update_listener(
     ),
   )
 }
+
+///|
+extern "js" fn js_add_shortcuts_raw(
+  view : @js_value.Value,
+  compartment : @js_value.Value,
+  keys : Array[String],
+  has_shift : Array[Bool],
+  on_shortcut : (Int, Bool) -> Unit,
+) -> () -> Unit =
+  #| (view, compartment, keys, hasShift, onShortcut) => {
+  #|   const cm = view._cmModule;
+  #|   if (!cm) {
+  #|     throw new Error("Shortcut attach requires a view created via js_create_view");
+  #|   }
+  #|   const bindings = keys.map((key, index) => {
+  #|     const binding = {
+  #|       key,
+  #|       run: () => {
+  #|         onShortcut(index, false);
+  #|         return true;
+  #|       },
+  #|     };
+  #|     if (hasShift[index]) {
+  #|       binding.shift = () => {
+  #|         onShortcut(index, true);
+  #|         return true;
+  #|       };
+  #|     }
+  #|     return binding;
+  #|   });
+  #|   const extension = cm.Prec.highest(cm.keymap.of(bindings));
+  #|   view.dispatch({ effects: compartment.reconfigure(extension) });
+  #|   let disposed = false;
+  #|   return () => {
+  #|     if (disposed) return;
+  #|     disposed = true;
+  #|     view.dispatch({ effects: compartment.reconfigure([]) });
+  #|   };
+  #| }
+
+///|
+/// Install ordered CodeMirror shortcuts in a dedicated compartment.
+///
+/// Each matching binding invokes `on_shortcut` with its array index and
+/// whether CodeMirror selected its shifted-command slot, then consumes the
+/// key event. `Prec.highest` makes these application commands
+/// deterministic relative to CodeMirror's default and consumer keymaps.
+pub fn js_add_shortcuts(
+  view : CmView,
+  compartment : Compartment,
+  keys : Array[String],
+  has_shift : Array[Bool],
+  on_shortcut : (Int, Bool) -> Unit,
+) -> Disposable {
+  Disposable(
+    js_add_shortcuts_raw(view.0, compartment.0, keys, has_shift, on_shortcut),
+  )
+}

--- a/modules/rabbita_codemirror/js/pkg.generated.mbti
+++ b/modules/rabbita_codemirror/js/pkg.generated.mbti
@@ -4,6 +4,8 @@ package "dowdiness/rabbita_codemirror/js"
 // Values
 pub fn cm_module_of(@moonbit-community/rabbita/js.Value) -> CmModule
 
+pub fn js_add_shortcuts(CmView, Compartment, Array[String], Array[Bool], (Int, Bool) -> Unit) -> Disposable
+
 pub fn js_add_update_listener(CmView, Compartment, (@moonbit-community/rabbita/js.Value) -> Unit, (@moonbit-community/rabbita/js.Value) -> Unit, (@moonbit-community/rabbita/js.Value) -> Unit, (@moonbit-community/rabbita/js.Value) -> Unit, include_doc? : Bool, include_change_doc? : Bool, source_version? : () -> String) -> Disposable
 
 pub fn js_compartment_new(CmModule) -> Compartment

--- a/modules/rabbita_codemirror/pkg.generated.mbti
+++ b/modules/rabbita_codemirror/pkg.generated.mbti
@@ -12,7 +12,7 @@ import {
 // Values
 pub fn insert(String, Int, String, failed? : @cmd.Emit[String]) -> @cmd.Cmd
 
-pub fn listen(String, doc? : @cmd.Emit[String], selection? : @cmd.Emit[SelRange], focus? : @cmd.Emit[Bool], on_change? : @cmd.Emit[Array[ChangeDelta]], on_change_with_doc? : @cmd.Emit[ChangeEvent], source_version? : () -> String) -> @sub.Sub
+pub fn listen(String, doc? : @cmd.Emit[String], selection? : @cmd.Emit[SelRange], focus? : @cmd.Emit[Bool], on_change? : @cmd.Emit[Array[ChangeDelta]], on_change_with_doc? : @cmd.Emit[ChangeEvent], shortcuts? : Array[Shortcut], source_version? : () -> String) -> @sub.Sub
 
 pub fn mount(String, String, init_doc? : String, source? : String, initial_theme? : @theme.Theme?, initial_readonly? : Bool, initial_keymap? : @keymap.Keymap?, initial_line_numbers? : Bool, initial_line_wrapping? : Bool, on_mounted? : @cmd.Cmd, failed? : @cmd.Emit[String], initial_extension? : ((@moonbit-community/rabbita/js.Value) -> @dowdiness/rabbita_codemirror/js.Extension raise)?) -> @cmd.Cmd
 
@@ -60,6 +60,13 @@ pub struct SelRange {
   to : Int
 }
 pub fn SelRange::new(Int, Int) -> Self
+
+pub struct Shortcut {
+  key : String
+  command : @cmd.Cmd
+  shift_command : @cmd.Cmd?
+}
+pub fn Shortcut::new(String, @cmd.Cmd, shift? : @cmd.Cmd) -> Self
 
 // Type aliases
 


### PR DESCRIPTION
## Summary

- add typed CodeMirror shortcuts to `rabbita_codemirror.listen`, scheduling Rabbita commands through the binding-owned subscription lifecycle
- route Ideal Text-mode undo/redo through `Msg::Undo` / `Msg::Redo` and remove its `request-undo` / `request-redo` CustomEvent path
- keep the Structure-mode TypeScript path unchanged and add browser coverage for exactly-once history transitions and zero Text-mode history CustomEvents

This is the first bounded mutation-path retirement slice for #1348.

## UI and review evidence

N/A — behavior and architecture change only; no labels, layout, styling, focus treatment, pointer interaction, or viewport behavior changed.

- [x] Any claimed Canopy rule cites its repository source; external guidance, recommendations, and preferences are labeled as such

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `listen` / `custom_sub` / `RunningSub.update_tagger` | `modules/rabbita_codemirror`, `deps/rabbita/rabbita/sub` | Yes | Preserves Rabbita's function-based subscription lifecycle and tagger rebinding |
| `Scheduler::add`, `Cmd`, `Emit` | `deps/rabbita/rabbita/cmd` | Yes | Schedules typed application commands without storing effects in `Model` |
| CodeMirror `Compartment`, `keymap.of`, `Prec.highest` | `modules/rabbita_codemirror/js` and loaded CM namespace | Yes | Owns shortcut installation, precedence, reconfiguration, and disposal inside the binding |
| `Array::map`, `join`, `get`, `copy` | MoonBit core `Array` | Yes | Builds injective subscription identity, safely indexes callbacks, and defensively owns subscription input |
| `String::length`, `Option` pattern matching, `Ref` | MoonBit core | Yes | Encodes shortcut identity, handles optional shifted commands, and allocates mount generations |
| `@sub.on_key_down` | Rabbita subscriptions | No | Document-level input is too coarse and CodeMirror consumes editor shortcuts first |
| addon `Keymap` / direct `@html` key handler | `modules/rabbita_codemirror/addon/keymap`, Rabbita HTML | No | Neither provides the binding-owned scheduler and CodeMirror precedence/lifecycle seam needed here |
| `StringBuilder` | MoonBit core | No | `Array::map` plus `join` is clearer for the small ordered shortcut signature |

New helpers added (if any):

- `Shortcut` / `Shortcut::new`: typed association between a CodeMirror key and Rabbita commands, including CodeMirror's native shifted-command slot
- `build_shortcut_signature`: private length-prefixed identity for ordered key bindings, shift shape, and duplicates
- `js_add_shortcuts`: raw binding adapter that installs and disposes shortcut extensions in a dedicated compartment

## Validation scope

Boundary matrix / first failing regression:

- Text `Mod-z`: one keypress rolls back exactly one independently grouped CRDT edit
- Text `Mod-Shift-z` and `Mod-y`: restore the same history group through `Msg::Redo`
- Text history shortcuts: dispatch zero `request-undo` / `request-redo` CustomEvents
- Structure mode: existing TypeScript event ownership remains unchanged
- first red result: exactly-one undo passed, but the observed Text `request-undo` event count was `1` instead of `0`

Target packages:

- `dowdiness/rabbita_codemirror`
- `dowdiness/rabbita_codemirror/js`
- `dowdiness/ideal-editor/main`

Additional conditional gates:

- workspace `moon check`: 0 errors
- workspace `moon test`: 2636 JS and 109 native tests passed
- `apps/ideal/web/e2e/editor-features.spec.ts`: 32 Chromium tests passed
- independent MoonBit review: no remaining findings after same-id remount subscription lifecycle was corrected

## Push and CI readiness

```bash
git fetch origin main
git push
```

- [x] The branch contains the fetched `origin/main`, and the normal push completed without bypassing Lefthook's affected local checks.
- [x] The committed `.mbti` diff against `origin/main` was reviewed for unintended API or trait-bound changes.
- [x] No submodule pointer changed; recorded submodule commits remain reachable.
- [x] The branch was pushed again after every commit, amend, rebase, cherry-pick, submodule-pointer, manifest, or generated-interface change.
- [x] Independent review findings were resolved before the final validation.
- [ ] GitHub CI's `All Checks Passed` gate is green before merge.
